### PR TITLE
Make the write() handler for /dev/null return the number of bytes written

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1236,7 +1236,7 @@ mergeInto(LibraryManager.library, {
       // setup /dev/null
       FS.registerDevice(FS.makedev(1, 3), {
         read: function() { return 0; },
-        write: function() { return 0; }
+        write: function(stream, buffer, offset, length, pos) { return length; }
       });
       FS.mkdev('/dev/null', FS.makedev(1, 3));
       // setup /dev/tty and /dev/tty1


### PR DESCRIPTION
The FS `write()` handler is supposed to return the number of bytes written, but the one for `/dev/null` always returns zero.  This can lead to infinite-loop behavior if the calling code does a classic "call write() repeatedly until all the data has been written" loop (see e.g. https://github.com/rfk/pypyjs/issues/82).