### PR TITLE
Speed up registerizeHarder for huge numbers of locals

### DIFF
--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3350,6 +3350,7 @@ void registerizeHarder(Ref ast) {
             if (block->lastKillLoc[otherName] < block->firstDeadLoc[name]) {
               jvar.conf.insert(otherName);
               getJunctionVariable(otherName).conf.insert(name);
+              break;
             }
           }
         }

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3335,9 +3335,10 @@ void registerizeHarder(Ref ast) {
 
       for (auto name : junc.live) {
         if (junctionVariables.count(name) == 0) initializeJunctionVariable(name);
+        JuncVar& jvar = junctionVariables[name];
         // It conflicts with all other names live at this junction.
-        junctionVariables[name].conf.insert(junc.live.begin(), junc.live.end()); // XXX this operation is very expensive
-        junctionVariables[name].conf.erase(name); // except for itself, of course
+        jvar.conf.insert(junc.live.begin(), junc.live.end()); // XXX this operation is very expensive
+        jvar.conf.erase(name); // except for itself, of course
 
         // It conflicts with any output vars of successor blocks,
         // if they're assigned before it goes dead in that block.
@@ -3346,7 +3347,7 @@ void registerizeHarder(Ref ast) {
           for (auto block : kv.second) {
             if (block->lastKillLoc[otherName] < block->firstDeadLoc[name]) {
               if (junctionVariables.count(otherName) == 0) initializeJunctionVariable(otherName);
-              junctionVariables[name].conf.insert(otherName);
+              jvar.conf.insert(otherName);
               junctionVariables[otherName].conf.insert(name);
             }
           }
@@ -3356,7 +3357,7 @@ void registerizeHarder(Ref ast) {
         for (auto block: possibleBlockLinks[name]) {
           IString linkName = block->link[name];
           if (junctionVariables.count(linkName) == 0) initializeJunctionVariable(linkName);
-          junctionVariables[name].link.insert(linkName);
+          jvar.link.insert(linkName);
           junctionVariables[linkName].link.insert(name);
         }
       }

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -62,7 +62,7 @@ void dump(const char *str, Ref node, bool pretty) {
 
 struct TraverseInfo {
   TraverseInfo() {}
-  TraverseInfo(Ref node, int index) : node(node), index(index) {}
+  TraverseInfo(Ref node) : node(node), index(0) {}
   Ref node;
   int index;
 };
@@ -123,7 +123,7 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
   if (!visitable(node)) return;
   visit(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node, 0));
+  stack.push_back(TraverseInfo(node));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.node->size()) {
@@ -131,7 +131,7 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
       top.index++;
       if (visitable(sub)) {
         visit(sub);
-        stack.push_back(TraverseInfo(sub, 0));
+        stack.push_back(TraverseInfo(sub));
       }
     } else {
       stack.pop_back();
@@ -144,7 +144,7 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
   if (!visitable(node)) return;
   visitPre(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node, 0));
+  stack.push_back(TraverseInfo(node));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.node->size()) {
@@ -152,7 +152,7 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
       top.index++;
       if (visitable(sub)) {
         visitPre(sub);
-        stack.push_back(TraverseInfo(sub, 0));
+        stack.push_back(TraverseInfo(sub));
       }
     } else {
       visitPost(top.node);
@@ -166,7 +166,7 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
   if (!visitable(node)) return;
   if (!visitPre(node)) return;
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node, 0));
+  stack.push_back(TraverseInfo(node));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.node->size()) {
@@ -174,7 +174,7 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
       top.index++;
       if (visitable(sub)) {
         if (visitPre(sub)) {
-          stack.push_back(TraverseInfo(sub, 0));
+          stack.push_back(TraverseInfo(sub));
         }
       }
     } else {


### PR DESCRIPTION
Stage 2 of being fed up with long compile times. There's some cleanup (as promised in #3364), but the important commit for performance is "Pre-compute possible links and conflicts when considering a junction". The motivation for changes around here was profiling and observing that the highlighted two lines
```
          Block* block = blocks[b];
          Junction& jSucc = junctions[block->exit];
          for (auto otherName : jSucc.live) {      <<<<<<<<<<<<
            if (junc.live.has(otherName)) continue;    <<<<<<<<<<<
            if (block->lastKillLoc[otherName] < block->firstDeadLoc[name]) {

```
were really hot.
By doing preprocessing we can do map+vector iteration rather than map+map iteration. Given that the inner loop is run O(n^2) times, I'm guessing making it a vec loop is a Good Idea.
The actual motivating idea for the rearrangement is that, when checking for conflicts, we actually want to check for each variable against other variables. Having to loop over blocks and follow pointers to actually find the variables is an implementation detail of how the data is structured.

Before:
```
tests $ python runner.py asm3.test_sqlite
[...]
Ran 1 test in 73.380s
[...]
tests $ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 6.09 seconds
```

After:
```
tests $ python runner.py asm3.test_sqlite
[...]
Ran 1 test in 60.924s
[...]
$ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 4.48 seconds
```