### PR TITLE
fix_emscripten_log

### DIFF
--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -5,7 +5,7 @@ mergeInto(LibraryManager.library, {
   // Returns the resulting string string as a character array.
   _formatString__deps: ['strlen', '_reallyNegative'],
   _formatString: function(format, varargs) {
-    assert((varargs & 7) === 0);
+    assert((varargs & 3) === 0);
     var textIndex = format;
     var argIndex = 0;
     function getNextArg(type) {

--- a/tests/emscripten_log/emscripten_log.cpp
+++ b/tests/emscripten_log/emscripten_log.cpp
@@ -134,6 +134,9 @@ void __attribute__((noinline)) Foo() // Arbitrary function signature to add some
 
 int main()
 {
+	int test = 123;
+	emscripten_log(EM_LOG_FUNC_PARAMS | EM_LOG_DEMANGLE | EM_LOG_CONSOLE, "test print %d\n", test);
+
 	Foo<int>();
 #ifdef REPORT_RESULT
 	REPORT_RESULT();

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7013,7 +7013,8 @@ Module.printErr = Module['printErr'] = function(){};
       # XXX Does not work in SpiderMonkey since callstacks cannot be captured when running in asm.js, see https://bugzilla.mozilla.org/show_bug.cgi?id=947996
       self.banned_js_engines = [SPIDERMONKEY_ENGINE] 
     if '-g' not in Building.COMPILER_TEST_OPTS: Building.COMPILER_TEST_OPTS.append('-g')
-    self.do_run('#define RUN_FROM_JS_SHELL\n' + open(path_from_root('tests', 'emscripten_log', 'emscripten_log.cpp')).read(), "Success!")
+    Building.COMPILER_TEST_OPTS += ['-DRUN_FROM_JS_SHELL']
+    self.do_run(open(path_from_root('tests', 'emscripten_log', 'emscripten_log.cpp')).read(), "Success!")
 
   def test_float_literals(self):
     self.do_run_from_file(path_from_root('tests', 'test_float_literals.cpp'), path_from_root('tests', 'test_float_literals.out'))


### PR DESCRIPTION
Add a new test case to emscripten_log.cpp to fix a logging crash, and fix it by removing a unnecessarily strict assertion in formatString (code in formatString only needs 4 byte alignment, but asserts 8 bytes)