### PR TITLE
Add note about changing `node` to `nodejs` in docs (please see #3296)

### DIFF
--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -150,7 +150,9 @@ Linux
 		
 		# Install Java
 		sudo apt-get install default-jre
-		
+
+  Please note that you will have to change the ``NODE_JS`` attribute of the ``~/.emscripten`` file from ``node`` to ``nodejs`` with certain package managers.
+	
 - *Git* is not installed automatically. Git is only needed if you want to use tools from one of the development branches **emscripten-incoming** or **emscripten-master**: 
 
 	::


### PR DESCRIPTION
For package managers that use `nodejs` instead of `node` for Node.js.

I'm not sure if the syntax is correct as I couldn't find a style guide anywhere for Sphinx code but it works. The content is the most important thing here.

Please see #3296 for more info