### PR TITLE
Add thorough type checking and fastpath modes for webidl_binder.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,4 +188,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jérôme Bernard <jerome.bernard@ercom.fr> (copyright owned by Ercom)
 * Chanhwi Choi <ccwpc@hanmail.net>
 * Fábio Santos <fabiosantosart@gmail.com>
-
+* Thibaut Despoulain <thibaut@artillery.com> (copyright owned by Artillery Games, Inc.)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6402,7 +6402,8 @@ def process(filename):
         src.write(open(path_from_root('tests', 'webidl', 'post.js')).read())
         src.write('\n\n')
         src.close()
-      self.do_run(src, open(path_from_root('tests', 'webidl', "output_%s.txt" % mode)).read(), post_build=(None, post))
+      self.do_run(src, open(path_from_root('tests', 'webidl', "output_%s.txt" % mode)).read(), post_build=(None, post),
+        output_nicerizer=(lambda out, err: out))
 
     do_test_in_mode('ALL')
     do_test_in_mode('FAST')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6377,28 +6377,36 @@ def process(filename):
   def test_webidl(self):
     if self.run_name == 'asm2': self.emcc_args += ['--closure', '1', '-g1'] # extra testing
 
-    output = Popen([PYTHON, path_from_root('tools', 'webidl_binder.py'),
-                            path_from_root('tests', 'webidl', 'test.idl'),
-                            'glue']).communicate()[0]
-    assert os.path.exists('glue.cpp')
-    assert os.path.exists('glue.js')
+    def do_test_in_mode(mode):
+      # Force IDL checks mode
+      os.environ['IDL_CHECKS'] = mode
 
-    # Export things on "TheModule". This matches the typical use pattern of the bound library
-    # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
-    open('export.js', 'w').write('''this['TheModule'] = Module;\n''')
-    self.emcc_args += ['--post-js', 'glue.js', '--post-js', 'export.js']
-    shutil.copyfile(path_from_root('tests', 'webidl', 'test.h'), self.in_dir('test.h'))
-    shutil.copyfile(path_from_root('tests', 'webidl', 'test.cpp'), self.in_dir('test.cpp'))
-    src = open('test.cpp').read()
-    def post(filename):
-      src = open(filename, 'a')
-      src.write('\n\n')
-      src.write('var TheModule = this.TheModule;\n')
-      src.write('\n\n')
-      src.write(open(path_from_root('tests', 'webidl', 'post.js')).read())
-      src.write('\n\n')
-      src.close()
-    self.do_run(src, open(path_from_root('tests', 'webidl', 'output.txt')).read(), post_build=(None, post))
+      output = Popen([PYTHON, path_from_root('tools', 'webidl_binder.py'),
+                              path_from_root('tests', 'webidl', 'test.idl'),
+                              'glue']).communicate()[0]
+      assert os.path.exists('glue.cpp')
+      assert os.path.exists('glue.js')
+
+      # Export things on "TheModule". This matches the typical use pattern of the bound library
+      # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
+      open('export.js', 'w').write('''this['TheModule'] = Module;\n''')
+      self.emcc_args += ['--post-js', 'glue.js', '--post-js', 'export.js']
+      shutil.copyfile(path_from_root('tests', 'webidl', 'test.h'), self.in_dir('test.h'))
+      shutil.copyfile(path_from_root('tests', 'webidl', 'test.cpp'), self.in_dir('test.cpp'))
+      src = open('test.cpp').read()
+      def post(filename):
+        src = open(filename, 'a')
+        src.write('\n\n')
+        src.write('var TheModule = this.TheModule;\n')
+        src.write('\n\n')
+        src.write(open(path_from_root('tests', 'webidl', 'post.js')).read())
+        src.write('\n\n')
+        src.close()
+      self.do_run(src, open(path_from_root('tests', 'webidl', "output_%s.txt" % mode)).read(), post_build=(None, post))
+
+    do_test_in_mode('ALL')
+    do_test_in_mode('FAST')
+    do_test_in_mode('DEFAULT')
 
   # TODO: test only worked in non-fastcomp
   def test_typeinfo(self):

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -98,6 +98,3 @@ Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <po
 Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>
 
 done.
-Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
-Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
-Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -92,5 +92,12 @@ struct_array[7].attr1 == 14
 struct_array[7].attr2 == 18
 struct_ptr_array[0]->attr1 == 100
 struct_ptr_array[0]->attr2 == 101
+Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
+Parent:42
+Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>
 
 done.
+Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
+Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>

--- a/tests/webidl/output_DEFAULT.txt
+++ b/tests/webidl/output_DEFAULT.txt
@@ -1,0 +1,99 @@
+Parent:42
+*
+84
+object
+object
+8
+c1
+Parent:7
+Child1:7
+7
+14
+196
+588
+14
+28
+Child1::parentFunc(90)
+c1 v2
+Parent:16
+Child1:15
+15
+30
+900
+2700
+c2
+Parent:9
+Child2:9
+9
+18
+5832
+0
+0
+1
+*static*
+*virtualf*
+*virtualf*
+*virtualf2*
+Parent:9
+Child2:9
+*js virtualf replacement*
+*js virtualf replacement*
+*js virtualf2 replacement*
+*js virtualf3 replacement 123*
+caught: a JSImplementation must implement all functions, you forgot Child2JS::virtualFunc4.
+*js virtualf3 replacement 43*
+*virtualf*
+*virtualf*
+*virtualf2*
+*ok*
+|hello|43|world|41|
+12.35
+a returned string
+C string addresses: "string A" ? "string A"  =>  0
+C string addresses: "string B" ? "string B"  =>  0
+C string addresses: "string A" ? "string B"  =>  -1
+C string addresses: "string B" ? "string A"  =>  1
+10
+object
+10
+11
+object
+10
+11
+21.12
+198
+0
+1
+34,34
+78
+return char 127
+char: 127
+char: -1
+return unsigned char -1
+unsigned char: 255
+return unsigned short -1
+unsigned short int: 65535
+return unsigned long -1
+unsigned long int: 4294967295
+void * 3
+int_array[0] == 0
+int_array[7] == 7
+int_array[0] == 42
+int_array[7] == 43
+idx -1: Array index -1 out of bounds: [0,8)
+idx 8: Array index 8 out of bounds: [0,8)
+struct_array[0].attr1 == 0
+struct_array[0].attr2 == 0
+struct_array[7].attr1 == 7
+struct_array[7].attr2 == -7
+struct_array[0].attr1 == 13
+struct_array[0].attr2 == 17
+struct_array[7].attr1 == 14
+struct_array[7].attr2 == 18
+struct_ptr_array[0]->attr1 == 100
+struct_ptr_array[0]->attr2 == 101
+Parent:0
+Parent:42
+|abc|1|(null)|123|
+
+done.

