### PR TITLE
fix tmpnam when running under node

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2795,7 +2795,7 @@ LibraryManager.library = {
     do {
       name += String.fromCharCode(65 + (Math.random() * 25)|0);
     } while (name in folder.contents);
-    var result = dir + '/' + name;
+    var result = folder.name + '/' + name;
     if (!_tmpnam.buffer) _tmpnam.buffer = _malloc(256);
     if (!s) s = _tmpnam.buffer;
     writeAsciiToMemory(result, s);


### PR DESCRIPTION
When running under node, emscripten uses the real filesystem. In this case, `dir` is never set inside `tmpnam` you get a path back like `undefined/foo` and it breaks my code because it can't actually create a file there. This seems to fix it.
