### PR TITLE
Don't replace empty (non-null) shader compilation info log.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2491,7 +2491,7 @@ var LibraryGL = {
 #endif
     var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
     // Work around a bug in Chromium which causes getShaderInfoLog to return null
-    if (!log) log = '(unknown error)';
+    if (log === null) log = '(unknown error)';
     log = log.substr(0, maxLength - 1);
     if (maxLength > 0 && infoLog) {
       writeStringToMemory(log, infoLog);
@@ -2516,7 +2516,7 @@ var LibraryGL = {
     if (pname == 0x8B84) { // GL_INFO_LOG_LENGTH
       var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
       // Work around a bug in Chromium which causes getShaderInfoLog to return null: https://code.google.com/p/chromium/issues/detail?id=111337
-      if (!log) log = '(unknown error)';
+      if (log === null) log = '(unknown error)';
       {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else {
       {{{ makeSetValue('p', '0', 'GLctx.getShaderParameter(GL.shaders[shader], pname)', 'i32') }}};

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2490,7 +2490,6 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.shaders, shader, 'glGetShaderInfoLog', 'shader');
 #endif
     var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
-    // Work around a bug in Chromium which causes getShaderInfoLog to return null
     if (log === null) log = '(unknown error)';
     log = log.substr(0, maxLength - 1);
     if (maxLength > 0 && infoLog) {
@@ -2515,7 +2514,6 @@ var LibraryGL = {
 #endif
     if (pname == 0x8B84) { // GL_INFO_LOG_LENGTH
       var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
-      // Work around a bug in Chromium which causes getShaderInfoLog to return null: https://code.google.com/p/chromium/issues/detail?id=111337
       if (log === null) log = '(unknown error)';
       {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else {

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2534,7 +2534,9 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.programs, program, 'glGetProgramiv', 'program');
 #endif
     if (pname == 0x8B84) { // GL_INFO_LOG_LENGTH
-      {{{ makeSetValue('p', '0', 'GLctx.getProgramInfoLog(GL.programs[program]).length + 1', 'i32') }}};
+      var log = GLctx.getProgramInfoLog(GL.programs[program]);
+      if (log === null) log = '(unknown error)';
+      {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else if (pname == 0x8B87 /* GL_ACTIVE_UNIFORM_MAX_LENGTH */) {
       var ptable = GL.programInfos[program];
       if (ptable) {
@@ -2654,11 +2656,7 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.programs, program, 'glGetProgramInfoLog', 'program');
 #endif
     var log = GLctx.getProgramInfoLog(GL.programs[program]);
-    // Work around a bug in Chromium which causes getProgramInfoLog to return null: https://code.google.com/p/chromium/issues/detail?id=111337
-    // Note that this makes glGetProgramInfoLog behavior to be inconsistent. If an error occurs, GL functions should not write anything
-    // to the output parameters, however with this workaround in place, we will always write an empty string out to 'infoLog', even if an
-    // error did occur.
-    if (!log) log = "";
+    if (log === null) log = '(unknown error)';
 
     log = log.substr(0, maxLength - 1);
     if (maxLength > 0 && infoLog) {
@@ -3428,16 +3426,22 @@ var LibraryGL = {
   glGetObjectParameteriv: function(id, type, result) {
     if (GL.programs[id]) {
       if (type == 0x8B84) { // GL_OBJECT_INFO_LOG_LENGTH_ARB
-        {{{ makeSetValue('result', '0', 'GLctx.getProgramInfoLog(GL.programs[id]).length', 'i32') }}};
+        var log = GLctx.getProgramInfoLog(GL.programs[id]);
+        if (log === null) log = '(unknown error)';
+        {{{ makeSetValue('result', '0', 'log.length', 'i32') }}};
         return;
       }
       _glGetProgramiv(id, type, result);
     } else if (GL.shaders[id]) {
       if (type == 0x8B84) { // GL_OBJECT_INFO_LOG_LENGTH_ARB
-        {{{ makeSetValue('result', '0', 'GLctx.getShaderInfoLog(GL.shaders[id]).length', 'i32') }}};
+        var log = GLctx.getShaderInfoLog(GL.shaders[id]);
+        if (log === null) log = '(unknown error)';
+        {{{ makeSetValue('result', '0', 'log.length', 'i32') }}};
         return;
       } else if (type == 0x8B88) { // GL_OBJECT_SHADER_SOURCE_LENGTH_ARB
-        {{{ makeSetValue('result', '0', 'GLctx.getShaderSource(GL.shaders[id]).length', 'i32') }}};
+        var source = GLctx.getShaderSource(GL.shaders[id]);
+        if (source === null) return; // If an error occurs, nothing will be written to result
+        {{{ makeSetValue('result', '0', 'source.length', 'i32') }}};
         return;
       }
       _glGetShaderiv(id, type, result);

--- a/tests/float_tex.cpp
+++ b/tests/float_tex.cpp
@@ -109,6 +109,7 @@ static void gl_init(void) {
     char msg[512];
     glGetProgramInfoLog(program, sizeof msg, NULL, msg);
     std::cout << "info: " <<  msg << std::endl;
+    assert(msg[0] == '\0');
     glUseProgram(program);
     std::vector<float> elements(nbNodes);
     int count = 0;

--- a/tests/float_tex.cpp
+++ b/tests/float_tex.cpp
@@ -1,5 +1,6 @@
 #define GL_GLEXT_PROTOTYPES
 #define EGL_EGLEXT_PROTOTYPES
+#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <vector>
@@ -97,6 +98,7 @@ GLuint createShader(const char source[], int type) {
     glCompileShader(shader);
     glGetShaderInfoLog(shader, sizeof msg, NULL, msg);
     std::cout << "Shader info: " << msg << std::endl;
+    assert(msg[0] == '\0');
     return shader;
 }
 static void gl_init(void) {


### PR DESCRIPTION
In my lib I'm printing shader/program info log to console even if the compilation/linking succeeded, in case there are any warnings, performance hints etc. Emscripten currently replaces *both* `null` values and empty strings in shader compilation info log with `(unknown error)`, which is then spamming the output if there are many shaders (and the message looks rather scary). I modified the fix to work only for `null` values.

Tested with both succeeded and failed compilation. Should I modify some test case to accommodate for this change?

Some additional notes:
* Most drivers are appending `\n` at the end of the log so console output that appears immediately after is printed cleanly on new line. Could that be that way also here (i.e. `'(unknown error)\n'`)? And possibly returning less scary value such as `(no error)` as `null` value means no error anyway?
* The related WebKit bug [was fixed in Feb 2012](https://bugs.webkit.org/show_bug.cgi?id=77149) and I suspect there aren't *that* old browsers that could handle current Emscripten/WebGL demands anymore, so I vote for removing the workaround altogether.