### PR TITLE
Show on-screen keyboard on mobile devices

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1312,6 +1312,14 @@ var LibraryJSEvents = {
     // TODO: In the future if multiple GL contexts are supported, use the 'target' parameter to find the canvas to query.
     if (!Module['ctx']) return true; // No context ~> lost context.
     return Module['ctx'].isContextLost();
+  },
+
+  emscripten_set_content_editable: function(target, editable) {
+    if (!target) target = '#canvas';
+    target = JSEvents.findEventTarget(target);
+    if (!target.contentEditable) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    target.contentEditable = (editable == 1);
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   }
 };
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1318,7 +1318,8 @@ var LibraryJSEvents = {
     if (!target) target = '#canvas';
     target = JSEvents.findEventTarget(target);
     if (!target.contentEditable) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    target.contentEditable = (editable == 1);
+    target.contentEditable = (editable != 0);
+    target.focus();
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   }
 };

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -642,6 +642,11 @@ extern EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback(const char
  */
 extern EM_BOOL emscripten_is_webgl_context_lost(const char *target);
 
+/*
+ * Sets contentEditable on target element, which will show the on-screen keyboard on mobile devices
+ */
+extern EMSCRIPTEN_RESULT emscripten_set_content_editable(const char *target, int editable);
+
 #ifdef __cplusplus
 } // ~extern "C"
 #endif

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -643,7 +643,14 @@ extern EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback(const char
 extern EM_BOOL emscripten_is_webgl_context_lost(const char *target);
 
 /*
- * Sets contentEditable on target element, which will show the on-screen keyboard on mobile devices
+ * Sets contentEditable on target element, which will show the on-screen keyboard
+ * on mobile devices. This works in Gecko based browsers only.
+ * Behaviour: if called with editable=1, then the on-screen keyboard will show up.
+ * If you want to force open it again, you have to first call it with editable=0
+ * and then again with editable=1.
+ * Unfortunately, there is no way to tell if the keyboard has been closed by the
+ * user.
+ * TODO: find a cross-browser solution
  */
 extern EMSCRIPTEN_RESULT emscripten_set_content_editable(const char *target, int editable);
 


### PR DESCRIPTION
this change sets contentEditable for a specific element, which when set to true, shows the on-screen keyboard on mobile devices.
