### PR TITLE
Fixed GLFW modifier keys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -171,4 +171,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Petr Babicka <babcca@gmail.com>
 * Akira Takahashi <faithandbrave@gmail.com>
 * Victor Costan <costan@gmail.com>
+* Rene Eichhorn <rene.eichhorn1@gmail.com>
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -255,10 +255,10 @@ var LibraryGLFW = {
 
     getModBits: function(win) {
       var mod = 0;
-      if (win.keys[0x10]) mod |= 0x0001; // GLFW_MOD_SHIFT
-      if (win.keys[0x11]) mod |= 0x0002; // GLFW_MOD_CONTROL
-      if (win.keys[0x12]) mod |= 0x0004; // GLFW_MOD_ALT
-      if (win.keys[0x5B]) mod |= 0x0008; // GLFW_MOD_SUPER
+      if (win.keys[340]) mod |= 0x0001; // GLFW_MOD_SHIFT
+      if (win.keys[341]) mod |= 0x0002; // GLFW_MOD_CONTROL
+      if (win.keys[342]) mod |= 0x0004; // GLFW_MOD_ALT
+      if (win.keys[343]) mod |= 0x0008; // GLFW_MOD_SUPER
       return mod;
     },
 


### PR DESCRIPTION
getModBits used DOM keycodes instead of the glfw keycodes.