### PR TITLE
emscripten_audio API for Web Audio

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2050,7 +2050,114 @@ Functions
 	:returns: :c:data:`EMSCRIPTEN_RESULT_SUCCESS`, or one of the other result values.
 	:rtype: |EMSCRIPTEN_RESULT|
 
+
+Audio
+=====
+
+``emscripten_audio_*`` provides a simple interface to Web Audio functionality in modern browsers. This is lower-level than e.g. SDL audio, but gives you more direct control.
+
+The API is mostly very direct and obvious, except for the fact that some parts of Web Audio are asynchronous. See notes in :c:func:`emscripten_audio_play`.
+
+Defines
+-------
+
+.. c:type:: EMSCRIPTEN_AUDIO_INSTANCE
+
+	An integer that represents a handle to Emscripten Audio object (either a channel or a buffer).
+
+.. c:function:: em_audio_channel_callback
+
+  Represents a callback function for channel creation. Receives one parameter, a ``void*``.	
 	
+	
+Functions
+---------
+
+.. c:function:: EMSCRIPTEN_RESULT emscripten_audio_init()
+
+	Initializes audio. This must be called before any other ``emscripten_audio_*`` calls.
+
+	:rtype: |EMSCRIPTEN_RESULT|
+
+.. c:function:: EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_load_pcm(int channels, int length, int sampleRate, float *ptr)
+
+	Loads raw PCM audio data in 32-bit float format.
+
+	:param int channels: Number of channels
+	:param int length: Length of the audio
+	:param int sampleRate: Sample rate
+	:param int ptr: Pointer to the raw data
+	:rtype: |EMSCRIPTEN_AUDIO_INSTANCE|
+
+.. c:function:: EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_load(void *ptr, int length)
+
+	Loads audio data in a standard binary format that the browser can understand.
+
+	:param int ptr: Pointer to the raw data
+	:param int length: Length of the audio
+	:rtype: |EMSCRIPTEN_AUDIO_INSTANCE|
+	
+.. c:function:: void emscripten_audio_free(EMSCRIPTEN_AUDIO_INSTANCE instance)
+
+	Frees an audio instance (a channel or a buffer) that was previously created.
+
+.. c:function:: EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_create_channel(em_audio_channel_callback callback, void* userData)
+
+	Creates a channel. Calls the callback with ``userData`` when a buffer completes playing.
+
+.. c:function:: void emscripten_audio_play(EMSCRIPTEN_AUDIO_INSTANCE bufferInstance, EMSCRIPTEN_AUDIO_INSTANCE channelInstance)
+
+	Plays a buffer of audio in a channel. Due to asynchronous decoding of audio, this may fail
+  if you call it too early. You can call ``emscripten_audio_get_load_state`` to know when it is
+  ok to play a buffer.
+
+.. c:function:: void emscripten_audio_set_paused(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int paused)
+
+	Pauses or unpauses a channel.
+
+.. c:function:: void emscripten_audio_set_loop(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int loop)
+
+	Sets whether a channel should loop.
+
+.. c:function:: void emscripten_audio_set_3d(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int threeD)
+
+	Sets whether a channel is 3D.
+
+.. c:function:: void emscripten_audio_stop(EMSCRIPTEN_AUDIO_INSTANCE channelInstance)
+
+	Stops a channel from playing.
+
+.. c:function:: void emscripten_audio_set_position(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double x, double y, double z)
+
+	Sets the position of a channel in space.
+
+.. c:function:: void emscripten_audio_set_velocity(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double x, double y, double z)
+
+	Sets the velocity of a channel.
+
+.. c:function:: void emscripten_audio_set_volume(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double v)
+
+	Sets the volume of a channel.
+
+.. c:function:: void emscripten_audio_set_listener_position(double x, double y, double z)
+
+	Sets the position in space of the listener.
+
+.. c:function:: void emscripten_audio_set_listener_velocity(double x, double y, double z)
+
+	Sets the velocity of the listener.
+
+.. c:function:: void emscripten_audio_set_listener_orientation(double x, double y, double z, double xUp, double yUp, double zUp)
+
+	Sets the orientation of the listener.
+
+.. c:function:: EMSCRIPTEN_RESULT emscripten_audio_get_load_state(EMSCRIPTEN_AUDIO_INSTANCE bufferInstance)
+
+	Checks if a buffer is ready to be played. This will return :c:data:`EMSCRIPTEN_RESULT_SUCCESS` if it is in fact ready, or :c:data:`EMSCRIPTEN_RESULT_DEFERRED` if not. If instead an error occurred, :c:data:`EMSCRIPTEN_RESULT_FAILED` will be returned.
+
+
+
+
 	
 .. COMMENT (not rendered): Section below is automated copy and replace text.
 
