### PR TITLE
Fix glGetString() and glewIsSupported() implicitly creating global variables

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -952,7 +952,7 @@ var LibraryGL = {
       case 0x1F03 /* GL_EXTENSIONS */:
         var exts = GLctx.getSupportedExtensions();
         var gl_exts = [];
-        for (i in exts) {
+        for (var i in exts) {
           gl_exts.push(exts[i]);
           gl_exts.push("GL_" + exts[i]);
         }

--- a/src/library_glew.js
+++ b/src/library_glew.js
@@ -110,7 +110,7 @@ var LibraryGLEW = {
 
   glewIsSupported: function(name) {
     var exts = Pointer_stringify(name).split(' ');
-    for (i in exts) {
+    for (var i in exts) {
       if (!GLEW.extensionIsSupported(exts[i]))
         return 0;
     }


### PR DESCRIPTION
The functions glGetString() and glewIsSupported() implicitly created global variables called i because i was not explicitly declared to be a local variable.