--- a/tests/webidl/output_FAST.txt
+++ b/tests/webidl/output_FAST.txt
@@ -1,0 +1,99 @@
+Parent:42
+*
+84
+object
+object
+8
+c1
+Parent:7
+Child1:7
+7
+14
+196
+588
+14
+28
+Child1::parentFunc(90)
+c1 v2
+Parent:16
+Child1:15
+15
+30
+900
+2700
+c2
+Parent:9
+Child2:9
+9
+18
+5832
+0
+0
+1
+*static*
+*virtualf*
+*virtualf*
+*virtualf2*
+Parent:9
+Child2:9
+*js virtualf replacement*
+*js virtualf replacement*
+*js virtualf2 replacement*
+*js virtualf3 replacement 123*
+caught: a JSImplementation must implement all functions, you forgot Child2JS::virtualFunc4.
+*js virtualf3 replacement 43*
+*virtualf*
+*virtualf*
+*virtualf2*
+*ok*
+|hello|43|world|41|
+12.35
+a returned string
+C string addresses: "string A" ? "string A"  =>  0
+C string addresses: "string B" ? "string B"  =>  0
+C string addresses: "string A" ? "string B"  =>  -1
+C string addresses: "string B" ? "string A"  =>  1
+10
+object
+10
+11
+object
+10
+11
+21.12
+198
+0
+1
+34,34
+78
+return char 127
+char: 127
+char: -1
+return unsigned char -1
+unsigned char: 255
+return unsigned short -1
+unsigned short int: 65535
+return unsigned long -1
+unsigned long int: 4294967295
+void * 3
+int_array[0] == 0
+int_array[7] == 7
+int_array[0] == 42
+int_array[7] == 43
+idx -1: Array index -1 out of bounds: [0,8)
+idx 8: Array index 8 out of bounds: [0,8)
+struct_array[0].attr1 == 0
+struct_array[0].attr2 == 0
+struct_array[7].attr1 == 7
+struct_array[7].attr2 == -7
+struct_array[0].attr1 == 13
+struct_array[0].attr2 == 17
+struct_array[7].attr1 == 14
+struct_array[7].attr2 == 18
+struct_ptr_array[0]->attr1 == 100
+struct_ptr_array[0]->attr2 == 101
+Parent:0
+Parent:42
+|abc|1|(null)|123|
+
+done.

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -207,6 +207,23 @@ arrayClass.set_struct_ptr_array(0, struct);
 TheModule.print('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
 TheModule.print('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
 
+
+// Test IDL_CHECKS=ALL
+
+try {
+  p = new TheModule.Parent(NaN); // Expects an integer
+} catch (e) {}
+
+try {
+  p = new TheModule.Parent(42);
+  p.voidStar(1234) // Expects a wrapped pointer
+} catch (e) {}
+
+try {
+  s = new TheModule.StringUser('abc', 1);
+  s.Print(123, null); // Expects a string or a wrapped pointer
+} catch (e) {}
+
 //
 
 TheModule.print('\ndone.')


### PR DESCRIPTION
__The goal of this PR is twofold: 1. Decrease the time spent in the wrapper to improve perf. 2. Give more thorough argument type errors in "debug" mode.___

- Setting `IDL_CHECKS=ALL` in your env will add thorough argument checking to the wrapper methods, catching NaNs, invalid pointers, invalid strings, etc. Note that we only special cased the most common argument types for simplicity; may extend later as needed.
- Setting `IDL_CHECKS=FAST` in your env will skip most type checking for performance (~3x faster than default on a vec3 setter).
- Setting `IDL_CHECKS` to anything else, or not setting it will behave as before, ensuring backward compatibility.
- Setting `IDL_VERBOSE=1` in your env will print debug info during render_function.
- Added inline type comments for readability: `argN <Type> [innerType]`.

`IDL_CHECKS=ALL`:
```js
// StringUser
function StringUser(arg0, arg1) {
  /* arg0 <String> [] */
  if(typeof arg0 !== 'undefined' && arg0 !== null) {
    assert(typeof arg0 === 'string' || (arg0 && typeof arg0 === 'object' && typeof arg0.ptr === 'number'), '[CHECK FAILED] StringUser::StringUser(arg0:str): Expecting <string>');
  }
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  /* arg1 <Long> [] */
  if(typeof arg1 !== 'undefined' && arg1 !== null) {
    assert(typeof arg1 === 'number' && !isNaN(arg1), '[CHECK FAILED] StringUser::StringUser(arg1:i): Expecting <integer>');
  }
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```

`IDL_CHECKS=FAST`:
```js
// StringUser
function StringUser(arg0, arg1) {
  /* arg0 <String> [] */
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  /* arg1 <Long> [] */
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```

legacy:
```js
// StringUser
function StringUser(arg0, arg1) {
  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
  else arg0 = ensureString(arg0);
  if (arg1 && typeof arg1 === 'object') arg1 = arg1.ptr;
  else arg1 = ensureString(arg1);
  if (arg0 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_0(); getCache(StringUser)[this.ptr] = this;return }
  if (arg1 === undefined) { this.ptr = _emscripten_bind_StringUser_StringUser_1(arg0); getCache(StringUser)[this.ptr] = this;return }
  this.ptr = _emscripten_bind_StringUser_StringUser_2(arg0, arg1);
  getCache(StringUser)[this.ptr] = this;
};
```