### PR TITLE
Remove prefixed GL extensions.

### DIFF
--- a/src/headlessCanvas.js
+++ b/src/headlessCanvas.js
@@ -451,7 +451,7 @@ function headlessCanvas() {
               }
             },
             getSupportedExtensions: function() {
-              return ["OES_texture_float", "OES_standard_derivatives", "EXT_texture_filter_anisotropic", "MOZ_EXT_texture_filter_anisotropic", "MOZ_WEBGL_lose_context", "MOZ_WEBGL_compressed_texture_s3tc", "MOZ_WEBGL_depth_texture"];
+              return ["OES_texture_float", "OES_standard_derivatives", "EXT_texture_filter_anisotropic"];
             },
             createShader: function(type) {
               var id = this.id++;

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -809,14 +809,8 @@ var LibraryGL = {
 #endif
 
       // Detect the presence of a few extensions manually, this GL interop layer itself will need to know if they exist. 
-      context.compressionExt = GLctx.getExtension('WEBGL_compressed_texture_s3tc') ||
-                          GLctx.getExtension('MOZ_WEBGL_compressed_texture_s3tc') ||
-                          GLctx.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc');
-
-      context.anisotropicExt = GLctx.getExtension('EXT_texture_filter_anisotropic') ||
-                          GLctx.getExtension('MOZ_EXT_texture_filter_anisotropic') ||
-                          GLctx.getExtension('WEBKIT_EXT_texture_filter_anisotropic');
-
+      context.compressionExt = GLctx.getExtension('WEBGL_compressed_texture_s3tc');
+      context.anisotropicExt = GLctx.getExtension('EXT_texture_filter_anisotropic');
       context.floatExt = GLctx.getExtension('OES_texture_float');
 
       // Extension available from Firefox 26 and Google Chrome 30
@@ -865,7 +859,6 @@ var LibraryGL = {
       var exts = GLctx.getSupportedExtensions();
       if (exts && exts.length > 0) {
         GLctx.getSupportedExtensions().forEach(function(ext) {
-          ext = ext.replace('MOZ_', '').replace('WEBKIT_', '');
           if (automaticallyEnabledExtensions.indexOf(ext) != -1) {
             GLctx.getExtension(ext); // Calling .getExtension enables that extension permanently, no need to store the return value to be enabled.
           }

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -312,7 +312,7 @@ WebGLClient.prefetch = function() {
   });
   // Try to enable some extensions, so we can access their parameters
   [{ extName: 'EXT_texture_filter_anisotropic', paramName: 'MAX_TEXTURE_MAX_ANISOTROPY_EXT' }].forEach(function(pair) {
-    var ext = ctx.getExtension(pair.extName) || ctx.getExtension('MOZ_' + pair.extName) || 'WEBKIT_' + ctx.getExtension(pair.extName);
+    var ext = ctx.getExtension(pair.extName);
     if (ext) {
       var id = ext[pair.paramName];
       parameters[id] = ctx.getParameter(id);

--- a/src/webGLWorker.js
+++ b/src/webGLWorker.js
@@ -523,17 +523,13 @@ function WebGLWorker() {
     if (i < 0) return null;
     commandBuffer.push(1, name);
     switch (name) {
-      case 'EXT_texture_filter_anisotropic':
-      case 'MOZ_EXT_texture_filter_anisotropic':
-      case 'WEBKIT_EXT_texture_filter_anisotropic': {
+      case 'EXT_texture_filter_anisotropic': {
         return {
           TEXTURE_MAX_ANISOTROPY_EXT:     0x84FE,
           MAX_TEXTURE_MAX_ANISOTROPY_EXT: 0x84FF
         };
       }
-      case 'OES_standard_derivatives':
-      case 'MOZ_OES_standard_derivatives':
-      case 'WEBKIT_OES_standard_derivatives': {
+      case 'OES_standard_derivatives': {
         return { FRAGMENT_SHADER_DERIVATIVE_HINT_OES: 0x8B8B };
       }
     };

--- a/tests/glfw.c
+++ b/tests/glfw.c
@@ -385,7 +385,7 @@ void PullInfo(){
   for(i = 0; i<nb_params; i++)
     printf(" - %-27s : %i\n", GetParamName(params[i]), glfwGetWindowParam(params[i]));
   
-  const char* extension = "MOZ_WEBGL_compressed_texture_s3tc";
+  const char* extension = "WEBGL_compressed_texture_s3tc";
   printf("'%s' extension is %s.\n", extension, glfwExtensionSupported(extension) ? "supported" : "not supported");  
   
   extension = "GL_EXT_framebuffer_object";


### PR DESCRIPTION
Remove references to MOZ_ and WEBKIT_ prefixed extensions, since prefix mechanism is reserved for in-development drafts only and not used for features that are shipping in stable browsers. Closes #3324.

See also
https://developer.mozilla.org/en-US/docs/Web/WebGL/Using_Extensions
https://bugzilla.mozilla.org/show_bug.cgi?id=924176
https://www.khronos.org/webgl/public-mailing-list/archives/1207/msg00168.html
https://www.khronos.org/registry/webgl/extensions/

If someone wants to use a draft extension, he is better of calling `emscripten_webgl_enable_extension` manually to enable it, since browsers are noisy to complain when those are used. The prefixed GL extensions that Emscripten did refer to are now all ratified, and implementation should no longer refer to them in prefixed form.