### PR TITLE
Override inspect function to fix #3416

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -90,6 +90,8 @@ if (ENVIRONMENT_IS_NODE) {
       throw ex;
     }
   });
+
+  Module.inspect = function () { return '[Emscripten Module object]'; };
 }
 else if (ENVIRONMENT_IS_SHELL) {
   if (!Module['print']) Module['print'] = print;


### PR DESCRIPTION
This fixes #3416 by overriding the Module.inspect function to return a simple string instead of letting util.inspect (the pretty-printer used for logging in the node REPL) recurse and process the huge Module object.