### PR TITLE
Exit with error when trying to use non-fastcomp mode

### DIFF
--- a/emcc
+++ b/emcc
@@ -109,7 +109,8 @@ stderr = PIPE if not DEBUG else None # unless we are in DEBUG mode
 EMCC_CXX = '--emscripten-cxx' in sys.argv
 sys.argv = filter(lambda x: x != '--emscripten-cxx', sys.argv)
 
-shared.check_sanity(force=DEBUG)
+if len(sys.argv) != 1 and '--help' not in sys.argv and sys.argv[1] != '--version':
+  shared.check_sanity(force=DEBUG)
 
 # Handle some global flags
 
@@ -944,7 +945,8 @@ try:
       fastcomp_opts += ['-emscripten-asyncify-whitelist=' + ','.join(shared.Settings.ASYNCIFY_WHITELIST)]
 
   else: # non-fastcomp
-    logging.warning('Using old (non-fastcomp) compiler due to EMCC_FAST_COMPILER=0 in the env. This is dangerous, as there are known bugs, and this code path is no longer maintained. Please use emscripten in the default configuration (i.e., do not disable fastcomp)')
+    logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
+    sys.exit(1)
 
   if shared.Settings.ASM_JS:
     assert opt_level >= 1 or fastcomp, 'asm.js requires -O1 or above'

--- a/emscripten.py
+++ b/emscripten.py
@@ -1527,6 +1527,9 @@ Runtime.getTempRet0 = asm['getTempRet0'];
 
 if os.environ.get('EMCC_FAST_COMPILER') != '0':
   emscript = emscript_fast
+else:
+  logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
+  sys.exit(1)
 
 def main(args, compiler_engine, cache, jcache, relooper, temp_files, DEBUG, DEBUG_CACHE):
   # Prepare settings for serialization to JSON.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -276,6 +276,29 @@ f.close()
     # TODO: test normal project linking, static and dynamic: get_library should not need to be told what to link!
     # TODO: deprecate llvm optimizations, dlmalloc, etc. in emscripten.py.
 
+  def test_emcc_nonfastcomp_fails(self):
+    open(os.path.join(self.get_dir(), 'test.c'), 'w').write(r'''
+      int main() {
+        return 0;
+      }
+    ''')
+    def check_errors(command):
+      process = Popen(command, stdout=PIPE, stderr=PIPE)
+      stdout, stderr = process.communicate()
+      self.assertEqual(stdout, '')
+      self.assertIn('Non-fastcomp compiler is no longer available', stderr)
+      self.assertEqual(process.returncode, 1)
+    def check_success(command):
+      process = Popen(command, stdout=PIPE, stderr=PIPE)
+      stdout, stderr = process.communicate()
+      self.assertEqual(stderr, '')
+      self.assertEqual(process.returncode, 0)
+    nonfastcomp(lambda: check_success([PYTHON, EMCC, '--version']))
+    nonfastcomp(lambda: check_success([PYTHON, EMCC, '--help']))
+    nonfastcomp(lambda: check_errors([PYTHON, EMCC, '-v']))
+    nonfastcomp(lambda: check_errors([PYTHON, EMCC, os.path.join(self.get_dir(), 'test.c')]))
+    self.assertFalse(os.path.exists('a.out.js'))
+
   def test_emcc_nonfastcomp(self):
     return self.skip('non-fastcomp is deprecated and fails in 3.5')
     nonfastcomp(self.test_emcc)

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -1,5 +1,5 @@
 
-import os, sys, subprocess, multiprocessing, re, string, json, shutil
+import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging
 import shared
 
 configuration = shared.configuration
@@ -62,7 +62,9 @@ def find_msbuild(sln_file, make_env):
   return [None, make_env]
 
 def get_native_optimizer():
-  if os.environ.get('EMCC_FAST_COMPILER') == '0': return None # need fastcomp for native optimizer
+  if os.environ.get('EMCC_FAST_COMPILER') == '0':
+    logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
+    sys.exit(1)
 
   # Allow users to override the location of the optimizer executable by setting an environment variable EMSCRIPTEN_NATIVE_OPTIMIZER=/path/to/optimizer(.exe)
   if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER') and len(os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER')) > 0: return os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -459,8 +459,12 @@ def check_sanity(force=False):
     # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
     check_llvm_version()
     check_node_version()
-    if os.environ.get('EMCC_FAST_COMPILER') != '0':
-      fastcomp_ok = check_fastcomp()
+
+    if os.environ.get('EMCC_FAST_COMPILER') == '0':
+      logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
+      sys.exit(1)
+
+    fastcomp_ok = check_fastcomp()
 
     if os.environ.get('EM_IGNORE_SANITY'):
       logging.info('EM_IGNORE_SANITY set, ignoring sanity checks')
@@ -711,9 +715,7 @@ except:
 # Target choice. Must be synced with src/settings.js (TARGET_*)
 def get_llvm_target():
   if os.environ.get('EMCC_FAST_COMPILER') == '0':
-    if not os.environ.get('EMCC_LLVM_TARGET'):
-      os.environ['EMCC_LLVM_TARGET'] = 'le32-unknown-nacl'
-    return os.environ.get('EMCC_LLVM_TARGET')
+    return 'unavailable-non-fastcomp'
   return os.environ.get('EMCC_LLVM_TARGET') or 'asmjs-unknown-emscripten'
 LLVM_TARGET = get_llvm_target()
 


### PR DESCRIPTION
Stage 1 of #3243 - prevent people from using non-fastcomp mode. This patch aims to be the minimal number of changes in order to be easily revertible (the idea is to trigger errors in key places when checking the env variable).

I've run the sanity test suite and the main test suite on default mode.
 - Two failures in sanity (one being a lack of closure compiler, the other verified as not a regression).
 - One failure in main suite (also verified as not a regression).

I wonder if this should hang around in incoming and go out for the next release without any other changes from #3243, so if there's a backlash (e.g. critical features missing from fastcomp making migration impossible) it can be easily undone.