### PR TITLE
Mount root fs via NODEFS

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1325,7 +1325,7 @@ mergeInto(LibraryManager.library, {
       });
     },
     shouldMountRootNodeFS: function() {
-      return (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_NODEWEBKIT) && Module['MOUNT_ROOT_NODEFS'];
+      return (ENVIRONMENT_IS_NODE) && Module['MOUNT_ROOT_NODEFS'];
     },
     staticInit: function() {
       FS.ensureErrnoError();

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -5,6 +5,9 @@ mergeInto(LibraryManager.library, {
     isWindows: false,
     staticInit: function() {
       NODEFS.isWindows = !!process.platform.match(/^win/);
+      if (FS.shouldMountRootNodeFS()) {
+        FS.mount(NODEFS, { root: '/' }, '/');
+      }
     },
     mount: function (mount) {
       assert(ENVIRONMENT_IS_NODE);


### PR DESCRIPTION
See also #2040.

This WIP patch introduces a new option `Module['MOUNT_ROOT_NODEFS']`, which allows the js file to mount the real filesystem into the emscripten user-space via node.js

An immediate use case is adapting the output of emscripten into frameworks like node-webkit, which allows a complete environment for web native apps.


Currently standard streams `/dev/std{in,out,err}` do not work. I'm not quite familiar with the implementation of fs in nodes.js, and here are my observations.

`fs.writeFileSync('/dev/stdout', 'hello')` does not work in node.js, where I got an ENXIO error, maybe because `/dev/stdout` is a special device.
`fs.writeSync(1, 'hello')` does work.
`ofstream fout('/dev/stdout'); fout << "hello";` does work in C++ -- not sure if this is undefined behavior, as some says that opening standard streams is undefined behavior.

Some ideas of making standard streams work:

- To manually create streams (via `FS.createStream` and `TTY`) and store the fd's to FS
 - The program may use `STDOUT`, but not `/dev/stdout`
- To mount all the subdirs under '/' except for '/dev'
 - Needs extra efforts to make them sync
- To mount the root into a dir (e.g. '/nodefs_root'), and add that prefix to all the `open()` calls
- To take special care of `/dev/std*` in FS, i.e., to create our own `/dev/std*` devices even when `/` is mounted from NODEFS

None of them seems elegant thought...


So I would like to know whether if this would be interesting to emscripten. And if there are better ideas than hacking FS/NODEFS to support standard streams.