@@ -2059,6 +2166,7 @@ Functions
 .. |EMSCRIPTEN_RESULT| replace:: :c:type:`EMSCRIPTEN_RESULT`
 .. |EM_BOOL| replace:: :c:type:`EM_BOOL`
 .. |EMSCRIPTEN_WEBGL_CONTEXT_HANDLE| replace:: :c:type:`EMSCRIPTEN_WEBGL_CONTEXT_HANDLE`
+.. |EMSCRIPTEN_AUDIO_INSTANCE| replace:: :c:type:`EMSCRIPTEN_AUDIO_INSTANCE`
 
 
 .. COMMENT (not rendered): Following values are common to many functions, and currently only updated in one place (here).

--- a/src/library_audio.js
+++ b/src/library_audio.js
@@ -1,0 +1,198 @@
+var LibraryAudio = {
+  $HTML5Audio: {
+    audioContext: {},
+    audioInstances: [null],
+    enabled: false,
+  },
+
+  emscripten_audio_init: function() {
+    try {
+      if (!window.AudioContext) window.AudioContext = window.webkitAudioContext;
+      HTML5Audio.audioContext = new AudioContext();
+      HTML5Audio.enabled = true;
+    }
+    catch(e) {
+      Module.printErr('Web Audio API is not supported in this browser');
+      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_audio_load_pcm: function(channels, length, sampleRate, ptr) {
+    if (!HTML5Audio.enabled) return 0;
+    var sound = {
+      buffer: HTML5Audio.audioContext.createBuffer(channels, length, sampleRate),
+      error: false
+    };
+    for (var i = 0; i < channels; i++) {
+      var offs = (ptr>>2) + length * i;
+      sound.buffer.copyToChannel(HEAPF32.subarray(offs, offs + length), i, 0);
+    }
+    var instance = HTML5Audio.audioInstances.push(sound) - 1;
+    return instance;
+  },
+
+  emscripten_audio_load: function(ptr, length) {
+    if (!HTML5Audio.enabled) return 0;
+    var sound = {
+      buffer: null,
+      error: false
+    };
+    var instance = HTML5Audio.audioInstances.push(sound) - 1;
+    HTML5Audio.audioContext.decodeAudioData(
+      HEAPU8.buffer.slice(ptr, ptr+length),
+      function(buffer) {
+        sound.buffer = buffer;
+      },
+      function() {
+        sound.error = true;
+        Module.printErr('Audio decode error.');
+      }
+    );
+    return instance;
+  },
+
+  emscripten_audio_free: function(instance) {
+    HTML5Audio.audioInstances[instance] = null;
+  },
+
+  emscripten_audio_create_channel: function(callback, userData) {
+    if (!HTML5Audio.enabled) return;
+
+    Module['noExitRuntime'] = true;
+
+    var channel = {
+      gain: HTML5Audio.audioContext.createGain(),
+      panner: HTML5Audio.audioContext.createPanner(),
+      threeD: false,
+      playBuffer: function(buffer) {
+        this.source.buffer = buffer;
+        var chan = this;
+        this.source.onended = function() {
+          if (callback) Runtime.dynCall('vi', callback, [userData]);
+          // recreate channel for future use.
+          chan.setup();
+        };
+        this.source.start(0);
+      },
+      setup: function() {
+        this.source = HTML5Audio.audioContext.createBufferSource();
+        this.setupPanning();
+      },
+      setupPanning: function() {
+        if (this.threeD) {
+          this.source.disconnect();
+          this.source.connect(this.panner);
+          this.panner.connect(this.gain);
+        } else {
+          this.panner.disconnect();
+          this.source.connect(this.gain);
+        }
+      }
+    };
+    //channel.panner.rolloffFactor = 0; // We calculate rolloff ourselves.
+    channel.gain.connect(HTML5Audio.audioContext.destination);
+    channel.setup();
+    return HTML5Audio.audioInstances.push(channel) - 1;
+  },
+
+  emscripten_audio_play__deps: ['emscripten_audio_stop'],
+  emscripten_audio_play: function(bufferInstance, channelInstance) {
+    if (!HTML5Audio.enabled) return;
+
+    // stop sound which is playing in the channel currently.
+    _emscripten_audio_stop(channelInstance);
+
+    var sound = HTML5Audio.audioInstances[bufferInstance];
+    var channel = HTML5Audio.audioInstances[channelInstance];
+    if (sound.buffer) {
+      channel.playBuffer(sound.buffer);
+    } else {
+      Module.printErr('Trying to play sound which is not loaded.');
+    }
+  },
+
+  emscripten_audio_set_paused: function(channelInstance, paused) {
+    if (!HTML5Audio.enabled) return;
+    // This is a bad hack to fake pausing by setting the pitch to 0.0000001 (as zero is not allowed).
+    // The Web Audio API has no built-in support for pausing (which seems to be one hell of an oversight.),
+    // and other commonly suggested workarounds based on remembering start and pause times of sounds, and seeking
+    // have other issues with looping and pitch, so I chose this simpler hack instead.
+    HTML5Audio.audioInstances[channelInstance].source.playbackRate.value = paused ? 0.0000001 : 1;
+  },
+
+  emscripten_audio_set_loop: function(channelInstance, loop) {
+    if (!HTML5Audio.enabled) return;
+    HTML5Audio.audioInstances[channelInstance].source.loop = loop;
+  },
+
+  emscripten_audio_set_3d: function(channelInstance, threeD) {
+    var channel = HTML5Audio.audioInstances[channelInstance];
+    if (channel.threeD !== threeD) {
+      channel.threeD = threeD;
+      channel.setupPanning();
+    }
+  },
+
+  emscripten_audio_stop: function(channelInstance) {
+    if (!HTML5Audio.enabled) return;
+
+    var channel = HTML5Audio.audioInstances[channelInstance];
+
+    // stop sound currently playing.
+    if (channel.source.buffer) {
+      channel.source.stop(0);
+
+      // disable callback for this channel when manually stopped.
+      channel.source.onended = function(){};
+
+      // recreate channel for future use.
+      channel.setup();
+    }
+  },
+
+  emscripten_audio_set_position: function(channelInstance, x, y, z) {
+    if (!HTML5Audio.enabled) return;
+    HTML5Audio.audioInstances[channelInstance].panner.setPosition(x, y, z);
+  },
+
+  emscripten_audio_set_velocity: function(channelInstance, x, y, z) {
+    if (!HTML5Audio.enabled) return;
+    HTML5Audio.audioInstances[channelInstance].panner.setVelocity(x, y, z);
+  },
+
+  emscripten_audio_set_volume: function(channelInstance, v) {
+    if (!HTML5Audio.enabled) return;
+    HTML5Audio.audioInstances[channelInstance].gain.gain.value = v;
+  },
+
+  emscripten_audio_set_listener_position: function(x, y, z) {
+    if (!HTML5Audio.enabled) return;
+
+    HTML5Audio.audioContext.listener.setPosition(x, y, z);
+  },
+
+  emscripten_audio_set_listener_velocity: function(x, y, z) {
+    if (!HTML5Audio.enabled) return;
+
+    HTML5Audio.audioContext.listener.setVelocity(x, y, z);
+  },
+
+  emscripten_audio_set_listener_orientation: function(x, y, z, xUp, yUp, zUp) {
+    if (!HTML5Audio.enabled) return;
+
+    HTML5Audio.audioContext.listener.setPosition(x, y, z, xUp, yUp, zUp);
+  },
+
+  emscripten_audio_get_load_state: function(bufferInstance) {
+    if (HTML5Audio.enabled == 0) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    var sound = HTML5Audio.audioInstances[bufferInstance];
+    if (sound.error) return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED') }}};
+    if (sound.buffer) return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+    return {{{ cDefine('EMSCRIPTEN_RESULT_DEFERRED') }}};
+  }
+};
+
+autoAddDeps(LibraryAudio, '$HTML5Audio');
+mergeInto(LibraryManager.library, LibraryAudio);
+

--- a/src/modules.js
+++ b/src/modules.js
@@ -457,6 +457,7 @@ var LibraryManager = {
       'library_uuid.js',
       'library_glew.js',
       'library_html5.js',
+      'library_audio.js',
       'library_signals.js',
       'library_async.js'
     ]).concat(additionalLibraries);

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -426,6 +426,27 @@ extern EM_BOOL emscripten_is_webgl_context_lost(const char *target);
 extern EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
 extern EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
 
+typedef int EMSCRIPTEN_AUDIO_INSTANCE;
+typedef void (*em_audio_channel_callback)(void *userData);
+
+extern EMSCRIPTEN_RESULT emscripten_audio_init(void);
+extern EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_load_pcm(int channels, int length, int sampleRate, float *ptr);
+extern EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_load(void *ptr, int length);
+extern void emscripten_audio_free(EMSCRIPTEN_AUDIO_INSTANCE instance);
+extern EMSCRIPTEN_AUDIO_INSTANCE emscripten_audio_create_channel(em_audio_channel_callback callback, void* userData);
+extern void emscripten_audio_play(EMSCRIPTEN_AUDIO_INSTANCE bufferInstance, EMSCRIPTEN_AUDIO_INSTANCE channelInstance);
+extern void emscripten_audio_set_paused(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int paused);
+extern void emscripten_audio_set_loop(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int loop);
+extern void emscripten_audio_set_3d(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, int threeD);
+extern void emscripten_audio_stop(EMSCRIPTEN_AUDIO_INSTANCE channelInstance);
+extern void emscripten_audio_set_position(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double x, double y, double z);
+extern void emscripten_audio_set_velocity(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double x, double y, double z);
+extern void emscripten_audio_set_volume(EMSCRIPTEN_AUDIO_INSTANCE channelInstance, double v);
+extern void emscripten_audio_set_listener_position(double x, double y, double z);
+extern void emscripten_audio_set_listener_velocity(double x, double y, double z);
+extern void emscripten_audio_set_listener_orientation(double x, double y, double z, double xUp, double yUp, double zUp);
+extern EMSCRIPTEN_RESULT emscripten_audio_get_load_state(EMSCRIPTEN_AUDIO_INSTANCE bufferInstance);
+
 #ifdef __cplusplus
 } // ~extern "C"
 #endif

