### PR TITLE
Speed up registerizeHarder variable conflict checking

### DIFF
--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3305,18 +3305,23 @@ void registerizeHarder(Ref ast) {
       JuncVar() : reg(-1) {}
     };
     std::unordered_map<IString, JuncVar> junctionVariables;
+    std::unordered_map<IString, std::vector<Block*>> possibleBlockConflicts;
+    std::unordered_map<IString, std::vector<Block*>> possibleBlockLinks;
 
+    junctionVariables.reserve(asmData.locals.size());
     for (Junction& junc : junctions) {
       for (IString name : junc.live) {
         junctionVariables[name].conf.reserve(asmData.locals.size());
       }
     }
+    possibleBlockConflicts.reserve(asmData.locals.size());
+    possibleBlockLinks.reserve(asmData.locals.size());
 
     for (Junction& junc : junctions) {
       // Pre-compute the possible conflicts and links for each block rather
       // than checking potentially impossible options for each var
-      std::unordered_map<IString, std::vector<Block*>> possibleBlockConflicts;
-      std::unordered_map<IString, std::vector<Block*>> possibleBlockLinks;
+      possibleBlockConflicts.clear(); // will leave reserved space
+      possibleBlockLinks.clear();
       for (auto b : junc.outblocks) {
         Block* block = blocks[b];
         Junction& jSucc = junctions[block->exit];


### PR DESCRIPTION
Results in a 50% speedup in sqlite compilation!

This PR is based on the observation that vector access is much faster than set/map access. By mapping names to numbers and using a vector we can speed up all conflict setting (first 3 commits). I then mitigate the perf hit to iteration by filtering the vector outside of the loop which would iterate over it (final commit).

All asm3 tests pass, as does test_other. I should probably be noting that I don't have spidermonkey installed so some parts of tests (e.g. actual sqlite execution, though I did check that with nodejs) aren't being run. This obviously also affects the before/after for sqlite below.

Before (after #3368):
```
~/em/emsdk/emscripten/incoming/tests $ python runner.py asm3.test_sqlite 2>&1 | grep 'test in'
Ran 1 test in 61.199s
~/em/emsdk/emscripten/incoming/tests $ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 5.23 seconds
~/em/emsdk/emscripten/incoming/tests $ cd ~/em/BananaBread/cube2/src/web
~/em/BananaBread/cube2/src/web $ (make && time make client server) 2>&1 | grep real
real    0m28.940s
```

After this pr:
```
~/em/emsdk/emscripten/incoming/tests $ python runner.py asm3.test_sqlite 2>&1 | grep 'test in'
Ran 1 test in 29.944s
~/em/emsdk/emscripten/incoming/tests $ EMCC_DEBUG=1 emcc -O3 --llvm-lto 1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -o out.js python/python.bc 2>&1 | grep 'js opts'
DEBUG    root: emcc step "js opts" took 3.17 seconds
~/em/emsdk/emscripten/incoming/tests $ cd ~/em/BananaBread/cube2/src/web
~/em/BananaBread/cube2/src/web $ (make && time make client server) 2>&1 | grep real
real    0m18.117s
```