### PR TITLE
Trivial fix for parsing -MT option as a source header.

### DIFF
--- a/emcc
+++ b/emcc
@@ -642,7 +642,7 @@ for i in range(1, len(sys.argv)):
   if not arg.startswith('-'):
     if arg.endswith(('.c','.m')):
       use_cxx = False
-    if arg.endswith('.h') and sys.argv[i-1] != '-include':
+    if arg.endswith('.h') and sys.argv[i-1] != '-include' and sys.argv[i-1] != '-MT' and sys.argv[i-1] != '-MQ':
       header = True
 
 if '-M' in sys.argv or '-MM' in sys.argv:


### PR DESCRIPTION
Fixes #1410

This fixes the issue that @draconx was having when his build system was using a compiler command line containing "-MT somefile.h". He's still hitting other problems, but they aren't related to the issue any more :)
