### PR TITLE
readlink should normalize against parent, not against cwd

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -838,7 +838,7 @@ mergeInto(LibraryManager.library, {
       if (!link.node_ops.readlink) {
         throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }
-      return PATH.resolve('.', link.node_ops.readlink(link));
+      return PATH.resolve(FS.getPath(lookup.node.parent), link.node_ops.readlink(link));
     },
     stat: function(path, dontFollow) {
       var lookup = FS.lookupPath(path, { follow: !dontFollow });

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -205,7 +205,7 @@ mergeInto(LibraryManager.library, {
         try {
           path = fs.readlinkSync(path);
           path = NODEJS_PATH.relative(NODEJS_PATH.resolve(node.mount.opts.root), path);
-          return PATH.join(node.mount.mountpoint, path);
+          return path;
         } catch (e) {
           if (!e.code) throw e;
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);

--- a/tests/unistd/links.out
+++ b/tests/unistd/links.out
@@ -21,11 +21,11 @@ symlink/normal
 ret: 0
 errno: 0
 readlink(created link)
-ret: 29
+ret: 36
 errno: 0
-result: /working/new-nonexistent-path
+result: /working/folder/new-nonexistent-path
 
 readlink(short buffer)
 ret: 3
 errno: 0
-result: /thrking/new-nonexistent-path
+result: /thrking/folder/new-nonexistent-path


### PR DESCRIPTION
Currently running the test suite, the tests I could find that utilize symlinks (unistd_links / stat) run ok now.

I verified the behavior specified in the modified test against gcc, previous definition was not correct.