### PR TITLE
GetProcAddress should strip ANGLE suffix.  Closes #3304

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -182,3 +182,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Philipp Wiesemann <philipp.wiesemann@arcor.de>
 * Jan Jongboom <janjongboom@gmail.com> (copyright owned by Telenor Digital AS)
 * Tiago Quelhas <tiagoq@gmail.com>
+* Reinier de Blois <rddeblois@gmail.com>

--- a/system/lib/gl.c
+++ b/system/lib/gl.c
@@ -1543,12 +1543,14 @@ GLAPI void APIENTRY emscripten_glVertexAttribDivisor (GLuint index, GLuint divis
 void* emscripten_GetProcAddress(const char *name_) {
   char *name = malloc(strlen(name_)+1);
   strcpy(name, name_);
-  // remove EXT|ARB|OES suffixes
+  // remove EXT|ARB|OES|ANGLE suffixes
   char *end = strstr(name, "EXT");
   if (end) *end = 0;
   end = strstr(name, "ARB");
   if (end) *end = 0;
   end = strstr(name, "OES");
+  if (end) *end = 0;
+  end = strstr(name, "ANGLE");
   if (end) *end = 0;
   // misc renamings
   if (!strcmp(name, "glCreateProgramObject")) name = "glCreateProgram";


### PR DESCRIPTION
Once again, but now against incoming branch and with name in authors file as requested.