### PR TITLE
Support .c++ file extension

### DIFF
--- a/emcc
+++ b/emcc
@@ -55,7 +55,7 @@ from tools.response_file import read_response_file
 
 # endings = dot + a suffix, safe to test by  filename.endswith(endings)
 C_ENDINGS = ('.c', '.C')
-CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.CPP', '.CXX', '.CC')
+CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.c++', '.CPP', '.CXX', '.CC', '.C++')
 OBJC_ENDINGS = ('.m',)
 OBJCXX_ENDINGS = ('.mm',)
 SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS


### PR DESCRIPTION
capnproto ( https://kentonv.github.io/capnproto/ ) uses this.