### PR TITLE
Adjust links from wiki to github pages

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -910,7 +910,7 @@ v1.12.2: 2/25/2014
 
 v1.12.1: 2/25/2014
 ------------------
- - TURNED ON FASTCOMP BY DEFAULT. This means that you will need to migrate to fastcomp-clang build. Either use an Emscripten SDK distribution, or to build manually, see https://github.com/kripken/emscripten/wiki/LLVM-Backend for info.
+ - TURNED ON FASTCOMP BY DEFAULT. This means that you will need to migrate to fastcomp-clang build. Either use an Emscripten SDK distribution, or to build manually, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html for info.
  - Migrate to requiring Clang 3.3 instead of Clang 3.2. The fastcomp-clang repository by Emscripten is based on Clang 3.3.
  - Deprecated old Emscripten libgc implementation.
  - asm.js will now be always enabled, even in -O0 builds in fastcomp.

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -204,7 +204,7 @@ if (phase == 'pre') {
       !SKIP_STACK_IN_SMALL || SAFE_HEAP || !DISABLE_EXCEPTION_CATCHING) {
     print('// Note: Some Emscripten settings will significantly limit the speed of the generated code.');
   } else {
-    print('// Note: For maximum-speed code, see "Optimizing Code" on the Emscripten wiki, https://github.com/kripken/emscripten/wiki/Optimizing-Code');
+    print('// Note: For maximum-speed code, see "Optimizing Code" on the Emscripten wiki, http://kripken.github.io/emscripten-site/docs/optimizing/Optimizing-Code.html');
   }
 
   if (DOUBLE_MODE || CORRECT_SIGNS || CORRECT_OVERFLOWS || CORRECT_ROUNDINGS || CHECK_HEAP_ALIGN) {

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1,5 +1,5 @@
 /*
- * GL support. See https://github.com/kripken/emscripten/wiki/OpenGL-support
+ * GL support. See http://kripken.github.io/emscripten-site/docs/porting/multimedia_and_graphics/OpenGL-support.html
  * for current status.
  */
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1853,7 +1853,7 @@ function checkBitcast(item) {
       } else {
         warnOnce('Casting a function pointer type to a potentially incompatible one (use -s VERBOSE=1 to see more)');
       }
-      warnOnce('See https://github.com/kripken/emscripten/wiki/CodeGuidelinesAndLimitations#function-pointer-issues for more information on dangerous function pointer casts');
+      warnOnce('See http://kripken.github.io/emscripten-site/docs/porting/guidelines/function_pointer_issues.html for more information on dangerous function pointer casts');
       if (ASM_JS) warnOnce('Incompatible function pointer casts are very dangerous with ASM_JS=1, you should investigate and correct these');
     }
     if (oldCount != newCount && oldCount && newCount) showWarning();

--- a/src/settings.js
+++ b/src/settings.js
@@ -299,7 +299,7 @@ var USE_WEBGL2 = 0; // Enables WebGL2 native functions. This mode will also crea
                     // context by default if no version is specified.
 var FULL_ES3 = 0;   // Forces support for all GLES3 features, not just the WebGL2-friendly subset.
 var LEGACY_GL_EMULATION = 0; // Includes code to emulate various desktop GL features. Incomplete but useful
-                             // in some cases, see https://github.com/kripken/emscripten/wiki/OpenGL-support
+                             // in some cases, see http://kripken.github.io/emscripten-site/docs/porting/multimedia_and_graphics/OpenGL-support.html
 var GL_FFP_ONLY = 0; // If you specified LEGACY_GL_EMULATION = 1 and only use fixed function pipeline in your code,
                      // you can also set this to 1 to signal the GL emulation layer that it can perform extra
                      // optimizations by knowing that the user code does not use shaders at all. If 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -199,7 +199,7 @@ class sanity(RunnerCore):
     assert os.environ.get('EMCC_FAST_COMPILER') != '0', 'must be using fastcomp to test fastcomp'
 
     WARNING = 'fastcomp in use, but LLVM has not been built with the JavaScript backend as a target'
-    WARNING2 = 'you can fall back to the older (pre-fastcomp) compiler core, although that is not recommended, see https://github.com/kripken/emscripten/wiki/LLVM-Backend'
+    WARNING2 = 'you can fall back to the older (pre-fastcomp) compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html'
 
     restore()
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -358,7 +358,7 @@ def check_fastcomp():
       print >> sys.stderr, '==========================================================================='
       print >> sys.stderr, llc_version_info,
       print >> sys.stderr, '==========================================================================='
-      logging.critical('you can fall back to the older (pre-fastcomp) compiler core, although that is not recommended, see https://github.com/kripken/emscripten/wiki/LLVM-Backend')
+      logging.critical('you can fall back to the older (pre-fastcomp) compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
       return False
 
     d = get_fastcomp_src_dir()
@@ -372,7 +372,7 @@ def check_fastcomp():
         clang_version = llvm_version # This LLVM compiler tree does not have a tools/clang, so it's probably an out-of-source build directory. No need for separate versioning.
       if EMSCRIPTEN_VERSION != llvm_version or EMSCRIPTEN_VERSION != clang_version:
         logging.error('Emscripten, llvm and clang versions do not match, this is dangerous (%s, %s, %s)', EMSCRIPTEN_VERSION, llvm_version, clang_version)
-        logging.error('Make sure to use the same branch in each repo, and to be up-to-date on each. See https://github.com/kripken/emscripten/wiki/LLVM-Backend')
+        logging.error('Make sure to use the same branch in each repo, and to be up-to-date on each. See http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
     else:
       logging.warning('did not see a source tree above or next to the LLVM root directory (guessing based on directory of %s), could not verify version numbers match' % LLVM_COMPILER)
     return True

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -2,7 +2,7 @@
 '''
 WebIDL binder
 
-https://github.com/kripken/emscripten/wiki/WebIDL-Binder
+http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html
 '''
 
 import os, sys


### PR DESCRIPTION
It looks a bit unprofessional if a URL printed by the latest version of the software points to a page containing a manual redirect link.