### PR TITLE
EMSCRIPTEN_TEMP_DIR only on demand.

### DIFF
--- a/emcc
+++ b/emcc
@@ -1234,12 +1234,13 @@ try:
   log_time('link')
 
   if DEBUG:
-    logging.debug('saving intermediate processing steps to %s', shared.EMSCRIPTEN_TEMP_DIR)
+    emscripten_temp_dir = shared.get_emscripten_temp_dir()
+    logging.debug('saving intermediate processing steps to %s', emscripten_temp_dir)
 
     intermediate_counter = 0
     def save_intermediate(name=None, suffix='js'):
       global intermediate_counter
-      shutil.copyfile(final, os.path.join(shared.EMSCRIPTEN_TEMP_DIR, 'emcc-%d%s.%s' % (intermediate_counter, '' if name is None else '-' + name, suffix)))
+      shutil.copyfile(final, os.path.join(emscripten_temp_dir, 'emcc-%d%s.%s' % (intermediate_counter, '' if name is None else '-' + name, suffix)))
       intermediate_counter += 1
 
     if not LEAVE_INPUTS_RAW: save_intermediate('basebc', 'bc')
@@ -1374,7 +1375,7 @@ try:
         open(memfile, 'wb').write(''.join(map(lambda x: chr(int(x or '0')), s.split(','))))
         if DEBUG:
           # Copy into temp dir as well, so can be run there too
-          shared.safe_copy(memfile, os.path.join(shared.EMSCRIPTEN_TEMP_DIR, os.path.basename(memfile)))
+          shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
         return 'var memoryInitializer = "%s";' % os.path.basename(memfile)
       src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
       open(final + '.mem.js', 'w').write(src)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -391,7 +391,7 @@ process(sys.argv[1])
     for name in os.listdir(self.get_dir()):
       try_delete(os.path.join(self.get_dir(), name) if not in_curr else name)
     emcc_debug = os.environ.get('EMCC_DEBUG')
-    if emcc_debug and not in_curr:
+    if emcc_debug and not in_curr and EMSCRIPTEN_TEMP_DIR:
       for name in os.listdir(EMSCRIPTEN_TEMP_DIR):
         try_delete(os.path.join(EMSCRIPTEN_TEMP_DIR, name))
 

--- a/tools/make_minigzip.py
+++ b/tools/make_minigzip.py
@@ -5,7 +5,8 @@ import shared
 
 print 'Building zlib'
 
-zlib = shared.Building.build_library('zlib', shared.EMSCRIPTEN_TEMP_DIR, shared.EMSCRIPTEN_TEMP_DIR, ['libz.a'], make_args=['libz.a'], copy_project=True, source_dir=shared.path_from_root('tests', 'zlib'))[0]
+emscripten_temp_dir = shared.get_emscripten_temp_dir()
+zlib = shared.Building.build_library('zlib', emscripten_temp_dir, emscripten_temp_dir, ['libz.a'], make_args=['libz.a'], copy_project=True, source_dir=shared.path_from_root('tests', 'zlib'))[0]
 
 print 'Building minigzip'
 


### PR DESCRIPTION
Refactor tools/shared.py to not create a emscripten_temp_xxxxx directory immediately on import, but only when asked. Fixes #706.