### PR TITLE
Call syncfs on the mount when fsync is called, powered by EMTERPRETIFY_ASYNC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,4 +188,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jérôme Bernard <jerome.bernard@ercom.fr> (copyright owned by Ercom)
 * Chanhwi Choi <ccwpc@hanmail.net>
 * Fábio Santos <fabiosantosart@gmail.com>
+* Tim Guan-tin Chien <timdream@gmail.com>
 

--- a/tests/fs/test_idbfs_fsync.c
+++ b/tests/fs/test_idbfs_fsync.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+
+int result = 1;
+
+void success()
+{
+  REPORT_RESULT();
+}
+
+int main() {
+  int fd;
+
+#if FIRST
+
+  // We first make sure the file doesn't currently exist
+  // (we delete it at the end of !FIRST). We then write a file,
+  // call fsync, and close the file.
+
+  struct stat st;
+
+  // a file whose contents are just 'az'
+  if ((stat("/working1/wakaka.txt", &st) != -1) || (errno != ENOENT))
+    result = -1000 - errno;
+  fd = open("/working1/wakaka.txt", O_RDWR | O_CREAT, 0666);
+  if (fd == -1)
+    result = -2000 - errno;
+  else
+  {
+    if (write(fd,"az",2) != 2)
+      result = -3000 - errno;
+
+    if (fsync(fd) != 0)
+      result = -4000 - errno;
+
+    if (close(fd) != 0)
+      result = -5000 - errno;
+  }
+
+  REPORT_RESULT();
+
+#else
+
+  // does the 'az' file exist, and does it contain 'az'?
+  fd = open("/working1/wakaka.txt", O_RDONLY);
+  if (fd == -1)
+    result = -6000 - errno;
+  else
+  {
+    char bf[4];
+    int bytes_read = read(fd,&bf[0],sizeof(bf));
+    if (bytes_read != 2)
+      result = -7000;
+    else if ((bf[0] != 'a') || (bf[1] != 'z'))
+      result = -8000;
+    if (close(fd) != 0)
+      result = -9000 - errno;
+    if (unlink("/working1/wakaka.txt") != 0)
+      result = -10000 - errno;
+  }
+
+  // sync from memory state to persisted and then
+  // run 'success'
+  EM_ASM(
+    FS.syncfs(function (err) {
+      assert(!err);
+      ccall('success', 'v');
+    });
+  );
+
+  emscripten_exit_with_live_runtime();
+
+  return 0;
+
+#endif
+}

--- a/tests/fs/test_memfs_fsync.c
+++ b/tests/fs/test_memfs_fsync.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+
+int result = 1;
+
+int main() {
+  int fd;
+
+  // We first make sure the file doesn't currently exist.
+  // We then write a file, call fsync, and close the file,
+  // to make sure synchronous calls to resume does not throw.
+
+  struct stat st;
+
+  // a file whose contents are just 'az'
+  if ((stat("/wakaka.txt", &st) != -1) || (errno != ENOENT))
+    result = -1000 - errno;
+  fd = open("/wakaka.txt", O_RDWR | O_CREAT, 0666);
+  if (fd == -1)
+    result = -2000 - errno;
+  else
+  {
+    if (write(fd,"az",2) != 2)
+      result = -3000 - errno;
+
+    if (fsync(fd) != 0)
+      result = -4000 - errno;
+
+    if (close(fd) != 0)
+      result = -5000 - errno;
+  }
+
+  REPORT_RESULT();
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1166,6 +1166,33 @@ keydown(100);keyup(100); // trigger the end
       self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DFIRST', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
       self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
 
+  def test_fs_idbfs_fsync(self):
+    # sync from persisted state into memory before main()
+    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+      Module.preRun = function() {
+        addRunDependency('syncfs');
+
+        FS.mkdir('/working1');
+        FS.mount(IDBFS, {}, '/working1');
+        FS.syncfs(true, function (err) {
+          if (err) throw err;
+          removeRunDependency('syncfs');
+        });
+      };
+    ''')
+
+    args = ['--pre-js', 'pre.js', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'];
+    for mode in [[], ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1']]:
+      secret = str(time.time())
+      self.btest(path_from_root('tests', 'fs', 'test_idbfs_fsync.c'), '1', force_c=True, args=args + mode + ['-DFIRST', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_success']'''])
+      self.btest(path_from_root('tests', 'fs', 'test_idbfs_fsync.c'), '1', force_c=True, args=args + mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_success']'''])
+
+  def test_fs_memfs_fsync(self):
+    args = ['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'];
+    for mode in [[], ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1']]:
+      secret = str(time.time())
+      self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
+
   def test_idbstore(self):
     secret = str(time.time())
     for stage in [0, 1, 2, 3, 0, 1, 2, 0, 0, 1, 4, 2, 5]:


### PR DESCRIPTION
This should fix #2492.

I don't understand how I could setup a test case for this -- is there a test suite with `EMTERPRETIFY_ASYNC=1` that runs on the browser?

Please guide me on how to write a test for this.