### PR TITLE
add test for noExitRuntime

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7041,6 +7041,26 @@ Module.printErr = Module['printErr'] = function(){};
     self.emcc_args += ['-s', 'INVOKE_RUN=0', '--post-js', 'post.js']
     self.do_run(src, 'hello, world!\ncleanup\nI see exit status: 118')
 
+  def test_noexitruntime(self):
+    src = r'''
+      #include <emscripten.h>
+      #include <stdio.h>
+      static int testPre = TEST_PRE;
+      struct Global {
+        Global() {
+          printf("in Global()\n");
+          if (testPre) { EM_ASM(Module['noExitRuntime'] = true;); }
+        }
+        ~Global() { printf("ERROR: in ~Global()\n"); }
+      } global;
+      int main() {
+        if (!testPre) { EM_ASM(Module['noExitRuntime'] = true;); }
+        printf("in main()\n");
+      }
+    '''
+    self.do_run(src.replace('TEST_PRE', '0'), 'in Global()\nin main()')
+    self.do_run(src.replace('TEST_PRE', '1'), 'in Global()\nin main()')
+
   def test_minmax(self):
     self.do_run(open(path_from_root('tests', 'test_minmax.c')).read(), 'NAN != NAN\nSuccess!')
 


### PR DESCRIPTION
I'm pretty sure something changed between emscripten 1.27 and 1.31
because we had to change our code for setting noExitRuntime when we
updated, but we couldn't find a bug in emscripten. Pushing this test
because we found it useful while debugging.