### PR TITLE
Pointer masking update

### DIFF
--- a/emcc
+++ b/emcc
@@ -976,10 +976,25 @@ try:
       shared.Settings.ASM_JS = 2
 
   if shared.Settings.POINTER_MASKING:
-    logging.warning('POINTER_MASKING is experimental')
-    size = shared.Settings.POINTER_MASKING + 1 # size plus 1 should be a power of 2
-    if size & (size-1) != 0:
-      raise Exception('POINTER_MASKING value must be a power of 2 minus 1')
+    if shared.Settings.ALLOW_MEMORY_GROWTH:
+      raise Exception('With POINTER_MASKING the ALLOW_MEMORY_GROWTH feature is not supported')
+    if not shared.Settings.POINTER_MASKING_DYNAMIC:
+      shared.Settings.POINTER_MASKING_DEFAULT_ENABLED = 1;
+      size = shared.Settings.TOTAL_MEMORY
+      if size & (size - 1) != 0:
+        raise Exception('With POINTER_MASKING the TOTAL_MEMORY must be a power of 2')
+      if shared.Settings.ASM_JS:
+        # Silently keep the total length a valid asm.js heap buffer length.
+        overflow = shared.Settings.POINTER_MASKING_OVERFLOW;
+        if overflow > 0:
+          if size <= 0x01000000:
+            shared.Settings.POINTER_MASKING_OVERFLOW = size;
+          else:
+            shared.Settings.POINTER_MASKING_OVERFLOW = (overflow + 0x00ffffff) & 0xff000000;
+  elif shared.Settings.POINTER_MASKING_DYNAMIC:
+    raise Exception('POINTER_MASKING_DYNAMIC requires POINTER_MASKING')
+  else:
+    shared.Settings.POINTER_MASKING_DEFAULT_ENABLED = 0;
 
   assert shared.LLVM_TARGET in shared.COMPILER_OPTS
   if shared.LLVM_TARGET == 'i386-pc-linux-gnu':
@@ -1554,7 +1569,8 @@ try:
       else:
         js_optimizer_queue += ['registerize']
 
-    if shared.Settings.POINTER_MASKING and shared.Settings.ASM_JS: js_optimizer_queue += ['pointerMasking']
+    if shared.Settings.POINTER_MASKING:
+      js_optimizer_queue += ['pointerMasking']
 
     if not shared.Settings.EMTERPRETIFY:
       do_minify()

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1331,7 +1331,48 @@ var TOTAL_STACK = Module['TOTAL_STACK'] || {{{ TOTAL_STACK }}};
 var TOTAL_MEMORY = Module['TOTAL_MEMORY'] || {{{ TOTAL_MEMORY }}};
 var FAST_MEMORY = Module['FAST_MEMORY'] || {{{ FAST_MEMORY }}};
 
