### PR TITLE
Add an emscripten_wake_sleep() function

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -48,11 +48,50 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  emscripten_sleep__deps: ['emscripten_async_resume'],
-  emscripten_sleep: function(ms) {
+  __emscripten_sleep_timer: null,
+  __emscripten_sleep_interruptible: false,
+  emscripten_sleep__deps: ['__emscripten_sleep_timer', '__emscripten_sleep_interruptible',
+                           'emscripten_async_resume'],
+  emscripten_sleep: function(ms, interruptible) {
+#if ASSERTIONS
+    assert(___emscripten_sleep_timer === null);
+#endif
     asm.setAsync(); // tell the scheduler that we have a callback on hold
-    Browser.safeSetTimeout(_emscripten_async_resume, ms);
+    if (interruptible === undefined) interruptible = false;
+    ___emscripten_sleep_interruptible = !!interruptible;
+    if (ms < 0) return;
+    ___emscripten_sleep_timer = setTimeout(function() {
+      ___emscripten_sleep_timer = null;
+      if (!ABORT) _emscripten_async_resume();
+    }, ms);
   },
+
+  // emscripten_wake_sleep() should not be called from within the C event loop
+  // directly.  It's there for use by JavaScript callbacks, such as WebSocket or
+  // XHR onmessage handlers, so that they can wake up the C application's
+  // asynchronous main loop, which might look like this with ASYNCIFY:
+  //
+  //   int main() {
+  //     try {
+  //       start_the_app();
+  //       while (true) {
+  //         emscripten_sleep(get_next_event_delay(), 1);
+  //         check_io_and_handle_input();
+  //         check_time_and_handle_expired();
+  //       }
+  //     } catch (std::exception& e) { fprintf(stderr, "error: %s\n", e.what()); }
+  //     return 1;
+  //   }
+  emscripten_wake_sleep__deps: ['__emscripten_sleep_timer', 'emscripten_async_resume'],
+  emscripten_wake_sleep: function() {
+    if (___emscripten_sleep_timer !== null && ___emscripten_sleep_interruptible) {
+      clearTimeout(___emscripten_sleep_timer);
+      ___emscripten_sleep_timer = null;
+      _emscripten_async_resume();
+      return true;
+    }
+    return false;
+  }
 
   emscripten_alloc_async_context__deps: ['__async_cur_frame'],
   emscripten_alloc_async_context__sig: 'iii',

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -91,7 +91,7 @@ mergeInto(LibraryManager.library, {
       return true;
     }
     return false;
-  }
+  },
 
   emscripten_alloc_async_context__deps: ['__async_cur_frame'],
   emscripten_alloc_async_context__sig: 'iii',

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -233,7 +233,7 @@ int emscripten_asm_const_int(const char *code, ...);
 double emscripten_asm_const_double(const char *code, ...);
 
 #if __EMSCRIPTEN__
-void emscripten_sleep(unsigned int ms);
+void emscripten_sleep(unsigned int ms, int interruptible);
 #else
 #define emscripten_sleep SDL_Delay
 #endif


### PR DESCRIPTION
This function makes it easy for application developers to write a main loop using an asynchronous main() with ASYNCIFY.

Our plan here is to skip using `emscripten_set_main_loop` functions since we're moving to using ASYNCIFY, and instead put the main loop in an interruptible wait.

Because we use some rather specific options and behaviour, we aren't using the `emscripten_wget` and emscripten sockets-as-WebSockets code, with our own JavaScript library for getting these events into our main loop.

I thought I'd like to contribute this change we're using to `emscripten_sleep` though, because I think it should be generally useful to other developers who want to build a main loop using ASYNCIFY.