### PR TITLE
Web worker proxy canvas bounding box (Issue #3570)

### DIFF
--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -86,7 +86,13 @@ var worker = new Worker('{{{ filename }}}.js');
 WebGLClient.prefetch();
 
 setTimeout(function() {
-  worker.postMessage({ target: 'worker-init', width: Module.canvas.width, height: Module.canvas.height, URL: document.URL, preMain: true });
+  worker.postMessage({
+    target: 'worker-init',
+    width: Module.canvas.width,
+    height: Module.canvas.height,
+    boundingClientRect: cloneObject(Module.canvas.getBoundingClientRect()),
+    URL: document.URL,
+    preMain: true });
 }, 0); // delay til next frame, to make sure html is ready
 
 var workerResponded = false;

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -433,6 +433,7 @@ onmessage = function onmessage(message) {
       Module.canvas = document.createElement('canvas');
       screen.width = Module.canvas.width_ = message.data.width;
       screen.height = Module.canvas.height_ = message.data.height;
+      Module.canvas.boundingClientRect = message.data.boundingClientRect;
       document.URL = message.data.URL;
       window.fireEvent({ type: 'load' });
       removeRunDependency('worker-init');

--- a/tests/canvas_size_proxy.c
+++ b/tests/canvas_size_proxy.c
@@ -1,0 +1,15 @@
+#include <math.h>
+#include <emscripten/html5.h>
+
+int main() 
+{
+    int result = 0;
+    double w, h;
+    emscripten_get_element_css_size(NULL, &w, &h);
+    if (isnan(w) || isnan(h))
+    {
+        result = 1;
+    }
+    REPORT_RESULT();
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2694,3 +2694,6 @@ window.close = function() {
 
   def test_canvas_style_proxy(self):
     self.btest('canvas_style_proxy.c', expected='1', args=['--proxy-to-worker', '--shell-file', path_from_root('tests/canvas_style_proxy_shell.html'), '--pre-js', path_from_root('tests/canvas_style_proxy_pre.js')])
+
+  def test_canvas_size_proxy(self):
+    self.btest(path_from_root('tests', 'canvas_size_proxy.c'), expected='0', args=['--proxy-to-worker'])


### PR DESCRIPTION
Fix issue running with `--proxy-to-worker` where `emscripten_get_element_css_size()` would return invalid values due to the bounding box not being proxied over in `worker-init`. Added test.