### PR TITLE
Correct enableExtensionsByDefault check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -171,4 +171,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Petr Babicka <babcca@gmail.com>
 * Akira Takahashi <faithandbrave@gmail.com>
 * Victor Costan <costan@gmail.com>
-
+* Pepijn Van Eeckhoudt <pepijn.vaneeckhoudt@luciad.com>

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -762,7 +762,7 @@ var LibraryGL = {
       // Store the created context object so that we can access the context given a canvas without having to pass the parameters again.
       if (ctx.canvas) ctx.canvas.GLctxObject = context;
       GL.contexts[handle] = context;
-      if (typeof webGLContextAttributes['webGLContextAttributes'] === 'undefined' || webGLContextAttributes.enableExtensionsByDefault) {
+      if (typeof webGLContextAttributes['enableExtensionsByDefault'] === 'undefined' || webGLContextAttributes.enableExtensionsByDefault) {
         GL.initExtensions(context);
       }
       return handle;


### PR DESCRIPTION
The code used to check
```
typeof webGLContextAttributes['webGLContextAttributes'] === 'undefined' || 
webGLContextAttributes.enableExtensionsByDefault
```
The first part of the check seems incorrect and should probably be
```
typeof webGLContextAttributes['enableExtensionsByDefault'] === 'undefined'
```
