### PR TITLE
Attempt to clarify INCLUDE_FULL_LIBRARY comments

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -437,14 +437,16 @@ var EXPORTED_GLOBALS = []; // Global non-function variables that are explicitly
                            // exported, so they are guaranteed to be
                            // accessible outside of the generated code.
 
-var INCLUDE_FULL_LIBRARY = 0; // Whether to include the whole library rather than just the
-                              // functions used by the generated code. This is needed when
-                              // dynamically loading modules that make use of runtime
+var INCLUDE_FULL_LIBRARY = 0; // Include all JS library functions instead of the sum of
+                              // DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + any functions used
+                              // by the generated code. This is needed when dynamically
+                              // loading (i.e. dlopen) modules that make use of runtime
                               // library functions that are not used in the main module.
-                              // Note that this includes js libraries but *not* C. You will
-                              // need the main file to include all needed C libraries. For
-                              // example, if a library uses malloc or new, you will need
-                              // to use those in the main file too to link in dlmalloc.
+                              // Note that this only applies to js libraries, *not* C. You
+                              // will need the main file to include all needed C libraries.
+                              // For example, if a module uses malloc or new, you will
+                              // need to use those in the main file too to pull in dlmalloc
+                              // for use by the module.
 
 var SHELL_FILE = 0; // set this to a string to override the shell file used
 


### PR DESCRIPTION
Unfortunately the following is still opaque to me, so not ready to merge yet:

> For example, if a library uses malloc or new, you will
> need to use those in the main file too to link in dlmalloc.

Should 'library' in the above be 'module'? That aside, I just don't understand this sentence. If you want to link in dlmalloc, why do you need to use malloc and/or new in the main module so other modules can use it? Should it actually be saying 'if you want have a module use dlmalloc, you must link it into your main module'?