### PR TITLE
Add a way to prevent the Module from being exported globally.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -567,7 +567,8 @@ var NECESSARY_BLOCKADDRS = []; // List of (function, block) for all block addres
 var JS_CHUNK_SIZE = 10240; // Used as a maximum size before breaking up expressions and lines into smaller pieces
 
 var EXPORT_NAME = 'Module'; // Global variable to export the module as for environments without a standardized module
-                            // loading system (e.g. the browser and SM shell).
+                            // loading system (e.g. the browser and SM shell).  Set to 'noexport' to disable exporting
+                            // as a global variable.
 
 var NO_DYNAMIC_EXECUTION = 0; // When enabled, we do not emit eval() and new Function(), which disables some functionality
                               // (causing runtime errors if attempted to be used), but allows the emitted code to be

--- a/src/shell.js
+++ b/src/shell.js
@@ -14,10 +14,14 @@
 // before the code. Then that object will be used in the code, and you
 // can continue to use Module afterwards as well.
 var Module;
+#if EXPORT_NAME != noexport
 #if CLOSURE_COMPILER
 if (!Module) Module = eval('(function() { try { return {{{ EXPORT_NAME }}} || {} } catch(e) { return {} } })()');
 #else
 if (!Module) Module = (typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : null) || {};
+#endif
+#else
+if (!Module) Module = {};
 #endif
 
 // Sometimes an existing Module object exists with properties
@@ -114,7 +118,9 @@ else if (ENVIRONMENT_IS_SHELL) {
     Module['arguments'] = arguments;
   }
 
+#if EXPORT_NAME != noexport
   this['{{{ EXPORT_NAME }}}'] = Module;
+#endif
 
 #if CLOSURE_COMPILER
   eval("if (typeof gc === 'function' && gc.toString().indexOf('[native code]') > 0) var gc = undefined"); // wipe out the SpiderMonkey shell 'gc' function, which can confuse closure (uses it as a minified name, and it is then initted to a non-falsey value unexpectedly)
@@ -149,11 +155,13 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
     }));
   }
 
+#if EXPORT_NAME != noexport
   if (ENVIRONMENT_IS_WEB) {
     window['{{{ EXPORT_NAME }}}'] = Module;
   } else {
     Module['load'] = importScripts;
   }
+#endif
 }
 else {
   // Unreachable because SHELL is dependant on the others


### PR DESCRIPTION
In our application, we stuff emscripten into a closure in pre- and post-
JS files, and export our interface without exposing the Module that we
use to implement some of it.