### PR TITLE
remove requirement to --clear-cache between calls to --tracing

### DIFF
--- a/emcc
+++ b/emcc
@@ -689,6 +689,13 @@ try:
     pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
     post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
 
+  if tracing:
+    dlMallocPath = shared.path_from_root('system/lib', 'dlmalloc.c')
+    if not newargs.__contains__(dlMallocPath):
+      tempDLMalloc = in_temp('dlmalloc.bc')
+      subprocess.call([shared.EMCC, dlMallocPath, '-o', tempDLMalloc, '--tracing'])
+      newargs.append(tempDLMalloc)
+
   if js_opts is None: js_opts = opt_level >= 2
   if llvm_opts is None: llvm_opts = LLVM_OPT_LEVEL[opt_level]
   if opt_level == 0: debug_level = max(3, debug_level)

--- a/site/source/docs/api_reference/trace.h.rst
+++ b/site/source/docs/api_reference/trace.h.rst
@@ -29,14 +29,6 @@ set the preprocessor flag ``__EMSCRIPTEN_TRACING__``. If you are invoking
 flag ``__EMSCRIPTEN_TRACING__`` is not defined, the tracing API implementation
 will be provided by inlined empty stubs.
 
-Also, since enabling tracing modifies the implementation of ``dlmalloc.c``
-in the ``libc`` implementation, it is advised that you manually clear your
-cache before switching to using the tracing API. If you do not do this, then
-you will not get full allocation details recorded.  You can clear the cache
-with this ``emcc`` command::
-
-    emcc --clear-cache
-
 Initialization and Teardown
 ---------------------------
 


### PR DESCRIPTION
to test:
```
emcc tests/hello_malloc.cpp --tracing
grep 'emscripten_trace' a.out.js

emcc tests/hello_malloc.cpp
grep 'emscripten_trace' a.out.js
```

#3178 