### PR TITLE
Better support for CMake: TestBigEndian, CheckTypeSize, CMAKE_CROSSCOMPILING_EMULATOR

### DIFF
--- a/cmake/Modules/CheckTypeSize.c.in
+++ b/cmake/Modules/CheckTypeSize.c.in
@@ -1,0 +1,37 @@
+@headers@
+
+#undef KEY
+#if defined(__i386)
+# define KEY '_','_','i','3','8','6'
+#elif defined(__x86_64)
+# define KEY '_','_','x','8','6','_','6','4'
+#elif defined(__ppc__)
+# define KEY '_','_','p','p','c','_','_'
+#elif defined(__ppc64__)
+# define KEY '_','_','p','p','c','6','4','_','_'
+#endif
+
+#define SIZE (sizeof(@type@))
+char info_size[] =  {'I', 'N', 'F', 'O', ':', 's','i','z','e','[',
+  ('0' + ((SIZE / 10000)%10)),
+  ('0' + ((SIZE / 1000)%10)),
+  ('0' + ((SIZE / 100)%10)),
+  ('0' + ((SIZE / 10)%10)),
+  ('0' +  (SIZE    % 10)),
+  ']',
+#ifdef KEY
+  ' ','k','e','y','[', KEY, ']',
+#endif
+  '\0'};
+
+#ifdef __CLASSIC_C__
+int main(argc, argv) int argc; char *argv[];
+#else
+int main(int argc, char *argv[])
+#endif
+{
+  int require = 0;
+  require += info_size[argc];
+  (void)argv;
+  return SIZE;
+}

