### PR TITLE
If '-o' is specified then pass it on when only preprocessing.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -188,4 +188,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jérôme Bernard <jerome.bernard@ercom.fr> (copyright owned by Ercom)
 * Chanhwi Choi <ccwpc@hanmail.net>
 * Fábio Santos <fabiosantosart@gmail.com>
+* Wei Tjong Yao <weitjong@gmail.com>
 

--- a/emcc
+++ b/emcc
@@ -1068,7 +1068,7 @@ try:
     input_files = map(lambda x: x[1], input_files)
     cmd = get_bitcode_args(input_files)
     if specified_target:
-        cmd += ['-o', specified_target]
+      cmd += ['-o', specified_target]
     logging.debug('just preprocessor ' + ' '.join(cmd))
     exit(subprocess.call(cmd))
 

--- a/emcc
+++ b/emcc
@@ -1067,6 +1067,8 @@ try:
   if '-E' in newargs:
     input_files = map(lambda x: x[1], input_files)
     cmd = get_bitcode_args(input_files)
+    if specified_target:
+        cmd += ['-o', specified_target]
     logging.debug('just preprocessor ' + ' '.join(cmd))
     exit(subprocess.call(cmd))
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3539,6 +3539,12 @@ EMSCRIPTEN_KEEPALIVE __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny
     bad = filter(lambda x: '-Wno-warn-absolute-paths' in x, diff)
     assert len(bad) == 0, '\n\n'.join(diff)
 
+  def test_dashE_respect_dashO(self): # issue #3365
+    with_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E', '-o', '/dev/null'], stdout=PIPE, stderr=PIPE).communicate()[0]
+    without_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE).communicate()[0]
+    assert len(with_dash_o) == 0
+    assert len(without_dash_o) != 0
+
   def test_malloc_implicit(self):
     open('src.cpp', 'w').write(r'''
 #include <stdlib.h>


### PR DESCRIPTION
This is related to recent commit b57ccfef1af94f812b58f890b77e97021aeafdbc for fixing issue #3365.