### PR TITLE
Update WebVR support to the latest API version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,4 +200,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Andreas Blixt <me@blixt.nyc>
 * Haofeng Zhang <h.z@duke.edu>
 * Cody Welsh <codyw@protonmail.com>
-
+* Sebastian Matthes <sebastianmatthes@outlook.com> (copyright owned by Volkswagen AG)

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -82,6 +82,15 @@ var LibraryWebVR = {
     return WebVR.deviceHardwareIds[dev.hardwareUnitId];
   },
 
+  emscripten_vr_get_device_name: function(deviceId) {
+    var dev = WebVR.getDeviceByID(deviceId);
+    var buffer, devName;
+    devName = dev ? dev.deviceName : ""
+    buf = _malloc(devName.length + 1);
+    writeStringToMemory(devName, buf);
+    return buf;
+  },
+
   emscripten_vr_get_device_type: function(deviceId) {
     var dev = WebVR.getDeviceByID(deviceId);
     if (!dev) return -1;

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -116,52 +116,44 @@ var LibraryWebVR = {
     return WebVR.selectedHMDId;
   },
 
-  emscripten_vr_hmd_get_eye_translation: function(deviceId, whichEye, translationPtr) {
-    if (!translationPtr) return 0;
+  emscripten_vr_hmd_get_eye_parameters: function(deviceId, whichEye, eyeParamsPtr) {
+    if (!eyeParamsPtr) return 0;
     var dev = WebVR.getDeviceByID(deviceId);
     if (!dev) return 0;
-    var translation = dev.getEyeTranslation(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-    {{{ makeSetValue('translationPtr', C_STRUCTS.WebVRPoint.x, 'translation.x', 'double') }}};
-    {{{ makeSetValue('translationPtr', C_STRUCTS.WebVRPoint.y, 'translation.y', 'double') }}};
-    {{{ makeSetValue('translationPtr', C_STRUCTS.WebVRPoint.z, 'translation.z', 'double') }}};
-    {{{ makeSetValue('translationPtr', C_STRUCTS.WebVRPoint.w, 'translation.w', 'double') }}};
-    return 1;
-  },
+    var params = dev.getEyeParameters(whichEye == WebVR.EYE_LEFT ? "left" : "right");
 
-  emscripten_vr_hmd_get_current_fov: function(deviceId, whichEye, fovPtr) {
-    if (!fovPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var fov = dev.getCurrentEyeFieldOfView(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.upDegrees, 'fov.upDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.downDegrees, 'fov.downDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.leftDegrees, 'fov.leftDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.rightDegrees, 'fov.rightDegrees', 'double') }}};
-    return 1;
-  },
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.upDegrees, 'params.minimumFieldOfView.upDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.downDegrees, 'params.minimumFieldOfView.downDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.leftDegrees, 'params.minimumFieldOfView.leftDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.rightDegrees, 'params.minimumFieldOfView.rightDegrees', 'double') }}};
 
-  emscripten_vr_hmd_get_recommended_fov: function(deviceId, whichEye, fovPtr) {
-    if (!fovPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var fov = dev.getRecommendedEyeFieldOfView(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.upDegrees, 'fov.upDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.downDegrees, 'fov.downDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.leftDegrees, 'fov.leftDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.rightDegrees, 'fov.rightDegrees', 'double') }}};
-    return 1;
-  },
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.upDegrees, 'params.maximumFieldOfView.upDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.downDegrees, 'params.maximumFieldOfView.downDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.leftDegrees, 'params.maximumFieldOfView.leftDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.rightDegrees, 'params.maximumFieldOfView.rightDegrees', 'double') }}};
 
-  emscripten_vr_hmd_get_maximum_fov: function(deviceId, whichEye, fovPtr) {
-    if (!fovPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var fov = dev.getMaximumEyeFieldOfView(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.upDegrees, 'fov.upDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.downDegrees, 'fov.downDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.leftDegrees, 'fov.leftDegrees', 'double') }}};
-    {{{ makeSetValue('fovPtr', C_STRUCTS.WebVRFieldOfView.rightDegrees, 'fov.rightDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.upDegrees, 'params.recommendedFieldOfView.upDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.downDegrees, 'params.recommendedFieldOfView.downDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.leftDegrees, 'params.recommendedFieldOfView.leftDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.rightDegrees, 'params.recommendedFieldOfView.rightDegrees', 'double') }}};
+
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.x, 'params.eyeTranslation.x', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.y, 'params.eyeTranslation.y', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.z, 'params.eyeTranslation.z', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.w, 'params.eyeTranslation.w', 'double') }}};
+
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.upDegrees, 'params.currentFieldOfView.upDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.downDegrees, 'params.currentFieldOfView.downDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.leftDegrees, 'params.currentFieldOfView.leftDegrees', 'double') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.rightDegrees, 'params.currentFieldOfView.rightDegrees', 'double') }}};
+
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.x, 'params.renderRect.x', 'i32') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.y, 'params.renderRect.y', 'i32') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.width, 'params.renderRect.width', 'i32') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.height, 'params.renderRect.height', 'i32') }}};
+
     return 1;
