### PR TITLE
Remove the pointer masking feature.

### DIFF
--- a/emcc
+++ b/emcc
@@ -969,27 +969,6 @@ try:
       logging.warning('not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
       shared.Settings.ASM_JS = 2
 
-  if shared.Settings.POINTER_MASKING:
-    if shared.Settings.ALLOW_MEMORY_GROWTH:
-      raise Exception('With POINTER_MASKING the ALLOW_MEMORY_GROWTH feature is not supported')
-    if not shared.Settings.POINTER_MASKING_DYNAMIC:
-      shared.Settings.POINTER_MASKING_DEFAULT_ENABLED = 1;
-      size = shared.Settings.TOTAL_MEMORY
-      if size & (size - 1) != 0:
-        raise Exception('With POINTER_MASKING the TOTAL_MEMORY must be a power of 2')
-      if shared.Settings.ASM_JS:
-        # Silently keep the total length a valid asm.js heap buffer length.
-        overflow = shared.Settings.POINTER_MASKING_OVERFLOW;
-        if overflow > 0:
-          if size <= 0x01000000:
-            shared.Settings.POINTER_MASKING_OVERFLOW = size;
-          else:
-            shared.Settings.POINTER_MASKING_OVERFLOW = (overflow + 0x00ffffff) & 0xff000000;
-  elif shared.Settings.POINTER_MASKING_DYNAMIC:
-    raise Exception('POINTER_MASKING_DYNAMIC requires POINTER_MASKING')
-  else:
-    shared.Settings.POINTER_MASKING_DEFAULT_ENABLED = 0
-
   shared.Settings.TARGET_ASMJS_UNKNOWN_EMSCRIPTEN = 1
 
   if shared.Settings.MAIN_MODULE:
@@ -1553,9 +1532,6 @@ try:
         js_optimizer_queue += ['registerizeHarder']
       else:
         js_optimizer_queue += ['registerize']
-
-    if shared.Settings.POINTER_MASKING:
-      js_optimizer_queue += ['pointerMasking']
 
     if not shared.Settings.EMTERPRETIFY:
       do_minify()

--- a/emscripten.py
+++ b/emscripten.py
@@ -1243,14 +1243,6 @@ function jsCall_%s_%s(%s) {
           if settings.get('SIDE_MODULE'): init = '(H_BASE+' + str(init) + ')|0'
           asm_global_vars += '  var %s=%s;\n' % (key, str(init))
 
-    if settings['POINTER_MASKING']:
-      for i in [0, 1, 2, 3]:
-        if settings['POINTER_MASKING_DYNAMIC']:
-          asm_global_vars += '  const MASK%d=env' % i + access_quote('MASK%d' % i) + '|0;\n';
-          basic_vars += ['MASK%d' %i]
-        else:
-          asm_global_vars += '  const MASK%d=%d;\n' % (i, (settings['TOTAL_MEMORY']-1) & (~((2**i)-1)));
-
     # sent data
     the_global = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in fundamentals]) + ' }'
     sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in basic_funcs + global_funcs + basic_vars + basic_float_vars + global_vars]) + ' }'
@@ -1360,12 +1352,7 @@ function _emscripten_replace_memory(newBuffer) {
   buffer = newBuffer;
   return true;
 }
