### PR TITLE
To find LLVM_ROOT, call "llvm-config --bindir" instead

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -219,7 +219,7 @@ else:
     config_file = '\n'.join(config_file)
     # autodetect some default paths
     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
-    llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
+    llvm_root = subprocess.check_output(['llvm-config', '--bindir']).strip()
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
     node = find_executable('node') or find_executable('nodejs') or 'node'
     config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))


### PR DESCRIPTION
When I was installing emscripten on a mac, the tools/shared.py file did not correctly find my LLVM bin directory location. Since LLVM is bundled with llvm-config and the bin directory can be found correctly by calling "llvm-config --bindir" and then trimming the whitespace.

I believe that this should work on all systems where the LLVM bin has been added to the path. But I am not sure, I was unable to try this on a non-unix system, and I am unsure of where exactly this tool is called.