### PR TITLE
check memprof requirements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -175,3 +175,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Stevie Trujillo <stevie.trujillo@gmail.com>
 * Edward Rudd <urkle@outoforder.cc>
 * Rene Eichhorn <rene.eichhorn1@gmail.com>
+* Nick Desaulniers <nick@mozilla.com> (copyright owned by Mozilla Foundation)


### PR DESCRIPTION
review? @kripken 

This initial patch tests for the presence of global variables the memory profiler needs.

The next patch will add the compiler flag and test that when set can test for memory leaks.

The test can be run individually from the top level of the repo with the command `python tests/runner.py test_memprof_requirements`.