### PR TITLE
Fixed problem with "Resize Canvas" not working on GLFW.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -193,3 +193,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Tim Guan-tin Chien <timdream@gmail.com>
 * Krzysztof Jakubowski <nadult@fastmail.fm>
 * Vladimír Vondruš <mosra@centrum.cz>
+* Javier Meseguer de Paz <j.meseguer@gmail.com>

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -400,35 +400,34 @@ var LibraryGLFW = {
       event.preventDefault();
     },
 
-    onFullScreenEventChange: function(event) {
+    onFullScreenEventChange: function() {
       if (!GLFW.active) return;
 
       if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
         GLFW.active.storedX = GLFW.active.x;
         GLFW.active.storedY = GLFW.active.y;
-        GLFW.active.x = GLFW.active.y = 0;
         GLFW.active.storedWidth = GLFW.active.width;
         GLFW.active.storedHeight = GLFW.active.height;
+        GLFW.active.x = GLFW.active.y = 0;
         GLFW.active.width = screen.width;
         GLFW.active.height = screen.height;
       } else {
-        document.removeEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
-        document.removeEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
-        document.removeEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
+        GLFW.active.x = GLFW.active.storedX;
+        GLFW.active.y = GLFW.active.storedY;
         GLFW.active.width = GLFW.active.storedWidth;
         GLFW.active.height = GLFW.active.storedHeight;
       }
 
-      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height);
+      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height, true); // resets the canvas size to counter the aspect preservation of Browser.updateCanvasDimensions
 
-      if (!GLFW.active.windowResizeFunc) return;
+      if (!GLFW.active.windowSizeFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.windowResizeFunc, [width, height]);
+      Runtime.dynCall('vii', GLFW.active.windowSizeFunc, [GLFW.active.width, GLFW.active.height]);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viii', GLFW.active.windowResizeFunc, [GLFW.active.id, width, height]);
+      Runtime.dynCall('viii', GLFW.active.windowSizeFunc, [GLFW.active.id, GLFW.active.width, GLFW.active.height]);
 #endif
     },
 
@@ -722,6 +721,10 @@ var LibraryGLFW = {
     Module["canvas"].addEventListener("mouseup", GLFW.onMouseButtonUp, true);
     Module["canvas"].addEventListener('wheel', GLFW.onMouseWheel, true);
     Module["canvas"].addEventListener('mousewheel', GLFW.onMouseWheel, true);
+
+    Browser.resizeListeners.push(function(width, height) {
+       GLFW.onFullScreenEventChange();
+    });
     return 1; // GL_TRUE
   },
 

--- a/tests/test_glfw_fullscreen.c
+++ b/tests/test_glfw_fullscreen.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+#define GLFW_INCLUDE_ES2
+#include <GLFW/glfw3.h>
+
+int result = 1;
+
+GLFWwindow* g_window;
+
+int inFullscreen = 0;
+int wasFullscreen = 0;
+
+void render();
+void error_callback(int error, const char* description);
+
+void render() {
+  glClearColor(1.0f, 1.0f, 0.0f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void error_callback(int error, const char* description) {
+  fprintf(stderr, "Error %d: %s\n", error, description);
+}
+
+void windowSizeCallback(GLFWwindow* window, int width, int height) {
+  int isInFullscreen = EM_ASM_INT_V(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
+  if (isInFullscreen && !wasFullscreen) {
+    printf("Successfully transitioned to fullscreen mode!\n");
+    wasFullscreen = isInFullscreen;
+  }
+  
+  if (wasFullscreen && !isInFullscreen) {
+    printf("Exited fullscreen. Test succeeded.\n");
+    result = 1;
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    wasFullscreen = isInFullscreen;
+    emscripten_cancel_main_loop();
+    return;
+  }  
+}
+
+int main() {
+  // Setup g_window
+  glfwSetErrorCallback(error_callback);
+  if (!glfwInit())
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif      
+    return -1;
+  }
+  glfwWindowHint(GLFW_RESIZABLE , 1);
+  g_window = glfwCreateWindow(600, 450, "GLFW resizing test - windowed", NULL, NULL);
+  if (!g_window)
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif           
+    glfwTerminate();
+    return -1;
+  }
+  glfwMakeContextCurrent(g_window);
+
+  // Install callbacks
+  glfwSetWindowSizeCallback(g_window, windowSizeCallback);
+
+  // Main loop
+  printf("You should see a yellow canvas.\n");
+  printf("Check the 'resize canvas' option on the upper right corner and then enter full screen mode.\n");
+  printf("When in full screen, you should see the whole screen filled yellow, and after exiting, the yellow canvas should be restored in the window.\n");
+  printf("REMARK: You MUST check the 'resize canvas' option!\n");
+  emscripten_set_main_loop(render, 0, 1);
+
+  glfwTerminate();
+
+  return 0;
+}

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -121,3 +121,6 @@ class interactive(BrowserCore):
 
   def test_vr(self):
     self.btest(path_from_root('tests', 'test_vr.c'), expected='0')
+
+  def test_glfw_fullscreen(self):
+    self.btest('test_glfw_fullscreen.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])


### PR DESCRIPTION
The GLFW library was not listening to Resize events, and thus Resizing Canvas was not working. This could be easily solved by adding a listener and preventing cascaded events (to avoid function call stack overflow).

(Same pull request as https://github.com/kripken/emscripten/pull/3526 but this time using the proper branches).