### PR TITLE
Add crude profiling for the optimizer

### DIFF
--- a/tools/optimizer/CMakeLists.txt
+++ b/tools/optimizer/CMakeLists.txt
@@ -11,6 +11,10 @@ else()
 	set(IS_GCC_LIKE FALSE)
 endif()
 
+# -DPROFILING will print crude timing information to stderr for initial
+# identification of areas to profile in more depth with
+# CALLGRIND_{START,STOP}_INSTRUMENTATION or similar
+
 if (IS_GCC_LIKE)
 	set(cFlags "-std=c++11 -fno-exceptions -fno-rtti")
 endif()

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3991,6 +3991,10 @@ int main(int argc, char **argv) {
   // Run passes on the Document
   for (int i = 2; i < argc; i++) {
     std::string str(argv[i]);
+#ifdef PROFILING
+    clock_t start = clock();
+    errv("starting %s", str.c_str());
+#endif
     if (str == "asm") {} // the default for us
     else if (str == "asmPreciseF32") {}
     else if (str == "receiveJSON" || str == "emitJSON") {}
@@ -4011,6 +4015,9 @@ int main(int argc, char **argv) {
       fprintf(stderr, "unrecognized argument: %s\n", str.c_str());
       assert(0);
     }
+#ifdef PROFILING
+    errv("    %s took %lu microseconds", str.c_str(), clock() - start);
+#endif
   }
 
   // Emit


### PR DESCRIPTION
This is basically to allow you to identify areas to profile - using callgrind for the whole program takes forever to run and finishes by telling you lots of time is spent hashing things and comparing equality.

Not helpful.

No need to merge it if you don't like the ifdefs everywhere, I just found it extremely useful.