### PR TITLE
Handling unsigned integers with bitshift unsigned operator

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -523,12 +523,21 @@ var LibraryEmbind = {
     }
 
     var shift = getShiftFromSize(size);
+    
+    var fromWireType = function(value) {
+        return value;
+    };
+    
+    if (minRange === 0) {
+        var bitshift = 32 - 8*size;
+        fromWireType = function(value) {
+            return (value << bitshift) >>> bitshift;
+        };
+    }
 
     registerType(primitiveType, {
         name: name,
-        'fromWireType': function(value) {
-            return value;
-        },
+        'fromWireType': fromWireType,
         'toWireType': function(destructors, value) {
             // todo: Here we have an opportunity for -O3 level "unsafe" optimizations: we could
             // avoid the following two if()s and assume value is of proper type.

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -732,6 +732,20 @@ module({
             assert.throws(TypeError, function() { cm.unsigned_long_to_string(4294967296); });
         });
 
+        test("unsigned values are correctly returned when stored in memory", function() {
+            cm.store_unsigned_char(255);
+            assert.equal(255, cm.load_unsigned_char());
+
+            cm.store_unsigned_short(32768);
+            assert.equal(32768, cm.load_unsigned_short());
+
+            cm.store_unsigned_int(2147483648);
+            assert.equal(2147483648, cm.load_unsigned_int());
+
+            cm.store_unsigned_long(2147483648);
+            assert.equal(2147483648, cm.load_unsigned_long());
+        });
+
         test("throws appropriate type error when attempting to coerce null to int", function() {
             var e = assert.throws(TypeError, function() {
                 cm.int_to_string(null);

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1585,6 +1585,43 @@ std::string unsigned_long_to_string(unsigned long val) {
     return str;
 }
 
+//test loading unsigned value from memory
+static unsigned char uchar;
+void store_unsigned_char(unsigned char arg) {
+	uchar = arg;
+}
+
+unsigned char load_unsigned_char() {
+	return uchar;
+}
+
+static unsigned short ushort;
+void store_unsigned_short(unsigned short arg) {
+	ushort = arg;
+}
+
+unsigned short load_unsigned_short() {
+	return ushort;
+}
+
+static unsigned int uint;
+void store_unsigned_int(unsigned int arg) {
+	uint = arg;
+}
+
+unsigned int load_unsigned_int() {
+	return uint;
+}
+
+static unsigned long ulong;
+void store_unsigned_long(unsigned long arg) {
+	ulong = arg;
+}
+
+unsigned long load_unsigned_long() {
+	return ulong;
+}
+
 EMSCRIPTEN_BINDINGS(tests) {
     register_vector<int>("IntegerVector");
     register_vector<char>("CharVector");
@@ -2047,6 +2084,15 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("unsigned_int_to_string", &unsigned_int_to_string);
     function("long_to_string", &long_to_string);
     function("unsigned_long_to_string", &unsigned_long_to_string);
+
+    function("store_unsigned_char", &store_unsigned_char);
+    function("load_unsigned_char", &load_unsigned_char);
+    function("store_unsigned_short", &store_unsigned_short);
+    function("load_unsigned_short", &load_unsigned_short);
+    function("store_unsigned_int", &store_unsigned_int);
+    function("load_unsigned_int", &load_unsigned_int);
+    function("store_unsigned_long", &store_unsigned_long);
+    function("load_unsigned_long", &load_unsigned_long);
 }
 
 int overloaded_function(int i) {


### PR DESCRIPTION
Change embind fromWireType function for integers in order to handle unsigned values return as signed values by js.
Corrects Issue #3246.