### PR TITLE
Wrong parameter name on document

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -183,3 +183,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jan Jongboom <janjongboom@gmail.com> (copyright owned by Telenor Digital AS)
 * Tiago Quelhas <tiagoq@gmail.com>
 * Reinier de Blois <rddeblois@gmail.com>
+* Yuichi Nishiwaki <yuichi.nishiwaki@gmail.com>

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -427,7 +427,7 @@ Options that are modified or new in *emcc* are listed below:
 		emcc -c a.c -o dir/
  
        
-``--valid_abspath path``
+``--valid-abspath path``
 	Whitelist an absolute path to prevent warnings about absolute include paths.
 	 
 .. _emcc-o-target:


### PR DESCRIPTION
'--valid_abspath' -> '--valid-abspath'