### PR TITLE
incorrect JS output with -g4

### DIFF
--- a/tools/eliminator/node_modules/uglify-js/lib/process.js
+++ b/tools/eliminator/node_modules/uglify-js/lib/process.js
@@ -1666,7 +1666,10 @@ function gen_code(ast, options) {
                         var out = [ "return" ];
                         var str = make(expr);
                         if (expr != null) out.push(str);
-                        return add_spaces(out) + ";" + (str ? str.lineComment() : '');
+                        str = add_spaces(out) + ";";
+                        if (options.debug && this.start)
+                          return new NodeWithLine(str, this.start.line);
+                        return str;
                 },
                 "binary": function(operator, lvalue, rvalue) {
                         var left = make(lvalue), right = make(rvalue);


### PR DESCRIPTION
Hi!

I'm running into an issue in which code like this:
```
function _treecount($e) {
 $e = $e | 0;
 var $3 = 0;
 if (!$e) return 0; //@line 1328 else {
  $3 = _treecount(HEAP32[$e + 4 >> 2] | 0) | 0; //@line 1332
  return $3 + 1 + (_treecount(HEAP32[$e >> 2] | 0) | 0) | 0; //@line 1337
 }
 return 0; //@line 1339
}
```
(note that there is no newline character after "@line 1328"; as a consequence, the resulting code fails to parse) is emitted for this test code:
```
struct _dtlink_s
{	Dtlink_t*	right;	/* right child		*/
        union
        { unsigned int	_hash;	/* hash value		*/
          Dtlink_t*	_left;	/* left child		*/
        } hl;
};

int treecount(register Dtlink_t* e)
{
  return e ? treecount(e->hl._left) + treecount(e->right) + 1 : 0;
}
```
when compiling with
```
emcc -s EXPORTED_FUNCTIONS="['_main', '_treecount']" --minify 0  -g4 -Oz -o test.js emscripten-bug-001.c
```

The attached patch fixes the dangling "else" by using the NodeWithLine class, which appears to avoid the problem. I'm not sure that's the right fix, though, as I don't fully understand this code.

The test code is from the graphviz library, where it's in lib/cdt/dtsize.c.