### PR TITLE
Fixed "resize canvas" not working on GLFW.

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -419,7 +419,7 @@ var LibraryGLFW = {
         GLFW.active.height = GLFW.active.storedHeight;
       }
 
-      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height);
+      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height, true);
 
       if (!GLFW.active.windowResizeFunc) return;
 
@@ -722,6 +722,10 @@ var LibraryGLFW = {
     Module["canvas"].addEventListener("mouseup", GLFW.onMouseButtonUp, true);
     Module["canvas"].addEventListener('wheel', GLFW.onMouseWheel, true);
     Module["canvas"].addEventListener('mousewheel', GLFW.onMouseWheel, true);
+	
+	Browser.resizeListeners.push(function(width, height) {
+       GLFW.onFullScreenEventChange();
+    });
     return 1; // GL_TRUE
   },
 


### PR DESCRIPTION
The GLFW library was not listening to Resize events, and thus Resizing Canvas was not working. This could be easily solved by adding a listener and preventing cascaded events (to avoid function call stack overflow).