--- a/tests/html5_audio.c
+++ b/tests/html5_audio.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <html5.h>
+#include <sys/stat.h>
+
+EMSCRIPTEN_AUDIO_INSTANCE sound3, channel;
+
+int did = 0;
+
+void done(void* x) {
+  assert(did);
+  printf("test is done\n");
+  int result = 1;
+  REPORT_RESULT();
+}
+
+void did_play(void* arg) {
+  printf("got a channel.\n");
+  assert(123 == (int)arg);
+  did = 1;
+  printf("did play\n");
+}
+
+void loop() {
+  EMSCRIPTEN_RESULT status = emscripten_audio_get_load_state(sound3);
+  if (status == EMSCRIPTEN_RESULT_DEFERRED) return;
+  assert(status == EMSCRIPTEN_RESULT_SUCCESS);
+
+  emscripten_audio_play(sound3, channel);
+  printf("you should now hear a sound.\n");
+
+  emscripten_async_call(done, NULL, 6000);
+
+  emscripten_cancel_main_loop();
+}
+
+int main(int argc, char **argv) {
+  EMSCRIPTEN_RESULT ret = emscripten_audio_init();
+  assert(ret == EMSCRIPTEN_RESULT_SUCCESS);
+
+  {
+    // load some data and create a buffer
+    struct stat info;
+    int result = stat("sound.ogg", &info);
+    char * bytes = malloc( info.st_size );
+    FILE * f = fopen("sound.ogg", "rb");
+    fread(bytes, 1, info.st_size, f);
+    fclose(f);
+    sound3 = emscripten_audio_load(bytes, info.st_size);
+    free(bytes);
+  }
+
+  EMSCRIPTEN_RESULT status = emscripten_audio_get_load_state(sound3);
+  assert(status == EMSCRIPTEN_RESULT_DEFERRED);
+
+  channel = emscripten_audio_create_channel(did_play, (void*)123);
+
+  emscripten_set_main_loop(loop, 0, 0);
+
+  return 0;
+}
+

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -107,3 +107,8 @@ class interactive(BrowserCore):
       assert os.path.exists(program)
       Popen([PYTHON, EMCC, '-O2', program, '-o', 'page.html']).communicate()
       self.run_browser('page.html', 'You should hear "Hello World!"')
+
+  def test_html5_audio(self):
+    shutil.copyfile(path_from_root('tests', 'sounds', 'alarmvictory_1.ogg'), os.path.join(self.get_dir(), 'sound.ogg'))
+    self.btest('html5_audio.c', '1', args=['--preload-file', 'sound.ogg'],)
+


### PR DESCRIPTION
This is not done yet (needs testing), but putting it up for feedback.

This provides a C API to Web Audio. It is based on Unity's approach, which in practice seems to be the best in terms of results of all the options across multiple browsers. They are ok with us using their code, so I reworked it into this pull request.

This provides access to some of the core parts of Web Audio, specifically creating buffers and channels, and playing them, and adjusting some parameters. It's very bare-bones and minimalistic (less than 200 lines of code), but by being closer to the actual browser API, perhaps it can help projects like JSMESS get better audio.
