### PR TITLE
Fix emcc pre-js option when used with the preload-file one

### DIFF
--- a/emcc
+++ b/emcc
@@ -1318,7 +1318,7 @@ try:
     if not closure:
       file_args.append('--no-closure')
     file_code = execute([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE)[0]
-    pre_js = file_code + pre_js
+    pre_js = pre_js + file_code
 
   # Apply pre and postjs files
   if pre_js or post_js:


### PR DESCRIPTION
When using the pre-js and preload-file options with emcc, the content of the pre-js file is inserted
after the data download code generated by tools/file_packager.py. 

This is problematic when one wants to use a custom location for the .data file through the use of 
the Module variable 'filePackagePrefixURL'. The value of that one is typically overridden in the pre-js file but as its content is inserted after the data download code, the value of the new prefix has not been set and the data download fails. 
