### PR TITLE
adding support for read-only filesystems

### DIFF
--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -5,33 +5,35 @@
   by 'root'.  'root' must be the address of a data structure which in C is the root ro_dir below:
     
   // struct used when a directory entry is a file (not another directory)
-  // and so has ro_dir_ent.is_dir = false.  In this case, ro_dir_ent.ptr.file
+  // and so has ro_dir_ent.is_dir = 0.  In this case, ro_dir_ent.ptr.file
   // points to one of these
-  struct ro_file_ent
+  struct ro_file
   {
     const char*  file_data;    // ptr to the data of the file
     size_t       file_data_sz; // size of the data pointed to by file_data
   };
 
   // struct used when a directory entry is another directory (not a file)
-  // and so has the owning ro_dir_ent.is_dir = true.  In this case
-  // ro_dir_ent.ptr.dir points to a ro_dir (below)
-  struct ro_dir_ent
-  {
-    const char* d_name;                   // the name of the file or directory
-    union {
-      const struct ro_file_ent*   file;   // if this is a file, then the pointer to the ro_file_ent
-      const struct ro_dir*        dir;    // otherwise if this another directory, the pointer to that ro_dir
-    } ptr;
-    int is_dir;                           // true if this ro_dir_ent is a directory, otherwise false (if it is a file)
-  };
-
-  // struct used to represent a directory
+  // and so has the owning ro_dir_ent.is_dir != 0.  In this case
+  // ro_dir_ent.ptr.dir points to one of these.
   struct ro_dir {
     size_t                    num_ents;   // number of entries (files or other directories) in this directory
     const struct ro_dir_ent*  ents;       // pointer to the list of entries in this directory
   };
-  
+
+  // struct used to represent an entry in a directory.  Each entry
+  // can either represent a file or another directory.  If is_dir != 0
+  // then it is a directory, otherwise it is a file
+  struct ro_dir_ent
+  {
+    const char* d_name;               // the name of the file or directory
+    union {
+      const struct ro_file*   file;   // if this is a file, then the pointer to the ro_file
+      const struct ro_dir*    dir;    // otherwise if this a directory, the pointer to that ro_dir
+    } ptr;
+    int is_dir;                       // != 0 if this ro_dir_ent is a directory, otherwise == 0 (if it is a file)
+  };
+ 
   This is only an _example_ of a way to do this.  The js code below uses several
   'makeGetValue' statements to read the fields in the C data structures described above.
   Were you to use this code as a starting point and modify these data structures, you

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -36,7 +36,7 @@
   'makeGetValue' statements to read the fields in the C data structures described above.
   Were you to use this code as a starting point and modify these data structures, you
   would also have to change the offsets passed to the makeGetValue statements to
-  match your modifications.  Search for 'makeGetValue' in this file.  The each represent
+  match your modifications.  Search for 'makeGetValue' in this file.  Each represents
   a place where it is offsetting an address to a field in one of these data structures.
 
 */

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -9,8 +9,8 @@
   // points to one of these
   struct ro_file_ent
   {
-    const unsigned char*  file_data;    // ptr to the data of the file
-    size_t                file_data_sz; // size of the data pointed to by file_data
+    const char*  file_data;    // ptr to the data of the file
+    size_t       file_data_sz; // size of the data pointed to by file_data
   };
 
   // struct used when a directory entry is another directory (not a file)
@@ -18,19 +18,26 @@
   // ro_dir_ent.ptr.dir points to a ro_dir (below)
   struct ro_dir_ent
   {
-    const char* d_name;             // the name of the file or directory
+    const char* d_name;                   // the name of the file or directory
     union {
-      const ro_file_ent*   file;    // if this is a file, then the pointer to the ro_file_ent
-      const struct ro_dir* dir;     // otherwise if this another directory, the pointer to that ro_dir
+      const struct ro_file_ent*   file;   // if this is a file, then the pointer to the ro_file_ent
+      const struct ro_dir*        dir;    // otherwise if this another directory, the pointer to that ro_dir
     } ptr;
-    int is_dir;                     // true if this ro_dir_ent is a directory, otherwise false (if it is a file)
+    int is_dir;                           // true if this ro_dir_ent is a directory, otherwise false (if it is a file)
   };
 
   // struct used to represent a directory
   struct ro_dir {
-    size_t              num_ents;   // number of entries (files or other directories) in this directory
-    const rez_dir_ent*  ents;       // pointer to the list of entries in this directory
+    size_t                    num_ents;   // number of entries (files or other directories) in this directory
+    const struct ro_dir_ent*  ents;       // pointer to the list of entries in this directory
   };
