### PR TITLE
Remove 'firefox' browser fallback on Linux.

### DIFF
--- a/emrun
+++ b/emrun
@@ -950,8 +950,6 @@ def main():
       options.browser = 'start'
     elif LINUX:
       options.browser = which('xdg-open')
-      if not options.browser:
-        options.browser = 'firefox'
     elif OSX:
       options.browser = 'safari'
 


### PR DESCRIPTION
This should make it possible to `emrun` with `--no_browser` on a system without the `firefox` package installed.