### PR TITLE
add Memprof

### DIFF
--- a/emcc
+++ b/emcc
@@ -415,6 +415,7 @@ try:
   js_libraries = []
   bind = False
   emrun = False
+  memprof = True
   jcache = False
   save_bc = False
   memory_init_file = None
@@ -669,6 +670,16 @@ try:
     elif newargs[i] == '--emrun':
       emrun = True
       newargs[i] = ''
+    elif newargs[i] == '--memprof':
+      tracing = True
+      memprof = True
+      newargs[i] = ''
+      newargs.append('-D__EMSCRIPTEN_TRACING__=1')
+      settings_changes.append('EMSCRIPTEN_TRACING=1')
+      js_libraries.append(shared.path_from_root('src', 'library_trace.js'))
+      js_libraries.append(shared.path_from_root('src', 'memprof_js_library.js'))
+      pre_js += open(shared.path_from_root('src', 'memprof_prejs.js')).read() + '\n'
+      post_js += open(shared.path_from_root('src', 'memprof_postjs.js')).read() + '\n'
     elif newargs[i] == '--default-obj-ext':
       newargs[i] = ''
       default_object_extension = newargs[i+1]

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -186,6 +186,9 @@ Options that are modified or new in *emcc* are listed below:
 "--tracing"
    Enable the *Emscripten Tracing API*.
 
+"--memprof"
+   Enable memory profiling visualizations.
+
 "--emit-symbol-map"
    Save a map file between the minified global names and the original
    function names. This allows you, for example, to reconstruct

--- a/src/memprof_js_library.js
+++ b/src/memprof_js_library.js
@@ -1,0 +1,9 @@
+mergeInto(LibraryManager.library, {
+  emscripten_trace_record_allocation: function (address, size) {
+    memProf.mallocProxy(address, size);
+  },
+  emscripten_trace_record_free: function (address) {
+    memProf.freeProxy(address);
+  },
+});
+

--- a/src/memprof_postjs.js
+++ b/src/memprof_postjs.js
@@ -1,0 +1,2 @@
+// Will contain memory leak checks.
+

--- a/src/memprof_prejs.js
+++ b/src/memprof_prejs.js
@@ -1,0 +1,8 @@
+// Will contain source of visualizations.
+var memProf = (function () {
+  return {
+    mallocProxy: function () { Module.print('mallocProxy'); },
+    freeProxy: function () { Module.print('freeProxy'); },
+  };
+})();
+

--- a/tests/mem_leak.c
+++ b/tests/mem_leak.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+int main() {
+  void* p = malloc(42);
+  void* q = malloc(43);
+  free(p);
+}
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7332,6 +7332,10 @@ int main(int argc, char **argv) {
     self.emcc_args += ['--js-library', os.path.join(self.get_dir(), 'lib.js')]
     self.do_run(open(os.path.join(self.get_dir(), 'main.cpp'), 'r').read(), 'able to run memprof')
 
+  def test_memprof_compiler_flag(self):
+    Building.COMPILER_TEST_OPTS += ['--memprof']
+    self.do_run(open(path_from_root('tests', 'mem_leak.c'), 'r').read(), 'mallocProxy\nfreeProxy');
+
 # Generate tests for everything
 def make_run(fullname, name=-1, compiler=-1, embetter=0, quantum_size=0,
     typed_arrays=0, emcc_args=None, env=None):


### PR DESCRIPTION
This is the second part of the memory profiler patch, implementing the necessary compiler flags, simplifying the command line arguments to 1 rather than 4.

`python tests/runner.py test_memprof_compiler_flag` passes but
`python tests/runner.py ALL.test_memprof_compiler_flag` does not :(

will investigate.