--- a/cmake/Modules/CheckTypeSize.cmake
+++ b/cmake/Modules/CheckTypeSize.cmake
@@ -1,0 +1,231 @@
+#.rst:
+# CheckTypeSize
+# -------------
+#
+# Check sizeof a type
+#
+# ::
+#
+#   CHECK_TYPE_SIZE(TYPE VARIABLE [BUILTIN_TYPES_ONLY]
+#                                 [LANGUAGE <language>])
+#
+# Check if the type exists and determine its size.  On return,
+# "HAVE_${VARIABLE}" holds the existence of the type, and "${VARIABLE}"
+# holds one of the following:
+#
+# ::
+#
+#    <size> = type has non-zero size <size>
+#    "0"    = type has arch-dependent size (see below)
+#    ""     = type does not exist
+#
+# Both ``HAVE_${VARIABLE}`` and ``${VARIABLE}`` will be created as internal
+# cache variables.
+#
+# Furthermore, the variable "${VARIABLE}_CODE" holds C preprocessor code
+# to define the macro "${VARIABLE}" to the size of the type, or leave
+# the macro undefined if the type does not exist.
+#
+# The variable "${VARIABLE}" may be "0" when CMAKE_OSX_ARCHITECTURES has
+# multiple architectures for building OS X universal binaries.  This
+# indicates that the type size varies across architectures.  In this
+# case "${VARIABLE}_CODE" contains C preprocessor tests mapping from
+# each architecture macro to the corresponding type size.  The list of
+# architecture macros is stored in "${VARIABLE}_KEYS", and the value for
+# each key is stored in "${VARIABLE}-${KEY}".
+#
+# If the BUILTIN_TYPES_ONLY option is not given, the macro checks for
+# headers <sys/types.h>, <stdint.h>, and <stddef.h>, and saves results
+# in HAVE_SYS_TYPES_H, HAVE_STDINT_H, and HAVE_STDDEF_H.  The type size
+# check automatically includes the available headers, thus supporting
+# checks of types defined in the headers.
+#
+# If LANGUAGE is set, the specified compiler will be used to perform the
+# check. Acceptable values are C and CXX
+#
+# Despite the name of the macro you may use it to check the size of more
+# complex expressions, too.  To check e.g.  for the size of a struct
+# member you can do something like this:
+#
+# ::
+#
+#   check_type_size("((struct something*)0)->member" SIZEOF_MEMBER)
+#
+#
+#
+# The following variables may be set before calling this macro to modify
+# the way the check is run:
+#
+# ::
+#
+#   CMAKE_REQUIRED_FLAGS = string of compile command line flags
+#   CMAKE_REQUIRED_DEFINITIONS = list of macros to define (-DFOO=bar)
+#   CMAKE_REQUIRED_INCLUDES = list of include directories
+#   CMAKE_REQUIRED_LIBRARIES = list of libraries to link
+#   CMAKE_REQUIRED_QUIET = execute quietly without messages
+#   CMAKE_EXTRA_INCLUDE_FILES = list of extra headers to include
+
+#=============================================================================
+# Copyright 2002-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
+
+cmake_policy(PUSH)
+cmake_policy(VERSION 3.0)
+
+get_filename_component(__check_type_size_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+#-----------------------------------------------------------------------------
+# Helper function.  DO NOT CALL DIRECTLY.
+function(__check_type_size_impl type var map builtin language)
+  if(NOT CMAKE_REQUIRED_QUIET)
+    message(STATUS "Check size of ${type}")
+  endif()
+
+  # Include header files.
+  set(headers)
+  if(builtin)
+    if(HAVE_SYS_TYPES_H)
+      set(headers "${headers}#include <sys/types.h>\n")
+    endif()
+    if(HAVE_STDINT_H)
+      set(headers "${headers}#include <stdint.h>\n")
+    endif()
+    if(HAVE_STDDEF_H)
+      set(headers "${headers}#include <stddef.h>\n")
+    endif()
+  endif()
+  foreach(h ${CMAKE_EXTRA_INCLUDE_FILES})
+    set(headers "${headers}#include \"${h}\"\n")
+  endforeach()
+
+  # Perform the check.
+
+  if("${language}" STREQUAL "C")
+    set(src ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${var}.c)
+  elseif("${language}" STREQUAL "CXX")
+    set(src ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${var}.cpp)
+  else()
+    message(FATAL_ERROR "Unknown language:\n  ${language}\nSupported languages: C, CXX.\n")
+  endif()
+  set(bin ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${var}.bin)
+  configure_file(${__check_type_size_dir}/CheckTypeSize.c.in ${src} @ONLY)
+  try_run(${var}_run_result HAVE_${var} ${CMAKE_BINARY_DIR} ${src}
+    COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+    LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES}
+    CMAKE_FLAGS
+      "-DCOMPILE_DEFINITIONS:STRING=${CMAKE_REQUIRED_FLAGS}"
+      "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"
+    RUN_OUTPUT_VARIABLE ${var}_run_output
+    COMPILE_OUTPUT_VARIABLE output
+    )
+
+  if(${HAVE_${var}} AND NOT "${${var}_run_result}" STREQUAL "FAILED_TO_RUN")
+    set(${var} ${${var}_run_result})
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Check size of ${type} - done")
+    endif()
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+      "Determining size of ${type} passed with the following output:\n${output}\n\n")
+    set(${var} "${${var}}" CACHE INTERNAL "CHECK_TYPE_SIZE: sizeof(${type})")
+  else()
+    # The check failed to compile.
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Check size of ${type} - failed")
+    endif()
+    file(READ ${src} content)
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+      "Determining size of ${type} failed with the following output:\n${output}\n${src}:\n${content}\n\n")
+    set(${var} "" CACHE INTERNAL "CHECK_TYPE_SIZE: ${type} unknown")
+    file(REMOVE ${map})
+  endif()
+endfunction()
+
+#-----------------------------------------------------------------------------
+macro(CHECK_TYPE_SIZE TYPE VARIABLE)
+  # parse arguments
+  unset(doing)
+  foreach(arg ${ARGN})
+    if("x${arg}" STREQUAL "xBUILTIN_TYPES_ONLY")
+      set(_CHECK_TYPE_SIZE_${arg} 1)
+      unset(doing)
+    elseif("x${arg}" STREQUAL "xLANGUAGE") # change to MATCHES for more keys
+      set(doing "${arg}")
+      set(_CHECK_TYPE_SIZE_${doing} "")
+    elseif("x${doing}" STREQUAL "xLANGUAGE")
+      set(_CHECK_TYPE_SIZE_${doing} "${arg}")
+      unset(doing)
+    else()
+      message(FATAL_ERROR "Unknown argument:\n  ${arg}\n")
+    endif()
+  endforeach()
+  if("x${doing}" MATCHES "^x(LANGUAGE)$")
+    message(FATAL_ERROR "Missing argument:\n  ${doing} arguments requires a value\n")
+  endif()
+  if(DEFINED _CHECK_TYPE_SIZE_LANGUAGE)
+    if(NOT "x${_CHECK_TYPE_SIZE_LANGUAGE}" MATCHES "^x(C|CXX)$")
+      message(FATAL_ERROR "Unknown language:\n  ${_CHECK_TYPE_SIZE_LANGUAGE}.\nSupported languages: C, CXX.\n")
+    endif()
+    set(_language ${_CHECK_TYPE_SIZE_LANGUAGE})
+  else()
+    set(_language C)
+  endif()
+
+  # Optionally check for standard headers.
+  if(_CHECK_TYPE_SIZE_BUILTIN_TYPES_ONLY)
+    set(_builtin 0)
+  else()
+    set(_builtin 1)
+    if("${_language}" STREQUAL "C")
+      check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+      check_include_file(stdint.h HAVE_STDINT_H)
+      check_include_file(stddef.h HAVE_STDDEF_H)
+    elseif("${_language}" STREQUAL "CXX")
+      check_include_file_cxx(sys/types.h HAVE_SYS_TYPES_H)
+      check_include_file_cxx(stdint.h HAVE_STDINT_H)
+      check_include_file_cxx(stddef.h HAVE_STDDEF_H)
+    endif()
+  endif()
+  unset(_CHECK_TYPE_SIZE_BUILTIN_TYPES_ONLY)
+  unset(_CHECK_TYPE_SIZE_LANGUAGE)
+
+  # Compute or load the size or size map.
+  set(${VARIABLE}_KEYS)
+  set(_map_file ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${VARIABLE}.cmake)
+  if(NOT DEFINED HAVE_${VARIABLE})
+    __check_type_size_impl(${TYPE} ${VARIABLE} ${_map_file} ${_builtin} ${_language})
+  endif()
+  include(${_map_file} OPTIONAL)
+  set(_map_file)
+  set(_builtin)
+
+  # Create preprocessor code.
+  if(${VARIABLE}_KEYS)
+    set(${VARIABLE}_CODE)
+    set(_if if)
+    foreach(key ${${VARIABLE}_KEYS})
+      set(${VARIABLE}_CODE "${${VARIABLE}_CODE}#${_if} defined(${key})\n# define ${VARIABLE} ${${VARIABLE}-${key}}\n")
+      set(_if elif)
+    endforeach()
+    set(${VARIABLE}_CODE "${${VARIABLE}_CODE}#else\n# error ${VARIABLE} unknown\n#endif")
+    set(_if)
+  elseif(${VARIABLE})
+    set(${VARIABLE}_CODE "#define ${VARIABLE} ${${VARIABLE}}")
+  else()
+    set(${VARIABLE}_CODE "/* #undef ${VARIABLE} */")
+  endif()
+endmacro()
+
+#-----------------------------------------------------------------------------
+cmake_policy(POP)

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -258,3 +258,14 @@ if ("${CMAKE_GENERATOR}" MATCHES "^Visual Studio.*")
 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EMSCRIPTEN_VS_LINKER_FLAGS}" CACHE STRING "")
 	set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${EMSCRIPTEN_VS_LINKER_FLAGS}" CACHE STRING "")
 endif()
