### PR TITLE
Quote Node's fs module calls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -201,4 +201,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Haofeng Zhang <h.z@duke.edu>
 * Cody Welsh <codyw@protonmail.com>
 * Hoong Ern Ng <hoongern@gmail.com>
-
+* Kagami Hiiragi <kagami@genshiken.org>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4915,6 +4915,8 @@ def process(filename):
     Settings.SYSCALL_DEBUG = 1
     src = open(path_from_root('tests', 'fs', 'test_nodefs_rw.c'), 'r').read()
     self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
+    self.emcc_args += ['--closure', '1']
+    self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
 
   def test_fs_trackingdelegate(self):
     src = path_from_root('tests', 'fs', 'test_trackingdelegate.c')

--- a/third_party/closure-compiler/node-externs/LICENSE
+++ b/third_party/closure-compiler/node-externs/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/closure-compiler/node-externs/README.md
+++ b/third_party/closure-compiler/node-externs/README.md
@@ -1,0 +1,64 @@
+![node.js Closure Compiler externs](https://raw.github.com/dcodeIO/node.js-closure-compiler-externs/master/NodejsClosureCompilerExterns.png)
+================================
+A collection of node.js externs for use with [Closure Compiler](https://developers.google.com/closure/compiler/docs/overview)
+/ [ClosureCompiler.js](https://github.com/dcodeIO/ClosureCompiler.js).
+
+See: [Advanced Compilation and Externs](https://developers.google.com/closure/compiler/docs/api-tutorial3) for details
+
+#### Naming convention ####
+
+* Externs for core components are all lower case
+* Externs for [non-core components](https://github.com/dcodeIO/node.js-closure-compiler-externs/tree/master/contrib) begin with an upper case character
+
+#### Node.js specific annotation ####
+
+If an extern file refers to a module that's usually loaded through `var modulename = require("modulename")`, a comment
+is added on top of the file. For example for the fs module:
+
+````javascript
+/**
+ BEGIN_NODE_INCLUDE
+ var fs = require('fs');
+ END_NODE_INCLUDE
+ */
+````
+
+**NOTE:** This comment on its own does nothing. But if you stick to the template, that is including the fs module exactly
+the same way naming it also "fs", the compiler will know how to handle the module and its subcomponents. For example:
+
+```javascript
+// This is bad:
+var EventEmitter = require("events").EventEmitter;
+
+// This is good:
+var events = require("events");
+var EventEmitter = events.EventEmitter;
+```
+
+If a file requires a dependency, it is named in the `@fileoverview` declaration. You should then include the dependency
+in your compile step, too.
+
+Testing [![Build Status](https://travis-ci.org/dcodeIO/node.js-closure-compiler-externs.png?branch=master)](https://travis-ci.org/dcodeIO/node.js-closure-compiler-externs)
+-------
+Externs are automatically syntax-validated through a [ClosureCompiler.js](https://github.com/dcodeIO/ClosureCompiler.js)
+test run. This does not imply that the extern is complete or does actually represent the underlying API (but it should).
+
+Usage with ClosureCompiler.js
+-----------------------------
+[ClosureCompiler.js](https://github.com/dcodeIO/ClosureCompiler.js) depends on an npm distribution of this repository.
+As a result, specifiying `--externs=node` automatically includes all node.js specific externs in your compile step. If
+you are using non-core modules, you may still need [additional externs](https://github.com/dcodeIO/ClosureCompiler.js#externs-for-advanced_optimizations)
+for these.
+
+Downloads
+---------
+* [ZIP-Archive](https://github.com/dcodeIO/node.js-closure-compiler-externs/archive/master.zip)
+* [Tarball](https://github.com/dcodeIO/node.js-closure-compiler-externs/tarball/master)
+
+License
+-------
+Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
+
+This repository is not officially supported by Google, Joyent or individual module authors. If the closure compiler 
+license header is used in a file, it is just there so signal that it is ok to include it in official closure channels.
+All rights belong to their respective owners.

--- a/third_party/closure-compiler/node-externs/assert.js
+++ b/third_party/closure-compiler/node-externs/assert.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's assert module
+ * @see http://nodejs.org/api/assert.html
+ * @see https://github.com/joyent/node/blob/master/lib/assert.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var assert = require('assert');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @param {*} value
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+var assert = function(value, message) {};
+
+/**
+ * @param {{message: string, actual: *, expected: *, operator: string}} options
+ * @constructor
+ * @extends Error
+ */
+assert.AssertionError = function(options) {};
+
+/**
+ * @return {string}
+ */
+assert.AssertionError.prototype.toString = function() {};
+
+/**
+ * @param {*} value
+ * @param {string=} message
+ * @throws {assert.AssertionError}
+ */
+assert.ok = function(value, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @param {string} operator
+ * @throws {assert.AssertionError}
+ */
+assert.fail = function(actual, expected, message, operator) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.equal = function(actual, expected, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.notEqual = function(actual, expected, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.deepEqual = function(actual, expected, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.notDeepEqual = function(actual, expected, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.strictEqual = function(actual, expected, message) {};
+
+/**
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ * @throws {assert.AssertionError}
+ */
+assert.notStrictEqual = function(actual, expected, message) {};
+
+/**
+ * @name assert.throws
+ * @function
+ * @param {function()} block
+ * @param {Function|RegExp|function(*)} error
+ * @param {string=} message
+ * @throws {assert.AssertionError}
+ */
+// Error: .\assert.js:120: ERROR - Parse error. missing name after . operator
+// assert.throws = function(block, error, message) {};
+
+/**
+ * @param {function()} block
+ * @param {Function|RegExp|function(*)} error
+ * @param {string=} message
+ * @throws {assert.AssertionError}
+ */
+assert.doesNotThrow = function(block, error, message) {};
+
+/**
+ * @param {*} value
+ * @throws {assert.AssertionError}
+ */
+assert.ifError = function(value) {};

--- a/third_party/closure-compiler/node-externs/buffer.js
+++ b/third_party/closure-compiler/node-externs/buffer.js
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's buffer module.
+ * @see http://nodejs.org/api/buffer.html
+ * @see https://github.com/joyent/node/blob/master/lib/buffer.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var buffer = require('buffer');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var buffer = {};
+
+/**
+ * @param {...*} var_args
+ * @constructor
+ * @nosideeffects
+ */
+buffer.Buffer = function(var_args) {};
+
+/**
+ * @param {string} encoding
+ * @return {boolean}
+ */
+buffer.Buffer.isEncoding = function(encoding) {};
+
+/**
+ * @param {*} obj
+ * @return {boolean}
+ * @nosideeffects
+ */
+buffer.Buffer.isBuffer = function(obj) {};
+
+/**
+ * @param {string} string
+ * @param {string=} encoding
+ * @return {number}
+ * @nosideeffects
+ */
+buffer.Buffer.byteLength = function(string, encoding) {};
+
+/**
+ * @param {Array.<buffer.Buffer>} list
+ * @param {number=} totalLength
+ * @return {buffer.Buffer}
+ * @nosideeffects
+ */
+buffer.Buffer.concat = function(list, totalLength) {};
+
+/**
+ * @param {number} offset
+ * @return {*}
+ */
+buffer.Buffer.prototype.get = function(offset) {};
+
+/**
+ * @param {number} offset
+ * @param {*} v
+ */
+buffer.Buffer.prototype.set = function(offset, v) {};
+
+/**
+ * @param {string} string
+ * @param {number|string=} offset
+ * @param {number|string=} length
+ * @param {number|string=} encoding
+ * @return {*}
+ */
+buffer.Buffer.prototype.write = function(string, offset, length, encoding) {};
+
+/**
+ * @return {Array}
+ */
+buffer.Buffer.prototype.toJSON = function() {};
+
+/**
+ * @type {number}
+ */
+buffer.Buffer.prototype.length;
+
+/**
+ * @param {buffer.Buffer} targetBuffer
+ * @param {number=} targetStart
+ * @param {number=} sourceStart
+ * @param {number=} sourceEnd
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.copy = function(targetBuffer, targetStart, sourceStart, sourceEnd){};
+
+/**
+ * @param {number=} start
+ * @param {number=} end
+ * @return {buffer.Buffer}
+ * @nosideeffects
+ */
+buffer.Buffer.prototype.slice = function(start, end) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readUInt8 = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readUInt16LE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readUInt16BE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readUInt32LE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readUInt32BE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readInt8 = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readInt16LE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readInt16BE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readInt32LE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readInt32BE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readFloatLE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readFloatBE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readDoubleLE = function(offset, noAssert) {};
+
+/**
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.readDoubleBE = function(offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeInt8 = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeFloatLE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeFloatBE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeDoubleLE = function(value, offset, noAssert) {};
+
+/**
+ * @param {number} value
+ * @param {number} offset
+ * @param {boolean=} noAssert
+ * @return {number}
+ */
+buffer.Buffer.prototype.writeDoubleBE = function(value, offset, noAssert) {};
+
+/**
+ * @param {*} value
+ * @param {number=} offset
+ * @param {number=} end
+ */
+buffer.Buffer.prototype.fill = function(value, offset, end) {};
+
+/**
+ * @param {string=} encoding
+ * @param {number=} start
+ * @param {number=} end
+ * @nosideeffects
+ */
+buffer.Buffer.prototype.toString = function(encoding, start, end) {};
+
+/**
+ * @type {number}
+ */
+buffer.Buffer.INSPECT_MAX_BYTES = 50;
+
+/**
+ * @param {number} size
+ */
+buffer.SlowBuffer = function(size) {};
+
+/**
+ * 
+ * @param {string} string
+ * @param {number|string} offset
+ * @param {number|string=} length
+ * @param {number|string=} encoding
+ * @return {*}
+ */
+buffer.SlowBuffer.prototype.write = function(string, offset, length, encoding) {};
+
+/**
+ * @param {number} start
+ * @param {number} end
+ * @return {buffer.Buffer}
+ */
+buffer.SlowBuffer.prototype.slice = function(start, end) {};
+
+/**
+ * @return {string}
+ */
+buffer.SlowBuffer.prototype.toString = function() {};
+
+//
+// Legacy
+//
+
+/**
+ * @param {number=} start
+ * @param {number=} end
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.utf8Slice = function(start, end) {};
+
+/**
+ * @param {number=} start
+ * @param {number=} end
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.binarySlice = function(start, end) {};
+
+/**
+ * @param {number=} start
+ * @param {number=} end
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.asciiSlice = function(start, end) {};
+
+/**
+ * @param {string} string
+ * @param {number=} offset
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.utf8Write = function(string, offset) {};
+
+/**
+ * @param {string} string
+ * @param {number=} offset
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.binaryWrite = function(string, offset) {};
+
+/**
+ * @param {string} string
+ * @param {number=} offset
+ * @return {buffer.Buffer}
+ */
+buffer.Buffer.prototype.asciiWrite = function(string, offset) {};

--- a/third_party/closure-compiler/node-externs/child_process.js
+++ b/third_party/closure-compiler/node-externs/child_process.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's child_process module. Depends on the events module.
+ * @see http://nodejs.org/api/child_process.html
+ * @see https://github.com/joyent/node/blob/master/lib/child_process.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var child_process = require('child_process');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var child_process = {};
+
+/**
+ * @constructor
+ * @param {...*} var_args
+ * @extends events.EventEmitter
+ */
+child_process.ChildProcess = function(var_args) {}; // Private?
+
+/**
+ * @type {stream.ReadableStream}
+ */
+child_process.ChildProcess.prototype.stdin;
+
+/**
+ * @type {stream.WritableStream}
+ */
+child_process.ChildProcess.prototype.stdout;
+
+/**
+ * @type {stream.WritableStream}
+ */
+child_process.ChildProcess.prototype.stderr;
+
+/**
+ * @type {number}
+ */
+child_process.ChildProcess.prototype.pid;
+
+/**
+ * @param {string=} signal
+ */
+child_process.ChildProcess.prototype.kill = function(signal) {};
+
+/**
+ * @param {Object.<string,*>} message
+ * @param {*} sendHandle
+ */
+child_process.ChildProcess.prototype.send = function(message, sendHandle) {};
+
+/**
+ */
+child_process.ChildProcess.prototype.disconnect = function() {};
+
+/**
+ * @typedef {{cwd: string, stdio: (Array|string), customFds: Array, env: Object.<string,*>, detached: boolean, uid: number, gid: number, encoding: string, timeout: number, maxBuffer: number, killSignal: string}}
+ */
+child_process.Options;
+
+/**
+ * @param {string} command
+ * @param {Array.<string>=} args
+ * @param {child_process.Options=} options
+ * @return {child_process.ChildProcess}
+ */
+child_process.ChildProcess.spawn = function(command, args, options) {};
+
+/**
+ * @param {string} command
+ * @param {child_process.Options|function(Error, buffer.Buffer, buffer.Buffer)=} options
+ * @param {function(Error, buffer.Buffer, buffer.Buffer)=} callback
+ * @return {child_process.ChildProcess}
+ */
+child_process.exec = function(command, options, callback) {};
+
+/**
+ * @param {string} file
+ * @param {Array.<string>} args
+ * @param {child_process.Options} options
+ * @param {function(Error, buffer.Buffer, buffer.Buffer)} callback
+ * @return {child_process.ChildProcess}
+ */
+child_process.execFile = function(file, args, options, callback) {};
+
+/**
+ * @param {string} modulePath
+ * @param {Array.<string>=} args
+ * @param {child_process.Options=} options
+ * @return {child_process.ChildProcess}
+ */
+child_process.fork = function(modulePath, args, options) {};

--- a/third_party/closure-compiler/node-externs/cluster.js
+++ b/third_party/closure-compiler/node-externs/cluster.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's cluster module. Depends on the events module.
+ * @see http://nodejs.org/api/cluster.html
+ * @see https://github.com/joyent/node/blob/master/lib/cluster.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var cluster = require('cluster');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type events.EventEmitter
+ */
+var cluster;
+
+/**
+ * @typedef {{exec: string, args: Array.<string>, silent: boolean}}
+ */
+cluster.Settings;
+
+/**
+ * @type {cluster.Settings}
+ */
+cluster.settings;
+
+/**
+ * @type {boolean}
+ */
+cluster.isMaster;
+
+/**
+ * @type {boolean}
+ */
+cluster.isWorker;
+
+/**
+ * @param {cluster.Settings=} settings
+ */
+cluster.setupMaster = function(settings) {};
+
+/**
+ * @param {Object.<string,*>} env
+ * @return {cluster.Worker}
+ */
+cluster.fork = function(env) {};
+
+/**
+ * @param {function()=} callback
+ */
+cluster.disconnect = function(callback) {};
+
+/**
+ * @type {?cluster.Worker}
+ */
+cluster.worker;
+
+/**
+ * @type {?Object.<string,cluster.Worker>}
+ */
+cluster.workers;
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+cluster.Worker = function() {};
+
+/**
+ * @type {string}
+ */
+cluster.Worker.prototype.id;
+
+/**
+ * @type {child_process.ChildProcess}
+ */
+cluster.Worker.prototype.process;
+
+/**
+ * @type {boolean}
+ */
+cluster.Worker.prototype.suicide;
+
+/**
+ * @param {Object} message
+ * @param {*=} sendHandle
+ */
+cluster.Worker.prototype.send = function(message, sendHandle) {};
+
+/**
+ */
+cluster.Worker.prototype.destroy = function() {};
+
+/**
+ */
+cluster.Worker.prototype.disconnect = function() {};

--- a/third_party/closure-compiler/node-externs/core.js
+++ b/third_party/closure-compiler/node-externs/core.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's core.
+ * @see http://nodejs.org/api/globals.html
+ * @see http://nodejs.org/api/modules.html
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ * @param name
+ * @return {*}
+ */
+var require = function(name) {}
+
+/**
+ * @return {string}
+ */
+require.resolve = function() {};
+
+/**
+ * @type {Object.<string,*>}
+ */
+require.cache;
+
+/**
+ * @type {Array}
+ */
+require.extensions;
+
+/**
+ * @type {Object}
+ */
+require.main;
+
+/**
+ * @type {string}
+ */
+var __filename;
+
+/**
+ * @type {string}
+ */
+var __dirname;
+
+/**
+ * @type {Object}
+ */
+var module = {};
+
+/**
+ * @type {*}
+ */
+var exports;
+
+/**
+ * @type {Object.<string,*>}
+ */
+module.exports;
+
+/**
+ * @type {function(string)}
+ */
+module.require;
+
+/**
+ * @type {string}
+ */
+module.filename;
+
+/**
+ * @type {boolean}
+ */
+module.loaded;
+
+/**
+ * @type {*}
+ */
+module.parent;
+
+/**
+ * @type {Array}
+ */
+module.children;
+
+/**
+ * @type {Object.<string,*>}
+ */
+var global = {};
+
+/**
+ * @type {buffer.Buffer}
+ */
+var Buffer;

--- a/third_party/closure-compiler/node-externs/crypto.js
+++ b/third_party/closure-compiler/node-externs/crypto.js
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's crypto module. Depends on the buffer module.
+ * @see http://nodejs.org/api/crypto.html
+ * @see https://github.com/joyent/node/blob/master/lib/crypto.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var crypto = require('crypto');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var crypto = {};
+
+/**
+ * @type {string}
+ */
+crypto.DEFAULT_ENCODING;
+
+/**
+ * @typedef {{pfx: (string|buffer.Buffer), key: (string|buffer.Buffer), passphrase: string, cert: (string|buffer.Buffer), ca: Array.<string|buffer.Buffer>, crl: (string|Array.<string>), ciphers: string}}
+ */
+crypto.Credentials;
+
+/**
+ * @param {Object.<string,string>=} details
+ * @return {crypto.Credentials}
+ */
+crypto.createCredentials = function(details) {};
+
+/**
+ * @param {string} algorithm
+ * @return {crypto.Hash}
+ */
+crypto.createHash = function(algorithm) {};
+
+/**
+ * @param {string} algorithm
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Hash = function(algorithm, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {string=} input_encoding
+ */
+crypto.Hash.prototype.update = function(data, input_encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string}
+ */
+crypto.Hash.prototype.digest = function(encoding) {};
+
+/**
+ * @param {string} algorithm
+ * @param {string|buffer.Buffer} key
+ * @return {crypto.Hmac}
+ */
+crypto.createHmac = function(algorithm, key) {};
+
+/**
+ * @param {string} hmac
+ * @param {string|buffer.Buffer} key
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Hmac = function(hmac, key, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ */
+crypto.Hmac.prototype.update = function(data) {};
+
+/**
+ * @param {string} encoding
+ */
+crypto.Hmac.prototype.digest = function(encoding) {};
+
+/**
+ * @param {string} algorithm
+ * @param {string|buffer.Buffer} password
+ * @return {crypto.Cipher}
+ */
+crypto.createCipher = function(algorithm, password) {};
+
+/**
+ * @param {string} algorithm
+ * @param {string|buffer.Buffer} key
+ * @param {string|buffer.Buffer} iv
+ * @return {crypto.Cipheriv}
+ */
+crypto.createCipheriv = function(algorithm, key, iv) {};
+
+/**
+ * @param {string|buffer.Buffer} cipher
+ * @param {string} password
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Cipher = function(cipher, password, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {string=} input_encoding
+ * @param {string=} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Cipher.prototype.update = function(data, input_encoding, output_encoding) {};
+
+/**
+ * @name crypto.Cipher.prototype.final
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Cipher.prototype['final'] = function(output_encoding) {};
+
+/**
+ * @param {boolean=} auto_padding
+ */
+crypto.Cipher.prototype.setAutoPadding = function(auto_padding) {};
+
+/**
+ * Note:  Cipheriv mixes update, final, and setAutoPadding from Cipher but
+ * doesn't inherit directly from Cipher.
+ *
+ * @param {string} cipher
+ * @param {string|buffer.Buffer} key
+ * @param {string|buffer.Buffer} iv
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Cipheriv = function(cipher, key, iv) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {string=} input_encoding
+ * @param {string=} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Cipheriv.prototype.update = function(data, input_encoding, output_encoding) {};
+
+/**
+ * @name crypto.Cipheriv.prototype.final
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Cipheriv.prototype['final'] = function(output_encoding) {};
+
+/**
+ * @param {boolean=} auto_padding
+ */
+crypto.Cipheriv.prototype.setAutoPadding = function(auto_padding) {};
+
+/**
+ * @param {string} algorithm
+ * @param {string|buffer.Buffer} password
+ * @return {crypto.Decipher}
+ */
+crypto.createDecipher = function(algorithm, password) {};
+
+/**
+ * @param {string} algorithm
+ * @param {string|buffer.Buffer} key
+ * @param {string|buffer.Buffer} iv
+ * @return {crypto.Decipheriv}
+ */
+crypto.createDecipheriv = function(algorithm, key, iv) {};
+
+/**
+ * Note:  Decipher mixes update, final, and setAutoPadding from Cipher but
+ * doesn't inherit directly from Cipher.
+ *
+ * @param {string|buffer.Buffer} cipher
+ * @param {string|buffer.Buffer} password
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Decipher = function(cipher, password, options) {}
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {string=} input_encoding
+ * @param {string=} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipher.prototype.update = function(data, input_encoding, output_encoding) {};
+
+/**
+ * @name crypto.Decipher.prototype.final
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipher.prototype['final'] = function(output_encoding) {};
+
+/**
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipher.prototype.finaltol = function(output_encoding) {};
+
+/**
+ * @param {boolean=} auto_padding
+ */
+crypto.Decipher.prototype.setAutoPadding = function(auto_padding) {};
+
+/**
+ * Note:  Decipheriv mixes update, final, and setAutoPadding from Cipher but
+ * doesn't inherit directly from Cipher.
+ *
+ * @param {string|buffer.Buffer|crypto.Decipheriv} cipher
+ * @param {string|buffer.Buffer} key
+ * @param {string|buffer.Buffer} iv
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+crypto.Decipheriv = function(cipher, key, iv, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {string=} input_encoding
+ * @param {string=} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipheriv.prototype.update = function(data, input_encoding, output_encoding) {};
+
+/**
+ * @name crypto.Decipheriv.prototype.final
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipheriv.prototype['final'] = function(output_encoding) {};
+
+/**
+ * @param {string} output_encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.Decipheriv.prototype.finaltol = function(output_encoding) {};
+
+/**
+ * @param {boolean=} auto_padding
+ */
+crypto.Decipheriv.prototype.setAutoPadding = function(auto_padding) {};
+
+/**
+ * @param {string} algorithm
+ * @return {crypto.Sign}
+ */
+crypto.createSign = function(algorithm) {};
+
+/**
+ * @param {string} algorithm
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Writable
+ */
+crypto.Sign = function(algorithm, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ */
+crypto.Sign.prototype.update = function(data) {};
+
+/**
+ * @param {string} private_key
+ * @param {string=} output_format
+ * @return {string|buffer.Buffer}
+ */
+crypto.Sign.prototype.sign = function(private_key, output_format) {};
+
+/**
+ * @param {string} algorithm
+ * @return crypto.Verify
+ */
+crypto.createVerify = function(algorithm) {};
+
+/**
+ * @param {string} algorithm
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Writable
+ */
+crypto.Verify = function(algorithm, options) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ */
+crypto.Verify.prototype.update = function(data) {};
+
+/**
+ * @param {string} object
+ * @param {string|buffer.Buffer} signature
+ * @param {string=} signature_format
+ * @return {boolean}
+ */
+crypto.Verify.prototype.verify = function(object, signature, signature_format) {};
+
+/**
+ * @param {number} prime
+ * @param {string=} encoding
+ * @return {crypto.DiffieHellman}
+ */
+crypto.createDiffieHellman = function(prime, encoding) {};
+
+/**
+ * @param {number} sizeOrKey
+ * @param {string=} encoding
+ * @constructor
+ */
+crypto.DiffieHellman = function(sizeOrKey, encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.generateKeys = function(encoding) {};
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} inEnc
+ * @param {string=} outEnc
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.computeSecret = function(key, inEnc, outEnc) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.getPrime = function(encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.getGenerator = function(encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.getPublicKey = function(encoding) {};
+
+/**
+ * @param {string} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellman.prototype.getPrivateKey = function(encoding) {}
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} encoding
+ * @return {crypto.DiffieHellman}
+ */
+crypto.DiffieHellman.prototype.setPublicKey = function(key, encoding) {};
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} encoding
+ * @return {crypto.DiffieHellman}
+ */
+crypto.DiffieHellman.prototype.setPrivateKey = function(key, encoding) {};
+
+/**
+ * Note:  DiffieHellmanGroup mixes DiffieHellman but doesn't inherit directly.
+ *
+ * @param {string} name
+ * @constructor
+ */
+crypto.DiffieHellmanGroup = function(name) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.generateKeys = function(encoding) {};
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} inEnc
+ * @param {string=} outEnc
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.computeSecret = function(key, inEnc, outEnc) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.getPrime = function(encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.getGenerator = function(encoding) {};
+
+/**
+ * @param {string=} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.getPublicKey = function(encoding) {};
+
+/**
+ * @param {string} encoding
+ * @return {string|buffer.Buffer}
+ */
+crypto.DiffieHellmanGroup.prototype.getPrivateKey = function(encoding) {}
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} encoding
+ * @return {crypto.DiffieHellmanGroup}
+ */
+crypto.DiffieHellmanGroup.prototype.setPublicKey = function(key, encoding) {};
+
+/**
+ * @param {string|buffer.Buffer} key
+ * @param {string=} encoding
+ * @return {crypto.DiffieHellmanGroup}
+ */
+crypto.DiffieHellmanGroup.prototype.setPrivateKey = function(key, encoding) {};
+
+/**
+ * @param {string} group_name
+ * @return {crypto.DiffieHellmanGroup}
+ */
+crypto.getDiffieHellman = function(group_name) {};
+
+/**
+ * @param {string|buffer.Buffer} password
+ * @param {string|buffer.Buffer} salt
+ * @param {number} iterations
+ * @param {number} keylen
+ * @param {function(*, string)} callback
+ */
+crypto.pbkdf2 = function(password, salt, iterations, keylen, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} password
+ * @param {string|buffer.Buffer} salt
+ * @param {number} iterations
+ * @param {number} keylen
+ */
+crypto.pbkdf2Sync = function(password, salt, iterations, keylen) {};
+
+/**
+ * @param {number} size
+ * @param {function(Error, buffer.Buffer)=} callback
+ */
+crypto.randomBytes = function(size, callback) {};
+
+/**
+ * @param {number} size
+ * @param {function(Error, buffer.Buffer)=} callback
+ */
+crypto.pseudoRandomBytes = function(size, callback) {};
+
+/**
+ * @param {number} size
+ * @param {function(Error, buffer.Buffer)=} callback
+ */
+crypto.rng = function(size, callback) {};
+
+/**
+ * @param {number} size
+ * @param {function(Error, buffer.Buffer)=} callback
+ */
+crypto.prng = function(size, callback) {};
+
+/**
+ * @return {Array.<string>}
+ */
+crypto.getCiphers = function() {};
+
+/**
+ * @return {Array.<string>}
+ */
+crypto.getHashes = function() {};

--- a/third_party/closure-compiler/node-externs/dgram.js
+++ b/third_party/closure-compiler/node-externs/dgram.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's dgram module. Depends on the events module.
+ * @see http://nodejs.org/api/dgram.html
+ * @see https://github.com/joyent/node/blob/master/lib/dgram.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var dgram = require('dgram');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var dgram = {};
+
+/**
+ * @param {string} type
+ * @param {function(...)=} callback
+ * @return {dgram.Socket}
+ */
+dgram.createSocket = function(type, callback) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+dgram.Socket = function() {};
+
+/**
+ * @param {buffer.Buffer} buf
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} port
+ * @param {string} address
+ * @param {function(...)=} callback
+ */
+dgram.Socket.prototype.send = function(buf, offset, length, port, address, callback) {};
+
+/** 
+ * @param {number} port
+ * @param {string=} address
+ */
+dgram.Socket.prototype.bind = function(port, address) {};
+
+/**
+ */
+dgram.Socket.prototype.close = function() {};
+
+/**
+ * @return {string}
+ */
+dgram.Socket.prototype.address = function() {};
+
+/**
+ * @param {boolean} flag
+ */
+dgram.Socket.prototype.setBroadcast = function(flag) {};
+
+/**
+ * @param {number} ttl
+ * @return {number}
+ */
+dgram.Socket.prototype.setTTL = function(ttl) {};
+
+/**
+ * @param {number} ttl
+ * @return {number}
+ */
+dgram.Socket.prototype.setMulticastTTL = function(ttl) {};
+
+/**
+ * @param {boolean} flag
+ */
+dgram.Socket.prototype.setMulticastLoopback = function(flag) {};
+
+/**
+ * @param {string} multicastAddress
+ * @param {string=} multicastInterface
+ */
+dgram.Socket.prototype.addMembership = function(multicastAddress, multicastInterface) {};
+
+/**
+ * @param {string} multicastAddress
+ * @param {string=} multicastInterface
+ */
+dgram.Socket.prototype.dropMembership = function(multicastAddress, multicastInterface) {};

--- a/third_party/closure-compiler/node-externs/dns.js
+++ b/third_party/closure-compiler/node-externs/dns.js
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's dns module.
+ * @see http://nodejs.org/api/dns.html
+ * @see https://github.com/joyent/node/blob/master/lib/dns.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var dns = require('dns');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var dns = {};
+
+/**
+ * @param {string} domain
+ * @param {string|function(Error,string,string)} family
+ * @param {function(?Error,string,string)=} callback
+ */
+dns.lookup = function(domain, family, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {string|function(?Error,Array)} rrtype
+ * @param {function(?Error,Array)=}callback
+ */
+dns.resolve = function(domain, rrtype, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolve4 = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolve6 = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolveMx = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolveTxt = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolveSrv = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolveNs = function(domain, callback) {};
+
+/**
+ * @param {string} domain
+ * @param {function(?Error,Array)}callback
+ */
+dns.resolveCname = function(domain, callback) {};
+
+/**
+ * @param {string} ip
+ * @param {function(?Error,Array)}callback
+ */
+dns.reverse = function(ip, callback) {};
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NODATA = 'ENODATA';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.FORMERR = 'EFORMERR';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.SERVFAIL = 'ESERVFAIL';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NOTFOUND = 'ENOTFOUND';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NOTIMP = 'ENOTIMP';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.REFUSED = 'EREFUSED';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADQUERY = 'EBADQUERY';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADNAME = 'EBADNAME';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADFAMILY = 'EBADFAMILY';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADRESP = 'EBADRESP';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.CONNREFUSED = 'ECONNREFUSED';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.TIMEOUT = 'ETIMEOUT';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.EOF = 'EOF';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.FILE = 'EFILE';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NOMEM = 'ENOMEM';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.DESTRUCTION = 'EDESTRUCTION';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADSTR = 'EBADSTR';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADFLAGS = 'EBADFLAGS';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NONAME = 'ENONAME';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.BADHINTS = 'EBADHINTS';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.NOTINITIALIZED = 'ENOTINITIALIZED';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.LOADIPHLPAPI = 'ELOADIPHLPAPI';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.ADDRGETNETWORKPARAMS = 'EADDRGETNETWORKPARAMS';
+
+/**
+ * @type {string}
+ * @const
+ */
+dns.CANCELLED = 'ECANCELLED';

--- a/third_party/closure-compiler/node-externs/domain.js
+++ b/third_party/closure-compiler/node-externs/domain.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's domain module. Depends on the events module.
+ * @see http://nodejs.org/api/domain.html
+ * @see https://github.com/joyent/node/blob/master/lib/domain.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var domain = {};
+
+/**
+ * @type {domain.Domain}
+ */
+domain.active;
+
+/**
+ * @return {domain.Domain}
+ */
+domain.create = function() {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+domain.Domain = function() {};
+
+/**
+ * @param {function()} fn
+ */
+domain.Domain.prototype.run = function(fn) {};
+
+/**
+ * @type {Array}
+ */
+domain.Domain.prototype.members;
+
+/**
+ * @param {events.EventEmitter} emitter
+ */
+domain.Domain.prototype.add = function(emitter) {};
+
+/**
+ * @param {events.EventEmitter} emitter
+ */
+domain.Domain.prototype.remove = function(emitter) {};
+
+/**
+ * @param {function(...[*])} callback
+ * @return {function(...[*])}
+ */
+domain.Domain.prototype.bind = function(callback) {};
+
+/**
+ * @param {function(...[*])} callback
+ * @return {function(...[*])}
+ */
+domain.Domain.prototype.intercept = function(callback) {};
+
+/**
+ */
+domain.Domain.prototype.dispose = function() {};
+
+// Undocumented
+
+/**
+ */
+domain.Domain.prototype.enter = function() {};
+
+/**
+ */
+domain.Domain.prototype.exit = function() {};

--- a/third_party/closure-compiler/node-externs/events.js
+++ b/third_party/closure-compiler/node-externs/events.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's "events" module.
+ * @see http://nodejs.org/api/events.html
+ * @see https://github.com/joyent/node/blob/master/lib/events.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+BEGIN_NODE_INCLUDE
+var events = require('events');
+END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var events = {};
+
+/**
+ * @constructor
+ */
+events.EventEmitter = function() {};
+
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.addListener = function(event, listener) {};
+
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.on = function(event, listener) {};
+
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.once = function(event, listener) {};
+
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.removeListener = function(event, listener) {};
+
+/**
+ * @param {string=} event
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.removeAllListeners = function(event) {};
+
+/**
+ * @param {number} n
+ */
+events.EventEmitter.prototype.setMaxListeners = function(n) {};
+
+/**
+ * @param {string} event
+ * @return {Array.<function(...)>}
+ */
+events.EventEmitter.prototype.listeners = function(event) {};
+
+/**
+ * @param {string} event
+ * @param {...*} var_args
+ * @return {boolean}
+ */
+events.EventEmitter.prototype.emit = function(event, var_args) {};
+
+// Undocumented
+
+/**
+ * @type {boolean}
+ */
+events.usingDomains;
+
+/**
+ * @param {events.EventEmitter} emitter
+ * @param {string} type
+ */
+events.EventEmitter.listenerCount = function(emitter, type) {};

--- a/third_party/closure-compiler/node-externs/fs.js
+++ b/third_party/closure-compiler/node-externs/fs.js
@@ -1,0 +1,625 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's fs module. Depends on the stream and events module.
+ * @see http://nodejs.org/api/fs.html
+ * @see https://github.com/joyent/node/blob/master/lib/fs.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var fs = require('fs');
+ END_NODE_INCLUDE
+ */
+
+var fs = {};
+
+/**
+ * @param {string} oldPath
+ * @param {string} newPath
+ * @param {function(...)=} callback
+ */
+fs.rename = function(oldPath, newPath, callback) {};
+
+/**
+ * @param {string} oldPath
+ * @param {string} newPath
+ */
+fs.renameSync = function(oldPath, newPath) {};
+
+/**
+ * @param {*} fd
+ * @param {number} len
+ * @param {function(...)=} callback
+ */
+fs.truncate = function(fd, len, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {number} len
+ */
+fs.truncateSync = function(fd, len) {};
+
+/**
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ * @param {function(...)=} callback
+ */
+fs.chown = function(path, uid, gid, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ */
+fs.chownSync = function(path, uid, gid) {};
+
+/**
+ * @param {*} fd
+ * @param {number} uid
+ * @param {number} gid
+ * @param {function(...)=} callback
+ */
+fs.fchown = function(fd, uid, gid, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {number} uid
+ * @param {number} gid
+ */
+fs.fchownSync = function(fd, uid, gid) {};
+
+/**
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ * @param {function(...)=} callback
+ */
+fs.lchown = function(path, uid, gid, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ */
+fs.lchownSync = function(path, uid, gid) {};
+
+/**
+ * @param {string} path
+ * @param {number} mode
+ * @param {function(...)=} callback
+ */
+fs.chmod = function(path, mode, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number} mode
+ */
+fs.chmodSync = function(path, mode) {};
+
+/**
+ * @param {*} fd
+ * @param {number} mode
+ * @param {function(...)=} callback
+ */
+fs.fchmod = function(fd, mode, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {number} mode
+ */
+fs.fchmodSync = function(fd, mode) {};
+
+/**
+ * @param {string} path
+ * @param {number} mode
+ * @param {function(...)=} callback
+ */
+fs.lchmod = function(path, mode, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number} mode
+ */
+fs.lchmodSync = function(path, mode) {};
+
+/**
+ * @param {string} path
+ * @param {function(string, fs.Stats)=} callback
+ */
+fs.stat = function(path, callback) {};
+
+/**
+ * @param {string} path
+ * @return {fs.Stats}
+ * @nosideeffects
+ */
+fs.statSync = function(path) {}
+
+/**
+ * @param {*} fd
+ * @param {function(string, fs.Stats)=} callback
+ */
+fs.fstat = function(fd, callback) {};
+
+/**
+ * @param {*} fd
+ * @return {fs.Stats}
+ * @nosideeffects
+ */
+fs.fstatSync = function(fd) {}
+
+/**
+ * @param {string} path
+ * @param {function(string, fs.Stats)=} callback
+ */
+fs.lstat = function(path, callback) {};
+
+/**
+ * @param {string} path
+ * @return {fs.Stats}
+ * @nosideeffects
+ */
+fs.lstatSync = function(path) {}
+
+/**
+ * @param {string} srcpath
+ * @param {string} dstpath
+ * @param {function(...)=} callback
+ */
+fs.link = function(srcpath, dstpath, callback) {};
+
+/**
+ * @param {string} srcpath
+ * @param {string} dstpath
+ */
+fs.linkSync = function(srcpath, dstpath) {};
+
+/**
+ * @param {string} srcpath
+ * @param {string} dstpath
+ * @param {string=} type
+ * @param {function(...)=} callback
+ */
+fs.symlink = function(srcpath, dstpath, type, callback) {};
+
+/**
+ * @param {string} srcpath
+ * @param {string} dstpath
+ * @param {string=} type
+ */
+fs.symlinkSync = function(srcpath, dstpath, type) {};
+
+/**
+ * @param {string} path
+ * @param {function(string, string)=} callback
+ */
+fs.readlink = function(path, callback) {};
+
+/**
+ * @param {string} path
+ * @return {string}
+ * @nosideeffects
+ */
+fs.readlinkSync = function(path) {};
+
+/**
+ * @param {string} path
+ * @param {Object.<string,string>|function(string, string)=} cache
+ * @param {function(string, string)=} callback
+ */
+fs.realpath = function(path, cache, callback) {};
+
+/**
+ * @param {string} path
+ * @param {Object.<string,string>=} cache
+ * @return {string}
+ * @nosideeffects
+ */
+fs.realpathSync = function(path, cache) {};
+
+/**
+ * @param {string} path
+ * @param {function(...)=} callback
+ */
+fs.unlink = function(path, callback) {};
+
+/**
+ * @param {string} path
+ */
+fs.unlinkSync = function(path) {};
+
+/**
+ * @param {string} path
+ * @param {function(...)=} callback
+ */
+fs.rmdir = function(path, callback) {};
+
+/**
+ * @param {string} path
+ */
+fs.rmdirSync = function(path) {};
+
+/**
+ * @param {string} path
+ * @param {number=} mode
+ * @param {function(...)=} callback
+ */
+fs.mkdir = function(path, mode, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number=} mode
+ */
+fs.mkdirSync = function(path, mode) {};
+
+/**
+ * @param {string} path
+ * @param {function(string,Array.<string>)=} callback
+ */
+fs.readdir = function(path, callback) {};
+
+/**
+ * @param {string} path
+ * @return {Array.<string>}
+ * @nosideeffects
+ */
+fs.readdirSync = function(path) {};
+
+/**
+ * @param {*} fd
+ * @param {function(...)=} callback
+ */
+fs.close = function(fd, callback) {};
+
+/**
+ * @param {*} fd
+ */
+fs.closeSync = function(fd) {};
+
+/**
+ * @param {string} path
+ * @param {string} flags
+ * @param {number=} mode
+ * @param {function(string, *)=} callback
+ */
+fs.open = function(path, flags, mode, callback) {};
+
+/**
+ * @param {string} path
+ * @param {string} flags
+ * @param {number=} mode
+ * @return {*}
+ * @nosideeffects
+ */
+fs.openSync = function(path, flags, mode) {};
+
+/**
+ * @param {string} path
+ * @param {number|Date} atime
+ * @param {number|Date} mtime
+ * @param {function(...)=} callback
+ */
+fs.utimes = function(path, atime, mtime, callback) {};
+
+/**
+ * @param {string} path
+ * @param {number|Date} atime
+ * @param {number|Date} mtime
+ * @nosideeffects
+ */
+fs.utimesSync = function(path, atime, mtime) {};
+
+/**
+ * @param {*} fd
+ * @param {number|Date} atime
+ * @param {number|Date} mtime
+ * @param {function(...)=} callback
+ */
+fs.futimes = function(fd, atime, mtime, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {number|Date} atime
+ * @param {number|Date} mtime
+ * @nosideeffects
+ */
+fs.futimesSync = function(fd, atime, mtime) {};
+
+/**
+ * @param {*} fd
+ * @param {function(...)=} callback
+ */
+fs.fsync = function(fd, callback) {};
+
+/**
+ * @param {*} fd
+ */
+fs.fsyncSync = function(fd) {};
+
+/**
+ * @param {*} fd
+ * @param {*} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @param {function(string, number, *)=} callback
+ */
+fs.write = function(fd, buffer, offset, length, position, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {*} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @return {number}
+ */
+fs.writeSync = function(fd, buffer, offset, length, position) {};
+
+/**
+ * @param {*} fd
+ * @param {*} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @param {function(string, number, *)=} callback
+ */
+fs.read = function(fd, buffer, offset, length, position, callback) {};
+
+/**
+ * @param {*} fd
+ * @param {*} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @return {number}
+ * @nosideeffects
+ */
+fs.readSync = function(fd, buffer, offset, length, position) {};
+
+/**
+ * @param {string} filename
+ * @param {string|{encoding:(string|undefined),flag:(string|undefined)}|function(string, (string|buffer.Buffer))=} encodingOrOptions
+ * @param {function(string, (string|buffer.Buffer))=} callback
+ */
+fs.readFile = function(filename, encodingOrOptions, callback) {};
+
+/**
+ * @param {string} filename
+ * @param {string|{encoding:(string|undefined),flag:(string|undefined)}=} encodingOrOptions
+ * @return {string|buffer.Buffer}
+ * @nosideeffects
+ */
+fs.readFileSync = function(filename, encodingOrOptions) {};
+
+/**
+ * @param {string} filename
+ * @param {*} data
+ * @param {string|{encoding:(string|undefined),mode:(number|undefined),flag:(string|undefined)}|function(string)=} encodingOrOptions
+ * @param {function(string)=} callback
+ */
+fs.writeFile = function(filename, data, encodingOrOptions, callback) {};
+
+/**
+ * @param {string} filename
+ * @param {*} data
+ * @param {string|{encoding:(string|undefined),mode:(number|undefined),flag:(string|undefined)}|function(string)=} encodingOrOptions
+ */
+fs.writeFileSync = function(filename, data, encodingOrOptions) {};
+
+/**
+ * @param {string} filename
+ * @param {*} data
+ * @param {string|function(string)=} encoding
+ * @param {function(string)=} callback
+ */
+fs.appendFile = function(filename, data, encoding, callback) {};
+
+/**
+ * @param {string} filename
+ * @param {*} data
+ * @param {string|function(string)=} encoding
+ */
+fs.appendFileSync = function(filename, data, encoding) {};
+
+/**
+ * @param {string} filename
+ * @param {{persistent: boolean, interval: number}|function(*,*)=} options
+ * @param {function(*,*)=} listener
+ */
+fs.watchFile = function(filename, options, listener) {};
+
+/**
+ * @param {string} filename
+ * @param {function(string, string)=} listener
+ */
+fs.unwatchFile = function(filename, listener) {};
+
+/**
+ * 
+ * @param {string} filename
+ * @param {{persistent: boolean}|function(string, string)=} options
+ * @param {function(string, string)=} listener
+ * @return {fs.FSWatcher}
+ */
+fs.watch = function(filename, options, listener) {};
+
+/**
+ * @param {string} path
+ * @param {function(boolean)} callback
+ */
+fs.exists = function(path, callback) {};
+
+/**
+ * @param {string} path
+ * @nosideeffects
+ */
+fs.existsSync = function(path) {};
+
+/**
+ * @constructor
+ */
+fs.Stats = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isFile = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isDirectory = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isBlockDevice = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isCharacterDevice = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isSymbolicLink = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isFIFO = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+fs.Stats.prototype.isSocket = function() {};
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.dev = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.ino = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.mode = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.nlink = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.uid = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.gid = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.rdev = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.size = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.blkSize = 0;
+
+/**
+ * @type {number}
+ */
+fs.Stats.prototype.blocks = 0;
+
+/**
+ * @type {Date}
+ */
+fs.Stats.prototype.atime;
+
+/**
+ * @type {Date}
+ */
+fs.Stats.prototype.mtime;
+
+/**
+ * @type {Date}
+ */
+fs.Stats.prototype.ctime;
+
+/**
+ * @param {string} path
+ * @param {{flags: string, encoding: ?string, fd: *, mode: number, bufferSize: number}=} options
+ * @return {fs.ReadStream}
+ * @nosideeffects
+ */
+fs.createReadStream = function(path, options) {};
+
+/**
+ * @constructor
+ * @extends stream.ReadableStream
+ */
+fs.ReadStream = function() {};
+
+/**
+ * @param {string} path
+ * @param {{flags: string, encoding: ?string, mode: number}=} options
+ * @return {fs.WriteStream}
+ * @nosideeffects
+ */
+fs.createWriteStream = function(path, options) {};
+
+/**
+ * @constructor
+ * @extends stream.WritableStream
+ */
+fs.WriteStream = function() {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+fs.FSWatcher = function() {};
+
+/**
+ */
+fs.FSWatcher.prototype.close = function() {};

--- a/third_party/closure-compiler/node-externs/http.js
+++ b/third_party/closure-compiler/node-externs/http.js
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's http module. Depends on the events module.
+ * @see http://nodejs.org/api/http.html
+ * @see https://github.com/joyent/node/blob/master/lib/http.js
+ * @externs
+ */
+
+/**
+BEGIN_NODE_INCLUDE
+var http = require('http');
+END_NODE_INCLUDE
+ */
+
+var http = {};
+
+/**
+ * @typedef {function(http.IncomingMessage, http.ServerResponse)}
+ */
+http.requestListener;
+
+/**
+ * @param {http.requestListener=} listener
+ * @return {http.Server}
+ */
+http.createServer = function(listener) {};
+
+/**
+ * @param {http.requestListener=} listener  
+ * @constructor
+ * @extends events.EventEmitter
+ */
+http.Server = function(listener) {};
+
+/**
+ * @param {(number|string)} portOrPath
+ * @param {(string|Function)=} hostnameOrCallback
+ * @param {Function=} callback
+ */
+http.Server.prototype.listen = function(portOrPath, hostnameOrCallback, callback) {};
+
+/**
+ */
+http.Server.prototype.close = function() {};
+
+/**
+ * @constructor
+ * @extends stream.Readable
+ */
+http.IncomingMessage = function() {};
+
+/**
+ * @type {?string}
+ * */
+http.IncomingMessage.prototype.method;
+
+/**
+ * @type {?string}
+ */
+http.IncomingMessage.prototype.url;
+
+/**
+ * @type {Object}
+ * */
+http.IncomingMessage.prototype.headers;
+
+/**
+ * @type {Object}
+ * */
+http.IncomingMessage.prototype.trailers;
+
+/**
+ * @type {string}
+ */
+http.IncomingMessage.prototype.httpVersion;
+
+/**
+ * @type {string}
+ */
+http.IncomingMessage.prototype.httpVersionMajor;
+
+/**
+ * @type {string}
+ */
+http.IncomingMessage.prototype.httpVersionMinor;
+
+/**
+ * @type {*}
+ */
+http.IncomingMessage.prototype.connection;
+
+/**
+ * @type {?number}
+ */
+http.IncomingMessage.prototype.statusCode;
+
+/**
+ * @type {net.Socket}
+ */
+http.IncomingMessage.prototype.socket;
+
+/**
+ * @param {number} msecs
+ * @param {function()} callback
+ */
+http.IncomingMessage.prototype.setTimeout = function(msecs, callback) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ * @private
+ */
+http.ServerResponse = function() {};
+
+/**
+ */
+http.ServerResponse.prototype.writeContinue = function() {};
+
+/**
+ * @param {number} statusCode
+ * @param {*=} reasonPhrase
+ * @param {*=} headers
+ */
+http.ServerResponse.prototype.writeHead = function(statusCode, reasonPhrase, headers) {};
+
+/**
+ * @type {number}
+ */
+http.ServerResponse.prototype.statusCode;
+
+/**
+ * @param {string} name
+ * @param {string} value
+ */
+http.ServerResponse.prototype.setHeader = function(name, value) {};
+
+/**
+ * @param {string} name
+ * @return {string|undefined} value
+ */
+http.ServerResponse.prototype.getHeader = function(name) {};
+
+/**
+ * @param {string} name
+ */
+http.ServerResponse.prototype.removeHeader = function(name) {};
+
+/**
+ * @param {string|Array|buffer.Buffer} chunk
+ * @param {string=} encoding
+ */
+http.ServerResponse.prototype.write = function(chunk, encoding) {};
+
+/**
+ * @param {Object} headers
+ */
+http.ServerResponse.prototype.addTrailers = function(headers) {};
+
+/**
+ * @param {(string|Array|buffer.Buffer)=} data
+ * @param {string=} encoding
+ */
+http.ServerResponse.prototype.end = function(data, encoding) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ * @private
+ */
+http.ClientRequest = function() {};
+
+/**
+ * @param {string|Array|buffer.Buffer} chunk
+ * @param {string=} encoding
+ */
+http.ClientRequest.prototype.write = function(chunk, encoding) {};
+
+/**
+ * @param {(string|Array|buffer.Buffer)=} data
+ * @param {string=} encoding
+ */
+http.ClientRequest.prototype.end = function(data, encoding) {};
+
+/**
+ */
+http.ClientRequest.prototype.abort = function() {};
+
+/**
+ * @param {Object} options
+ * @param {function(http.IncomingMessage)} callback
+ * @return {http.ClientRequest}
+ */
+http.request = function(options, callback) {};
+
+/**
+ * @param {Object} options
+ * @param {function(http.IncomingMessage)} callback
+ * @return {http.ClientRequest}
+ */
+http.get = function(options, callback) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+http.Agent = function() {};
+
+/**
+ * @type {number}
+ */
+http.Agent.prototype.maxSockets;
+
+/**
+ * @type {number}
+ */
+http.Agent.prototype.sockets;
+
+/**
+ * @type {Array.<http.ClientRequest>}
+ */
+http.Agent.prototype.requests;
+
+/**
+ * @type {http.Agent}
+ */
+http.globalAgent;

--- a/third_party/closure-compiler/node-externs/https.js
+++ b/third_party/closure-compiler/node-externs/https.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's https module. Depends on the tls module.
+ * @see http://nodejs.org/api/https.html
+ * @see https://github.com/joyent/node/blob/master/lib/https.js
+ * @externs
+ */
+
+/**
+BEGIN_NODE_INCLUDE
+var https = require('https');
+END_NODE_INCLUDE
+ */
+
+var https = {};
+
+/**
+ * @constructor
+ * @extends tls.Server
+ */
+https.Server = function() {};
+
+/**
+ * @param {...*} var_args
+ */
+https.Server.prototype.listen = function(var_args) {};
+
+/**
+ * @param {function()=} callback
+ */
+https.Server.prototype.close = function(callback) {};
+
+/**
+ * @param {tls.CreateOptions} options
+ * @param {function(http.IncomingMessage, http.ServerResponse)=} requestListener
+ */
+https.createServer = function(options, requestListener) {};
+
+/**
+ * @typedef {{host: ?string, hostname: ?string, port: ?number, method: ?string, path: ?string, headers: ?Object.<string,string>, auth: ?string, agent: ?(https.Agent|boolean), pfx: ?(string|buffer.Buffer), key: ?(string|buffer.Buffer), passphrase: ?string, cert: ?(string|buffer.Buffer), ca: ?Array.<string>, ciphers: ?string, rejectUnauthorized: ?boolean}}
+ */
+https.ConnectOptions;
+
+/**
+ * @param {https.ConnectOptions|string} options
+ * @param {function(http.IncomingMessage)} callback
+ * @return {http.ClientRequest}
+ */
+https.request = function(options, callback) {};
+
+/**
+ * @param {https.ConnectOptions|string} options
+ * @param {function(http.IncomingMessage)} callback
+ * @return {http.ClientRequest}
+ */
+https.get = function(options, callback) {};
+
+/**
+ * @constructor
+ * @extends http.Agent
+ */
+https.Agent = function() {};
+
+/**
+ * @type {https.Agent}
+ */
+https.globalAgent;

--- a/third_party/closure-compiler/node-externs/net.js
+++ b/third_party/closure-compiler/node-externs/net.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's net module. Depends on the events and buffer modules.
+ * @see http://nodejs.org/api/net.html
+ * @see https://github.com/joyent/node/blob/master/lib/net.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var net = require('net');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var net = {};
+
+/**
+ * @typedef {{allowHalfOpen: ?boolean}}
+ */
+net.CreateOptions;
+
+/**
+ * @param {(net.CreateOptions|function(...))=} options
+ * @param {function(...)=} connectionListener
+ * @return {net.Server}
+ */
+net.createServer = function(options, connectionListener) {};
+
+/**
+ * @typedef {{port: ?number, host: ?string, localAddress: ?string, path: ?string, allowHalfOpen: ?boolean}}
+ */
+net.ConnectOptions;
+
+/**
+ * @param {net.ConnectOptions|number|string} arg1
+ * @param {(function(...)|string)=} arg2
+ * @param {function(...)=} arg3
+ */
+net.connect = function(arg1, arg2, arg3) {};
+
+/**
+ * @param {net.ConnectOptions|number|string} arg1
+ * @param {(function(...)|string)=} arg2
+ * @param {function(...)=} arg3
+ */
+net.createConnection = function(arg1, arg2, arg3) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+net.Server = function() {};
+
+/**
+ * 
+ * @param {number|*} port
+ * @param {(string|number|function(...))=} host
+ * @param {(number|function(...))=} backlog
+ * @param {function(...)=} callback
+ */
+net.Server.prototype.listen = function(port, host, backlog, callback) {};
+
+/**
+ * @param {function(...)=} callback
+ */
+net.Server.prototype.close = function(callback) {};
+
+/**
+ * @return {{port: number, family: string, address: string}}
+ */
+net.Server.prototype.address = function() {};
+
+/**
+ * @type {number}
+ */
+net.Server.prototype.maxConnectinos;
+
+/**
+ * @type {number}
+ */
+net.Server.prototype.connections;
+
+/**
+ * @constructor
+ * @param {{fd: ?*, type: ?string, allowHalfOpen: ?boolean}=} options
+ * @extends events.EventEmitter
+ */
+net.Socket = function(options) {};
+
+/**
+ * @param {number|string|function(...)} port
+ * @param {(string|function(...))=} host
+ * @param {function(...)=} connectListener
+ */
+net.Socket.prototype.connect = function(port, host, connectListener) {};
+
+/**
+ * @type {number}
+ */
+net.Socket.prototype.bufferSize;
+
+/**
+ * @param {?string=} encoding
+ */
+net.Socket.prototype.setEncoding = function(encoding) {};
+
+/**
+ * @param {string|buffer.Buffer} data
+ * @param {(string|function(...))=}encoding
+ * @param {function(...)=} callback
+ */
+net.Socket.prototype.write = function(data, encoding, callback) {};
+
+/**
+ * @param {(string|buffer.Buffer)=}data
+ * @param {string=} encoding
+ */
+net.Socket.prototype.end = function(data, encoding) {};
+
+/**
+ */
+net.Socket.prototype.destroy = function() {};
+
+/**
+ */
+net.Socket.prototype.pause = function() {};
+
+/**
+ */
+net.Socket.prototype.resume = function() {};
+
+/**
+ * @param {number} timeout
+ * @param {function(...)=} callback
+ */
+net.Socket.prototype.setTimeout = function(timeout, callback) {};
+
+/**
+ * @param {boolean=} noDelay
+ */
+net.Socket.prototype.setNoDelay = function(noDelay) {};
+
+/**
+ * @param {(boolean|number)=} enable
+ * @param {number=} initialDelay
+ */
+net.Socket.prototype.setKeepAlive = function(enable, initialDelay) {};
+
+/**
+ * @return {string}
+ */
+net.Socket.prototype.address = function() {};
+
+/**
+ * @type {?string}
+ */
+net.Socket.prototype.remoteAddress;
+
+/**
+ * @type {?number}
+ */
+net.Socket.prototype.remotePort;
+
+/**
+ * @type {number}
+ */
+net.Socket.prototype.bytesRead;
+
+/**
+ * @type {number}
+ */
+net.Socket.prototype.bytesWritten;
+
+/**
+ * @param {*} input
+ * @return {number}
+ */
+net.isIP = function(input) {};
+
+/**
+ * @param {*} input
+ * @return {boolean}
+ */
+net.isIPv4 = function(input) {};
+
+/**
+ * @param {*} input
+ * @return {boolean}
+ */
+net.isIPv6 = function(input) {};

--- a/third_party/closure-compiler/node-externs/os.js
+++ b/third_party/closure-compiler/node-externs/os.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's os module.
+ * @see http://nodejs.org/api/os.html
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var os = require('os');
+ END_NODE_INCLUDE
+ */
+    
+var os = {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.tmdDir = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.hostname = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.type = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.platform = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.arch = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+os.release = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+os.uptime = function() {};
+
+/**
+ * @return {Array.<number>}
+ * @nosideeffects
+ */
+os.loadavg = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+os.totalmem = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+os.freemem = function() {};
+
+/**
+ * @typedef {{model: string, speed: number, times: {user: number, nice: number, sys: number, idle: number, irg: number}}}
+ */
+var osCpusInfo;
+
+/**
+ * @return {Array.<osCpusInfo>}
+ * @nosideeffects
+ */
+os.cpus = function() {};
+
+/**
+ * @typedef {{address: string, family: string, internal: boolean}}
+ */
+var osNetworkInterfacesInfo;
+
+/**
+ * @return {Object.<string,osNetworkInterfacesInfo>}
+ * @nosideeffects
+ */
+os.networkInterfaces = function() {};
+
+/**
+ * @type {string}
+ */
+os.EOL;

--- a/third_party/closure-compiler/node-externs/path.js
+++ b/third_party/closure-compiler/node-externs/path.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's path module.
+ * @see http://nodejs.org/api/path.html
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var path = require('path');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var path = {};
+
+/**
+ * @param {string} p
+ * @return {string}
+ * @nosideeffects
+ */
+path.normalize = function(p) {};
+
+/**
+ * @param {...string} var_args
+ * @return {string}
+ * @nosideeffects
+ */
+path.join = function(var_args) {};
+
+/**
+ * @param {string} from
+ * @param {string=} to
+ * @return {string}
+ * @nosideeffects
+ */
+path.resolve = function(from, to) {};
+
+/**
+ * @param {string} from
+ * @param {string} to
+ * @return {string}
+ * @nosideeffects
+ */
+path.relative = function(from, to) {};
+
+/**
+ * @param {string} p
+ * @return {string}
+ * @nosideeffects
+ */
+path.dirname = function(p) {};
+
+/**
+ * @param {string} p
+ * @param {string=} ext
+ * @return {string}
+ * @nosideeffects
+ */
+path.basename = function(p, ext) {};
+
+/**
+ * @param {string} p
+ * @return {string}
+ * @nosideeffects
+ */
+path.extname = function(p) {};
+
+/**
+ * @type {string}
+ */
+path.sep;

--- a/third_party/closure-compiler/node-externs/process.js
+++ b/third_party/closure-compiler/node-externs/process.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's global process object. Depends on the stream module.
+ * @see http://nodejs.org/api/process.html
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+var process = function() {};
+
+/**
+ * @type {stream.ReadableStream}
+ */
+process.stdin;
+
+/**
+ * @type {stream.WritableStream}
+ */
+process.stdout;
+
+/**
+ * @type {stream.WritableStream}
+ */
+process.stderr;
+
+/**
+ * @type {Array.<string>}
+ */
+process.argv;
+
+/**
+ * @type {string}
+ */
+process.execPath;
+
+/**
+ */
+process.abort = function() {};
+
+/**
+ * @param {string} directory
+ */
+process.chdir = function(directory) {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ */
+process.cwd = function() {};
+
+/**
+ * @type {Object.<string,string>}
+ */
+process.env;
+
+/**
+ * @param {number=} code
+ */
+process.exit = function(code) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+process.getgid = function() {};
+
+/**
+ * @param {number} id
+ */
+process.setgid = function(id) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+process.getuid = function() {};
+
+/**
+ * @param {number} id
+ */
+process.setuid = function(id) {};
+
+/**
+ * @type {!string}
+ */
+process.version;
+
+/**
+ * @type {Object.<string,string>}
+ */
+process.versions;
+
+/**
+ * @type {Object.<string,*>}
+ */
+process.config;
+
+/**
+ * @param {number} pid
+ * @param {string=} signal
+ */
+process.kill = function(pid, signal) {};
+
+/**
+ * @type {number}
+ */
+process.pid;
+
+/**
+ * @type {string}
+ */
+process.title;
+
+/**
+ * @type {string}
+ */
+process.arch;
+
+/**
+ * @type {string}
+ */
+process.platform;
+
+/**
+ * @return {Object.<string,number>}
+ * @nosideeffects
+ */
+process.memoryUsage = function() {};
+
+/**
+ * @param {!function()} callback
+ */
+process.nextTick = function(callback) {};
+
+/**
+ * @param {number=} mask
+ */
+process.umask = function(mask) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+process.uptime = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+process.hrtime = function() {};

--- a/third_party/closure-compiler/node-externs/punycode.js
+++ b/third_party/closure-compiler/node-externs/punycode.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's punycode module.
+ * @see http://nodejs.org/api/punycode.html
+ * @see https://github.com/joyent/node/blob/master/lib/punycode.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var punycode = require('punycode');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var punycode = {};
+
+/**
+ * @param {string} string
+ * @return {string}
+ */
+punycode.decode = function(string) {};
+
+/**
+ * @param {string} string
+ * @return {string}
+ */
+punycode.encode = function(string) {};
+
+/**
+ * @param {string} domain
+ * @return {string}
+ */
+punycode.toUnicode = function(domain) {};
+
+/**
+ * @param {string} domain
+ * @return {string}
+ */
+punycode.toASCII = function(domain) {};
+
+/**
+ * @type {Object.<string,*>}
+ */
+punycode.ucs2 = {};
+
+/**
+ * @param {string} string
+ * @return {Array.<number>}
+ */
+punycode.ucs2.decode = function(string) {};
+
+/**
+ * @param {Array.<number>} codePoints
+ * @return {string}
+ */
+punycode.ucs2.encode = function(codePoints) {};
+
+/**
+ * @type {string}
+ */
+punycode.version;

--- a/third_party/closure-compiler/node-externs/querystring.js
+++ b/third_party/closure-compiler/node-externs/querystring.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's querystring module.
+ * @see http://nodejs.org/api/querystring.html
+ * @see https://github.com/joyent/node/blob/master/lib/querystring.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var querystring = require('querystring');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var querystring = {};
+
+/**
+ * @param {Object.<string,*>} obj
+ * @param {string=} sep
+ * @param {string=} eq
+ * @return {string}
+ * @nosideeffects
+ */
+querystring.stringify = function(obj, sep, eq) {};
+
+/**
+ * @param {string} str
+ * @param {string=} sep
+ * @param {string=} eq
+ * @param {*=} options
+ * @nosideeffects
+ */
+querystring.parse = function(str, sep, eq, options) {};
+
+/**
+ * @param {string} str
+ * @return {string}
+ */
+querystring.escape = function(str) {};
+
+/**
+ * @param {string} str
+ * @return {string}
+ */
+querystring.unescape = function(str) {};
+
+/**
+ * @param {buffer.Buffer} s
+ * @param {boolean} decodeSpaces
+ */
+querystring.unescapeBuffer = function(s, decodeSpaces) {};

--- a/third_party/closure-compiler/node-externs/readline.js
+++ b/third_party/closure-compiler/node-externs/readline.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's readline module. Depends on the events module.
+ * @see http://nodejs.org/api/readline.html
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var readline = require('readline');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var readline = {};
+
+/**
+ * @param {{input: stream.ReadableStream, output: stream.WritableStream, completer: function(string, function(*, Array)=), terminal: boolean}} options
+ * @return {readline.Interface}
+ */
+readline.createInterface = function(options) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+readline.Interface = function() {};
+
+/**
+ * @param {string} prompt
+ * @param {number} length
+ */
+readline.Interface.prototype.setPrompt = function(prompt, length) {};
+
+/**
+ * @param {boolean=} preserveCursor
+ */
+readline.Interface.prototype.prompt = function(preserveCursor) {};
+
+/**
+ * @param {string} query
+ * @param {function(string)} callback
+ */
+readline.Interface.prototype.question = function(query, callback) {};
+
+/**
+ */
+readline.Interface.prototype.pause = function() {};
+
+/**
+ */
+readline.Interface.prototype.resume = function() {};
+
+/**
+ */
+readline.Interface.prototype.close = function() {};
+
+/**
+ * @param {string} data
+ * @param {Object.<string,*>=} key
+ */
+readline.Interface.prototype.write = function(data, key) {};

--- a/third_party/closure-compiler/node-externs/readme.txt
+++ b/third_party/closure-compiler/node-externs/readme.txt
@@ -1,0 +1,3 @@
+Source repository:
+
+https://github.com/dcodeIO/node.js-closure-compiler-externs

--- a/third_party/closure-compiler/node-externs/repl.js
+++ b/third_party/closure-compiler/node-externs/repl.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's repl module. Depends on the events and stream modules.
+ * @see http://nodejs.org/api/repl.html
+ * @see https://github.com/joyent/node/blob/master/lib/repl.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var repl = require('repl');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var repl = {};
+
+/**
+ * @param {{prompt: ?string, input: ?stream.Readable, output: ?stream.Writable, terminal: ?boolean, eval: ?function(string), useColors: ?boolean, useGlobal: ?boolean, ignoreUndefined: ?boolean, writer: ?function(string)}} options
+ * @return {repl.REPLServer}
+ */
+repl.start = function(options) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+repl.REPLServer = function() {};
+
+/**
+ * @type {Object.<string,*>}
+ */
+repl.REPLServer.prototype.context;

--- a/third_party/closure-compiler/node-externs/stream.js
+++ b/third_party/closure-compiler/node-externs/stream.js
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's stream module. Depends on the events module.
+ * @see http://nodejs.org/api/stream.html
+ * @see https://github.com/joyent/node/blob/master/lib/stream.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var stream = require('stream');
+ END_NODE_INCLUDE
+ */
+
+var stream = {};
+
+/**
+ * @constructor
+ * @param {Object=} options
+ * @extends events.EventEmitter
+ */
+stream.Stream = function(options) {};
+
+/**
+ * @param {stream.Writable} dest
+ * @param {{end: boolean}=} pipeOpts
+ * @return {stream.Writable}
+ */
+stream.Stream.prototype.pipe = function(dest, pipeOpts) {};
+
+/**
+ * @constructor
+ * @extends stream.Readable
+ */
+stream.ReadableStream = function() {};
+
+/**
+ * @type {boolean}
+ */
+stream.ReadableStream.prototype.readable;
+
+/**
+ * @param {string=} encoding
+ */
+stream.ReadableStream.prototype.setEncoding = function(encoding) {};
+
+/**
+ */
+stream.ReadableStream.prototype.destroy = function() {};
+
+/**
+ * @constructor
+ * @extends stream.Writable
+ */
+stream.WritableStream = function() {};
+
+/**
+ */
+stream.WritableStream.prototype.drain = function() {};
+
+/**
+ * @type {boolean}
+ */
+stream.WritableStream.prototype.writable;
+
+/**
+ * @param {string|buffer.Buffer} buffer
+ * @param {string=} encoding
+ */
+stream.WritableStream.prototype.write = function(buffer, encoding) {};
+
+/**
+ * @param {string|buffer.Buffer=} buffer
+ * @param {string=} encoding
+ * @param {function(*=)=} cb
+ */
+stream.WritableStream.prototype.end = function(buffer, encoding, cb) {};
+
+/**
+ */
+stream.WritableStream.prototype.destroy = function() {};
+
+/**
+ */
+stream.WritableStream.prototype.destroySoon = function() {};
+
+// Undocumented
+
+/**
+ * @constructor
+ * @param {Object=} options
+ * @extends stream.Stream
+ */
+stream.Readable = function(options) {};
+
+/**
+ * @type {boolean}
+ * @deprecated
+ */
+stream.Readable.prototype.readable;
+
+/**
+ * @protected
+ * @param {string|buffer.Buffer|null} chunk
+ * @return {boolean}
+ */
+stream.Readable.prototype.push = function(chunk) {};
+
+/**
+ * @param {string|buffer.Buffer|null} chunk
+ * @return {boolean}
+ */
+stream.Readable.prototype.unshift = function(chunk) {};
+
+/**
+ * @param {string} enc
+ */
+stream.Readable.prototype.setEncoding = function(enc) {};
+
+/**
+ * @param {number=} n
+ * @return {buffer.Buffer|string|null}
+ */
+stream.Readable.prototype.read = function(n) {};
+
+/**
+ * @protected
+ * @param {number} n
+ */
+stream.Readable.prototype._read = function(n) {};
+
+/**
+ * @param {stream.Writable=} dest
+ * @return {stream.Readable}
+ */
+stream.Readable.prototype.unpipe = function(dest) {};
+
+/**
+ */
+stream.Readable.prototype.resume = function() {};
+
+/**
+ */
+stream.Readable.prototype.pause = function() {};
+
+/**
+ * @param {stream.Stream} stream
+ * @return {stream.Readable}
+ */
+stream.Readable.prototype.wrap = function(stream) {};
+
+/**
+ * @constructor
+ * @param {Object=} options
+ * @extends stream.Stream
+ */
+stream.Writable = function(options) {};
+
+/**
+ * @deprecated
+ * @type {boolean}
+ */
+stream.Writable.prototype.writable;
+
+/**
+ * @param {string|buffer.Buffer} chunk
+ * @param {string=} encoding
+ * @param {function(*=)=} cb
+ * @return {boolean}
+ */
+stream.Writable.prototype.write = function(chunk, encoding, cb) {};
+
+/**
+ * @protected
+ * @param {string|buffer.Buffer} chunk
+ * @param {string} encoding
+ * @param {function(*=)} cb
+ */
+stream.Writable.prototype._write = function(chunk, encoding, cb) {};
+
+/**
+ * @param {string|buffer.Buffer=} chunk
+ * @param {string=} encoding
+ * @param {function(*=)=} cb
+ */
+stream.Writable.prototype.end = function(chunk, encoding, cb) {};
+
+/**
+ * @constructor
+ * @param {Object=} options
+ * @extends stream.Readable
+ * Xextends stream.Writable
+ */
+stream.Duplex = function(options) {};
+
+/**
+ * @type {boolean}
+ */
+stream.Duplex.prototype.allowHalfOpen;
+
+
+/**
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Duplex
+ */
+stream.Transform = function(options) {};
+
+/**
+ * @protected
+ * @param {string|buffer.Buffer} chunk
+ * @param {string} encoding
+ * @param {function(*=)} cb
+ */
+stream.Transform._transform = function(chunk, encoding, cb) {};
+
+/**
+ * @protected
+ * @param {function(*=)} cb
+ */
+stream.Transform._flush = function(cb) {};
+
+/**
+ * @param {Object=} options
+ * @constructor
+ * @extends stream.Transform
+ */
+stream.PassThrough = function(options) {};

--- a/third_party/closure-compiler/node-externs/string_decoder.js
+++ b/third_party/closure-compiler/node-externs/string_decoder.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's string_decoder module. Depends on the buffer module.
+ * @see http://nodejs.org/api/string_decoder.html
+ * @see https://github.com/joyent/node/blob/master/lib/string_decoder.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var StringDecoder = require('string_decoder');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @param {string} encoding
+ * @constructor
+ */
+var StringDecoder = function(encoding) {};
+
+/**
+ * @param {buffer.Buffer} buffer
+ * @return {string}
+ */
+StringDecoder.prototype.write = function(buffer) {};
+
+/**
+ * @return {string}
+ */
+StringDecoder.prototype.toString = function() {};
+
+/**
+ * @param {buffer.Buffer} buffer
+ * @return {number}
+ */
+StringDecoder.prototype.detectIncompleteChar = function(buffer) {};
+
+/**
+ * @param {buffer.Buffer} buffer
+ * @return {string}
+ */
+StringDecoder.prototype.end = function(buffer) {};

--- a/third_party/closure-compiler/node-externs/tls.js
+++ b/third_party/closure-compiler/node-externs/tls.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's tls module. Depends on the stream module.
+ * @see http://nodejs.org/api/tls.html
+ * @see https://github.com/joyent/node/blob/master/lib/tls.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var tls = require('tls');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var tls = {};
+
+/**
+ * @typedef {{pfx: (string|buffer.Buffer), key: (string|buffer.Buffer), passphrase: string, cert: (string|buffer.Buffer), ca: Array.<string|buffer.Buffer>, crl: (string|Array.<string>), ciphers: string, honorCipherOrder: boolean, requestCert: boolean, rejectUnauthorized: boolean, NPNProtocols: (Array|buffer.Buffer), SNICallback: function(string), sessionIdContext: string}}
+ */
+tls.CreateOptions;
+
+/**
+ * 
+ * @param {tls.CreateOptions} options
+ * @param {function(...)=} secureConnectionListener
+ * @return {tls.Server}
+ */
+tls.createServer = function(options, secureConnectionListener) {};
+
+/**
+ * @typedef {{host: string, port: number, socket: *, pfx: (string|buffer.Buffer), key: (string|buffer.Buffer), passphrase: string, cert: (string|buffer.Buffer), ca: Array.<string>, rejectUnauthorized: boolean, NPNProtocols: Array.<string|buffer.Buffer>, servername: string}}
+ */
+tls.ConnectOptions;
+
+/**
+ * 
+ * @param {number|tls.ConnectOptions} port
+ * @param {(string|tls.ConnectOptions|function(...))=} host
+ * @param {(tls.ConnectOptions|function(...))=} options
+ * @param {function(...)=} callback
+ */
+tls.connect = function(port, host, options, callback) {};
+
+/**
+ * @param {crypto.Credentials=} credentials
+ * @param {boolean=} isServer
+ * @param {boolean=} requestCert
+ * @param {boolean=} rejectUnauthorized
+ * @return {tls.SecurePair}
+ */
+tls.createSecurePair = function(credentials, isServer, requestCert, rejectUnauthorized) {};
+
+/**
+ * @constructor
+ * @extends events.EventEmitter
+ */
+tls.SecurePair = function() {};
+
+/**
+ * @constructor
+ * @extends net.Server
+ */
+tls.Server = function() {};
+
+/**
+ * @param {string} hostname
+ * @param {string|buffer.Buffer} credentials
+ */
+tls.Server.prototype.addContext = function(hostname, credentials) {};
+
+/**
+ * @constructor
+ * @extends stream.Duplex
+ */
+tls.CleartextStream = function() {};
+
+/**
+ * @type {boolean}
+ */
+tls.CleartextStream.prototype.authorized;
+
+/**
+ * @type {?string}
+ */
+tls.CleartextStream.prototype.authorizationError;
+
+/**
+ * @return {Object.<string,(string|Object.<string,string>)>}
+ */
+tls.CleartextStream.prototype.getPeerCertificate = function() {};
+
+/**
+ * @return {{name: string, version: string}}
+ */
+tls.CleartextStream.prototype.getCipher = function() {};
+
+/**
+ * @return {{port: number, family: string, address: string}}
+ */
+tls.CleartextStream.prototype.address = function() {};
+
+/**
+ * @type {string}
+ */
+tls.CleartextStream.prototype.remoteAddress;
+
+/**
+ * @type {number}
+ */
+tls.CleartextStream.prototype.remotePort;

--- a/third_party/closure-compiler/node-externs/tty.js
+++ b/third_party/closure-compiler/node-externs/tty.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's tty module. Depends on the net module.
+ * @see http://nodejs.org/api/tty.html
+ * @see https://github.com/joyent/node/blob/master/lib/tty.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var tty = require('tty');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var tty = {};
+
+/**
+ * @param {*} fd
+ * @return {boolean}
+ */
+tty.isatty = function(fd) {};
+
+/**
+ * @param {boolean} mode
+ */
+tty.setRawMode = function(mode) {};
+
+/**
+ * @constructor
+ * @extends net.Socket
+ */
+tty.ReadStream = function() {};
+
+/**
+ * @type {boolean}
+ */
+tty.ReadStream.prototype.isRaw;
+
+/**
+ * @param {boolean} mode
+ */
+tty.ReadStream.prototype.setRawMode = function(mode) {};
+
+/**
+ * @constructor
+ * @extends net.Socket
+ */
+tty.WriteStream = function() {};
+
+/**
+ * @type {number}
+ */
+tty.WriteStream.prototype.columns;
+
+/**
+ * @type {number}
+ */
+tty.WriteStream.prototype.rows;

--- a/third_party/closure-compiler/node-externs/url.js
+++ b/third_party/closure-compiler/node-externs/url.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's url module.
+ * @see http://nodejs.org/api/url.html
+ * @see https://github.com/joyent/node/blob/master/lib/url.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var url = require('url');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var url = {};
+
+/**
+ * @typedef {{href: ?string, protocol: ?string, host: ?string, auth: ?string, hostname: ?string, port: ?string, pathname: ?string, search: ?string, path: ?string, query: ?string, hash: ?string}}
+ */
+url.URL;
+
+/**
+ * @param {string} urlStr
+ * @param {boolean=} parseQueryString
+ * @param {boolean=} slashesDenoteHost
+ * @return {url.URL}
+ * @nosideeffects
+ */
+url.parse = function(urlStr, parseQueryString, slashesDenoteHost) {};
+
+/**
+ * @param {url.URL} urlObj
+ * @return {string}
+ * @nosideeffects
+ */
+url.format = function(urlObj) {};
+
+/**
+ * @param {string} from
+ * @param {string} to
+ * @return {string}
+ * @nosideeffects
+ */
+url.resolve = function(from, to) {};

--- a/third_party/closure-compiler/node-externs/util.js
+++ b/third_party/closure-compiler/node-externs/util.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's util module. Depends on the stream module.
+ * @see http://nodejs.org/api/util.html
+ * @see https://github.com/joyent/node/blob/master/lib/util.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var util = require('util');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var util = {};
+
+/**
+ * @param {string} format
+ * @param {...*} var_args
+ * @return {string}
+ * @nosideeffects
+ */
+util.format = function(format, var_args) {};
+
+/**
+ * @param {string} string
+ */
+util.debug = function(string) {};
+
+/**
+ * @param {...*} var_args
+ */
+util.error = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+util.puts = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+util.print = function(var_args) {};
+
+/**
+ * @param {string} string
+ */
+util.log = function(string) {};
+
+/**
+ * @param {*} object
+ * @param {{showHidden: (boolean|undefined),
+ *          depth: (number|null|undefined),
+ *          colors: (boolean|undefined),
+ *          customInspect: (boolean|undefined)}=} options
+ * @return {string}
+ * @nosideeffects
+ */
+util.inspect;
+
+/**
+ * @param {*} object
+ * @return {boolean}
+ * @nosideeffects
+ */
+util.isArray = function(object) {};
+
+/**
+ * @param {*} object
+ * @return {boolean}
+ * @nosideeffects
+ */
+util.isRegExp = function(object) {};
+
+/**
+ * @param {*} object
+ * @return {boolean}
+ * @nosideeffects
+ */
+util.isDate = function(object) {};
+
+/**
+ * @param {*} object
+ * @return {boolean}
+ * @nosideeffects
+ */
+util.isError = function(object) {};
+
+/**
+ * @param {stream.ReadableStream} readableStream
+ * @param {stream.WritableStream} writableStream
+ * @param {function(...)=} callback
+ * @deprecated
+ */
+util.pump = function(readableStream, writableStream, callback) {};
+
+/**
+ * @param {Function} constructor
+ * @param {Function} superConstructor
+ */
+util.inherits = function(constructor, superConstructor) {};

--- a/third_party/closure-compiler/node-externs/vm.js
+++ b/third_party/closure-compiler/node-externs/vm.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's vm module.
+ * @see http://nodejs.org/api/vm.html
+ * @see https://github.com/joyent/node/blob/master/lib/vm.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var vm = require('vm');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var vm = {};
+
+/**
+ * @constructor
+ */
+vm.Context = function() {}; // Does not really exist
+
+/**
+ * @param {string} code
+ * @param {string=} filename
+ */
+vm.runInThisContext = function(code, filename) {};
+
+/**
+ * @param {string} code
+ * @param {Object.<string,*>=} sandbox
+ * @param {string=} filename
+ */
+vm.runInNewContext = function(code, sandbox, filename) {};
+
+/**
+ * @param {string} code
+ * @param {vm.Context} context
+ * @param {string=} filename
+ */
+vm.runInContext = function(code, context, filename) {};
+
+/**
+ * @param {Object.<string,*>=} initSandbox
+ * @return {vm.Context}
+ * @nosideeffects
+ */
+vm.createContext = function(initSandbox) {};
+
+/**
+ * @constructor
+ */
+vm.Script = function() {};
+
+/**
+ * @param {string} code
+ * @param {string=} filename
+ * @return {vm.Script}
+ * @nosideeffects
+ */
+vm.createScript = function(code, filename) {};
+
+/**
+ */
+vm.Script.prototype.runInThisContext = function() {};
+
+/**
+ * @param {Object.<string,*>=} sandbox
+ */
+vm.Script.prototype.runInNewContext = function(sandbox) {};

--- a/third_party/closure-compiler/node-externs/zlib.js
+++ b/third_party/closure-compiler/node-externs/zlib.js
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for node's zlib module. Depends on the events and buffer modules.
+ * @see http://nodejs.org/api/zlib.html
+ * @see https://github.com/joyent/node/blob/master/lib/zlib.js
+ * @externs
+ * @author Daniel Wirtz <dcode@dcode.io>
+ */
+
+/**
+ BEGIN_NODE_INCLUDE
+ var zlib = require('zlib');
+ END_NODE_INCLUDE
+ */
+
+/**
+ * @type {Object.<string,*>}
+ */
+var zlib = {};
+
+/**
+ * @typedef {{chunkSize: ?number, windowBits: ?number, level: ?number, memLevel: ?number, strategy: ?number, dictionary: ?Object}}
+ */
+zlib.Options;
+
+
+
+/**
+ * @constructor
+ * @extends stream.Transform
+ */
+zlib.Zlib = function() {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.Gzip = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.Gunzip = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.Deflate = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.Inflate = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.DeflateRaw = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.InflateRaw = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @constructor
+ * @extends zlib.Zlib
+ */
+zlib.Unzip = function(options) {};
+
+
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.Gzip}
+ */
+zlib.createGzip = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.Gunzip}
+ */
+zlib.createGunzip = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.Deflate}
+ */
+zlib.createDeflate = function(options) {};
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.Inflate}
+ */
+zlib.createInflate = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.DeflateRaw}
+ */
+zlib.createDeflateRaw = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.InflateRaw}
+ */
+zlib.createInflateRaw = function(options) {};
+
+/**
+ * @param {zlib.Options} options
+ * @return {zlib.Unzip}
+ */
+zlib.createUnzip = function(options) {};
+
+
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.deflate = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.deflateRaw = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.gzip = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.gunzip = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.inflate = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.inflateRaw = function(buf, callback) {};
+
+/**
+ * @param {string|buffer.Buffer} buf
+ * @param {function(...)} callback
+ */
+zlib.unzip = function(buf, callback) {};
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_NO_FLUSH = 0;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_PARTIAL_FLUSH = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_SYNC_FLUSH = 2;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_FULL_FLUSH = 3;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_FINISH = 4;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_BLOCK = 5;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_TREES = 6;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_OK = 0;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_STREAM_END = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_NEED_DICT = 2;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_ERRNO = -1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_STREAM_ERROR = -2;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_DATA_ERROR = -3;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_MEM_ERROR = -4;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_BUF_ERROR = -5;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_VERSION_ERROR = -6;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_NO_COMPRESSION = 0;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_BEST_SPEED = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_BEST_COMPRESSION = 9;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_DEFAULT_COMPRESSION = -1;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_FILTERED = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_HUFFMAN_ONLY = 2;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_RLE = 3;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_FIXED = 4;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_DEFAULT_STRATEGY = 0;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_BINARY = 0;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_TEXT = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_ASCII = 1;
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_UNKNOWN = 2;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_DEFLATED = 8;
+
+
+
+/**
+ * @type {number}
+ * @const
+ */
+zlib.Z_NULL = 0;

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1587,6 +1587,10 @@ class Building:
       raise Exception('Closure compiler appears to be missing, looked at: ' + str(CLOSURE_COMPILER))
 
     CLOSURE_EXTERNS = path_from_root('src', 'closure-externs.js')
+    NODE_EXTERNS_BASE = path_from_root('third_party', 'closure-compiler', 'node-externs')
+    NODE_EXTERNS = os.listdir(NODE_EXTERNS_BASE)
+    NODE_EXTERNS = [os.path.join(NODE_EXTERNS_BASE, name) for name in NODE_EXTERNS
+                    if name.endswith('.js')]
 
     # Something like this (adjust memory as needed):
     #   java -Xmx1024m -jar CLOSURE_COMPILER --compilation_level ADVANCED_OPTIMIZATIONS --variable_map_output_file src.cpp.o.js.vars --js src.cpp.o.js --js_output_file src.cpp.o.cc.js
@@ -1598,6 +1602,9 @@ class Building:
             '--externs', CLOSURE_EXTERNS,
             #'--variable_map_output_file', filename + '.vars',
             '--js', filename, '--js_output_file', filename + '.cc.js']
+    for extern in NODE_EXTERNS:
+        args.append('--externs')
+        args.append(extern)
     if pretty: args += ['--formatting', 'PRETTY_PRINT']
     if os.environ.get('EMCC_CLOSURE_ARGS'):
       args += shlex.split(os.environ.get('EMCC_CLOSURE_ARGS'))


### PR DESCRIPTION
Fixes #3230

I searched for them with `grep -r '\bfs\.' src`, fixed with `:%s/\vfs\.([^(]+)/fs['\1']/gc` in vim. So there shouldn't be issues with fs calls anymore.

@kripken do I need to provide test for this?