-'''] + \
-  ['' if not settings['POINTER_MASKING'] or settings['POINTER_MASKING_DYNAMIC'] else '''
-function _declare_heap_length() {
-  return HEAP8[%s] | 0;
-}
-  ''' % (settings['TOTAL_MEMORY'] + settings['POINTER_MASKING_OVERFLOW'] - 1)] + ['''
+'''] + ['''
 // EMSCRIPTEN_START_FUNCS
 function stackAlloc(size) {
   size = size|0;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1273,48 +1273,6 @@ try {
 var TOTAL_STACK = Module['TOTAL_STACK'] || {{{ TOTAL_STACK }}};
 var TOTAL_MEMORY = Module['TOTAL_MEMORY'] || {{{ TOTAL_MEMORY }}};
 
-#if POINTER_MASKING
-
-#if POINTER_MASKING_DYNAMIC
-var POINTER_MASKING_ENABLED = Module['POINTER_MASKING_DEFAULT_ENABLED'] || {{{ POINTER_MASKING_DEFAULT_ENABLED }}};
-var POINTER_MASKING_OVERFLOW = Module['POINTER_MASKING_OVERFLOW'] || {{{ POINTER_MASKING_OVERFLOW }}}
-var MASK0 = -1, MASK1 = -1, MASK2 = -1, MASK3 = -1;
-function initPointerMasking() {
-  var totalMemory = 64*1024;
-  while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
-    if (POINTER_MASKING_ENABLED || totalMemory < 16*1024*1024) {
-      totalMemory *= 2;
-    } else {
-      totalMemory += 16*1024*1024
-    }
-  }
-  if (totalMemory !== TOTAL_MEMORY) {
-    Module.printErr('increasing TOTAL_MEMORY to ' + totalMemory + ' to be compliant with the asm.js spec (and given that TOTAL_STACK=' + TOTAL_STACK + ')');
-    TOTAL_MEMORY = totalMemory;
-  }
-  // Silently keep the total length a valid asm.js heap buffer length.
-  if (POINTER_MASKING_OVERFLOW > 0) {
-    if (TOTAL_MEMORY <= 0x01000000) {
-      POINTER_MASKING_OVERFLOW = TOTAL_MEMORY;
-    } else {
-      POINTER_MASKING_OVERFLOW = (POINTER_MASKING_OVERFLOW + 0x00ffffff) & 0xff000000;
-    }
-  }
-  MASK0 = POINTER_MASKING_ENABLED ? TOTAL_MEMORY - 1 : -1;
-  MASK1 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~1 : -1;
-  MASK2 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~3 : -1;
-  MASK3 = POINTER_MASKING_ENABLED ? (TOTAL_MEMORY - 1) & ~7 : -1;
-}
-initPointerMasking();
-#else // POINTER_MASKING_DYNAMIC
-var totalMemory = 64*1024;
-while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
-  totalMemory *= 2;
-}
-#endif // POINTER_MASKING_DYNAMIC
-
-#else // POINTER_MASKING
-
 var totalMemory = 64*1024;
 while (totalMemory < TOTAL_MEMORY || totalMemory < 2*TOTAL_STACK) {
   if (totalMemory < 16*1024*1024) {
@@ -1331,23 +1289,12 @@ if (totalMemory !== TOTAL_MEMORY) {
   TOTAL_MEMORY = totalMemory;
 }
 
-#endif // POINTER_MASKING
-
-
 // Initialize the runtime's memory
 // check for full engine support (use string 'subarray' to avoid closure compiler confusion)
 assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' && !!(new Int32Array(1)['subarray']) && !!(new Int32Array(1)['set']),
        'JS engine does not provide full typed array support');
 
-#if POINTER_MASKING
-#if POINTER_MASKING_DYNAMIC
-var buffer = new ArrayBuffer(TOTAL_MEMORY + (POINTER_MASKING_ENABLED ? POINTER_MASKING_OVERFLOW : 0));
-#else
-var buffer = new ArrayBuffer(TOTAL_MEMORY + {{{ POINTER_MASKING_OVERFLOW }}});
-#endif
-#else
 var buffer = new ArrayBuffer(TOTAL_MEMORY);
-#endif // POINTER_MASKING
 
 HEAP8 = new Int8Array(buffer);
 HEAP16 = new Int16Array(buffer);

--- a/src/settings.js
+++ b/src/settings.js
@@ -177,26 +177,6 @@ var OUTLINING_LIMIT = 0; // A function size above which we try to automatically 
 var AGGRESSIVE_VARIABLE_ELIMINATION = 0; // Run aggressiveVariableElimination in js-optimizer.js
 var SIMPLIFY_IFS = 1; // Whether to simplify ifs in js-optimizer.js
 
-var POINTER_MASKING = 0; // Whether pointers can be masked to a power-of-two heap
-                         // length. An experimental optimization trying to reduce VM
-                         // bounds checks.
-var POINTER_MASKING_OVERFLOW = 64 * 1024; // The length added to the heap length to allow
-                                          // the compiler to derive that accesses are
-                                          // within bounds even when adding small constant
-                                          // offsets. This defaults to 64K, but in asm.js
-                                          // mode it is silently adjusted to keep the
-                                          // total buffer length a valid asm.js heap
-                                          // buffer length.
-var POINTER_MASKING_DYNAMIC = 0; // When disabled, the masking is baked into the code with
-				 // static masks and a static heap buffer length and the
-				 // TOTAL_MEMORY must be a power of 2. When enabled, the
-				 // masks are defined at runtime rather than compling them
-				 // into the asm.js module as literal constants and the
-				 // TOTAL_MEMORY can be defined at run time.
-var POINTER_MASKING_DEFAULT_ENABLED = 1; // When POINTER_MASKING_DYNAMIC is enabled this
-					 // sets the default for POINTER_MASKING_ENABLED,
-					 // enabling or disabling pointer masking.
-
 // Generated code debugging options
 var SAFE_HEAP = 0; // Check each write to the heap, for example, this will give a clear
                    // error on what would be segfaults in a native build (like deferencing
@@ -655,3 +635,5 @@ var SAFE_HEAP_LINES = [];
 // That file is automatically parsed by tools/gen_struct_info.py.
 // If you modify the headers, just clear your cache and emscripten libc should see
 // the new values.
+
+// Reserved: variables containing POINTER_MASKING.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5182,22 +5182,15 @@ return malloc(size);
       Settings.PRECISE_F32 = 1
 
     for aggro in ([0, 1] if Settings.ASM_JS and '-O2' in self.emcc_args else [0]):
-      for masking in ([0, 1] if Settings.ASM_JS and '-O2' in self.emcc_args else [0]):
-        Settings.AGGRESSIVE_VARIABLE_ELIMINATION = aggro
-        Settings.POINTER_MASKING = masking
-        Settings.TOTAL_MEMORY = total_memory
-        if masking:
-          total = 2
-          while 2*total <= total_memory:
-            total *= 2
-          Settings.TOTAL_MEMORY = total
-        print aggro, masking
-        self.do_run('',
-                    'hello lua world!\n17\n1\n2\n3\n4\n7',
-                    args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
-                    libraries=self.get_library('lua', [os.path.join('src', 'lua'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None),
-                    includes=[path_from_root('tests', 'lua')],
-                    output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
+      Settings.AGGRESSIVE_VARIABLE_ELIMINATION = aggro
+      Settings.TOTAL_MEMORY = total_memory
+      print aggro
+      self.do_run('',
+                  'hello lua world!\n17\n1\n2\n3\n4\n7',
+                  args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
+                  libraries=self.get_library('lua', [os.path.join('src', 'lua'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None),
+                  includes=[path_from_root('tests', 'lua')],
+                  output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
 
   def get_freetype(self):
     Settings.DEAD_FUNCTIONS += ['_inflateEnd', '_inflate', '_inflateReset', '_inflateInit2_']


### PR DESCRIPTION
Could the unmaintained pointer masking feature be removed from the main source repo? It will be confusing for developers to see benchmarks and discussion of the pointer-masking feature and to find an unrepresentative and unmaintained version in the main source repo.