### PR TITLE
Add try-except for failed registry key lookup on Windows

### DIFF
--- a/emrun
+++ b/emrun
@@ -687,18 +687,20 @@ def win_get_default_browser():
   # Manually find the default system browser on Windows without relying on 'start %1' since
   # that method has an issue, see comment below.
 
-  # In Py3, this module is called winreg without the underscore
+  # In Py3, the _winreg module is called winreg without the underscore
+  try:
+    with OpenKey(HKEY_CURRENT_USER, r"Software\Classes\http\shell\open\command") as key:
+      cmd = QueryValue(key, None)
+      if cmd:
+        parts = shlex.split(cmd)
+        if len(parts) > 0:
+          return [parts[0]]
+  except WindowsError:
+    logv("Unable to find default browser key in Windows registry. Trying fallback.")
 
-  with OpenKey(HKEY_CURRENT_USER, r"Software\Classes\http\shell\open\command") as key:
-    cmd = QueryValue(key, None)
-    if cmd:
-      parts = shlex.split(cmd)
-      if len(parts) > 0:
-        return [parts[0]]
-
-    # Fall back to 'start %1', which we have to treat as if user passed --serve_forever, since
-    # for some reason, we are not able to detect when the browser closes when this is passed.
-    return ['cmd', '/C', 'start']
+  # Fall back to 'start %1', which we have to treat as if user passed --serve_forever, since
+  # for some reason, we are not able to detect when the browser closes when this is passed.
+  return ['cmd', '/C', 'start']
 
 def find_browser(name):
   if WINDOWS and name == 'start':

--- a/emrun
+++ b/emrun
@@ -684,10 +684,8 @@ def which(program):
   return None
 
 def win_get_default_browser():
-  # Manually find the default system browser on Windows without relying on 'start %1' since
-  # that method has an issue, see comment below.
-
-  # In Py3, the _winreg module is called winreg without the underscore
+  # Look in the registry for the default system browser on Windows without relying on
+  # 'start %1' since that method has an issue, see comment below.
   try:
     with OpenKey(HKEY_CURRENT_USER, r"Software\Classes\http\shell\open\command") as key:
       cmd = QueryValue(key, None)


### PR DESCRIPTION
Without a default browser configured in the Windows registry, emrun's `win_get_default_browser()` function fails with an assertion:
```
"[...]\emscripten\emscripten\1.27.0\\emrun", line 678, in win_get_default_browser
    with OpenKey(HKEY_CURRENT_USER, r"Software\Classes\http\shell\open\command") as key:
WindowsError: [Error 2] The system cannot find the file specified
```
This pull request wraps that code in a try-except to enable continuing on to the existing fallback.

It also updates the comments, deleting the obsolete comment about `_winreg` vs. `winreg`, which no longer applied since that module's symbols are imported explicitly and the module name not used in this function, and tweaking the main explanatory comment slightly.