### PR TITLE
Fix JS engine detection to not incorrectly detect nodejs as d8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -165,7 +165,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Long <longster@gmail.com>
 * David Anderson <danderson@mozilla.com> (copyright owned by Mozilla Foundation)
 * Eric Rannaud <e@nanocritical.com> (copyright owned by Nanocritical Corp.)
-* William Furr <william.furr@gmail.com>
+* William Furr <wfurr@google.com> (copyright owned by Google, Inc.)
 * Dan Glastonbury <dglastonbury@mozilla.com> (copyright owned by Mozilla Foundation)
 * Warren Seine <warren.seine@aerys.in> (copyright owned by Aerys SAS)
 * Petr Babicka <babcca@gmail.com>

--- a/tests/print_args.js
+++ b/tests/print_args.js
@@ -1,0 +1,18 @@
+// Print command-line arguments to script.
+// Used in test_sanity.py
+
+var print = print || console.log;
+var args = []
+
+if (typeof process !== 'undefined') {
+  // Use process global in node
+  args = process.argv.slice(2);
+} else {
+  // Use arguments object for d8 and jsc
+  args = Array.prototype.slice.call(arguments);
+}
+
+args.forEach(function (val, index, array) {
+  print(index + ': ' + val);
+});
+

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -20,7 +20,17 @@ def timeout_run(proc, timeout=None, note='unnamed process', full_output=False):
 def make_command(filename, engine=None, args=[]):
   if type(engine) is not list:
     engine = [engine]
-  return engine + [filename] + (['--'] if 'd8' in engine[0] or 'jsc' in engine[0] else []) + args
+  # Emscripten supports multiple javascript runtimes.  The default is nodejs but
+  # it can also use d8 (the v8 engine shell) or jsc (JavaScript Core aka
+  # Safari).  Both d8 and jsc require a '--' to delimit arguments to be passed
+  # to the executed script from d8/jsc options.  Node does not require a
+  # delimeter--arguments after the filename are passed to the script.
+  #
+  # Check only the last part of the engine path to ensure we don't accidentally
+  # label a path to nodejs containing a 'd8' as spidermonkey instead.
+  jsengine = os.path.split(engine[0])[-1]
+  # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
+  return engine + [filename] + (['--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
 
 def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False, assert_returncode=0, error_limit=-1):
   #  # code to serialize out the test suite files


### PR DESCRIPTION
...when d8 occurs in the path.

This was a problem because our build system generates temporary directories with hashes in them, which contain 'd8' about 1 in 32 runs.