### PR TITLE
Do not warn about missing m library.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -177,4 +177,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Rene Eichhorn <rene.eichhorn1@gmail.com>
 * Nick Desaulniers <nick@mozilla.com> (copyright owned by Mozilla Foundation)
 * Luke Wagner <luke@mozilla.com> (copyright owned by Mozilla Foundation)
-
+* Matt McCormick <matt.mccormick@kitware.com>

--- a/emcc
+++ b/emcc
@@ -843,7 +843,7 @@ try:
             break
         if found: break
       if found: break
-    if not found and lib not in ['GL', 'GLU', 'glut', 'SDL']: # whitelist our default libraries
+    if not found and lib not in ['GL', 'GLU', 'glut', 'm', 'SDL']: # whitelist our default libraries
       logging.warning('emcc: cannot find library "%s"', lib)
 
   # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so


### PR DESCRIPTION
According to Issue #2600, the math library, linked with -lm, is implemented in
the musl libc that is already used. Do not emit:

WARNING  root: emcc: cannot find library "m"