### PR TITLE
Missing OpenGL ES 2 extension function aliases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -192,4 +192,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Wei Tjong Yao <weitjong@gmail.com>
 * Tim Guan-tin Chien <timdream@gmail.com>
 * Krzysztof Jakubowski <nadult@fastmail.fm>
-
+* Vladimír Vondruš <mosra@centrum.cz>

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -6437,6 +6437,11 @@ var LibraryGL = {
 
     GL.currentContext.drawBuffersExt(bufArray);
   },
+
+  // OpenGL ES 2.0 draw buffer extensions compatibility
+
+  glDrawBuffersEXT: 'glDrawBuffers',
+
   // signatures of simple pass-through functions, see later
 
   glActiveTexture__sig: 'vi',

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -6421,6 +6421,9 @@ var LibraryGL = {
   glVertexAttribDivisorARB: 'glVertexAttribDivisor',
   glDrawArraysInstancedARB: 'glDrawArraysInstanced',
   glDrawElementsInstancedARB: 'glDrawElementsInstanced',
+  glVertexAttribDivisorANGLE: 'glVertexAttribDivisor',
+  glDrawArraysInstancedANGLE: 'glDrawArraysInstanced',
+  glDrawElementsInstancedANGLE: 'glDrawElementsInstanced',
 
 
   glDrawBuffers__sig: 'vii',


### PR DESCRIPTION
Since the [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/) WebGL extension is based on [EXT_draw_buffers](https://www.khronos.org/registry/gles/extensions/EXT/EXT_draw_buffers.txt) ES2 extension and [ANGLE_instanced_arrays](https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/) WebGL extension is based on [ANGLE_instanced_arrays](https://www.khronos.org/registry/gles/extensions/ANGLE/ANGLE_instanced_arrays.txt) ES2 extension, I thought it would make sense to expose also functions that are present in ES2 extension headers:

    glDrawBuffersEXT()
    glVertexAttribDivisorANGLE()
    glDrawArraysInstancedANGLE()
    glDrawElementsInstancedANGLE()

This should also partially fix #2510, except for additions to the headers (I'm using my own headers generated using [flextGL](https://github.com/ginkgo/flextGL) so that doesn't bother me).

I looked around the code to discover what's the actual policy for extension function suffixes, but it seems that all suffixes of given function are always present without checking whether we are on legacy GL emulation, WebGL-friendly subset or else, so I just added these to existing aliases. 

Note: if I understand correctly, the `WEBGL_draw_buffers` and `ANGLE_instanced_arrays` extensions shouldn't be exposed on WebGL 2 (because the above functions are then in core), thus aliases with these suffixes also shouldn't be present for WebGL 2, but maybe that's not a problem here.

Thanks!