### PR TITLE
async_wget2 and async_wget2_data additionalHeaders argument

### DIFF
--- a/site/build/text/docs/api_reference/emscripten.h.txt
+++ b/site/build/text/docs/api_reference/emscripten.h.txt
@@ -690,7 +690,7 @@ void emscripten_async_wget_data(const char* url, void *arg, em_async_wget_onlo
 
         * *(void*)* : A pointer to "arg" (user defined data).
 
-int emscripten_async_wget2(const char* url, const char* file, const char* requesttype, const char* param, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress)
+int emscripten_async_wget2(const char* url, const char* file, const char* requesttype, const char* param, const char* additionalHeader, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress)
 
    Loads a file from a URL asynchronously.
 
@@ -719,6 +719,9 @@ int emscripten_async_wget2(const char* url, const char* file, const char* req
         requests (see "requesttype"). The parameters are specified in
         the same way as they would be in the URL for an equivalent GET
         request: e.g. "key=value&key2=value2".
+
+      * **additionalHeader** (*const char**) -- Request header entries
+        as a Json formatted string for any request type.
 
       * **arg** (*void**) -- User-defined data that is passed to the
         callbacks, untouched by the API itself. This may be be used by
@@ -755,7 +758,7 @@ int emscripten_async_wget2(const char* url, const char* file, const char* req
       A handle to request ("int") that can be used to "abort" the
       request.
 
-int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress)
+int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, const char* additionalHeader, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress)
 
    Loads a buffer from a URL asynchronously.
 
@@ -791,6 +794,9 @@ int emscripten_async_wget2_data(const char* url, const char* requesttype, cons
         requests (see "requesttype"). The parameters are specified in
         the same way as they would be in the URL for an equivalent GET
         request: e.g. "key=value&key2=value2".
+
+      * **additionalHeader** (*const char**) -- Request header entries
+        as a Json formatted string for any request type.
 
       * **arg** (*void**) -- User-defined data that is passed to the
         callbacks, untouched by the API itself. This may be be used by

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -492,7 +492,7 @@ Functions
 		- *(void*)* : A pointer to ``arg`` (user defined data).
 
 
-.. c:function:: int emscripten_async_wget2(const char* url, const char* file,  const char* requesttype, const char* param, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress)
+.. c:function:: int emscripten_async_wget2(const char* url, const char* file,  const char* requesttype, const char* param, const char* additionalHeader, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress)
 		 
 	Loads a file from a URL asynchronously. 
 	
@@ -510,6 +510,8 @@ Functions
 	:type requesttype: const char* 	
 	:param param: Request parameters for POST requests (see ``requesttype``). The parameters are specified in the same way as they would be in the URL for an equivalent GET request: e.g. ``key=value&key2=value2``.
 	:type param: const char*
+    :param additionalHeader: Request header entries as a Json formatted string for any request type.
+    :type additionalHeader: const char*
 	:param void* arg: User-defined data that is passed to the callbacks, untouched by the API itself. This may be be used by a callback to identify the associated call.
 	:param em_async_wget2_onload_func onload: Callback on successful load of the file. The callback function parameter values are:	
 	
@@ -529,7 +531,7 @@ Functions
 	:returns: A handle to request (``int``) that can be used to :c:func:`abort <emscripten_async_wget2_abort>` the request.
 	
 	
-.. c:function:: int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress)
+.. c:function:: int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, const char* additionalHeader, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress)
 		 
 	Loads a buffer from a URL asynchronously. 
 	
@@ -547,6 +549,8 @@ Functions
 	:type requesttype: const char*	
 	:param param: Request parameters for POST requests (see ``requesttype``). The parameters are specified in the same way as they would be in the URL for an equivalent GET request: e.g. ``key=value&key2=value2``.
 	:type param: const char*
+    :param additionalHeader: Request header entries as a Json formatted string for any request type.
+    :type additionalHeader: const char*
 	:param void* arg: User-defined data that is passed to the callbacks, untouched by the API itself. This may be be used by a callback to identify the associated call.
 	:param const int free: Tells the runtime whether to free the returned buffer after ``onload`` is complete. If ``false`` freeing the buffer is the receiver's responsibility.
 	:type free: const int

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -758,7 +758,7 @@ mergeInto(LibraryManager.library, {
     }, true /* no need for run dependency, this is async but will not do any prepare etc. step */ );
   },
 
