### PR TITLE
Add pointer-masking runtime validation checks. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * Manfred Manik Nerurkar <nerurkar*at*made-apps.biz> (copyright owned by MADE, GmbH)
 * Joseph Gentle <me@josephg.com>
 * Douglas T. Crosher <dtc-moz@scieneer.com> (copyright owned by Mozilla Foundation)
+* Douglas T. Crosher <info@jsstats.com> (copyright owned by Scieneer Pty Ltd)
 * Soeren Balko <soeren.balko@gmail.com>
 * Ryan Kelly (ryan@rfk.id.au)
 * Michael Lelli <toadking@toadking.com>

--- a/emcc
+++ b/emcc
@@ -987,6 +987,10 @@ try:
             shared.Settings.POINTER_MASKING_OVERFLOW = (overflow + 0x00ffffff) & 0xff000000;
   elif shared.Settings.POINTER_MASKING_DYNAMIC:
     raise Exception('POINTER_MASKING_DYNAMIC requires POINTER_MASKING')
+  elif shared.Settings.SAFE_POINTER_MASKING:
+    raise Exception('SAFE_POINTER_MASKING requires POINTER_MASKING')
+  elif shared.Settings.POINTER_MASKING_BLACKLIST:
+    raise Exception('POINTER_MASKING_BLACKLIST requires POINTER_MASKING')
   else:
     shared.Settings.POINTER_MASKING_DEFAULT_ENABLED = 0
 
@@ -1437,6 +1441,8 @@ try:
           passes += ['symbolMap='+target+'.symbols']
         if profiling_funcs and 'minifyNames' in passes:
           passes += ['profilingFuncs']
+        if shared.Settings.SAFE_POINTER_MASKING:
+          passes = ['safeMask'] + passes
         if minify_whitespace and 'last' in passes:
           passes += ['minifyWhitespace']
         logging.debug('applying js optimization passes: %s', ' '.join(passes))
@@ -1552,6 +1558,9 @@ try:
         js_optimizer_queue += ['closure']
       elif debug_level <= 2 and not shared.Settings.MAIN_MODULE and shared.Settings.FINALIZE_ASM_JS and not closure:
         js_optimizer_queue += ['cleanup']
+
+  if shared.Settings.POINTER_MASKING_BLACKLIST:
+    js_optimizer_extra_info['pointerMaskingBlacklist'] = list(shared.Settings.POINTER_MASKING_BLACKLIST)
 
   if js_opts:
     if shared.Settings.ASM_JS and shared.Settings.SAFE_HEAP: js_optimizer_queue += ['safeHeap']

--- a/emscripten.py
+++ b/emscripten.py
@@ -402,6 +402,7 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
 
     basic_funcs = ['abort', 'assert', 'asmPrintInt', 'asmPrintFloat'] + [m.replace('.', '_') for m in math_envs]
     if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_FT_MASK']
+    if settings['SAFE_POINTER_MASKING']: basic_funcs += ['SAFE_MASK_REPORT']
     if settings['CHECK_HEAP_ALIGN']: basic_funcs += ['CHECK_ALIGN_2', 'CHECK_ALIGN_4', 'CHECK_ALIGN_8']
     if settings['ASSERTIONS']:
       basic_funcs += ['nullFunc']