+
   },
 
   emscripten_vr_hmd_set_fov: function(deviceId, leftFovPtr, rightFovPtr, zNear, zFar) {
@@ -184,23 +176,11 @@ var LibraryWebVR = {
     return 1;
   },
 
-  emscripten_vr_hmd_get_eye_render_rect: function(deviceId, whichEye, rectPtr) {
-    if (!rectPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var rect = dev.getRecommendedEyeRenderRect(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-    {{{ makeSetValue('rectPtr', C_STRUCTS.WebVRIntRect.x, 'rect.x', 'i32') }}};
-    {{{ makeSetValue('rectPtr', C_STRUCTS.WebVRIntRect.y, 'rect.y', 'i32') }}};
-    {{{ makeSetValue('rectPtr', C_STRUCTS.WebVRIntRect.width, 'rect.width', 'i32') }}};
-    {{{ makeSetValue('rectPtr', C_STRUCTS.WebVRIntRect.height, 'rect.height', 'i32') }}};
-    return 1;
-  },
-
-  emscripten_vr_sensor_get_state: function(deviceId, timeOffset, statePtr) {
+  emscripten_vr_sensor_get_state: function(deviceId, immediate, statePtr) {
     if (!statePtr) return 0;
     var dev = WebVR.getDeviceByID(deviceId);
     if (!dev) return 0;
-    var state = dev.getState(timeOffset);
+    var state = immediate ? dev.getImmediateState : dev.getState();
 
     {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.timeStamp, 'state.timeStamp', 'double') }}};
 
@@ -239,7 +219,7 @@ var LibraryWebVR = {
   emscripten_vr_sensor_zero: function(deviceId) {
     var dev = WebVR.getDeviceByID(deviceId);
     if (!dev) return 0;
-    dev.zeroSensor();
+    dev.resetSensor();
     return 1;
   }
 };

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1417,6 +1417,14 @@
 	      { "orientation": [ "x", "y", "z", "w" ] },
 	      { "angularVelocity": [ "x", "y", "z", "w" ] },
 	      { "angularAcceleration": [ "x", "y", "z", "w" ] }
+	    ],
+        "WebVREyeParameters": [
+          { "minimumFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
+          { "maximumFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
+          { "recommendedFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
+          { "eyeTranslation": [ "x", "y", "z", "w" ] },
+          { "currentFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
+          { "renderRect": [ "x", "y", "width", "height"] }
 	    ]
         }
     },

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -4,6 +4,7 @@
 #define __emscripten_vr_h__
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * This file provides some basic interfaces for interacting with WebVR from Emscripten.
@@ -58,6 +59,16 @@ typedef struct WebVRPositionState {
     WebVRPoint angularAcceleration;
 } WebVRPositionState;
 
+typedef struct WebVREyeParameters {
+    WebVRFieldOfView minimumFieldOfView;
+    WebVRFieldOfView maximumFieldOfView;
+    WebVRFieldOfView recommendedFieldOfView;
+    WebVRPoint eyeTranslation;
+
+    WebVRFieldOfView currentFieldOfView;
+    WebVRIntRect renderRect;
+} WebVREyeParameters;
+
 extern void emscripten_vr_init();
 extern int emscripten_vr_ready();
 
@@ -72,19 +83,16 @@ extern WebVRDeviceId emscripten_vr_get_selected_hmd_device();
 
 // For HMD devices.
 // All of these return 1 on success, <= 0 on failure.
-extern int emscripten_vr_hmd_get_eye_translation(WebVRDeviceId deviceId, WebVREye whichEye, WebVRPoint *translation);
-extern int emscripten_vr_hmd_get_current_fov(WebVRDeviceId deviceId, WebVREye whichEye, WebVRFieldOfView *fov);
-extern int emscripten_vr_hmd_get_recommended_fov(WebVRDeviceId deviceId, WebVREye whichEye, WebVRFieldOfView *fov);
-extern int emscripten_vr_hmd_get_maximum_fov(WebVRDeviceId deviceId, WebVREye whichEye, WebVRFieldOfView *fov);
+extern int emscripten_vr_hmd_get_eye_parameters(WebVRDeviceId deviceId, WebVREye whichEye, WebVREyeParameters *eyeParams);
 extern int emscripten_vr_hmd_set_fov(WebVRDeviceId deviceId,
                                      const WebVRFieldOfView *leftFov,
                                      const WebVRFieldOfView *rightFov,
                                      double zNear, double zFar);
-extern int emscripten_vr_hmd_get_eye_render_rect(WebVRDeviceId deviceId, WebVREye whichEye, WebVRIntRect *rect);
+
 
 // for Position devices
 // All of these return 1 on success, <= 0 on failure.
-extern int emscripten_vr_sensor_get_state(WebVRDeviceId deviceId, double timeOffset, WebVRPositionState *state);
+extern int emscripten_vr_sensor_get_state(WebVRDeviceId deviceId, bool immediate, WebVRPositionState *state);
 extern int emscripten_vr_sensor_zero(WebVRDeviceId deviceId);
 
 #ifdef __cplusplus

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -76,6 +76,7 @@ extern int emscripten_vr_count_devices();
 extern WebVRDeviceId emscripten_vr_get_device_id(int deviceIndex);
 extern WebVRDeviceType emscripten_vr_get_device_type(WebVRDeviceId deviceId);
 extern WebVRHardwareUnitId emscripten_vr_get_device_hwid(WebVRDeviceId deviceId);
+extern char *emscripten_vr_get_device_name(WebVRDeviceId deviceId);
 
 // select the given device as the fullscreen HMD device
 extern int emscripten_vr_select_hmd_device(WebVRDeviceId deviceId);

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 #include <emscripten.h>
 #include <emscripten/vr.h>
 
@@ -40,17 +41,23 @@ mainloop()
             report_result(0);
             return;
         }
+        printf("%d VR devices found\n", gDevCount);
+
 
         int hwid = -1;
+        char *devName;
         for (int i = 0; i < gDevCount; ++i) {
             WebVRDeviceId devid = emscripten_vr_get_device_id(i);
             if (hwid == -1 || hwid == emscripten_vr_get_device_hwid(devid)) {
                 hwid = emscripten_vr_get_device_hwid(devid);
+                devName = emscripten_vr_get_device_name(devid);
 
                 if (emscripten_vr_get_device_type(devid) == WebVRHMDDevice) {
                     gHmdDev = devid;
+                    printf("Using WebVRHMDDevice '%s' (deviceId '%d'; hardwareUnitId '%d'.)\n", devName, gHmdDev,  hwid);
                 } else if (emscripten_vr_get_device_type(devid) == WebVRPositionSensorDevice) {
                     gPosDev = devid;
+                    printf("Using WebVRPositionSensorDevice '%s' (deviceId '%d'; hardwareUnitId '%d').\n", devName, gPosDev,  hwid);
                 }
             }
         }
@@ -72,7 +79,9 @@ mainloop()
     }
 
     WebVRPositionState state;
-    emscripten_vr_sensor_get_state(gPosDev, 0.0, &state);
+    emscripten_vr_sensor_get_state(gPosDev, false, &state);
+    printf("Timestamp: %f, hasPosition: %s , hasOrientation: %s\n", state.timeStamp, 
+           state.hasPosition ? "true" : "false", state.hasOrientation ? "true" : "false");
     printf("State: orientation: [%f %f %f %f] position: [%f %f %f]\n",
            state.orientation.x, state.orientation.y, state.orientation.z, state.orientation.w,
            state.position.x, state.position.y, state.position.z);

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -62,10 +62,11 @@ mainloop()
             return;
         }
 
