### PR TITLE
Make ENVIRONMENT_IS_NODE false if ENVIRONMENT_IS_WORKER is true

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -194,3 +194,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Krzysztof Jakubowski <nadult@fastmail.fm>
 * Vladimír Vondruš <mosra@centrum.cz>
 * Brion Vibber <brion@pobox.com>
+* Andreas Blixt <me@blixt.nyc>

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -14,8 +14,8 @@ try {
 var arguments_ = [];
 
 var ENVIRONMENT_IS_WEB = typeof window === 'object';
-var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB;
 var ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
+var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
 var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 
 if (ENVIRONMENT_IS_NODE) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -35,12 +35,12 @@ for (var key in Module) {
 // The environment setup code below is customized to use Module.
 // *** Environment setup code ***
 var ENVIRONMENT_IS_WEB = typeof window === 'object';
-var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB;
 // Three configurations we can be running in:
 // 1) We could be the application main() thread running in the main JS UI thread. (ENVIRONMENT_IS_WORKER == false and ENVIRONMENT_IS_PTHREAD == false)
 // 2) We could be the application main() thread proxied to worker. (with Emscripten -s PROXY_TO_WORKER=1) (ENVIRONMENT_IS_WORKER == true, ENVIRONMENT_IS_PTHREAD == false)
 // 3) We could be an application pthread running in a worker. (ENVIRONMENT_IS_WORKER == true and ENVIRONMENT_IS_PTHREAD == true)
 var ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
+var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
 #if USE_PTHREADS
 var ENVIRONMENT_IS_PTHREAD;
 if (!ENVIRONMENT_IS_PTHREAD) ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.


### PR DESCRIPTION
Web Workers are also run in web environments (albeit without the `window` global), and cannot access Node.js specifics. Considering them to be web will avoid breaking Browserify scripts that are run as Web Workers (because Browserify simulates a Node.js environment, making Emscripten think it's running as Node.js).

I've successfully used code with this change, but please take into consideration corner cases where `ENVIRONMENT_IS_WEB`-only code attempts to access the `window` global or any other global that is not accessible within a Web Worker.