### PR TITLE
Fix removing handlers when destroying GL context

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -784,7 +784,7 @@ var LibraryGL = {
 
     deleteContext: function(contextHandle) {
       if (GL.currentContext === GL.contexts[contextHandle]) GL.currentContext = null;
-      if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
+      if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].GLctx.canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
       if (GL.contexts[contextHandle] && GL.contexts[contextHandle].GLctx.canvas) GL.contexts[contextHandle].GLctx.canvas.GLctxObject = undefined; // Make sure the canvas object no longer refers to the context object so there are no GC surprises.
       GL.contexts[contextHandle] = null;
     },

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -125,11 +125,11 @@ var LibraryJSEvents = {
 
     isInternetExplorer: function() { return navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0; },
 
-    // Removes all event handlers on the given DOM element of the given type. Pass in eventType == undefined/null to remove all event handlers regardless of the type.
+    // Removes all event handlers on the given DOM element of the given type. Pass in eventTypeString == undefined/null to remove all event handlers regardless of the type.
     removeAllHandlersOnTarget: function(target, eventTypeString) {
       for(var i = 0; i < JSEvents.eventHandlers.length; ++i) {
         if (JSEvents.eventHandlers[i].target == target && 
-          (!eventType || eventTypeString == JSEvents.eventHandlers[i].eventTypeString)) {
+          (!eventTypeString || eventTypeString == JSEvents.eventHandlers[i].eventTypeString)) {
            JSEvents._removeHandler(i--);
          }
       }


### PR DESCRIPTION
The internal function removeAllHandlersOnTarget() could access a not defined variable. Until now this did not happen because the only caller of removeAllHandlersOnTarget() passed wrong arguments which lets the function exit before accessing the not defined variable.

Calling emscripten_webgl_destroy_context() did not remove event handlers because the function passed undefined instead of the canvas as target to the internal function removeAllHandlersOnTarget().
