### PR TITLE
Disable the (name+num)+num = name+newnum optimization.

### DIFF
--- a/tests/optimizer/test-js-optimizer-output.js
+++ b/tests/optimizer/test-js-optimizer-output.js
@@ -55,6 +55,7 @@ function maths() {
  check(17);
  check(95);
  __ZN6b2Vec2C1Ev($this1 + 76 | 0);
+ __ZN6b2Vec2C1Ev($this1 + 20 + 8 + 8 + 8 + 8 + 8 + 8 + 8 | 0);
 }
 function hoisting() {
  if ($i < $N) {

--- a/tests/optimizer/test-js-optimizer.js
+++ b/tests/optimizer/test-js-optimizer.js
@@ -54,6 +54,7 @@ function bits() {
 function maths() {
  check(5+12);
  check(90+3+2);
+ __ZN6b2Vec2C1Ev($this1 + ((((((((20 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) | 0);
  __ZN6b2Vec2C1Ev(((((((($this1 + 20 | 0 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0) + 8 | 0);
 }
 function hoisting() {

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -754,19 +754,10 @@ function simplifyExpressions(ast) {
         return node;
       } else if (type === 'binary' && node[1] === '+') {
         // The most common mathop is addition, e.g. in getelementptr done repeatedly. We can join all of those,
-        // by doing (num+num) ==> newnum, and (name+num)+num = name+newnum
+        // by doing (num+num) ==> newnum.
         if (node[2][0] === 'num' && node[3][0] === 'num') {
           node[2][1] += node[3][1];
           return node[2];
-        }
-        for (var i = 2; i <= 3; i++) {
-          var ii = 5-i;
-          for (var j = 2; j <= 3; j++) {
-            if (node[i][0] === 'num' && node[ii][0] === 'binary' && node[ii][1] === '+' && node[ii][j][0] === 'num') {
-              node[ii][j][1] += node[i][1];
-              return node[ii];
-            }
-          }
         }
       }
     });

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -1839,21 +1839,11 @@ void simplifyExpressions(Ref ast) {
         return;
       } else if (type == BINARY && node[1] == PLUS) {
         // The most common mathop is addition, e.g. in getelementptr done repeatedly. We can join all of those,
-        // by doing (num+num) ==> newnum, and (name+num)+num = name+newnum
+        // by doing (num+num) ==> newnum.
         if (node[2][0] == NUM && node[3][0] == NUM) {
           node[2][1]->setNumber(jsD2I(node[2][1]->getNumber()) + jsD2I(node[3][1]->getNumber()));
           safeCopy(node, node[2]);
           return;
-        }
-        for (int i = 2; i <= 3; i++) {
-          int ii = 5-i;
-          for (int j = 2; j <= 3; j++) {
-            if (node[i][0] == NUM && node[ii][0] == BINARY && node[ii][1] == PLUS && node[ii][j][0] == NUM) {
-              node[ii][j][1]->setNumber(jsD2I(node[ii][j][1]->getNumber()) + jsD2I(node[i][1]->getNumber()));
-              safeCopy(node, node[ii]);
-              return;
-            }
-          }
         }
       }
     });


### PR DESCRIPTION
This optimization reassociates addition and can introduce situations where intermediate computation wraps around the address space, creating inefficiency in JS engines which are optimized for no-wraparound address arithmetic.

In its place, the fastcomp backend is being enhanced in https://github.com/kripken/emscripten-fastcomp/pull/98 to fold getelementptrs with constant bases in more cases, which is the main case where the above optimization happens in practice.