### PR TITLE
Add system/bin to start of PATH so our SDL config programs are used

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4773,4 +4773,7 @@ Descriptor desc;
       print args, expected
       out, err = Popen([PYTHON, path_from_root('system', 'bin', 'sdl2-config')] + args, stdout=PIPE, stderr=PIPE).communicate()
       assert expected in out, out
+      print 'via emmake'
+      out, err = Popen([PYTHON, path_from_root('emmake'), 'sdl2-config'] + args, stdout=PIPE, stderr=PIPE).communicate()
+      assert expected in out, out
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1019,6 +1019,7 @@ class Building:
     env['PKG_CONFIG_LIBDIR'] = path_from_root('system', 'local', 'lib', 'pkgconfig') + os.path.pathsep + path_from_root('system', 'lib', 'pkgconfig')
     env['PKG_CONFIG_PATH'] = os.environ.get ('EM_PKG_CONFIG_PATH') or ''
     env['EMSCRIPTEN'] = path_from_root()
+    env['PATH'] = path_from_root('system', 'bin') + os.pathsep + env['PATH']
     return env
 
   # Finds the given executable 'program' in PATH. Operates like the Unix tool 'which'.


### PR DESCRIPTION
Both `sdl-config` and `sdl2-config` exist now, but `emconfigure ./configure` will run the system versions instead normally. The compiler flags from system versions are wrong for Emscripten. This changes the `PATH` exported to `configure` so that Emscripten SDL configuration scripts are used automatically.

Pull request as [requested in emscripten-discuss](https://groups.google.com/forum/#!msg/emscripten-discuss/GL3tW-cayMY/8tGpa2xenM8J).