### PR TITLE
Fix WebIDL Binder raising NameError on wrong enum

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -499,7 +499,7 @@ for name, enum in enums.iteritems():
         # namespace is a namespace, so the enums get collapsed into the top level namespace.
         deferred_js += ["Module['%s'] = _emscripten_enum_%s();\n" % (identifier, function_id)]
     else:
-      throw ("Illegal enum value %s" % value)
+      raise Exception("Illegal enum value %s" % value)
 
 mid_c += ['\n}\n\n']
 mid_js += ['''


### PR DESCRIPTION
Instead of an Exception with a useful message a NameError was raised because the undefined function "throw" was called (instead of using the keyword "raise"). Without the brackets it would have been a SyntaxError.

Found by pylint.