-#if ASM_JS
+#if POINTER_MASKING
+
+#if POINTER_MASKING_DYNAMIC
+var POINTER_MASKING_ENABLED = Module['POINTER_MASKING_DEFAULT_ENABLED'] || {{{ POINTER_MASKING_DEFAULT_ENABLED }}};
+var POINTER_MASKING_OVERFLOW = Module['POINTER_MASKING_OVERFLOW'] || {{{ POINTER_MASKING_OVERFLOW }}}
+var MASK0 = -1, MASK1 = -1, MASK2 = -1, MASK3 = -1;
+function initPointerMasking() {
+  var totalMemory = 64*1024;
+  while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
+    if (POINTER_MASKING_ENABLED || totalMemory < 16*1024*1024) {
+      totalMemory *= 2;
+    } else {
+      totalMemory += 16*1024*1024
+    }
+  }
+  if (totalMemory !== TOTAL_MEMORY) {
+    Module.printErr('increasing TOTAL_MEMORY to ' + totalMemory + ' to be compliant with the asm.js spec (and given that TOTAL_STACK=' + TOTAL_STACK + ')');
+    TOTAL_MEMORY = totalMemory;
+  }
+  // Silently keep the total length a valid asm.js heap buffer length.
+  if (POINTER_MASKING_OVERFLOW > 0) {
+    if (TOTAL_MEMORY <= 0x01000000) {
+      POINTER_MASKING_OVERFLOW = TOTAL_MEMORY;
+    } else {
+      POINTER_MASKING_OVERFLOW = (POINTER_MASKING_OVERFLOW + 0x00ffffff) & 0xff000000;
+    }
+  }
+  MASK0 = POINTER_MASKING_ENABLED ? TOTAL_MEMORY - 1 : -1;
+  MASK1 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~1 : -1;
+  MASK2 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~3 : -1;
+  MASK3 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~7 : -1;
+}
+initPointerMasking();
+#else // POINTER_MASKING_DYNAMIC
+var totalMemory = 64*1024;
+while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
+  totalMemory *= 2;
+}
+#endif // POINTER_MASKING_DYNAMIC
+
+#else // POINTER_MASKING
+
 var totalMemory = 64*1024;
 while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
   if (totalMemory < 16*1024*1024) {
@@ -1347,7 +1388,9 @@ if (totalMemory !== TOTAL_MEMORY) {
   Module.printErr('increasing TOTAL_MEMORY to ' + totalMemory + ' to be compliant with the asm.js spec (and given that TOTAL_STACK=' + TOTAL_STACK + ')');
   TOTAL_MEMORY = totalMemory;
 }
-#endif
+
+#endif // POINTER_MASKING
+
 
 // Initialize the runtime's memory
 #if USE_TYPED_ARRAYS
@@ -1362,8 +1405,19 @@ IHEAPU = new Uint32Array(IHEAP.buffer);
 FHEAP = new Float64Array(TOTAL_MEMORY);
 #endif
 #endif
+
 #if USE_TYPED_ARRAYS == 2
+#if POINTER_MASKING
+#if POINTER_MASKING_DYNAMIC
+var buffer = new ArrayBuffer(TOTAL_MEMORY + (POINTER_MASKING_ENABLED ? POINTER_MASKING_OVERFLOW : 0));
+#else
+var buffer = new ArrayBuffer(TOTAL_MEMORY + {{{ POINTER_MASKING_OVERFLOW }}});
+#endif
+#else
 var buffer = new ArrayBuffer(TOTAL_MEMORY);
+#endif // POINTER_MASKING
+#endif // USE_TYPED_ARRAYS == 2
+
 HEAP8 = new Int8Array(buffer);
 HEAP16 = new Int16Array(buffer);
 HEAP32 = new Int32Array(buffer);

--- a/src/settings.js
+++ b/src/settings.js
@@ -190,8 +190,26 @@ var OUTLINING_LIMIT = 0; // A function size above which we try to automatically 
 
 var AGGRESSIVE_VARIABLE_ELIMINATION = 0; // Run aggressiveVariableElimination in js-optimizer.js
 var SIMPLIFY_IFS = 1; // Whether to simplify ifs in js-optimizer.js
-var POINTER_MASKING = 0; // Whether to mask pointers (experimental optimization trying to reduce VM bounds checks).
-                         // When using this option, TOTAL_MEMORY must be a power of 2.
+
+var POINTER_MASKING = 0; // Whether pointers can be masked to a power-of-two heap
+                         // length. An experimental optimization trying to reduce VM
+                         // bounds checks.
+var POINTER_MASKING_OVERFLOW = 64 * 1024; // The length added to the heap length to allow
+                                          // the compiler to derive that accesses are
+                                          // within bounds even when adding small constant
+                                          // offsets. This defaults to 64K, but in asm.js
+                                          // mode it is silently adjusted to keep the
+                                          // total buffer length a valid asm.js heap
+                                          // buffer length.
+var POINTER_MASKING_DYNAMIC = 0; // When disabled, the masking is baked into the code with
+				 // static masks and a static heap buffer length and the
+				 // TOTAL_MEMORY must be a power of 2. When enabled, the
+				 // masks are defined at runtime rather than compling them
+				 // into the asm.js module as literal constants and the
+				 // TOTAL_MEMORY can be defined at run time.
+var POINTER_MASKING_DEFAULT_ENABLED = 1; // When POINTER_MASKING_DYNAMIC is enabled this
+					 // sets the default for POINTER_MASKING_ENABLED,
+					 // enabling or disabling pointer masking.
 
 // Generated code debugging options
 var SAFE_HEAP = 0; // Check each write to the heap, for example, this will give a clear

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1,3 +1,6 @@
+// -*- Mode: javascript; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 ; js-indent-level : 2 ; js-curly-indent-offset: 0 -*-
+// vim: set ts=2 et sw=2 tw=80:
+
 //==============================================================================
 // Optimizer tool. This is meant to be run after the emscripten compiler has
 // finished generating code. These optimizations are done on the generated
@@ -6071,46 +6074,63 @@ function optimizeFrounds(ast) {
   traverseChildren(ast, fix);
 }
 
-// Optimize heap expressions into   HEAP32[(x&m)+c>>2]    where c is a small aligned constant, and m guarantees the pointer is without range+aligned
+// Optimize heap expressions into HEAP32[(x&m)+c>>2] where c is an aligned
+// constant, and m guarantees the pointer is within bounds and aligned.
 function pointerMasking(ast) {
-  var MAX_SMALL_OFFSET = 32;
+  var parseHeapTemp = makeTempParseHeap();
 
   traverse(ast, function(node, type) {
     if (type === 'sub' && node[1][0] === 'name' && node[1][1][0] === 'H' && node[2][0] === 'binary' && node[2][1] === '>>' && node[2][3][0] === 'num') {
-      var addee = node[2][2];
-      if (!(addee[0] === 'binary' && addee[1] === '+')) return;
       var shifts = node[2][3][1];
-      if (!parseHeap(node[1][1])) return;
-      if (parseHeapTemp.bits !== 8*Math.pow(2, shifts)) return;
-      // this is an HEAP[U]N[x + y >> n] expression. gather up all the top-level added items, seek a small constant amongst them
+      var addee = node[2][2];
+
+      if (!parseHeap(node[1][1], parseHeapTemp)) return;
+      if (parseHeapTemp.bits !== 8 * Math.pow(2, shifts)) return;
+
+      // Don't mask a shifted constant index. It will be folded later,
+      // and it is assumed that they are within bounds.
+      if (addee[0] === 'num') return;
+
+      if (!(addee[0] === 'binary' && addee[1] === '+')) {
+        node[2][2] = ['binary', '&', addee, ['name', 'MASK' + shifts]];
+        return;
+      }
+
+      // This is a HEAP[U]N[x + y >> n] expression. Gather up all the top-level
+      // added items, summing constants amongst them.
+      var addedConstants = 0;
       var addedElements = [];
       function addElements(node) {
         if (node[0] === 'binary' && node[1] === '+') {
           addElements(node[2]);
           addElements(node[3]);
+        } else if (node[0] === 'num') {
+          var c = node[1];
+          // Check that it is aligned.
+          if (((c >> shifts) << shifts) === c) {
+            addedConstants += c;
+          } else {
+            addedElements.push(node);
+          }
         } else {
           addedElements.push(node);
         }
       }
       addElements(addee);
-      assert(addedElements.length >= 2);
-      for (var i = 0; i < addedElements.length; i++) {
-        var element = addedElements[i];
-        if (element[0] === 'num') {
-          var c = element[1];
-          if (c < MAX_SMALL_OFFSET && ((c >> shifts) << shifts) === c) {
-            // this is a small aligned offset, we are good to go. gather the others, and finalize
-            addedElements.splice(i, 1);
-            var others = addedElements[0];
-            for (var j = 1; j < addedElements.length; j++) {
-              others = ['binary', '+', others, addedElements[j]];
-            }
-            others = ['binary', '&', others, ['name', 'MASK' + shifts]];
-            node[2][2] = ['binary', '+', others, element];
-            return;
-          }
+      if (addedElements.length > 0) {
+        var others = addedElements[0];
+        for (var j = 1; j < addedElements.length; j++) {
+          others = ['binary', '+', others, addedElements[j]];
         }
+        others = ['binary', '&', others, ['name', 'MASK' + shifts]];
+        if (addedConstants != 0) {
+          others = ['binary', '+', others, ['num' , addedConstants]];
+        }
+        node[2][2] = others;
+        return;
       }
+
+      node[2][2] = ['num' , addedConstants];
     }
   });
 }


### PR DESCRIPTION
Update the POINTER_MASKING feature. The POINTER_MASKING argument is
now a boolean rather than the mask. The TOTAL_MEMORY is now expected
to be a power of two, and this is checked. The actual allocated buffer
length extended by 16M to support index offsets. A heap length
declaration function is now emitted for the benefit of Odin. The masks
are emitted using a 'const' rather than a 'var' for the benefit of
Odin. The array access optimization now folds constant indexes, and
accepts offsets up to 16M to match the guard zone added to the heap length.