### PR TITLE
Add mmap / msync / munmap against real filesystem for node.js

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1324,7 +1324,7 @@ var asm = (function(global, env, buffer) {
      access_quote('Uint16Array'),
      access_quote('Uint32Array'),
      access_quote('Float32Array'),
-     access_quote('Float64Array')) if not settings['ALLOW_MEMORY_GROWTH'] else '''
+     access_quote('Float64Array')) if not settings['PROXY_HEAP'] and not settings['ALLOW_MEMORY_GROWTH'] else '''
   var Int8View = global%s;
   var Int16View = global%s;
   var Int32View = global%s;
@@ -1349,7 +1349,7 @@ var asm = (function(global, env, buffer) {
      access_quote('Uint16Array'),
      access_quote('Uint32Array'),
      access_quote('Float32Array'),
-     access_quote('Float64Array'))) + '\n' + asm_global_vars + '''
+     access_quote('Float64Array')) if settings['ALLOW_MEMORY_GROWTH'] else '') + '\n' + asm_global_vars + '''
   var __THREW__ = 0;
   var threwValue = 0;
   var setjmpId = 0;

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1097,6 +1097,7 @@ mergeInto(LibraryManager.library, {
       return bytesRead;
     },
     write: function(stream, buffer, offset, length, position, canOwn) {
+      // console.log('FS.write', offset, length, position);
       if (length < 0 || position < 0) {
         throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }
@@ -1153,6 +1154,18 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
       }
       return stream.stream_ops.mmap(stream, buffer, offset, length, position, prot, flags);
+    },
+    msync: function(stream, map, len, flags) {
+      if (!stream.stream_ops.msync) {
+        return 0;
+      }
+      return stream.stream_ops.msync(map, len, flags);
+    },
+    munmap: function(stream, map, num) {
+      if (!stream.stream_ops.msync) {
+        return 0;
+      }
+      return stream.stream_ops.munmap(map, num);
     },
     ioctl: function(stream, cmd, arg) {
       if (!stream.stream_ops.ioctl) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -589,6 +589,8 @@ var USE_GLFW = 2; // Specify the GLFW version that is being linked against.
                   // Only relevant, if you are linking against the GLFW library.
                   // Valid options are 2 for GLFW2 and 3 for GLFW3.
 
+var PROXY_HEAP = 1;
+
 // Ports
 
 var USE_SDL = 1; // Specify the SDL version that is being linked against.


### PR DESCRIPTION
**Why?**

NODEFS contains a bunch of wrappers to deal with things on the real filesystem, but unfortunately does not have mmap. All mmap operations in emscripten are done on emscripten's heap, which is unfortunate when you're dealing with real files. My usecase was dealing with a library that wants raw access to `/dev/mem`, which it does through mmap.

**How?**

There is two issues at the moment:

1. Node.js does not support mmap out of the box
2. The cross-compiled C application does operations on the heap, and this is 'static'. Only way to modify it is by explicitly setting data, but the data in the mmap always changes.

To solve the first problem I wrote a native node module: [emscripten-node-mmap](https://github.com/janjongboom/emscripten-node-mmap). It is a small wrapper around mmap/msync/munmap, plus has operations to read and write to random addresses (to access the mmap). When user calls `mmap` from C, it goes to NODEFS, goes to the native module which gives a pointer back. Nodefs then allocates a pointer on emscripten's filesystem and has a mapping of emscripten pointers -> real pointers. When someone wants to read data from the address we pass it back to Nodefs, it calculates the real pointer value, and then queries the native module for that data.

The second issue is quite troublesome. We know what part of memory we need to allocate, so I figured I'd make a getter on buffer[XXX] which calls back to NODEFS instead of returning a cached value, but this is not supported by Typed Arrays (it is by normal arrays). To get around this I used proxies to monitor heap access. When you write the map to memory I tag all addresses, and when you read/write to one of those addresses you'll be sent to NODEFS instead. I would like to see how much performance impact this has.

**Urm. And now?**

This is step 1 in another change I want to make. We're going to add [low level filesystem access in Gecko](https://groups.google.com/forum/#!topic/mozilla.dev.webapi/t4Xh2EH0rIo) and I want to write a new emscripten filesystem backend for this. One of the devices that this is going to run on is the Raspberry Pi and the most popular library for dealing with Rpi internals (GPIO/I2C) needs mmap access to /dev/mem to control the pins. Figured to see what we'd need first by implementing this in node.

Please let me know your thoughts. I know it's kind of a crazy hack, but I put it behind a flag :-)