+
+if (NOT DEFINED CMAKE_CROSSCOMPILING_EMULATOR)
+  find_program(node_js_executable NAMES node nodejs)
+  if(node_js_executable)
+    set(CMAKE_CROSSCOMPILING_EMULATOR "${node_js_executable}" CACHE FILEPATH "Path to the emulator for the target system.")
+  endif()
+endif()
+# No-op on CMAKE_CROSSCOMPILING_EMULATOR so older versions of cmake do not
+# complain about unused CMake variable.
+if(CMAKE_CROSSCOMPILING_EMULATOR)
+endif()

--- a/cmake/Modules/TestBigEndian.cmake
+++ b/cmake/Modules/TestBigEndian.cmake
@@ -1,0 +1,30 @@
+#.rst:
+# TestBigEndian
+# -------------
+#
+# The TestBigEndian.cmake module that ships with CMake, which
+# checks if the system is big endian or little endian, assumes
+# that a binary is produced that will have bytes that correspond to the
+# endianness on the target system. Since emscripten produces Javascript, we
+# override the default behavior and always return little endian.
+#
+# ::
+#
+#   TEST_BIG_ENDIAN(VARIABLE)
+#   VARIABLE - variable to store the result to
+#=============================================================================
+# Copyright 2002-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+function(TEST_BIG_ENDIAN VARIABLE)
+  set(${VARIABLE} 0 CACHE INTERNAL "Result of TEST_BIG_ENDIAN" FORCE)
+endfunction()