-        WebVRFieldOfView leftFov, rightFov;
-        emscripten_vr_hmd_get_current_fov(gHmdDev, WebVREyeLeft, &leftFov);
-        emscripten_vr_hmd_get_current_fov(gHmdDev, WebVREyeRight, &rightFov);
+        WebVREyeParameters leftParams, rightParams;
+        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeLeft, &leftParams);
+        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeLeft, &rightParams);
 
+        WebVRFieldOfView leftFov = leftParams.currentFieldOfView, rightFov = rightParams.currentFieldOfView;
         printf("Left FOV: %f %f %f %f\n", leftFov.upDegrees, leftFov.downDegrees, leftFov.rightDegrees, leftFov.leftDegrees);
         printf("Right FOV: %f %f %f %f\n", rightFov.upDegrees, rightFov.downDegrees, rightFov.rightDegrees, rightFov.leftDegrees);
     }


### PR DESCRIPTION
This PR implements the semi-recent changes to the [WebVR specification](http://mozvr.github.io/webvr-spec/webvr.html):
 * a [new](https://github.com/MozVR/webvr-spec/commit/b5c0863464b85bad8954b9285eca344b0f34fea2) _[VREyeParameters](http://mozvr.github.io/webvr-spec/webvr.html#vreyeparameters)_ interface now bundles the FOVs, RenderRect and EyeTranslation parameters required for stereoscopic rendering
 * `PositionSensorVRDevice:zeroSensor()` is now `PositionSensorVRDevice:resetSensor()`
 * `PositionsSensorVRDevice:getState()` [no longer accepts](https://github.com/MozVR/webvr-spec/commit/8b71ecece26a82b7ee8ebc1193b2123082ebe11c) a _timeOffset_ argument. In its place, a `PositionSensorVRDevice:getImmediateState()` method [has been added](http://mozvr.github.io/webvr-spec/webvr.html#positionsensorvrdevicemethods)

Additional changes:
* a method to query the name of a VR device has been added to the emscripten WebVR API
* some additional debug output has been added to the WebVR test

The updated _interactive.test_vr_ test was run to verify the changes work.