### PR TITLE
emcc: Remove EMCC_LEAVE_INPUTS_RAW from env.

### DIFF
--- a/emcc
+++ b/emcc
@@ -93,6 +93,10 @@ LEAVE_INPUTS_RAW = os.environ.get('EMCC_LEAVE_INPUTS_RAW') # Do not compile .ll 
                                                            # specific need.
                                                            # One major limitation with this mode is that libc and libc++ cannot be
                                                            # added in. Also, LLVM optimizations will not be done, nor dead code elimination
+# If emcc is running with LEAVE_INPUTS_RAW and then launches an emcc to build something like the struct info, then we don't want
+# LEAVE_INPUTS_RAW to be active in that emcc subprocess.
+if LEAVE_INPUTS_RAW:
+  del os.environ['EMCC_LEAVE_INPUTS_RAW']
 AUTODEBUG = os.environ.get('EMCC_AUTODEBUG') # If set to 1, we will run the autodebugger (the automatic debugging tool, see tools/autodebugger).
                                              # Note that this will disable inclusion of libraries. This is useful because including
                                              # dlmalloc makes it hard to compare native and js builds


### PR DESCRIPTION
If emcc is running with LEAVE_INPUTS_RAW and then launches an
emcc to build something like the struct info, then we don't want
LEAVE_INPUTS_RAW to be active in that emcc subprocess.

This is an issue for people who use emscripten and do their own
bitcode processing and optimization.