--- a/emcmake
+++ b/emcmake
@@ -4,5 +4,6 @@ import os, subprocess, sys
 from tools import shared
 
 configure_path = shared.path_from_root('emconfigure')
-exit(subprocess.call([shared.PYTHON, configure_path] + sys.argv[1:]))
-
+exit(subprocess.call([shared.PYTHON, configure_path] + \
+                     sys.argv[1] + \
+                     ['-DCMAKE_CROSSCOMPILING_EMULATOR=' + shared.NODE_JS] + sys.argv[2:]))

--- a/tests/cmake/target_js/CMakeLists.txt
+++ b/tests/cmake/target_js/CMakeLists.txt
@@ -73,6 +73,15 @@ if (NOT ${endian_result} EQUAL 0)
         message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
 endif()
 
+# Requires CMAKE_CROSSCOMPILING_EMULATOR support.
+if(${CMAKE_VERSION} VERSION_GREATER 3.2.20150502)
+  include(CheckTypeSize)
+  check_type_size("int" int_size)
+  if (NOT ${int_size} EQUAL 4)
+          message(FATAL_ERROR "CHECK_TYPE_SIZE with int did not return 4!")
+  endif()
+endif()
+
 add_executable(test_cmake ${sourceFiles})
 
 # GOTCHA: If your project has custom link flags, these must be set *before* calling any of the em_link_xxx functions!

--- a/tests/cmake/target_js/CMakeLists.txt
+++ b/tests/cmake/target_js/CMakeLists.txt
@@ -67,6 +67,12 @@ if (NOT CMAKE_C_SIZEOF_DATA_PTR)
 	message(FATAL_ERROR "CMAKE_C_SIZEOF_DATA_PTR was not defined!")
 endif()
 
+include(TestBigEndian)
+test_big_endian(endian_result)
+if (NOT ${endian_result} EQUAL 0)
+        message(FATAL_ERROR "TEST_BIG_ENDIAN did not return 0!")
+endif()
+
 add_executable(test_cmake ${sourceFiles})
 
 # GOTCHA: If your project has custom link flags, these must be set *before* calling any of the em_link_xxx functions!


### PR DESCRIPTION
This overrides two CMake modules that are commonly used by projects, especially scientific projects or projects that aim to support a number of platforms.

The TestBigEndian modules is replaced.  This addresses:

  https://github.com/kripken/emscripten/issues/1106

Also the CheckTypeSize module is replaced.

  https://github.com/kripken/emscripten/issues/400

The fix for CheckTypeSize involves the use of the CMake try_run command.  Also ease the building of CMake project files by adding support for the CMAKE_CROSSCOMPILING_EMULATOR variable, and pointing it to nodejs.  This prevents the need to manually populate CMake TryRunResults.cmake files. It currently requires CMake Git master (to be released as  CMake 3.3).  Everything should still work with older CMake.

New tests are added to the test suite.  All tests passed when

  tests/runner.py

was executed.