### PR TITLE
support stdin in node

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -178,3 +178,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nick Desaulniers <nick@mozilla.com> (copyright owned by Mozilla Foundation)
 * Luke Wagner <luke@mozilla.com> (copyright owned by Mozilla Foundation)
 * Matt McCormick <matt.mccormick@kitware.com>
+* Thaddée Tyl <thaddee.tyl@gmail.com>

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -17,11 +17,13 @@ def timeout_run(proc, timeout=None, note='unnamed process', full_output=False):
     logging.info('Process ' + str(proc.pid) + ' finished after ' + str(time.time() - start) + ' seconds. Exit code: ' + str(proc.returncode))
   return '\n'.join(out) if full_output else out[0]
 
-def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False, assert_returncode=0, error_limit=-1):
+def make_command(filename, engine=None, args=[]):
   if type(engine) is not list:
     engine = [engine]
+  return engine + [filename] + (['--'] if 'd8' in engine[0] or 'jsc' in engine[0] else []) + args
 
-  #  # code to serlialize out the test suite files
+def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False, assert_returncode=0, error_limit=-1):
+  #  # code to serialize out the test suite files
   #  # XXX make sure to disable memory init files, and clear out the base_dir. you may also need to manually grab e.g. paper.pdf.js from a run of test_poppler
   #  import shutil, json
   #  base_dir = '/tmp/emscripten_suite'
@@ -40,7 +42,7 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
   #  commands += os.path.basename(curr) + ',' + json.dumps(args) + '\n'
   #  open(commands_file, 'w').write(commands)
 
-  command = engine + [filename] + (['--'] if 'd8' in engine[0] or 'jsc' in engine[0] else []) + args
+  command = make_command(filename, engine, args)
   try:
     if cwd is not None: os.environ['EMCC_BUILD_DIR'] = os.getcwd()
     proc = Popen(
@@ -55,7 +57,7 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
   if TRACK_PROCESS_SPAWNS:
     logging.info('Blocking on process ' + str(proc.pid) + ': ' + str(command) + (' for ' + str(timeout) + ' seconds' if timeout else ' until it finishes.'))
   ret = timeout_run(
-    proc, 
+    proc,
     timeout,
     'Execution',
     full_output=full_output)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -835,6 +835,11 @@ def check_engine(engine):
     print 'Checking JS engine %s failed. Check %s. Details: %s' % (str(engine), EM_CONFIG, str(e))
     return False
 
+def make_js_command(filename, engine=None, *args):
+  if engine is None:
+    engine = JS_ENGINES[0]
+  return jsrun.make_command(filename, engine, *args)
+
 def run_js(filename, engine=None, *args, **kw):
   if engine is None:
     engine = JS_ENGINES[0]


### PR DESCRIPTION
The compiled JS programs failed to run on node when relying on stdin, because the code simply ignored any input stream and acted as if the empty string was entered, for simplicity (node doesn't… encourage… blocking stdin).

I could not get emscripten to work on Windows. However, I did verify that all the pieces used in this PR worked on Windows (the way I handle stdin in node, and the way the test works (the python and shell bits)).

On Linux, `python tests/runner.py random100` gave an OK, and `python tests/runner.py other.test_stdin` worked, too.