### PR TITLE
Check if process.platform exists before using

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -4,7 +4,7 @@ mergeInto(LibraryManager.library, {
   $NODEFS: {
     isWindows: false,
     staticInit: function() {
-      NODEFS.isWindows = !!process.platform.match(/^win/);
+      NODEFS.isWindows = process.platform && !!process.platform.match(/^win/);
     },
     mount: function (mount) {
       assert(ENVIRONMENT_IS_NODE);


### PR DESCRIPTION
I was having problems loading an emscripten built file in Chrome because process.platform was undefined.

Recompiling emscripten with this patch fixed that problem.

However, this is my first time even trying emscripten so I'm sorry if this was actually a feature, not a bug, and if I should change my build process instead.

Hope this helps