### PR TITLE
add scandir and alpha sort for musl libc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -173,4 +173,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Victor Costan <costan@gmail.com>
 * Pepijn Van Eeckhoudt <pepijn.vaneeckhoudt@luciad.com> (copyright owned by Luciad NV)
 * Stevie Trujillo <stevie.trujillo@gmail.com>
-
+* Edward Rudd <urkle@outoforder.cc>

--- a/system/lib/libc/musl/src/dirent/alphasort.c
+++ b/system/lib/libc/musl/src/dirent/alphasort.c
@@ -1,0 +1,10 @@
+#include <string.h>
+#include <dirent.h>
+#include "libc.h"
+
+int alphasort(const struct dirent **a, const struct dirent **b)
+{
+	return strcoll((*a)->d_name, (*b)->d_name);
+}
+
+LFS64(alphasort);

--- a/system/lib/libc/musl/src/dirent/scandir.c
+++ b/system/lib/libc/musl/src/dirent/scandir.c
@@ -1,0 +1,48 @@
+#include <dirent.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stddef.h>
+#include "libc.h"
+
+int scandir(const char *path, struct dirent ***res,
+	int (*sel)(const struct dirent *),
+	int (*cmp)(const struct dirent **, const struct dirent **))
+{
+	DIR *d = opendir(path);
+	struct dirent *de, **names=0, **tmp;
+	size_t cnt=0, len=0;
+	int old_errno = errno;
+
+	if (!d) return -1;
+
+	while ((errno=0), (de = readdir(d))) {
+		if (sel && !sel(de)) continue;
+		if (cnt >= len) {
+			len = 2*len+1;
+			if (len > SIZE_MAX/sizeof *names) break;
+			tmp = realloc(names, len * sizeof *names);
+			if (!tmp) break;
+			names = tmp;
+		}
+		names[cnt] = malloc(de->d_reclen);
+		if (!names[cnt]) break;
+		memcpy(names[cnt++], de, de->d_reclen);
+	}
+
+	closedir(d);
+
+	if (errno) {
+		if (names) while (cnt-->0) free(names[cnt]);
+		free(names);
+		return -1;
+	}
+	errno = old_errno;
+
+	if (cmp) qsort(names, cnt, sizeof *names, (int (*)(const void *, const void *))cmp);
+	*res = names;
+	return cnt;
+}
+
+LFS64(scandir);

--- a/system/lib/libcextra.symbols
+++ b/system/lib/libcextra.symbols
@@ -21,6 +21,7 @@
          T __wcscoll_l
          T __wcsxfrm_l
          W __wctype_l
+         T alphasort
          T asprintf
          T atoll
          T bcmp
@@ -137,6 +138,7 @@
          T regfree
          T rindex
          T scalbnf
+         T scandir
          D signgam
          T sscanf
          T stpcpy

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -313,6 +313,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
         'wctrans.c',
         'wcwidth.c',
        ]],
+       ['dirent', [
+        'alphasort.c',
+        'scandir.c',
+       ]],
        ['legacy', [
         'err.c',
        ]],


### PR DESCRIPTION


This adds the scandir and alphasort implementations from musl into the emscripten libcextra lib.
