### PR TITLE
Fix an error when in strict mode.

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -16,7 +16,7 @@ if (memoryInitializer) {
 #endif
   } else {
     addRunDependency('memory initializer');
-    function applyMemoryInitializer(data) {
+    var applyMemoryInitializer = function(data) {
       if (data.byteLength) data = new Uint8Array(data);
 #if USE_TYPED_ARRAYS == 2
 #if ASSERTIONS


### PR DESCRIPTION
Move a function in the postamble to the correct scope to fix an
error when running this code in strict mode.