### PR TITLE
Fix unresolved functions SDL_malloc and SDL_free

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1777,8 +1777,8 @@ var LibrarySDL = {
 
   SDL_SetError: function() {},
 
-  SDL_Malloc: 'malloc',
-  SDL_Free: 'free',
+  SDL_malloc: 'malloc',
+  SDL_free: 'free',
 
   SDL_CreateRGBSurface: function(flags, width, height, depth, rmask, gmask, bmask, amask) {
     return SDL.makeSurface(width, height, flags, false, 'CreateRGBSurface', rmask, gmask, bmask, amask);


### PR DESCRIPTION
Two functions from SDL_stdinc.h were implemented with a typo in their name (incorrectly as SDL_Malloc and SDL_Free) and therefore could not be resolved if spelled correctly like the prototype in the header file.