### PR TITLE
Support .c++ file extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -172,4 +172,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Akira Takahashi <faithandbrave@gmail.com>
 * Victor Costan <costan@gmail.com>
 * Pepijn Van Eeckhoudt <pepijn.vaneeckhoudt@luciad.com> (copyright owned by Luciad NV)
+* Stevie Trujillo <stevie.trujillo@gmail.com>
 

--- a/emcc
+++ b/emcc
@@ -55,7 +55,7 @@ from tools.response_file import read_response_file
 
 # endings = dot + a suffix, safe to test by  filename.endswith(endings)
 C_ENDINGS = ('.c', '.C')
-CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.CPP', '.CXX', '.CC')
+CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.c++', '.CPP', '.CXX', '.CC', '.C++')
 OBJC_ENDINGS = ('.m',)
 OBJCXX_ENDINGS = ('.mm',)
 SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS


### PR DESCRIPTION
capnproto ( https://kentonv.github.io/capnproto/ ) uses this.

(it didn't allow me to add to #3131 after I deleted everything)