### PR TITLE
Additions to keyCodes array.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -50,11 +50,13 @@ mergeInto(LibraryManager.library, {
     
     // Results of browser detection (in init()).
     // For cases where feature detection is not enough.
-    isFirefox: false,
-    isChrome: false,
-    isSafari: false,
-    isOpera: false,
-    isIE: false,
+    // The property matching the browser (if any)
+    // receives a string with browser's version (e.g. "1.4.31a").
+    isFirefox: "",
+    isChrome: "",
+    isSafari: "",
+    isOpera: "",
+    isIE: "",
 
     init: function() {
       if (!Module["preloadPlugins"]) Module["preloadPlugins"] = []; // needs to exist even in workers
@@ -64,18 +66,35 @@ mergeInto(LibraryManager.library, {
 
       // Browser detection.
       // Currently based on navigator.userAgent string: http://www.useragentstring.com
-      if (/Firefox/i.test(navigator.userAgent)) {
-        Browser.isFirefox = true;
-      } else if (/Chrome/i.test(navigator.userAgent)) {
-        // Chrome also has "Safari" in its navigator.userAgent string,
-        // so it must be checked before Safari.
-        Browser.isChrome = true;
-      } else if (/Safari/i.test(navigator.userAgent)) {
-        Browser.isSafari = true;
-      } else if (/Opera/i.test(navigator.userAgent)) {
-        Browser.isOpera = true;
-      } else if (/MSIE/i.test(navigator.userAgent)) {
-        Browser.isIE = true;
+      var match;
+      
+      // OPERA:
+      // Some Operas have "MSIE", "Firefox" etc. in its user agent string,
+      // so it must be checked before these.
+      // Opera 15 switched to WebKit. "OPR" replaced "Opera" in user agent string.
+      // Get version after string "Version/" if present.
+      if (match = navigator.userAgent.match(/\b(Opera|OPR)[\/ ](.*\bVersion\/)?([.\w]+)/i)) {
+        Browser.isOpera = match[3];
+      } else
+      // FIREFOX:
+              if (match = navigator.userAgent.match(/\bFirefox\/([.\w]+)/i)) {
+        Browser.isFirefox = match[1];
+      } else
+      // CHROME:
+      // Chrome also has "Safari" in its user agent string,
+      // so it must be checked before Safari.
+             if (match = navigator.userAgent.match(/\bChrome\/([.\w]+)/i)) {
+        Browser.isChrome = match[1];
+      } else
+      // SAFARI:
+             if (match = navigator.userAgent.match(/\bSafari\/([.\w]+)/i)) {
+        Browser.isSafari = match[1];
+      } else
+      // INTERNET EXPLORER:
+      // IE 11 dropped "MSIE" in user agent string;
+      // "Trident" remains, with version after string "rv:".
+             if (match = navigator.userAgent.match(/\b(MSIE |Trident\b.+\brv:\s*)([.\w]+)/i)) {
+        Browser.isIE = match[2];
       }
 
       try {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -68,32 +68,28 @@ mergeInto(LibraryManager.library, {
       // Currently based on navigator.userAgent string: http://www.useragentstring.com
       var match;
       
-      // OPERA:
-      // Some Operas have "MSIE", "Firefox" etc. in its user agent string,
-      // so it must be checked before these.
-      // Opera 15 switched to WebKit. "OPR" replaced "Opera" in user agent string.
-      // Get version after string "Version/" if present.
       if (match = navigator.userAgent.match(/\b(Opera|OPR)[\/ ](.*\bVersion\/)?([.\w]+)/i)) {
+        // OPERA:
+        // Some Operas have "MSIE", "Firefox" etc. in its user agent string,
+        // so it must be checked before these.
+        // Opera 15 switched to WebKit. "OPR" replaced "Opera" in user agent string.
+        // Get version after string "Version/" if present.
         Browser.isOpera = match[3];
-      } else
-      // FIREFOX:
-              if (match = navigator.userAgent.match(/\bFirefox\/([.\w]+)/i)) {
+      } else if (match = navigator.userAgent.match(/\bFirefox\/([.\w]+)/i)) {
+        // FIREFOX:
         Browser.isFirefox = match[1];
-      } else
-      // CHROME:
-      // Chrome also has "Safari" in its user agent string,
-      // so it must be checked before Safari.
-             if (match = navigator.userAgent.match(/\bChrome\/([.\w]+)/i)) {
+      } else if (match = navigator.userAgent.match(/\bChrome\/([.\w]+)/i)) {
+        // CHROME:
+        // Chrome also has "Safari" in its user agent string,
+        // so it must be checked before Safari.
         Browser.isChrome = match[1];
-      } else
-      // SAFARI:
-             if (match = navigator.userAgent.match(/\bSafari\/([.\w]+)/i)) {
+      } else if (match = navigator.userAgent.match(/\bSafari\/([.\w]+)/i)) {
+        // SAFARI:
         Browser.isSafari = match[1];
-      } else
-      // INTERNET EXPLORER:
-      // IE 11 dropped "MSIE" in user agent string;
-      // "Trident" remains, with version after string "rv:".
-             if (match = navigator.userAgent.match(/\b(MSIE |Trident\b.+\brv:\s*)([.\w]+)/i)) {
+      } else if (match = navigator.userAgent.match(/\b(MSIE |Trident\b.+\brv:\s*)([.\w]+)/i)) {
+        // INTERNET EXPLORER:
+        // IE 11 dropped "MSIE" in user agent string;
+        // "Trident" remains, with version after string "rv:".
         Browser.isIE = match[2];
       }
 
@@ -481,36 +477,9 @@ mergeInto(LibraryManager.library, {
       // Firefox and Opera keycodes will be translated to them.
       var mapping;
       if (Browser.isOpera) {
-        mapping = {
-          219: 91, // Windows key
-          0: 93, // Windows menu key
-          
-          48: 96, // Numpad 0
-          49: 97, // Numpad 1
-          50: 98, // Numpad 2
-          51: 99, // Numpad 3
-          52: 100, // Numpad 4
-          53: 101, // Numpad 5
-          54: 102, // Numpad 6
-          55: 103, // Numpad 7
-          56: 104, // Numpad 8
-          57: 105, // Numpad 9
-          42: 106, // Numpad *
-          43: 107, // Numpad +
-          // 45: 109, // Numpad - -- Discarded, because 45 is also Insert.
-          // 78: 110, // Numpad . -- Discarded, because 78 is also N.
-          47: 111, // Numpad /
-          
-          59: 186, // ; :
-          61: 187, // = +
-          109: 189 // - _
-        };
+        mapping = Browser.keyCodeMapping.opera;
       } else if (Browser.isFirefox) {
-        mapping = {
-          59: 186, // ; :
-          107: 187, // = +
-          109: 189 // - _
-        };
+        mapping = Browser.keyCodeMapping.firefox;
       }
       // Return the mapped keycode, if it exists,
       // or else the original event.keyCode.
@@ -518,7 +487,38 @@ mergeInto(LibraryManager.library, {
              mapping[event.keyCode] :
              event.keyCode;
     },
-    
+    keyCodeMapping: {
+      opera: {
+        219: 91, // Windows key
+        0: 93, // Windows menu key
+        
+        48: 96, // Numpad 0
+        49: 97, // Numpad 1
+        50: 98, // Numpad 2
+        51: 99, // Numpad 3
+        52: 100, // Numpad 4
+        53: 101, // Numpad 5
+        54: 102, // Numpad 6
+        55: 103, // Numpad 7
+        56: 104, // Numpad 8
+        57: 105, // Numpad 9
+        42: 106, // Numpad *
+        43: 107, // Numpad +
+        // 45: 109, // Numpad - -- Discarded, because 45 is also Insert.
+        // 78: 110, // Numpad . -- Discarded, because 78 is also N.
+        47: 111, // Numpad /
+        
+        59: 186, // ; :
+        61: 187, // = +
+        109: 189 // - _
+      },
+      firefox: {
+        59: 186, // ; :
+        107: 187, // = +
+        109: 189 // - _
+      }
+    },
+
 
     getMovementX: function(event) {
       return event['movementX'] ||

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -94,7 +94,6 @@ var LibrarySDL = {
 
       17:  1248, // control (right, or left)
       18:  1250, // alt
-      173: 45, // minus
       16:  1249, // shift
       
       96: 88 | 1<<10, // keypad 0
@@ -125,6 +124,28 @@ var LibrarySDL = {
       190: 46, // period
       191: 47, // slash (/)
       192: 96, // backtick/backquote (`)
+      
+      219: 91, // left bracket ([)
+      220: 92, // backslash (\)
+      221: 93, // right bracket (])
+
+      // Next 3 keycodes may vary across browsers, as seen in:
+      // http://www.javascripter.net/faq/keycodes.htm
+      // and might need to be determined programmatically.
+      // Keycodes common to MSIE, Safari and Chrome:
+      186: 59, // semicolon (;)
+      187: 61, // equals (=)
+      189: 45, // minus (-)
+      /*
+      // Keycodes in Firefox:
+      59: 59, // semicolon (;)
+      107: 61, // equals (=)
+      109: 45, // minus (-)
+      // Keycodes in Opera:
+      59: 59, // semicolon (;)
+      61: 61, // equals (=)
+      109: 45, // minus (-)
+      */
     },
 
     scanCodes: { // SDL keycode ==> SDL scancode. See SDL_scancode.h

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -83,29 +83,26 @@ var LibrarySDL = {
     DOMEventToSDLEvent: {},
 
     keyCodes: { // DOM code ==> SDL code. See https://developer.mozilla.org/en/Document_Object_Model_%28DOM%29/KeyboardEvent and SDL_keycode.h
-      46: 127, // SDLK_DEL == '\177'
-      38:  1106, // up arrow
-      40:  1105, // down arrow
-      37:  1104, // left arrow
-      39:  1103, // right arrow
-
-      33: 1099, // pagedup
-      34: 1102, // pagedown
-
-      17:  1248, // control (right, or left)
-      18:  1250, // alt
-      16:  1249, // shift
+      // 8: 8, // backspace
+      // 9: 9, // tab
+      // 13: 13, // enter
+      // 27: 27, // esc
       
-      96: 88 | 1<<10, // keypad 0
-      97: 89 | 1<<10, // keypad 1
-      98: 90 | 1<<10, // keypad 2
-      99: 91 | 1<<10, // keypad 3
-      100: 92 | 1<<10, // keypad 4
-      101: 93 | 1<<10, // keypad 5
-      102: 94 | 1<<10, // keypad 6
-      103: 95 | 1<<10, // keypad 7
-      104: 96 | 1<<10, // keypad 8
-      105: 97 | 1<<10, // keypad 9
+      222: 39, // apostrophe (')
+      188: 44, // comma (,)
+      189: 45, // minus (-)
+      190: 46, // period (.)
+      191: 47, // slash (/)
+      186: 59, // semicolon (;)
+      187: 61, // equals (=)
+      219: 91, // left bracket ([)
+      220: 92, // backslash (\)
+      221: 93, // right bracket (])
+      192: 96, // backtick/backquote (`)
+
+      46: 127, // delete
+
+      20: 57 | 1<<10, // caps lock
 
       112: 58 | 1<<10, // F1
       113: 59 | 1<<10, // F2
@@ -120,32 +117,44 @@ var LibrarySDL = {
       122: 68 | 1<<10, // F11
       123: 69 | 1<<10, // F12
 
-      188: 44, // comma
-      190: 46, // period
-      191: 47, // slash (/)
-      192: 96, // backtick/backquote (`)
+      44: 70 | 1<<10, // print screen
+      145: 71 | 1<<10, // scroll lock
+      19: 72 | 1<<10, // pause
       
-      219: 91, // left bracket ([)
-      220: 92, // backslash (\)
-      221: 93, // right bracket (])
+      45: 73 | 1<<10, // insert
+      36: 74 | 1<<10, // home
+      33: 75 | 1<<10, // page up
+      35: 77 | 1<<10, // end
+      34: 78 | 1<<10, // page down
+      39: 79 | 1<<10, // right arrow
+      37: 80 | 1<<10, // left arrow
+      40: 81 | 1<<10, // down arrow
+      38: 82 | 1<<10, // up arrow
+      
+      144: 83 | 1<<10, // num lock
 
-      // Next 3 keycodes may vary across browsers, as seen in:
-      // http://www.javascripter.net/faq/keycodes.htm
-      // and might need to be determined programmatically.
-      // Keycodes common to MSIE, Safari and Chrome:
-      186: 59, // semicolon (;)
-      187: 61, // equals (=)
-      189: 45, // minus (-)
-      /*
-      // Keycodes in Firefox:
-      59: 59, // semicolon (;)
-      107: 61, // equals (=)
-      109: 45, // minus (-)
-      // Keycodes in Opera:
-      59: 59, // semicolon (;)
-      61: 61, // equals (=)
-      109: 45, // minus (-)
-      */
+      111: 84 | 1<<10, // keypad /
+      106: 85 | 1<<10, // keypad *
+      109: 86 | 1<<10, // keypad -
+      107: 87 | 1<<10, // keypad +
+      97: 89 | 1<<10, // keypad 1
+      98: 90 | 1<<10, // keypad 2
+      99: 91 | 1<<10, // keypad 3
+      100: 92 | 1<<10, // keypad 4
+      101: 93 | 1<<10, // keypad 5
+      102: 94 | 1<<10, // keypad 6
+      103: 95 | 1<<10, // keypad 7
+      104: 96 | 1<<10, // keypad 8
+      105: 97 | 1<<10, // keypad 9
+      96: 98 | 1<<10, // keypad 0
+      110: 99 | 1<<10, // keypad .
+
+      17: 224 | 1<<10, // control (right, or left)
+      16: 225 | 1<<10, // shift
+      18: 226 | 1<<10, // alt
+      91: 227 | 1<<10, // windows key
+      93: 231 | 1<<10, // windows menu key
+
     },
 
     scanCodes: { // SDL keycode ==> SDL scancode. See SDL_scancode.h
@@ -549,11 +558,12 @@ var LibrarySDL = {
       switch (event.type) {
         case 'keydown': case 'keyup': {
           var down = event.type === 'keydown';
-          var code = event.keyCode;
+          var normalizedKeyCode = Browser.getKeyCode(event);
+          var code = normalizedKeyCode;
           if (code >= 65 && code <= 90) {
             code += 32; // make lowercase for SDL
           } else {
-            code = SDL.keyCodes[event.keyCode] || event.keyCode;
+            code = SDL.keyCodes[normalizedKeyCode] || normalizedKeyCode;
           }
 
           {{{ makeSetValue('SDL.keyboardState', 'code', 'down', 'i8') }}};
@@ -563,7 +573,7 @@ var LibrarySDL = {
             ({{{ makeGetValue('SDL.keyboardState', '1250', 'i8') }}} ? 0x0100 | 0x0200 : 0); // KMOD_LALT & KMOD_RALT
 
           if (down) {
-            SDL.keyboardMap[code] = event.keyCode; // save the DOM input, which we can use to unpress it during blur
+            SDL.keyboardMap[code] = normalizedKeyCode; // save the DOM input, which we can use to unpress it during blur
           } else {
             delete SDL.keyboardMap[code];
           }
@@ -600,11 +610,12 @@ var LibrarySDL = {
         case 'keydown': case 'keyup': {
           var down = event.type === 'keydown';
           //Module.print('Received key event: ' + event.keyCode);
-          var key = event.keyCode;
+          var normalizedKeyCode = Browser.getKeyCode(event); // Cross-browser.
+          var key = normalizedKeyCode;
           if (key >= 65 && key <= 90) {
             key += 32; // make lowercase for SDL
           } else {
-            key = SDL.keyCodes[event.keyCode] || event.keyCode;
+            key = SDL.keyCodes[normalizedKeyCode] || normalizedKeyCode;
           }
           var scan;
           if (key >= 1024) {


### PR DESCRIPTION
Added keycode mappings for left bracket, backslash, right bracket, semicolon, equals and minus. These last three may vary across browsers and might need to be determined programmatically in a future version. Additional mappings are still needed (for the Insert key, for instance).
