### PR TITLE
Speed up registerizeHarder optimizer for huge functions

### DIFF
--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3236,60 +3236,49 @@ void registerizeHarder(Ref ast) {
       block->lastKillLoc = lastKillLoc;
     };
 
-    std::unordered_set<int> jWorklistMap;
-    jWorklistMap.insert(EXIT_JUNCTION);
-    std::vector<int> jWorklist;
-    jWorklist.push_back(EXIT_JUNCTION);
-    std::unordered_set<int> bWorklistMap;
-    std::vector<int> bWorklist;
+    // Ordered map to work in reverse order
+    std::set<int> jWorkSet;
+    jWorkSet.insert(EXIT_JUNCTION);
+    std::set<int> bWorkSet;
 
     // Be sure to visit every junction at least once.
     // This avoids missing some vars because we disconnected them
     // when processing the labelled jumps.
     for (int i = junctions.size() - 1; i >= EXIT_JUNCTION; i--) {
-      jWorklistMap.insert(i);
-      jWorklist.push_back(i);
+      jWorkSet.insert(i);
     }
 
-    while (jWorklist.size() > 0) {
+    while (jWorkSet.size() > 0) {
       // Iterate on just the junctions until we get stable live sets.
       // The first run of this loop will grow the live sets to their maximal size.
       // Subsequent runs will shrink them based on eliminated in-block uses.
-      while (jWorklist.size() > 0) {
-        Junction& junc = junctions[jWorklist.back()];
-        jWorklist.pop_back();
-        jWorklistMap.erase(junc.id);
+      while (jWorkSet.size() > 0) {
+        auto last = jWorkSet.end();
+        --last;
+        Junction& junc = junctions[*last];
+        jWorkSet.erase(last);
         StringSet oldLive = junc.live; // copy it here, to check for changes later
         bool oldChecked = junc.checkedLive;
         analyzeJunction(junc);
         if (oldChecked != junc.checkedLive || oldLive != junc.live) {
           // Live set changed, updated predecessor blocks and junctions.
           for (auto b : junc.inblocks) {
-            if (bWorklistMap.count(b) == 0) {
-              bWorklistMap.insert(b);
-              bWorklist.push_back(b);
-            }
-            int jPred = blocks[b]->entry;
-            if (jWorklistMap.count(jPred) == 0) {
-              jWorklistMap.insert(jPred);
-              jWorklist.push_back(jPred);
-            }
+            bWorkSet.insert(b);
+            jWorkSet.insert(blocks[b]->entry);
           }
         }
       }
       // Now update the blocks based on the calculated live sets.
-      while (bWorklist.size() > 0) {
-        Block* block = blocks[bWorklist.back()];
-        bWorklist.pop_back();
-        bWorklistMap.erase(block->id);
+      while (bWorkSet.size() > 0) {
+        auto last = bWorkSet.end();
+        --last;
+        Block* block = blocks[*last];
+        bWorkSet.erase(last);
         auto oldUse = block->use;
         analyzeBlock(block);
         if (oldUse != block->use) {
           // The use set changed, re-process the entry junction.
-          if (jWorklistMap.count(block->entry) == 0) {
-            jWorklistMap.insert(block->entry);
-            jWorklist.push_back(block->entry);
-          }
+          jWorkSet.insert(block->entry);
         }
       }
     }

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3130,7 +3130,6 @@ void registerizeHarder(Ref ast) {
         }
       }
       junc.live = live;
-      junc.checkedLive = true;
     };
 
     auto analyzeBlock = [&](Block* block) {
@@ -3258,9 +3257,9 @@ void registerizeHarder(Ref ast) {
         Junction& junc = junctions[*last];
         jWorkSet.erase(last);
         StringSet oldLive = junc.live; // copy it here, to check for changes later
-        bool oldChecked = junc.checkedLive;
         analyzeJunction(junc);
-        if (oldChecked != junc.checkedLive || oldLive != junc.live) {
+        if (!junc.checkedLive || oldLive != junc.live) {
+          junc.checkedLive = true;
           // Live set changed, updated predecessor blocks and junctions.
           for (auto b : junc.inblocks) {
             bWorkSet.insert(b);

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -11,6 +11,7 @@
 #include <iomanip>
 #include <functional>
 #include <algorithm>
+#include <set>
 #include <unordered_set>
 #include <unordered_map>
 


### PR DESCRIPTION
My benchmarking (with emtcl) indicates that this PR speeds up the js optimisation part of a -O3 build significantly for codebases with huge functions (and therefore especially with llvm-lto). As with my previous optimizer PR, 'caveat emptor' - I first used C++11 a couple of weeks ago. Please review carefully in case I've made a critical mistake which makes it all wrong (:cry:).

The first commit is the main one. My reading of the code is that (previously) a vector was used to attempt to keep track of the 'last' junction in order to try and go from back to front in one shot. Unfortunately using a vector as a stack isn't actually a reliable way to do this as we push junctions back onto the list in an arbitrary order (with `for (auto b : junc.inblocks)`).
Using an ordered set:
 - lets us reliably choose the 'last' junction, regardless of insertion order
 - allows elimination of a data structure
 - allows us to not worry about checking before inserting

The second commit is just a minor tweak, I don't know if it gives any speedup. It was just misleading to compare against a different variable when we're actually checking for `true`.

I've run the first 50 tests (alphabetically) from test_core and all of test_other. They all (bar four seemingly irrelevant other tests) pass.

Python is a good example to see the speedup as it has a huge function:
```
$ # before
$ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 9.12 seconds
# after
$ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 5.91 seconds
```