### PR TITLE
Fix emscripten_get_gamepad_status() causing TypeError

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -178,3 +178,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nick Desaulniers <nick@mozilla.com> (copyright owned by Mozilla Foundation)
 * Luke Wagner <luke@mozilla.com> (copyright owned by Mozilla Foundation)
 * Matt McCormick <matt.mccormick@kitware.com>
+* Philipp Wiesemann <philipp.wiesemann@arcor.de>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1670,9 +1670,16 @@ var LibraryJSEvents = {
     if (index < 0 || index >= gamepads.length) {
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
     }
+    // For previously disconnected gamepads there should be a null at the index.
+    // This is because gamepads must keep their original position in the array.
+    // For example, removing the first of two gamepads produces [null, gamepad].
+    // Older implementations of the Gamepad API used undefined instead of null.
+    // The following check works because null and undefined evaluate to false.
     if (!gamepads[index]) {
+      // There is a "false" but no gamepad at index because it was disconnected.
       return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
     }
+    // There should be a gamepad at index which can be queried.
     JSEvents.fillGamepadEventData(gamepadState, gamepads[index]);
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1670,7 +1670,7 @@ var LibraryJSEvents = {
     if (index < 0 || index >= gamepads.length) {
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
     }
-    if (typeof gamepads[index] === 'undefined') {
+    if (!gamepads[index]) {
       return {{{ cDefine('EMSCRIPTEN_RESULT_NO_DATA') }}};
     }
     JSEvents.fillGamepadEventData(gamepadState, gamepads[index]);


### PR DESCRIPTION
Passing the index of a previously disconnected gamepad to the function emscripten_get_gamepad_status() caused a TypeError. This was possible if multiple gamepads were connected and one with a small index was removed. In this case the array returned by navigator.getGamepads() will contain a null entry. The function emscripten_get_gamepad_status() only checked for undefined entries and returned EMSCRIPTEN_RESULT_NO_DATA if this was the case. A null entry was not detected and the null was then passed on assuming it was an actual gamepad. This eventually caused the TypeError. The fault was fixed by changing the check to include null (and the other values evaluating to false which therefore also can not be gamepads).
