### PR TITLE
test_glgears_animation_race

### DIFF
--- a/tests/hello_world_gles_shell.html
+++ b/tests/hello_world_gles_shell.html
@@ -44,7 +44,7 @@
         setTimeout(function() {
           var secondImage = Module.canvas.toDataURL();
           reportResult(firstImage != secondImage);
-        }, 0);
+        }, 500);
       }
       Module.postRun = doTest;
 


### PR DESCRIPTION
Attempt to fix browser.test_glgears_animation by applying a delay to keyboard event and result report. With timeout 0, there seems to be a race condition between the report result set timeout, and re-rendering event of the page, and depending on which one fires first, the test either passes or fails. Delaying the report result should guarantee that the canvas is repainted with changed contents.