### PR TITLE
added new AUTORUN setting

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -115,6 +115,8 @@ function run(args) {
     return;
   }
 
+  preInit();
+
   preRun();
 
   if (runDependencies > 0) {
@@ -185,24 +187,22 @@ Module['abort'] = Module.abort = abort;
 
 // {{PRE_RUN_ADDITIONS}}
 
-if (Module['preInit']) {
-  if (typeof Module['preInit'] == 'function') Module['preInit'] = [Module['preInit']];
-  while (Module['preInit'].length > 0) {
-    Module['preInit'].pop()();
-  }
-}
-
 // shouldRunNow refers to calling main(), not run().
 #if INVOKE_RUN
 var shouldRunNow = true;
 #else
 var shouldRunNow = false;
+Module.printErr('INVOKE_RUN=0 is now deprecated, please instead use AUTORUN=0 to customize the startup sequence');
 #endif
+
 if (Module['noInitialRun']) {
   shouldRunNow = false;
+  Module.printErr('noInitialRun is now deprecated, please instead use AUTORUN=0 to customize the startup sequence');
 }
 
+#if AUTORUN
 run();
+#endif
 
 // {{POST_RUN_ADDITIONS}}
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -936,6 +936,7 @@ function callRuntimeCallbacks(callbacks) {
   }
 }
 
+var __ATPREINIT__ = []; // functions called before prerun
 var __ATPRERUN__  = []; // functions called before the runtime is initialized
 var __ATINIT__    = []; // functions called during startup
 var __ATMAIN__    = []; // functions called when main() is to be run
@@ -944,41 +945,58 @@ var __ATPOSTRUN__ = []; // functions called after the runtime has exited
 
 var runtimeInitialized = false;
 
+// compatibility - merge in any startup tasks from the Module object at this time
+if (Module['preInit']) {
+  if (typeof Module['preInit'] == 'function') Module['preInit'] = [Module['preInit']];
+  __ATPREINIT__.push.apply(__ATPREINIT__, Module['preInit']);
+}
+
+if (Module['preRun']) {
+  if (typeof Module['preRun'] == 'function') Module['preRun'] = [Module['preRun']];
+  __ATPRERUN__.push.apply(__ATPRERUN__, Module['preRun']);
+}
+
+if (Module['postRun']) {
+  if (typeof Module['postRun'] == 'function') Module['postRun'] = [Module['postRun']];
+  __ATPOSTRUN__.push.apply(__ATPOSTRUN__, Module['postRun']);
+}
+
+function preInit() {
+  callRuntimeCallbacks(__ATPREINIT__);
+}
+Module['preInit'] = Module.preInit = preInit;
+
 function preRun() {
-  // compatibility - merge in anything from Module['preRun'] at this time
-  if (Module['preRun']) {
-    if (typeof Module['preRun'] == 'function') Module['preRun'] = [Module['preRun']];
-    while (Module['preRun'].length) {
-      addOnPreRun(Module['preRun'].shift());
-    }
-  }
   callRuntimeCallbacks(__ATPRERUN__);
 }
+Module['preRun'] = Module.preRun = preRun;
 
 function ensureInitRuntime() {
   if (runtimeInitialized) return;
   runtimeInitialized = true;
   callRuntimeCallbacks(__ATINIT__);
 }
+Module['initRuntime'] = Module.initRuntime = ensureInitRuntime;
 
 function preMain() {
   callRuntimeCallbacks(__ATMAIN__);
 }
+Module['preMain'] = Module.preMain = preMain;
 
 function exitRuntime() {
   callRuntimeCallbacks(__ATEXIT__);
 }
+Module['exitRuntime'] = Module.exitRuntime = exitRuntime;
 
 function postRun() {
-  // compatibility - merge in anything from Module['postRun'] at this time
-  if (Module['postRun']) {
-    if (typeof Module['postRun'] == 'function') Module['postRun'] = [Module['postRun']];
-    while (Module['postRun'].length) {
-      addOnPostRun(Module['postRun'].shift());
-    }
-  }
   callRuntimeCallbacks(__ATPOSTRUN__);
 }
+Module['postRun'] = Module.postRun = postRun;
+
+function addOnPreInit(cb) {
+  __ATPREINIT__.unshift(cb);
+}
+Module['addOnPreInit'] = Module.addOnPreInit = addOnPreInit;
 
 function addOnPreRun(cb) {
   __ATPRERUN__.unshift(cb);

--- a/src/settings.js
+++ b/src/settings.js
@@ -45,7 +45,12 @@ var ASSERTIONS = 1; // Whether we should add runtime assertions, for example to
                     // ASSERTIONS == 2 gives even more runtime checks
 var VERBOSE = 0; // When set to 1, will generate more verbose output during compilation.
 
-var INVOKE_RUN = 1; // Whether we will run the main() function. Disable if you embed the generated
+var AUTORUN = 1; // Whether we will call run() automatically or not. Disable if you'd instead
+                 // like to manually manage the file preloading, runtime initialization and
+                 // entry point invocation.
+
+var INVOKE_RUN = 1; // This feature is now deprecated, please instead use AUTORUN.
+                    // Whether we will run the main() function. Disable if you embed the generated
                     // code in your own, and will call main() yourself at the right time (which you
                     // can do with Module.callMain(), with an optional parameter of commandline args).
 var INIT_HEAP = 0; // Whether to initialize memory anywhere other than the stack to 0.


### PR DESCRIPTION
- added new AUTORUN setting to enable completely disabling emscripten's default startup sequence
- preInit was moved inside of run so that it wasn't called at all when using AUTORUN=0
- exported preInit, preRun, etc. functions to enable users to completely customize the startup sequence
- deprecate INVOKE_RUN

The general idea here is that we're now exporting all of the functions used by run, such that if run is disabled, the user can fine-tune the startup sequence to their liking. Or, if they'd just like to delay calling run, they can always AUTORUN=0 and call run manually. This closes https://github.com/kripken/emscripten/issues/1562.

The only nasty side to this change is that we export Module['preRun'] as the preRun function, yet that's also used to specify the initial preRun tasks. However, I don't think this actually presents a problem for any current use case. I've ran `browser` and `default` tests on this change.

Finally, I'm curious to know if it's possible to deprecate preInit and preMain as well to simplify the startup. preInit isn't used by emscripten internally and preMain is used for a very minor FS feature that we could work around. 
