### PR TITLE
Web worker cursor style

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,4 +200,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Andreas Blixt <me@blixt.nyc>
 * Haofeng Zhang <h.z@duke.edu>
 * Cody Welsh <codyw@protonmail.com>
+* Hoong Ern Ng <hoongern@gmail.com>
 

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -140,6 +140,10 @@ worker.onmessage = function worker_onmessage(event) {
           }
           break;
         }
+        case 'setStyle': {
+          Module.canvas.style[data.property] = data.value;
+          break;
+        }
         default: throw 'eh?';
       }
       break;

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -254,6 +254,28 @@ document.createElement = function document_createElement(what) {
         }
       });
 
+      var style = {
+        parentCanvas: canvas,
+        removeProperty: function(){},
+        setProperty:  function(){},
+      };
+
+      Object.defineProperty(style, 'cursor', {
+        set: function(value) {
+          if (!style.cursor_ || style.cursor_ !== value) {
+            style.cursor_ = value;
+            if (style.parentCanvas === Module['canvas']) {
+              postMessage({ target: 'canvas', op: 'setStyle', property: 'cursor', value: style.cursor_ });
+            }
+          }
+        },
+        get: function() {
+          return style.cursor_;
+        }
+      });
+
+      canvas.style = style;
+
       return canvas;
     }
     default: throw 'document.createElement ' + what;

--- a/tests/canvas_style_proxy.c
+++ b/tests/canvas_style_proxy.c
@@ -1,0 +1,7 @@
+#include <emscripten.h>
+
+int main() {
+    EM_ASM({
+        Module['canvas'].style['cursor'] = 'pointer';
+    });
+}

--- a/tests/canvas_style_proxy_pre.js
+++ b/tests/canvas_style_proxy_pre.js
@@ -1,0 +1,5 @@
+var Module = Module || {};
+Module.postRun = Module.postRun || [];
+Module.postRun.push(function () {
+  postMessage({ target: 'window', method: 'verifyCanvasStyle' });
+})

--- a/tests/canvas_style_proxy_shell.html
+++ b/tests/canvas_style_proxy_shell.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      textarea.emscripten { font-family: monospace; width: 80%; }
+      div.emscripten { text-align: center; }
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; }
+
+      .spinner {
+        height: 50px;
+        width: 50px;
+        margin: 0px auto;
+        -webkit-animation: rotation .8s linear infinite;
+        -moz-animation: rotation .8s linear infinite;
+        -o-animation: rotation .8s linear infinite;
+        animation: rotation 0.8s linear infinite;
+        border-left: 10px solid rgb(0,150,240);
+        border-right: 10px solid rgb(0,150,240);
+        border-bottom: 10px solid rgb(0,150,240);
+        border-top: 10px solid rgb(100,0,200);
+        border-radius: 100%;
+        background-color: rgb(200,100,250);
+      }
+      @-webkit-keyframes rotation {
+        from {-webkit-transform: rotate(0deg);}
+        to {-webkit-transform: rotate(360deg);}
+      }
+      @-moz-keyframes rotation {
+        from {-moz-transform: rotate(0deg);}
+        to {-moz-transform: rotate(360deg);}
+      }
+      @-o-keyframes rotation {
+        from {-o-transform: rotate(0deg);}
+        to {-o-transform: rotate(360deg);}
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+    </style>
+  </head>
+  <body>
+    <hr/>
+    <figure style="overflow:visible;" id="spinner"><div class="spinner"></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
+    <div class="emscripten" id="status">Downloading...</div>
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>  
+    </div>
+    <div class="emscripten_border">
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <hr/>
+    <div class="emscripten">
+      <input type="checkbox" id="resize">Resize canvas
+      <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
+      &nbsp;&nbsp;&nbsp;
+      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+                                                                                document.getElementById('resize').checked)">
+    </div>
+    
+    <hr/>
+    <textarea class="emscripten" id="output" rows="8"></textarea>
+    <hr>
+    <script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          if (0) { // XXX disabled for safety typeof dump == 'function') {
+            dump(text + '\n'); // fast, straight to the real console
+          } else {
+            console.error(text);
+          }
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+          setCanvasStyle(canvas);
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Date.now() < 30) return; // if this is a progress update, skip it if too soon
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function() {
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) Module.printErr('[post-exception status] ' + text);
+        };
+      };
+
+      function setCanvasStyle(canvas) {
+        canvas.style.cursor = 'none';
+      }
+
+      window.verifyCanvasStyle = function () {
+        var success = Module.canvas.style.cursor === 'pointer';
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8888/report_result?' + (success ? 1 : 0));
+        xhr.send();
+        setTimeout(function() { window.close() }, 1000);
+      }
+
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2691,3 +2691,6 @@ window.close = function() {
     self.btest(d, expected='0', args=args + ["--closure", "0"])
     self.btest(d, expected='0', args=args + ["--closure", "0", "-g"])
     self.btest(d, expected='0', args=args + ["--closure", "1"])
+
+  def test_canvas_style_proxy(self):
+    self.btest('canvas_style_proxy.c', expected='1', args=['--proxy-to-worker', '--shell-file', path_from_root('tests/canvas_style_proxy_shell.html'), '--pre-js', path_from_root('tests/canvas_style_proxy_pre.js')])


### PR DESCRIPTION
Implements a basic style property on the web worker's canvas to allow css cursor style to be proxied back to the main thread. More properties could theoretically be added in the future, I am unsure as to how you prefer to handle unimplemented properties (currently they are ignored with no warnings) and whether you need tests.