### PR TITLE
Remove unnecessary relpath in emar. Fixes #3525.

### DIFF
--- a/emar
+++ b/emar
@@ -40,7 +40,7 @@ if len(newargs) > 2:
           parts = base_name.split('.')
           parts[0] += '_' + h
           newname = '.'.join(parts)
-          full_newname = os.path.relpath(os.path.join(dir_name, newname))
+          full_newname = os.path.join(dir_name, newname)
           if not os.path.exists(full_newname):
             try: # it is ok to fail here, we just don't get hashing
               shutil.copyfile(orig_name, full_newname)


### PR DESCRIPTION
Examining the code, I am not sure why there needs to be a `relpath`call to compute `full_newname` since absolute paths should work here fine as well? This change enabled @asRIA to successfully build on Windows (tested locally on his machine).