### PR TITLE
emcc flag for custom proxy files

### DIFF
--- a/emcc
+++ b/emcc
@@ -505,6 +505,15 @@ Options that are modified or new in %s include:
   --proxy-to-worker        Generates both html and js files. The main
                            program is in js, and the html proxies to/from it.
 
+  --proxy-files <client> <worker> Use custom proxy  files.Only useful in conjunction with
+                                  --proxy-to-worker. The client file will be embedded in the
+                                  HTML and must contain the token:
+                                  {{{ filename }}}
+                                  so that it knows the filename which contains the application code.
+                                  The worker file will be included as part of the application.
+                                  See src/proxyClient.js and src/proxyWorker.js for the default
+                                  proxy files.
+
   --emrun                  Enables the generated output to be aware of the
                            emrun command line tool. This allows stdout, stderr
                            and exit(returncode) capture when running the
@@ -811,6 +820,8 @@ try:
   no_heap_copy = False
   proxy_to_worker = False
   default_object_extension = '.o'
+  proxy_client_file = shared.path_from_root('src', 'proxyClient.js')
+  proxy_worker_file = shared.path_from_root('src', 'proxyWorker.js')
 
   if use_cxx:
     default_cxx_std = '-std=c++03' # Enforce a consistent C++ standard when compiling .cpp files, if user does not specify one on the cmdline.
@@ -1014,6 +1025,13 @@ try:
     elif newargs[i] == '--proxy-to-worker':
       proxy_to_worker = True
       newargs[i] = ''
+    elif newargs[i].startswith('--proxy-files'):
+      check_bad_eq(newargs[i])
+      proxy_client_file = os.path.abspath(newargs[i+1])
+      proxy_worker_file = os.path.abspath(newargs[i+2])
+      newargs[i] = ''
+      newargs[i+1] = ''
+      newargs[i+2] = ''
     elif newargs[i].startswith(('-I', '-L')):
       path_name = newargs[i][2:]
       if not absolute_warning_shown and os.path.isabs(path_name):
@@ -1328,6 +1346,9 @@ try:
 
   if proxy_to_worker:
     shared.Settings.PROXY_TO_WORKER = 1
+
+  if proxy_worker_file:
+    shared.Settings.PROXY_WORKER_FILE = proxy_worker_file
 
   if js_opts:
     shared.Settings.RUNNING_JS_OPTS = 1
@@ -1768,7 +1789,7 @@ try:
     js_target = unsuffixed(target) + '.js'
     base_js_target = os.path.basename(js_target)
     if proxy_to_worker:
-      html.write(shell.replace('{{{ SCRIPT }}}', '<script>' + open(shared.path_from_root('src', 'proxyClient.js')).read().replace('{{{ filename }}}', target_basename) + '</script>'))
+      html.write(shell.replace('{{{ SCRIPT }}}', '<script>' + open(proxy_client_file).read().replace('{{{ filename }}}', target_basename) + '</script>'))
       shutil.move(final, js_target)
     elif not Compression.on:
       # Normal code generation path

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -1899,7 +1899,7 @@ function JSify(data, functionsOnly) {
       print('}');
     }
     if (PROXY_TO_WORKER) {
-      print(read('proxyWorker.js'));
+      print(read((PROXY_WORKER_FILE?PROXY_WORKER_FILE:'proxyWorker.js')));
     }
     if (RUNTIME_TYPE_INFO) {
       Types.cleanForRuntime();

--- a/src/settings.js
+++ b/src/settings.js
@@ -414,6 +414,7 @@ var BUILD_AS_WORKER = 0; // If set to 1, this is a worker library, a special kin
 var PROXY_TO_WORKER = 0; // If set to 1, we build the project into a js file that will run
                          // in a worker, and generate an html file that proxies input and
                          // output to/from it.
+var PROXY_WORKER_FILE = 0; // set this to a string to override the default worker file
 var LINKABLE = 0; // If set to 1, this file can be linked with others, either as a shared
                   // library or as the main file that calls a shared library. To enable that,
                   // we will not internalize all symbols and cull the unused ones, in other

--- a/tests/fs/test_idbfs_sync.c
+++ b/tests/fs/test_idbfs_sync.c
@@ -13,7 +13,9 @@ int main() {
   );
 
 #if FIRST
-  // store local files to backing IDB
+  // store local files to backing IDB. Note that we use the JS FS API for everything here, but we
+  // could use normal libc fwrite etc. to do the writing. All we need the JS FS API for is to
+  // mount the filesystem and do syncfs.
   EM_ASM_ARGS({
     FS.writeFile('/working/waka.txt', 'az');
     FS.writeFile('/working/moar.txt', $0);


### PR DESCRIPTION
Right now src/proxyWorker.js and src/proxyClient.js are hardcoded as the proxy files when generating code to run in a worker. The default files aren't appropriate for every project. This patch adds a flag to use a custom pair of files.
