### PR TITLE
correct the value for d_reclen to be the size of the dirent struct (not ...

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -150,7 +150,7 @@ LibraryManager.library = {
     }
     {{{ makeSetValue('entry', C_STRUCTS.dirent.d_ino, 'id', 'i32') }}};
     {{{ makeSetValue('entry', C_STRUCTS.dirent.d_off, 'stream.position', 'i32') }}};
-    {{{ makeSetValue('entry', C_STRUCTS.dirent.d_reclen, 'name.length + 1', 'i32') }}};
+    {{{ makeSetValue('entry', C_STRUCTS.dirent.d_reclen, C_STRUCTS.dirent.__size__, 'i32') }}};
     for (var i = 0; i < name.length; i++) {
       {{{ makeSetValue('entry + ' + C_STRUCTS.dirent.d_name, 'i', 'name.charCodeAt(i)', 'i8') }}};
     }

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -71,12 +71,15 @@ void test() {
   ent = readdir(dir);
   assert(!strcmp(ent->d_name, "."));
   assert(ent->d_type & DT_DIR);
+  assert(ent->d_reclen == sizeof(*ent));
   ent = readdir(dir);
   assert(!strcmp(ent->d_name, ".."));
   assert(ent->d_type & DT_DIR);
+  assert(ent->d_reclen == sizeof(*ent));
   ent = readdir(dir);
   assert(!strcmp(ent->d_name, "file.txt"));
   assert(ent->d_type & DT_REG);
+  assert(ent->d_reclen == sizeof(*ent));
   ent = readdir(dir);
   assert(!ent);
 


### PR DESCRIPTION
This makes it so the scandir implementation works correctly from #3161

from the getdirentries syscall man page (on OS X)
```The d_reclen entry is the length, in bytes, of the directory record.```
OS X and Linux at least optimize the padding of the dirent structures so even through OS X has an 8K buffer for d_name it only uses what is needed (aligned to 8 byte boundaries). so the d_reclen is used to "walk" through the data structure correctly.

Since we are not doing any padding like this in the JS implementation of readdir then d_reclen should be the size of the full struct.