### PR TITLE
Remove EM_CACHE environment variable.

### DIFF
--- a/emcc
+++ b/emcc
@@ -639,8 +639,7 @@ try:
       newargs[i] = ''
     elif newargs[i] == '--cache':
       check_bad_eq(newargs[i])
-      os.environ['EM_CACHE'] = newargs[i+1]
-      shared.reconfigure_cache()
+      shared.reconfigure_cache(newargs[i+1])
       newargs[i] = ''
       newargs[i+1] = ''
     elif newargs[i] == '--clear-cache':

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -429,7 +429,6 @@ Options that are modified or new in *emcc* are listed below:
    specify this argument first.
 
    The Emscripten cache defaults to being located in the path name
-   stored in the "EM_CACHE" environment variable or
    "~/.emscripten_cache".
 
 "--clear-cache"

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -352,8 +352,8 @@ Options that are modified or new in *emcc* are listed below:
   If using this in combination with ``--clear-cache``, be sure to specify
   this argument first.
 
-  The Emscripten cache defaults to being located in the path name stored
-  in the ``EM_CACHE`` environment variable or ``~/.emscripten_cache``.
+  The Emscripten cache defaults to being located in the path name
+  ``~/.emscripten_cache``.
 
 .. _emcc-clear-cache:
 	 

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -5,8 +5,6 @@ import tempfiles
 # Permanent cache for dlmalloc and stdlibc++
 class Cache:
   def __init__(self, dirname=None, debug=False):
-    if dirname is None:
-      dirname = os.environ.get('EM_CACHE')
     if not dirname:
       dirname = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
     self.dirname = dirname

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1654,9 +1654,9 @@ class Building:
 Cache = cache.Cache(debug=DEBUG_CACHE)
 chunkify = cache.chunkify
 
-def reconfigure_cache():
+def reconfigure_cache(dirname):
   global Cache
-  Cache = cache.Cache(debug=DEBUG_CACHE)
+  Cache = cache.Cache(dirname=dirname, debug=DEBUG_CACHE)
 
 class JS:
   memory_initializer_pattern = '/\* memory initializer \*/ allocate\(\[([\d, ]*)\], "i8", ALLOC_NONE, ([\d+Runtime\.GLOBAL_BASEH]+)\);'


### PR DESCRIPTION
The path to the emscripten cache can be set via the --cache command
line parameter for emcc since September, 2014.