### PR TITLE
Fix test related sdl get keyboard state fix

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -691,10 +691,16 @@ var LibrarySDL = {
           scan = SDL.scanCodes[scan] || scan;
 
           {{{ makeSetValue('SDL.keyboardState', 'scan', 'down', 'i8') }}};
-          // TODO: lmeta, rmeta, numlock, capslock, KMOD_MODE, KMOD_RESERVED
-          SDL.modState = ({{{ makeGetValue('SDL.keyboardState', '1248', 'i8') }}} ? 0x0040 | 0x0080 : 0) | // KMOD_LCTRL & KMOD_RCTRL
-            ({{{ makeGetValue('SDL.keyboardState', '1249', 'i8') }}} ? 0x0001 | 0x0002 : 0) | // KMOD_LSHIFT & KMOD_RSHIFT
-            ({{{ makeGetValue('SDL.keyboardState', '1250', 'i8') }}} ? 0x0100 | 0x0200 : 0); // KMOD_LALT & KMOD_RALT
+          SDL.modState =
+            ({{{ makeGetValue('SDL.keyboardState',  '83', 'i8') }}} ? 0x1000 : 0) | // KMOD_NUM
+            ({{{ makeGetValue('SDL.keyboardState',  '57', 'i8') }}} ? 0x2000 : 0) | // KMOD_CAPS
+            ({{{ makeGetValue('SDL.keyboardState', '257', 'i8') }}} ? 0x4000 : 0) | // KMOD_MODE
+            ({{{ makeGetValue('SDL.keyboardState', '224', 'i8') }}} ? 0x0040 : 0) | // KMOD_LCTRL
+            ({{{ makeGetValue('SDL.keyboardState', '228', 'i8') }}} ? 0x0080 : 0) | // KMOD_RCTRL
+            ({{{ makeGetValue('SDL.keyboardState', '225', 'i8') }}} ? 0x0001 : 0) | // KMOD_LSHIFT
+            ({{{ makeGetValue('SDL.keyboardState', '229', 'i8') }}} ? 0x0002 : 0) | // KMOD_RSHIFT
+            ({{{ makeGetValue('SDL.keyboardState', '226', 'i8') }}} ? 0x0100 : 0) | // KMOD_LALT
+            ({{{ makeGetValue('SDL.keyboardState', '230', 'i8') }}} ? 0x0200 : 0) ; // KMOD_RALT
 
           if (down) {
             SDL.keyboardMap[code] = event.keyCode; // save the DOM input, which we can use to unpress it during blur

--- a/tests/sdl_pumpevents.c
+++ b/tests/sdl_pumpevents.c
@@ -19,7 +19,7 @@ int loop1()
    while (SDL_PollEvent(&e));
 
    const Uint8 *keys = SDL_GetKeyState(NULL);
-   if (keys[SDLK_LEFT])
+   if (keys[SDL_SCANCODE_LEFT])
       r = 1;
 
    return r;
@@ -34,7 +34,7 @@ int loop2()
    SDL_PumpEvents();
 
    const Uint8 *keys = SDL_GetKeyState(NULL);
-   if (keys[SDLK_RIGHT])
+   if (keys[SDL_SCANCODE_RIGHT])
       r = 2;
 
    return r;
@@ -48,7 +48,7 @@ int alphakey()
    SDL_PumpEvents();
 
    const Uint8 *keys = SDL_GetKeyState(NULL);
-   if (keys[SDLK_a])
+   if (keys[SDL_SCANCODE_A])
       r = 4;
 
    return r;


### PR DESCRIPTION
Related: #2297 Fix sdl get keyboard state not based on scan code bug

This is two fix up related #2297:
1. Fix test code `tests/sdl_pumpevents.c`. The test code was assumed buggy behavior as SDL_GetKeyboardState return SDL-KeyCode. It fix for currently no buggy behavior as it return SDL-ScanCode. Then, test `browser.test_sdl_pumpevents` is OK.
2. Fix library code `src/library_sdl.js`. I was fix SDL_GetKeyboardState behavior in #2297 but the fix is not follow SDL.modState as mod keys state. It fix SDL.modState correctly for after #2297 behavior, and add support L/R distinction and numlock, capslock, mode keys in passing. Then, test `browser.test_sdl_key_proxy` and `browser.test_sdl_key` is OK.