-  emscripten_async_wget2: function(url, file, request, param, arg, onload, onerror, onprogress) {
+  emscripten_async_wget2: function(url, file, request, param, additionalHeader, arg, onload, onerror, onprogress) {
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
     var _request = Pointer_stringify(request);
@@ -812,6 +812,13 @@ mergeInto(LibraryManager.library, {
       http.channel.redirectionLimit = 0;
     } catch (ex) { /* whatever */ }
 
+    try {
+      var additionalHeaderObject = JSON.parse(Pointer_stringify(additionalHeader));
+      for (var entry in additionalHeaderObject) {
+        http.setRequestHeader(entry, additionalHeaderObject[entry]);
+      }
+    } catch (ex) { }
+
     if (_request == "POST") {
       //Send the proper header information along with the request
       http.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
@@ -827,7 +834,7 @@ mergeInto(LibraryManager.library, {
     return handle;
   },
 
-  emscripten_async_wget2_data: function(url, request, param, arg, free, onload, onerror, onprogress) {
+  emscripten_async_wget2_data: function(url, request, param, additionalHeader, arg, free, onload, onerror, onprogress) {
     var _url = Pointer_stringify(url);
     var _request = Pointer_stringify(request);
     var _param = Pointer_stringify(param);
@@ -840,7 +847,7 @@ mergeInto(LibraryManager.library, {
 
     // LOAD
     http.onload = function http_onload(e) {
-      if (http.status == 200 || _url.substr(0,4).toLowerCase() != "http") {
+      if (http.status == 200 || http.status == 206 || _url.substr(0,4).toLowerCase() != "http") {
         var byteArray = new Uint8Array(http.response);
         var buffer = _malloc(byteArray.length);
         HEAPU8.set(byteArray, buffer);
@@ -875,6 +882,13 @@ mergeInto(LibraryManager.library, {
       if (http.channel instanceof Ci.nsIHttpChannel)
       http.channel.redirectionLimit = 0;
     } catch (ex) { /* whatever */ }
+
+    try {
+      var additionalHeaderObject = JSON.parse(Pointer_stringify(additionalHeader));
+      for (var entry in additionalHeaderObject) {
+        http.setRequestHeader(entry, additionalHeaderObject[entry]);
+      }
+    } catch (ex) { }
 
     if (_request == "POST") {
       //Send the proper header information along with the request

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -155,13 +155,13 @@ void emscripten_async_wget_data(const char* url, void *arg, em_async_wget_onload
 typedef void (*em_async_wget2_onload_func)(unsigned, void*, const char*);
 typedef void (*em_async_wget2_onstatus_func)(unsigned, void*, int);
 
-int emscripten_async_wget2(const char* url, const char* file,  const char* requesttype, const char* param, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress);
+int emscripten_async_wget2(const char* url, const char* file,  const char* requesttype, const char* param, const char* additionalHeader, void *arg, em_async_wget2_onload_func onload, em_async_wget2_onstatus_func onerror, em_async_wget2_onstatus_func onprogress);
 
 typedef void (*em_async_wget2_data_onload_func)(unsigned, void*, void*, unsigned);
 typedef void (*em_async_wget2_data_onerror_func)(unsigned, void*, int, const char*);
 typedef void (*em_async_wget2_data_onprogress_func)(unsigned, void*, int, int);
 
-int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress);
+int emscripten_async_wget2_data(const char* url, const char* requesttype, const char* param, const char* additionalHeader, void *arg, int free, em_async_wget2_data_onload_func onload, em_async_wget2_data_onerror_func onerror, em_async_wget2_data_onprogress_func onprogress);
 
 void emscripten_async_wget2_abort(int handle);
 

--- a/tests/http.cpp
+++ b/tests/http.cpp
@@ -116,7 +116,7 @@ void http::runRequest(const char* page, int assync) {
 			_targetFileName = format("prepare%d",_uid);
 		}
 
-		_handle = emscripten_async_wget2(url.c_str(), _targetFileName.c_str(), (_request==REQUEST_GET) ? "GET":"POST", _param.c_str(), this, http::onLoaded, http::onError, http::onProgress);
+		_handle = emscripten_async_wget2(url.c_str(), _targetFileName.c_str(), (_request==REQUEST_GET) ? "GET":"POST", _param.c_str(), "", this, http::onLoaded, http::onError, http::onProgress);
 	
 	} else {
 		_error = format("malformed url : %s\n",url.c_str());


### PR DESCRIPTION
Update async_wget2 and async_wget2_data to allow passing additional headers to http requests.
Add support for range response status 206 to async_wget2_data.

The aim is primarily to support http ranges with 'GET' requests.