### PR TITLE
Parallel test core exitcode

### DIFF
--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -29,10 +29,10 @@ def run_mode(args):
   mode = args[0]
   if len(args) > 1:
     # If args has multiple elements, then only the selected tests from that suite are run e.g. args=['asm1', 'test_hello_world', 'test_i64'] runs only tests asm1.test_hello_world and asm1.test_i64.
-    for i in range(1, len(args)):
+    args = args[1:]
+    for i in range(len(args)):
       if args[i].startswith('test_'):
         args[i] = mode + '.' + args[i]
-    args = args[1:]
     print '<< running %s >>' % str(args)
   else:
     # If args has only one argument, e.g. args=['default'] or args=['asm1'], all tests are run in one suite.
@@ -40,7 +40,8 @@ def run_mode(args):
 
   proc = subprocess.Popen([PYTHON, path_from_root('tests', 'runner.py')] + args, stdout=open(mode + '.out', 'w'), stderr=open(mode + '.err', 'w'))
   proc.communicate()
-  print '<< %s finished >>' % mode
+  print '<< %s finished with exit code %d >>' % (mode, proc.returncode)
+  return proc.returncode
 
 def main():
   # clean up previous output
@@ -55,7 +56,7 @@ def main():
   cores = int(os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
   pool = multiprocessing.Pool(processes=cores)
   args = [[x] + sys.argv[1:] for x in optimal_order]
-  filenames = pool.map(run_mode, args, chunksize=1)
+  num_failures = pool.map(run_mode, args, chunksize=1)
 
   # quit watcher
   Watcher.stop = True
@@ -66,6 +67,7 @@ def main():
     if os.path.exists(mode + '.err'):
       print >> sys.stderr, open(mode + '.err').read()
     print >> sys.stderr
+  return sum(num_failures)
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -27,7 +27,17 @@ class Watcher(threading.Thread):
 # run tests for one mode
 def run_mode(args):
   mode = args[0]
-  print '<< running %s >>' % mode
+  if len(args) > 1:
+    # If args has multiple elements, then only the selected tests from that suite are run e.g. args=['asm1', 'test_hello_world', 'test_i64'] runs only tests asm1.test_hello_world and asm1.test_i64.
+    for i in range(1, len(args)):
+      if args[i].startswith('test_'):
+        args[i] = mode + '.' + args[i]
+    args = args[1:]
+    print '<< running %s >>' % str(args)
+  else:
+    # If args has only one argument, e.g. args=['default'] or args=['asm1'], all tests are run in one suite.
+    print '<< running %s >>' % mode
+
   proc = subprocess.Popen([PYTHON, path_from_root('tests', 'runner.py')] + args, stdout=open(mode + '.out', 'w'), stderr=open(mode + '.err', 'w'))
   proc.communicate()
   print '<< %s finished >>' % mode


### PR DESCRIPTION
Enables running `python tests\parallel_test_core.py test_a test_b test_c` to run only the given specified tests in all suites.

tests\runner.py returns the number of failed tests as exit code. Sum up the exit codes in tests\parallel_test_core.py and return the accumulated number of failed tests as exit code of tests\parallel_test_core.py so that buildbot knows how many tests failed.