### PR TITLE
Support for setting title

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1697,7 +1697,9 @@ var LibrarySDL = {
 #endif
 
   SDL_WM_SetCaption: function(title, icon) {
-    title = title && Pointer_stringify(title);
+    if (title && typeof Module['setWindowTitle'] !== 'undefined') {
+      Module['setWindowTitle'](Pointer_stringify(title));
+    }
     icon = icon && Pointer_stringify(icon);
   },
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -150,6 +150,10 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   if (ENVIRONMENT_IS_WORKER) {
     Module['load'] = importScripts;
   }
+
+  if (typeof Module['setWindowTitle'] === 'undefined') {
+    Module['setWindowTitle'] = function(title) { document.title = title };
+  }
 }
 else {
   // Unreachable because SHELL is dependant on the others


### PR DESCRIPTION
This adds `Module['setWindowTitle']()` for setting `document.title`. It can be used via the `title` parameter of `SDL_WM_SetCaption()` or via https://github.com/emscripten-ports/SDL2/pull/6

If `Module['setWindowTitle']` was set before, it is not changed. This allows title changing to be blocked or redirected elsewhere.

I tested this with SDL 1 and 2. Does this need an automated test?