+  
+  This is only an _example_ of a way to do this.  The js code below uses several
+  'makeGetValue' statements to read the fields in the C data structures described above.
+  Were you to use this code as a starting point and modify these data structures, you
+  would also have to change the offsets passed to the makeGetValue statements to
+  match your modifications.  Search for 'makeGetValue' in this file.  The each represent
+  a place where it is offsetting an address to a field in one of these data structures.
 
 */
 mergeInto(LibraryManager.library, {

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -152,15 +152,12 @@ mergeInto(LibraryManager.library, {
         else
           mode = {{{ cDefine('S_IFREG') }}} | 292/*0444*/;
         var node = FS.createNode(parent, d_name, mode, 0);
-        if (is_dir != 0)
-        {
+        if (is_dir != 0) {
           node.node_ops = ROFS.ops_table.dir.node;
           node.stream_ops = ROFS.ops_table.dir.stream;
           node.contents = ['.', '..'];
           ROFS.recursive_mount_dir(ptr, node);
-        }
-        else
-        {
+        } else {
           node.node_ops = ROFS.ops_table.file.node;
           node.stream_ops = ROFS.ops_table.file.stream;
           node.contents = ptr;

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -1,0 +1,184 @@
+
+/*
+  example of a read-only filesystem.  Call FS.mount(ROFS, {root_addr: root}, path)
+  to cause 'path' to be a read-only file system containing all of the "files" described
+  by 'root'.  'root' must be the address of a data structure which in C is the root ro_dir below:
+    
+  // struct used when a directory entry is a file (not another directory)
+  // and so has ro_dir_ent.is_dir = false.  In this case, ro_dir_ent.ptr.file
+  // points to one of these
+  struct ro_file_ent
+  {
+    const unsigned char*  file_data;    // ptr to the data of the file
+    size_t                file_data_sz; // size of the data pointed to by file_data
+  };
+
+  // struct used when a directory entry is another directory (not a file)
+  // and so has the owning ro_dir_ent.is_dir = true.  In this case
+  // ro_dir_ent.ptr.dir points to a ro_dir (below)
+  struct ro_dir_ent
+  {
+    const char* d_name;             // the name of the file or directory
+    union {
+      const ro_file_ent*   file;    // if this is a file, then the pointer to the ro_file_ent
+      const struct ro_dir* dir;     // otherwise if this another directory, the pointer to that ro_dir
+    } ptr;
+    int is_dir;                     // true if this ro_dir_ent is a directory, otherwise false (if it is a file)
+  };
+
+  // struct used to represent a directory
+  struct ro_dir {
+    size_t              num_ents;   // number of entries (files or other directories) in this directory
+    const rez_dir_ent*  ents;       // pointer to the list of entries in this directory
+  };
+
+*/
+mergeInto(LibraryManager.library, {
+  $ROFS__deps: ['$ERRNO_CODES', '$FS', '$MEMFS'],
+  $ROFS: {
+  
+    ops_table: null,
+    
+    mount: function(mount) {
+    console.log('ROFS.mount');
+      if (!ROFS.ops_table) {
+        ROFS.ops_table = {
+          dir: {
+            node: {
+              getattr: ROFS.node_ops.getattr,
+              lookup: MEMFS.node_ops.lookup,
+              readdir: ROFS.node_ops.readdir,
+              mknod: ROFS.node_ops.mknod,
+            },
+            stream: {
+            },
+          },
+          file: {
+            node: {
+              getattr: ROFS.node_ops.getattr,
+              setattr: ROFS.node_ops.setattr,
+            },
+            stream: {
+              llseek: MEMFS.stream_ops.llseek,
+              read: ROFS.stream_ops.read,
+            }
+          },
+        };
+      }
+      
+      var node = FS.createNode(null,'/',{{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */, 0);
+    
+      node.node_ops = ROFS.ops_table.dir.node;
+      node.stream_ops = ROFS.ops_table.dir.stream; // currently empty (see dir.stream above), but FS needs a non-null stream_ops.
+      node.contents = ['.', '..'];
+      
+      ROFS.recursive_mount_dir(mount.opts.root_addr, node);
+      
+      return node;
+    },
+    
+    node_ops: {
+    
+      getattr: function(node) {
+        var attr = {};
+        attr.dev = 1;
+        attr.ino = node.id;
+        attr.mode = node.mode;
+        attr.nlink = 1;
+        attr.uid = 0;
+        attr.gid = 0;
+        attr.rdev = node.rdev;
+        if (FS.isDir(node.mode)) {
+          attr.size = 4096;
+        } else /*if (FS.isFile(node.mode))*/ {
+          attr.size = {{{ makeGetValue('node.contents', '4', 'i32') }}};  // <- this line is why we need a custom getattr
+        }
+        attr.atime = new Date(node.timestamp);
+        attr.mtime = new Date(node.timestamp);
+        attr.ctime = new Date(node.timestamp);
+        attr.blksize = 4096;
+        attr.blocks = Math.ceil(attr.size / attr.blksize);
+        return attr;
+      },
+      readdir: function(node) {
+        return node.contents;
+      },
+      setattr: function(node, attr) {
+        throw new FS.ErrnoError(ERRNO_CODES.EROFS);
+      },
+      mknod: function(parent, name, mode, dev) {
+        throw new FS.ErrnoError(ERRNO_CODES.EROFS);
+      }
+    
+    },
+    
+    stream_ops: {
+      
+      read: function(stream, buffer, offset, length, position) {
+        var contents = stream.node.contents;
+        var ptr = {{{ makeGetValue('contents', '0', 'i32') }}};
+        var len = {{{ makeGetValue('contents', '4', 'i32') }}};
+        if (position >= len)
+          return 0;
+        var size = length;
+        if (position + size > len)
+          size = len - position;
+#if USE_TYPED_ARRAYS == 2
+        if (size > 8)
+          buffer.set(HEAP8.subarray(ptr+position, ptr+position+size), offset);
+        else
+#endif
+        {
+          for (var i = 0; i < size; i++)
+            buffer[offset + i] = HEAP8[ptr + position + i];
+        }
+        return size;
+      },
+    
+    },
+    
+    recursive_mount_dir: function (dir_addr, parent)  {
+      var num_ents = {{{ makeGetValue('dir_addr', '0', 'i32') }}};
+      var ents_addr = {{{ makeGetValue('dir_addr', '4', 'i32') }}};
+      
+      for (var i = 0; i < num_ents; i++) {
+        var d_name_addr = {{{ makeGetValue('ents_addr', 'i*12', 'i32') }}};
+        var d_name = Pointer_stringify(d_name_addr);
+        var ptr = {{{ makeGetValue('ents_addr', 'i*12+4', 'i32') }}};
+        var is_dir = {{{ makeGetValue('ents_addr', 'i*12+8', 'i32') }}};
+        
+        var mode;
+        if (is_dir != 0)
+          mode = {{{ cDefine('S_IFDIR') }}} | 511/*0777*/;
+        else
+          mode = {{{ cDefine('S_IFREG') }}} | 292/*0444*/;
+        var node = FS.createNode(parent, d_name, mode, 0);
+        if (is_dir != 0)
+        {
+          node.node_ops = ROFS.ops_table.dir.node;
+          node.stream_ops = ROFS.ops_table.dir.stream;
+          node.contents = ['.', '..'];
+          ROFS.recursive_mount_dir(ptr, node);
+        }
+        else
+        {
+          node.node_ops = ROFS.ops_table.file.node;
+          node.stream_ops = ROFS.ops_table.file.stream;
+          node.contents = ptr;
+        }
+        parent.contents.push(d_name);
+        
+      }
+      MEMFS.node_ops.setattr(parent, {mode: {{{ cDefine('S_IFDIR') }}} | 365/*0555*/});
+      parent.is_readonly_fs = true;
+    }
+  
+  },
+  
+  rofs_mount__sig: 'vii',
+  rofs_mount__deps: ['$ROFS'],
+  rofs_mount: function (pathAddr, root_addr) {
+    FS.mount(ROFS, {root_addr: root_addr}, Pointer_stringify(pathAddr));
+  }
+  
+});

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -40,7 +40,6 @@ mergeInto(LibraryManager.library, {
     ops_table: null,
     
     mount: function(mount) {
-    console.log('ROFS.mount');
       if (!ROFS.ops_table) {
         ROFS.ops_table = {
           dir: {

--- a/tests/fs/library_rofs.js
+++ b/tests/fs/library_rofs.js
@@ -176,7 +176,7 @@ mergeInto(LibraryManager.library, {
   },
   
   rofs_mount__sig: 'vii',
-  rofs_mount__deps: ['$ROFS'],
+  rofs_mount__deps: ['$ROFS', '$FS'],
   rofs_mount: function (pathAddr, root_addr) {
     FS.mount(ROFS, {root_addr: root_addr}, Pointer_stringify(pathAddr));
   }

--- a/tests/fs/test_rofs.c
+++ b/tests/fs/test_rofs.c
@@ -65,7 +65,7 @@ struct ro_dir root_dir = { 3, &dir_ents[0] };
 // implemented in library_rofs.js, which must be included
 // in the list of libraries compiled/linked by emcc.  See
 // test_core.py, test_fs_rofs for an example of how to do this.
-void rofs_mount(const char* path, struct ro_dir* root);
+void rofs_mount(const char* path, const struct ro_dir* root);
 
 int main() {
 

--- a/tests/fs/test_rofs.c
+++ b/tests/fs/test_rofs.c
@@ -1,0 +1,123 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+// struct used when a directory entry is a file (not another directory)
+// and so has ro_dir_ent.is_dir = false.  In this case, ro_dir_ent.ptr.file
+// points to one of these
+struct ro_file_ent
+{
+  const char*  file_data;    // ptr to the data of the file
+  size_t       file_data_sz; // size of the data pointed to by file_data
+};
+
+// struct used when a directory entry is another directory (not a file)
+// and so has the owning ro_dir_ent.is_dir = true.  In this case
+// ro_dir_ent.ptr.dir points to a ro_dir (below)
+struct ro_dir_ent
+{
+  const char* d_name;                   // the name of the file or directory
+  union {
+    const struct ro_file_ent*   file;   // if this is a file, then the pointer to the ro_file_ent
+    const struct ro_dir*        dir;    // otherwise if this another directory, the pointer to that ro_dir
+  } ptr;
+  int is_dir;                           // true if this ro_dir_ent is a directory, otherwise false (if it is a file)
+};
+
+// struct used to represent a directory
+struct ro_dir {
+  size_t                    num_ents;   // number of entries (files or other directories) in this directory
+  const struct ro_dir_ent*  ents;       // pointer to the list of entries in this directory
+};
+
+#define file1_contents "contents of file1"
+#define file2_contents "contents of file2"
+#define file3_contents "yes, the contents of file3"
+
+// static initialization of the data structures representing the three files
+// with a directory structure looking like:
+//
+//  root
+//      file1           -> contains file1_contents
+//      file2           -> contains file2_contents
+//      subdir
+//          file3       -> contains file3_contents
+
+struct ro_file_ent file1_ent = { file1_contents, sizeof(file1_contents) - 1 }; // we'll not include the null byte
+struct ro_file_ent file2_ent = { file2_contents, sizeof(file2_contents) - 1 };
+struct ro_file_ent file3_ent = { file3_contents, sizeof(file3_contents) - 1 };
+
+struct ro_dir_ent  subdir_ents[] = {
+  {"file3",{&file3_ent},0}
+};
+struct ro_dir subdir = { 1, &subdir_ents[0] };
+
+struct ro_dir_ent  dir_ents[] = {
+  {"file1",{&file1_ent},0},
+  {"file2",{&file2_ent},0},
+  {"subdir",{(const struct ro_file_ent*)&subdir},1}
+};
+struct ro_dir root_dir = { 3, &dir_ents[0] };
+
+void rofs_mount(const char* path, struct ro_dir* root);
+
+int main() {
+
+  int fd;
+
+  mkdir("/readonly", 0777);
+  rofs_mount("/readonly", &root_dir);
+  
+  struct stat st;
+  if (stat("/readonly", &st) != 0) {
+    printf("stat(\"/readonly\", &st) failed with errno: %d\n", errno);
+    return 0;
+  }
+
+  if (st.st_mode != (S_IFDIR | S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR | S_IXGRP | S_IXOTH)) {
+    printf("stat(\"/readonly\", &st) incorrectly reported st_mode as 0%o\n", st.st_mode);
+    return 0;
+  }
+  
+  fd = open("/readonly/file1", O_RDONLY);
+  if (fd == -1) {
+    printf("open(\"/readonly/file1\", O_RDONLY) failed with errno: %d\n", errno);
+    return 0;
+  }
+  close(fd);
+  
+  fd = open("/readonly/file1", O_RDWR);
+  if (fd != -1 || errno != EROFS) {
+    printf("open(\"/readonly/file1\", O_RDWR) returned %d, errno: %d\n", fd, errno);
+    return 0;
+  }
+  
+  fd = open("/readonly/does_not_exist", O_RDONLY | O_CREAT, 0666);
+  if (fd != -1 || errno != EROFS) {
+    printf("open(\"/readonly/does_not_exist\", O_RDONLY | O_CREAT, 0666) returned %d, errno: %d\n", fd, errno);
+    return 0;
+  }
+  
+  fd = open("/readonly/subdir/file3", O_RDONLY);
+  if (fd == -1) {
+    printf("open(\"/readonly/subdir/file3\", O_RDONLY) failed with errno: %d\n", errno);
+    return 0;
+  }
+  close(fd);
+  
+  if (stat("/readonly/subdir/file3", &st) != 0) {
+    printf("stat(\"/readonly/subdir/file3\", &st) failed with errno: %d\n", errno);
+    return 0;
+  }
+  
+  if (st.st_size != sizeof(file3_contents) - 1) {
+    printf("stat(\"/readonly/subdir/file3\", &st) reported file size as %d instead of %d\n", (int)(st.st_size), (int)(sizeof(file3_contents) - 1));
+    return 0;
+  }
+
+  printf("success\n");
+  return 0;
+}

--- a/tests/fs/test_rofs.c
+++ b/tests/fs/test_rofs.c
@@ -62,6 +62,9 @@ struct ro_dir_ent  dir_ents[] = {
 };
 struct ro_dir root_dir = { 3, &dir_ents[0] };
 
+// implemented in library_rofs.js, which must be included
+// in the list of libraries compiled/linked by emcc.  See
+// test_core.py, test_fs_rofs for an example of how to do this.
 void rofs_mount(const char* path, struct ro_dir* root);
 
 int main() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4231,10 +4231,12 @@ def process(filename):
     self.do_run(src, 'success', force_c=True)
   
   def test_fs_rofs(self):
+    real_orig_args = self.emcc_args
     orig_args = self.emcc_args if self.emcc_args else []
     self.emcc_args = orig_args + ['--js-library', path_from_root('tests', 'fs', 'library_rofs.js')]
     src = open(path_from_root('tests', 'fs', 'test_rofs.c'), 'r').read()
     self.do_run(src, 'success', force_c=True)
+    self.emcc_args = real_orig_args
 
   def test_fwrite_0(self):
     test_path = path_from_root('tests', 'core', 'test_fwrite_0')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4229,6 +4229,12 @@ def process(filename):
   def test_mount(self):
     src = open(path_from_root('tests', 'fs', 'test_mount.c'), 'r').read()
     self.do_run(src, 'success', force_c=True)
+  
+  def test_fs_rofs(self):
+    orig_args = self.emcc_args if self.emcc_args else []
+    self.emcc_args = orig_args + ['--js-library', path_from_root('tests', 'fs', 'library_rofs.js')]
+    src = open(path_from_root('tests', 'fs', 'test_rofs.c'), 'r').read()
+    self.do_run(src, 'success', force_c=True)
 
   def test_fwrite_0(self):
     test_path = path_from_root('tests', 'core', 'test_fwrite_0')


### PR DESCRIPTION
This work mainly permits correct implementations of read-only filesystems by teaching library_fs.js a small amount allowing it to understand when to use EACCES vs. EROFS.  This additional logic allows a filesystem implementation to set the 'is_readonly_fs' attribute of directory nodes, and when set FS will use EROFS instead of EACCES for certain access violation cases.  In addition to this there is new test code showing one example of how one might implement a read-only filesystem -- in this case populated with simple, static file-like data represented as global char arrays in C.  There is a new 'test_fs_rofs' test case in test_core.py which builds and runs the new test_rofs.c test code.  The testing code in test_rofs.c is primarily attempting to validate that io operations which would change the file data in the mounted read-only filesystem correctly fail and set errno to EROFS.
