### PR TITLE
Access a literal wide string after a memory growth [embind]

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -182,3 +182,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Philipp Wiesemann <philipp.wiesemann@arcor.de>
 * Jan Jongboom <janjongboom@gmail.com> (copyright owned by Telenor Digital AS)
 * Tiago Quelhas <tiagoq@gmail.com>
+* Jérôme Bernard <jerome.bernard@ercom.fr> (copyright owned by Ercom)

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -443,10 +443,12 @@ module({
             assert.equal(expected, cm.take_and_return_std_wstring(expected));
         });
 
-        test("can access a literal wstring after a memory growth", function() {    
-            cm.force_memory_growth();
-            assert.equal("get_literal_wstring", cm.get_literal_wstring());
-        });
+        if (Module.isMemoryGrowthEnabled) {
+            test("can access a literal wstring after a memory growth", function() {
+                cm.force_memory_growth();
+                assert.equal("get_literal_wstring", cm.get_literal_wstring());
+            });
+        }
 
     });
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -442,6 +442,12 @@ module({
                 String.fromCharCode(65535);
             assert.equal(expected, cm.take_and_return_std_wstring(expected));
         });
+
+        test("can access a literal wstring after a memory growth", function() {    
+            cm.force_memory_growth();
+            assert.equal("get_literal_wstring", cm.get_literal_wstring());
+        });
+
     });
 
     BaseFixture.extend("embind", function() {

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -443,7 +443,7 @@ module({
             assert.equal(expected, cm.take_and_return_std_wstring(expected));
         });
 
-        if (Module.isMemoryGrowthEnabled) {
+        if (cm.isMemoryGrowthEnabled) {
             test("can access a literal wstring after a memory growth", function() {
                 cm.force_memory_growth();
                 assert.equal("get_literal_wstring", cm.get_literal_wstring());

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -121,6 +121,15 @@ std::wstring get_non_ascii_wstring() {
     return ws;
 }
 
+std::wstring get_literal_wstring() {
+    return L"get_literal_wstring";
+}
+
+void force_memory_growth() {
+    auto heapu8 = val::global("Module")["HEAPU8"];
+    delete [] new char[heapu8["byteLength"].as<size_t>() + 1];
+}
+
 std::string emval_test_take_and_return_const_char_star(const char* str) {
     return str;
 }
@@ -1657,6 +1666,9 @@ EMSCRIPTEN_BINDINGS(tests) {
 
     function("get_non_ascii_string", &get_non_ascii_string);
     function("get_non_ascii_wstring", &get_non_ascii_wstring);
+    function("get_literal_wstring", &get_literal_wstring);
+    function("force_memory_growth", &force_memory_growth);
+
     //function("emval_test_take_and_return_const_char_star", &emval_test_take_and_return_const_char_star);
     function("emval_test_take_and_return_std_string", &emval_test_take_and_return_std_string);
     function("emval_test_take_and_return_std_string_const_ref", &emval_test_take_and_return_std_string_const_ref);

--- a/tests/embind/isMemoryGrowthEnabled=true.cpp
+++ b/tests/embind/isMemoryGrowthEnabled=true.cpp
@@ -1,0 +1,7 @@
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+EMSCRIPTEN_BINDINGS(settings) {
+    constant("isMemoryGrowthEnabled", true);
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2185,6 +2185,7 @@ int f() {
           path_from_root('tests', 'embind', 'embind_test.cpp'),
           '--pre-js', path_from_root('tests', 'embind', 'test.pre.js'),
           '--post-js', path_from_root('tests', 'embind', 'test.post.js'),
+          '-s', 'ALLOW_MEMORY_GROWTH=1',
         ] + args,
         stderr=PIPE if fail else None,
         env=environ).communicate()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2168,6 +2168,7 @@ int f() {
       (['--bind', '-O1'], False),
       (['--bind', '-O2'], False),
       (['--bind', '-O2', '--closure', '1'], False),
+      (['--bind', '-O2', '-s', 'ALLOW_MEMORY_GROWTH=1', path_from_root('tests', 'embind', 'isMemoryGrowthEnabled=true.cpp')], False),
     ]:
       print args, fail
       self.clear()
@@ -2185,7 +2186,6 @@ int f() {
           path_from_root('tests', 'embind', 'embind_test.cpp'),
           '--pre-js', path_from_root('tests', 'embind', 'test.pre.js'),
           '--post-js', path_from_root('tests', 'embind', 'test.post.js'),
-          '-s', 'ALLOW_MEMORY_GROWTH=1',
         ] + args,
         stderr=PIPE if fail else None,
         env=environ).communicate()


### PR DESCRIPTION
Fix the issue #3299.

*Important*: I've added "-s ALLOW_MEMORY_GROWTH=1" to the compilation of the tests in test_embind() of tests/test_other.py.

Tests : other.test_embind + the following random 100:

* asm1i.test_strstr
* asm2g.test_emscripten_get_compiler_setting
* asm3i.test_stack_varargs
* asm2.test_stdvec
* asm3i.test_trickystring
* asm2nn.test_longjmp_throw
* asm2nn.test_ptrtoint
* asm2nn.test_dynamic_cast_2
* asm3i.test_lua
* asm2nn.test_fuzz
* default.test_atomic
* asm2g.test_unsigned
* asm2.test_locale
* asm3i.test_bigarray
* default.test_cases
* asm2.test_sintvars
* asm2f.test_parseInt
* asm3.test_safe_dyncalls
* asm3i.test_stack_align
* asm2g.test_memmove3
* asm3.test_inlinejs3
* asm3i.test_memcpy3
* asm2g.test_exceptions_refcount
* asm1.test_systypes
* asm2f.test_dlfcn_mallocs
* asm1.test_openjpeg
* asm1.test_longjmp_funcptr
* asm3.test_unicode_js_library
* asm3.test_cases
* asm2.test_strcmp_uni
* asm2f.test_multiply_defined_symbols
* asm1i.test_corruption_3
* asm2.test_exceptions_std
* asm2.test_simd5
* asm1i.test_alloca
* asm2g.test_tracing
* asm1i.test_std_cout_new
* asm3.test_frexp
* asm2.test_sintvars
* asm2.test_the_bullet
* asm2nn.test_unistd_sleep
* asm2f.test_systypes
* asm2g.test_sizeof
* asm3i.test_funcs
* asm2.test_sscanf_3
* asm2nn.test_strstr
* asm2nn.test_funcptr_namecollide
* asm1i.test_systypes
* asm2nn.test_i64_umul
* asm3i.test_double_varargs
* asm1i.test_math_lgamma
* asm2nn.test_inherit
* asm3.test_unsigned
* asm1i.test_atexit
* asm1i.test_stat
* asm3.test_line_endings
* asm2g.test_getopt
* asm1i.test_dlfcn_data_and_fptr
* asm2.test_sscanf_skip
* asm2nn.test_fs_emptyPath
* asm2f.test_stack_overflow
* asm1i.test_errar
* asm3.test_sscanf_whitespace
* asm2nn.test_tcgetattr
* asm3i.test_alloca
* default.test_freetype
* asm1.test_simd5
* asm2f.test_environ
* asm3i.test_unicode_js_library
* asm2g.test_zerodiv
* default.test_inherit
* asm1.test_polymorph
* asm1.test_time
* asm3.test_istream
* asm2.test_math
* asm2f.test_corruption
* asm1i.test_strptime_reentrant
* asm2nn.test_random
* asm2g.test_openjpeg
* asm1i.test_fasta
* asm3.test_memcpy3
* asm1.test_unistd_misc
* asm1i.test_unistd_login
* asm3i.test_strtod
* asm2f.test_strtol_bin
* asm3.test_trickystring
* asm2nn.test_dlfcn_varargs
* default.test_flexarray_struct
* asm2f.test_locale
* asm2nn.test_embind_2
* asm3.test_fast_math
* asm3.test_the_bullet
* asm3.test_dlfcn_qsort
* asm1.test_nestedstructs
* asm3.test_unistd_close
* asm3.test_strndup
* asm2nn.test_fcvt
* asm1i.test_trickystring
* default.test_strftime
* asm2g.test_dynamic_cast
* asm1.test_complex

