### PR TITLE
Fix SDL.joystickAxisValueConversion to clamp the axis value in [-1, 1].

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1258,6 +1258,7 @@ var LibrarySDL = {
     // value [-32768, 32767]
     joystickAxisValueConversion: function(value) {
       // Ensures that 0 is 0, 1 is 32767, and -1 is 32768.
+      value = Math.min(1.0, Math.max(value, -1.0));
       return Math.ceil(((value+1) * 32767.5) - 32768);
     },
 


### PR DESCRIPTION
Some web browsers gamepad API might give values out of the [-1, 1] range for some extreme cases, probably because of some float precision issues. SDL.joystickAxisValueConversion will now clamp the axis value in order to avoid conversion issues.