### PR TITLE
Revert https://github.com/kripken/emscripten/pull/3038

### DIFF
--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -49,10 +49,6 @@ caught: a JSImplementation must implement all functions, you forgot Child2JS::vi
 |hello|43|world|41|
 12.35
 a returned string
-C string addresses: "string A" ? "string A"  =>  0
-C string addresses: "string B" ? "string B"  =>  0
-C string addresses: "string A" ? "string B"  =>  -1
-C string addresses: "string B" ? "string A"  =>  1
 10
 object
 10

--- a/tests/webidl/output_DEFAULT.txt
+++ b/tests/webidl/output_DEFAULT.txt
@@ -49,10 +49,6 @@ caught: a JSImplementation must implement all functions, you forgot Child2JS::vi
 |hello|43|world|41|
 12.35
 a returned string
-C string addresses: "string A" ? "string A"  =>  0
-C string addresses: "string B" ? "string B"  =>  0
-C string addresses: "string A" ? "string B"  =>  -1
-C string addresses: "string B" ? "string A"  =>  1
 10
 object
 10

--- a/tests/webidl/output_FAST.txt
+++ b/tests/webidl/output_FAST.txt
@@ -49,10 +49,6 @@ caught: a JSImplementation must implement all functions, you forgot Child2JS::vi
 |hello|43|world|41|
 12.35
 a returned string
-C string addresses: "string A" ? "string A"  =>  0
-C string addresses: "string B" ? "string B"  =>  0
-C string addresses: "string A" ? "string B"  =>  -1
-C string addresses: "string B" ? "string A"  =>  1
 10
 object
 10

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -103,12 +103,6 @@ suser.Print(41, "world");
 suser.PrintFloat(12.3456);
 TheModule.print(suser.returnAString());
 
-// Verify that subsequent calls with the same string value re-use the string storage.
-suser.CompareCStringAddress("string A", "string A");
-suser.CompareCStringAddress("string B", "string B");
-suser.CompareCStringAddress("string A", "string B");
-suser.CompareCStringAddress("string B", "string A");
-
 var bv = new TheModule.RefUser(10);
 var bv2 = new TheModule.RefUser(11);
 TheModule.print(bv2.getValue(bv));

--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -59,10 +59,6 @@ public:
   }
   void PrintFloat(float f) { printf("%.2f\n", f); }
   const char* returnAString() { return "a returned string"; }
-
-  void CompareCStringAddress(const char* s1, const char* s2) {
-    printf("C string addresses: \"%s\" ? \"%s\"  =>  %d\n", s1, s2, s1 < s2 ? -1 : (s1 == s2 ? 0 : 1));
-  }
 };
 
 struct RefUser {

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -52,7 +52,6 @@ interface StringUser {
   void Print(long anotherInteger, DOMString anotherString);
   void PrintFloat(float f);
   [Const] DOMString returnAString();
-  void CompareCStringAddress(DOMString str1, DOMString str2);
 };
 
 interface RefUser {

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -139,20 +139,10 @@ function getClass(obj) {
 Module['getClass'] = getClass;
 
 // Converts a value into a C-style string.
-var ensureString = (function() {
-  var stringCache = {};
-  function ensureString(value) {
-    if (typeof value == 'string') {
-      var cachedVal = stringCache[value];
-      if (cachedVal) return cachedVal;
-      var ret = allocate(intArrayFromString(value), 'i8', ALLOC_STACK);
-      stringCache[value] = ret;
-      return ret;
-    }
-    return value;
-  }
-  return ensureString;
-})();
+function ensureString(value) {
+  if (typeof value == 'string') return allocate(intArrayFromString(value), 'i8', ALLOC_STACK);
+  return value;
+}
 
 ''']
 


### PR DESCRIPTION
It turns out #3038 was unnecessary and insane. The strings were being allocated from the stack, and hence the memory was released after the call returned. The caching of course, eventually caused crashes when identical strings were passed multiple times over the life of the program. Amazingly we ran for 4 months on the broken code without any noticeable problems. (Probably due to most strings being unique).