### PR TITLE
Silence clang warning that appears any time stdin, stdout, or stderr is ...

### DIFF
--- a/system/include/libc/stdio.h
+++ b/system/include/libc/stdio.h
@@ -52,10 +52,6 @@ extern FILE *const stdin;
 extern FILE *const stdout;
 extern FILE *const stderr;
 
-#define stdin  (stdin)
-#define stdout (stdout)
-#define stderr (stderr)
-
 FILE *fopen(const char *__restrict, const char *__restrict);
 FILE *freopen(const char *__restrict, const char *__restrict, FILE *__restrict);
 int fclose(FILE *);


### PR DESCRIPTION
These macros defined in Emscripten's stdio.h cause clang warnings (warning: disabled expansion of recursive macro [-Wdisabled-macro-expansion]) every time stdin, stdout, or stderr is referenced. Whatever the original change was intended to do can likely be achieved some other way that doesn't cause warnings.
