### PR TITLE
misc : broken link to contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -183,3 +183,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jan Jongboom <janjongboom@gmail.com> (copyright owned by Telenor Digital AS)
 * Tiago Quelhas <tiagoq@gmail.com>
 * Reinier de Blois <rddeblois@gmail.com>
+* Chanhwi Choi <ccwpc@hanmail.net>

--- a/site/source/_themes/emscripten_sphinx_rtd_theme/footer.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/footer.html
@@ -90,7 +90,7 @@
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %} 
       {%- else %}
         <!-- {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %} -->
-		&copy; Copyright {{ copyright }} <a href="{{ pathto("docs\contributing\AUTHORS") }}">Emscripten Contributors</a>.
+		&copy; Copyright {{ copyright }} <a href="{{ pathto("docs/contributing/AUTHORS") }}">Emscripten Contributors</a>.
 		<!-- update theme to remove the translation stuff here - it was breaking due to link to AUTHORS file. This is a cludge to allow specific link to my authors file -->
       {%- endif %}
     {%- endif %}


### PR DESCRIPTION
![](https://dl.dropboxusercontent.com/u/146680594/rm%20-rf%20.all/footer.png)

Because I found the link is broken, I just changed \\ of paths to /. I don't know about behind tools of static website generation, but I thought that can fix that.

![](https://dl.dropboxusercontent.com/u/146680594/rm%20-rf%20.all/404not.png)