### PR TITLE
Several OpenAL alGetSource*() fixes

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1036,7 +1036,7 @@ var LibraryOpenAL = {
     case 0x1010 /* AL_SOURCE_STATE */:
     case 0x1015 /* AL_BUFFERS_QUEUED */:
     case 0x1016 /* AL_BUFFERS_PROCESSED */:
-      this._alGetSourcei(source, param, values);
+      _alGetSourcei(source, param, values);
       break;
     default:
 #if OPENAL_DEBUG
@@ -1132,7 +1132,7 @@ var LibraryOpenAL = {
     case 0x1024 /* AL_SEC_OFFSET */:
     case 0x1025 /* AL_SAMPLE_OFFSET */:
     case 0x1026 /* AL_BYTE_OFFSET */:
-      this._alGetSourcef(source, param, values);
+      _alGetSourcef(source, param, values);
       break;
     case 0x1004 /* AL_POSITION */:
       var position = src.position;

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1066,6 +1066,7 @@ var LibraryOpenAL = {
     }
   },
 
+  alGetSourcefv__deps: ['alGetSourcef'],
   alGetSourcefv: function(source, param, values) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -1082,6 +1083,21 @@ var LibraryOpenAL = {
       return;
     }
     switch (param) {
+    case 0x1003 /* AL_PITCH */:
+    case 0x100A /* AL_GAIN */:
+    case 0x100D /* AL_MIN_GAIN */:
+    case 0x100E /* AL_MAX_GAIN */:
+    case 0x1023 /* AL_MAX_DISTANCE */:
+    case 0x1021 /* AL_ROLLOFF_FACTOR */:
+    case 0x1022 /* AL_CONE_OUTER_GAIN */:
+    case 0x1001 /* AL_CONE_INNER_ANGLE */:
+    case 0x1002 /* AL_CONE_OUTER_ANGLE */:
+    case 0x1020 /* AL_REFERENCE_DISTANCE */:
+    case 0x1024 /* AL_SEC_OFFSET */:
+    case 0x1025 /* AL_SAMPLE_OFFSET */:
+    case 0x1026 /* AL_BYTE_OFFSET */:
+      this._alGetSourcef(source, param, values);
+      break;
     case 0x1004 /* AL_POSITION */:
       var position = src.position;
       {{{ makeSetValue('values', '0', 'position[0]', 'float') }}}

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1011,6 +1011,42 @@ var LibraryOpenAL = {
     }
   },
 
+  alGetSourceiv__deps: ['alGetSourcei'],
+  alGetSourceiv: function(source, param, values) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alGetSourceiv called without a valid context");
+#endif
+      return;
+    }
+    var src = AL.currentContext.src[source];
+    if (!src) {
+#if OPENAL_DEBUG
+      console.error("alGetSourceiv called with an invalid source");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return;
+    }
+    switch (param) {
+    case 0x202 /* AL_SOURCE_RELATIVE */:
+    case 0x1001 /* AL_CONE_INNER_ANGLE */:
+    case 0x1002 /* AL_CONE_OUTER_ANGLE */:
+    case 0x1007 /* AL_LOOPING */:
+    case 0x1009 /* AL_BUFFER */:
+    case 0x1010 /* AL_SOURCE_STATE */:
+    case 0x1015 /* AL_BUFFERS_QUEUED */:
+    case 0x1016 /* AL_BUFFERS_PROCESSED */:
+      this._alGetSourcei(source, param, values);
+      break;
+    default:
+#if OPENAL_DEBUG
+      console.error("alGetSourceiv with param " + param + " not implemented yet");
+#endif
+      AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+      break;
+    }
+  },
+
   alGetSourcef: function(source, param, value) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -973,6 +973,9 @@ var LibraryOpenAL = {
     case 0x1002 /* AL_CONE_OUTER_ANGLE */:
       {{{ makeSetValue('value', '0', 'src.coneOuterAngle', 'i32') }}};
       break;
+    case 0x1007 /* AL_LOOPING */:
+      {{{ makeSetValue('value', '0', 'src.loop', 'i32') }}};
+      break;
     case 0x1009 /* AL_BUFFER */:
       if (!src.queue.length) {
         {{{ makeSetValue('value', '0', '0', 'i32') }}};


### PR DESCRIPTION
This pull request corrects a few things about Emscripten's OpenAL implementation, notably what alGetSource* should do.

These still aren't perfectly to-spec, as mostly-useless queries like asking for AL_GAIN through alGetSourceiv() will generate an AL error instead of returning 0 or 1, etc, but it fixes some common API uses.