@@ -1083,6 +1084,7 @@ def emscript_fast(infile, settings, outfile, libraries=[], compiler_engine=None,
 
     basic_funcs = ['abort', 'assert'] + [m.replace('.', '_') for m in math_envs]
     if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_FT_MASK']
+    if settings['SAFE_POINTER_MASKING']: basic_funcs += ['SAFE_MASK_REPORT']
     if settings['CHECK_HEAP_ALIGN']: basic_funcs += ['CHECK_ALIGN_2', 'CHECK_ALIGN_4', 'CHECK_ALIGN_8']
     if settings['ASSERTIONS']:
       if settings['ASSERTIONS'] >= 2: import difflib
@@ -1353,7 +1355,15 @@ function _emscripten_replace_memory(newBuffer) {
 function _declare_heap_length() {
   return HEAP8[%s] | 0;
 }
-  ''' % (settings['TOTAL_MEMORY'] + settings['POINTER_MASKING_OVERFLOW'] - 1)] + ['''
+  ''' % (settings['TOTAL_MEMORY'] + settings['POINTER_MASKING_OVERFLOW'] - 1)] + \
+  ['' if not settings['SAFE_POINTER_MASKING'] else '''
+function _safe_mask_check(value, mask) {
+  value = value | 0;
+  mask = mask | 0;
+  if (((value & mask) | 0) != (value | 0)) SAFE_MASK_REPORT(value | 0, mask | 0);
+  return value | 0;
+}
+  '''] + ['''
 // EMSCRIPTEN_START_FUNCS
 function stackAlloc(size) {
   size = size|0;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -25,6 +25,21 @@ Module.realPrint = Module.print;
 Module.print = Module.printErr = function(){};
 #endif
 
+
+#if POINTER_MASKING
+#if SAFE_POINTER_MASKING
+function SAFE_MASK_REPORT(value, mask) {
+  value = value | 0;
+  mask = mask | 0;
+  if ((value & mask) != value) {
+    console.log("Heap access mask error: pointer is " + value + " which is masked by " + mask + ", add the function to the POINTER_MASKING_BLACKLIST." + stackTrace());
+  }
+  return value | 0;
+}
+#endif
+#endif
+
+
 #if SAFE_HEAP
 #if ASM_JS == 0
 //========================================

--- a/src/settings.js
+++ b/src/settings.js
@@ -202,6 +202,15 @@ var POINTER_MASKING_DYNAMIC = 0; // When disabled, the masking is baked into the
 var POINTER_MASKING_DEFAULT_ENABLED = 1; // When POINTER_MASKING_DYNAMIC is enabled this
 					 // sets the default for POINTER_MASKING_ENABLED,
 					 // enabling or disabling pointer masking.
+var SAFE_POINTER_MASKING = 0; // When enabled the masking checks that it does not alter
+                              // the index which it should not do if used only as an
+                              // optimization.
+var POINTER_MASKING_BLACKLIST = []; // List of functions to blacklist from the pointer
+				    // masking offset dehoisting optimization. For these
+				    // functions the masking will be emitted as a[(i+c)&m]
+				    // rather than a[(i&m)+c] which may lead to less
+				    // optimized code generation but is necessary when 'i'
+				    // can be negative.
 
 // Generated code debugging options
 var SAFE_HEAP = 0; // Check each write to the heap, for example, this will give a clear

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -6082,61 +6082,77 @@ function optimizeFrounds(ast) {
 // Optimize heap expressions into HEAP32[(x&m)+c>>2] where c is an aligned
 // constant, and m guarantees the pointer is within bounds and aligned.
 function pointerMasking(ast) {
+  var BLACKLIST = extraInfo ? set(extraInfo.pointerMaskingBlacklist) : [];
   var parseHeapTemp = makeTempParseHeap();
 
-  traverse(ast, function(node, type) {
-    if (type === 'sub' && node[1][0] === 'name' && node[1][1][0] === 'H' && node[2][0] === 'binary' && node[2][1] === '>>' && node[2][3][0] === 'num') {
-      var shifts = node[2][3][1];
-      var addee = node[2][2];
+  printErr('pointerMasking blacklist: ' + BLACKLIST);
 
-      if (!parseHeap(node[1][1], parseHeapTemp)) return;
-      if (parseHeapTemp.bits !== 8 * Math.pow(2, shifts)) return;
+  traverseGeneratedFunctions(ast, function(func) {
+    var blacklisted = func[1] in BLACKLIST;
+    printErr(' pointerMasking traverse func:' + func[1] + ', blacklisted ' + blacklisted);
 
-      // Don't mask a shifted constant index. It will be folded later,
-      // and it is assumed that they are within bounds.
-      if (addee[0] === 'num') return;
+    traverse(func, function(node, type) {
+      if (type === 'sub' && node[1][0] === 'name' && node[1][1][0] === 'H' && node[2][0] === 'binary' && node[2][1] === '>>' && node[2][3][0] === 'num') {
+        var shifts = node[2][3][1];
+        var addee = node[2][2];
 
-      if (!(addee[0] === 'binary' && addee[1] === '+')) {
-        node[2][2] = ['binary', '&', addee, ['name', 'MASK' + shifts]];
-        return;
-      }
+        if (!parseHeap(node[1][1], parseHeapTemp)) return;
+        if (parseHeapTemp.bits !== 8 * Math.pow(2, shifts)) return;
 
-      // This is a HEAP[U]N[x + y >> n] expression. Gather up all the top-level
-      // added items, summing constants amongst them.
-      var addedConstants = 0;
-      var addedElements = [];
-      function addElements(node) {
-        if (node[0] === 'binary' && node[1] === '+') {
-          addElements(node[2]);
-          addElements(node[3]);
-        } else if (node[0] === 'num') {
-          var c = node[1];
-          // Check that it is aligned.
-          if (((c >> shifts) << shifts) === c) {
-            addedConstants += c;
+        // Don't mask a shifted constant index. It will be folded later,
+        // and it is assumed that they are within bounds.
+        if (addee[0] === 'num') return;
+
+        if (blacklisted || !(addee[0] === 'binary' && addee[1] === '+')) {
+          if (safeMask) {
+            node[2][2] = ['binary', '|', ['call', ['name', '_safe_mask_check'], [['binary', '|', addee, ['num', 0]], ['name', 'MASK' + shifts]]], ['num', 0]];
+          } else {
+            node[2][2] = ['binary', '&', addee, ['name', 'MASK' + shifts]];
+          }
+          return;
+        }
+
+        // This is a HEAP[U]N[x + y >> n] expression. Gather up all the top-level
+        // added items, summing constants amongst them.
+        var addedConstants = 0;
+        var addedElements = [];
+        function addElements(node) {
+          if (node[0] === 'binary' && node[1] === '+') {
+            addElements(node[2]);
+            addElements(node[3]);
+          } else if (node[0] === 'num') {
+            var c = node[1];
+            // Check that it is aligned.
+            if (((c >> shifts) << shifts) === c) {
+              addedConstants += c;
+            } else {
+              addedElements.push(node);
+            }
           } else {
             addedElements.push(node);
           }
-        } else {
-          addedElements.push(node);
         }
-      }
-      addElements(addee);
-      if (addedElements.length > 0) {
-        var others = addedElements[0];
-        for (var j = 1; j < addedElements.length; j++) {
-          others = ['binary', '+', others, addedElements[j]];
+        addElements(addee);
+        if (addedElements.length > 0) {
+          var others = addedElements[0];
+          for (var j = 1; j < addedElements.length; j++) {
+            others = ['binary', '+', others, addedElements[j]];
+          }
+          if (safeMask) {
+            others = ['binary', '|', ['call', ['name', '_safe_mask_check'], [['binary', '|', others, ['num', 0]], ['name', 'MASK' + shifts]]], ['num', 0]];
+          } else {
+            others = ['binary', '&', others, ['name', 'MASK' + shifts]];
+          }
+          if (addedConstants != 0) {
+            others = ['binary', '+', others, ['num' , addedConstants]];
+          }
+          node[2][2] = others;
+          return;
         }
-        others = ['binary', '&', others, ['name', 'MASK' + shifts]];
-        if (addedConstants != 0) {
-          others = ['binary', '+', others, ['num' , addedConstants]];
-        }
-        node[2][2] = others;
-        return;
-      }
 
-      node[2][2] = ['num' , addedConstants];
-    }
+        node[2][2] = ['num' , addedConstants];
+      }
+    });
   });
 }
 
@@ -7935,7 +7951,7 @@ function eliminateDeadFuncs(ast) {
 
 // Passes table
 
-var minifyWhitespace = false, printMetadata = true, asm = false, asmPreciseF32 = false, emitJSON = false, last = false;
+var minifyWhitespace = false, printMetadata = true, asm = false, asmPreciseF32 = false, emitJSON = false, last = false, safeMask = false;
 
 var passes = {
   // passes
@@ -7979,6 +7995,7 @@ var passes = {
   emitJSON: function() { emitJSON = true },
   receiveJSON: function() { }, // handled in a special way, before passes are run
   last: function() { last = true },
+  safeMask: function() { safeMask = true },
 };
 
 // Main

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -6085,11 +6085,8 @@ function pointerMasking(ast) {
   var BLACKLIST = extraInfo ? set(extraInfo.pointerMaskingBlacklist) : [];
   var parseHeapTemp = makeTempParseHeap();
 
-  printErr('pointerMasking blacklist: ' + BLACKLIST);
-
   traverseGeneratedFunctions(ast, function(func) {
     var blacklisted = func[1] in BLACKLIST;
-    printErr(' pointerMasking traverse func:' + func[1] + ', blacklisted ' + blacklisted);
 
     traverse(func, function(node, type) {
       if (type === 'sub' && node[1][0] === 'name' && node[1][1][0] === 'H' && node[2][0] === 'binary' && node[2][1] === '>>' && node[2][3][0] === 'num') {


### PR DESCRIPTION
These replace the bitand operation with a call to a function that checks that the result of masking the index equals the argument, in other words that the bitand operation is a nop.

Some cases have been found in which replacing a[(i+c)&m] with a[(i&m)+c] can give invalid results, in particular when 'i' is negative, and this runtime test will detect this.

While runtime checks are not a good long term solution, they help validate benchmarks used to test JS implementation performance and this avoids blocking JS implementation development.

This patch also adds support for blacklisting some functions from using the above transform, and for these functions all accesses are emitted as a[(i+c)&m].