### PR TITLE
Embind: Skip over preset values when extracting first outstanding emval

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -38,7 +38,7 @@ var LibraryEmVal = {
 
   $get_first_emval__deps: ['$emval_handle_array'],
   $get_first_emval: function() {
-    for (var i = 1; i < emval_handle_array.length; ++i) {
+    for (var i = 5; i < emval_handle_array.length; ++i) {
         if (emval_handle_array[i] !== undefined) {
             return emval_handle_array[i];
         }


### PR DESCRIPTION
This is upstreaming a fix from IMVU. ``get_first_emval`` isn't used in any public code.