### PR TITLE
Expose FS API to the outside world via Module.FS

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1,6 +1,7 @@
 mergeInto(LibraryManager.library, {
   $FS__deps: ['$ERRNO_CODES', '$ERRNO_MESSAGES', '__setErrNo', '$PATH', '$TTY', '$MEMFS', '$IDBFS', '$NODEFS', 'stdin', 'stdout', 'stderr', 'fflush'],
   $FS__postset: 'FS.staticInit();' +
+                'Module["FS"] = FS;' +
                 '__ATINIT__.unshift(function() { if (!Module["noFSInit"] && !FS.init.initialized) FS.init() });' +
                 '__ATMAIN__.push(function() { FS.ignorePermissions = false });' +
                 '__ATEXIT__.push(function() { FS.quit() });' +


### PR DESCRIPTION
if -s MODULARIZE=1, all of the Emscripten API is hidden in a function. This is great for combining it with different modules (I am using browserify for that). It is critical however to be able to configure the emsciptified Module's behaviour. This can be done by passing a Module object to the exported function.

This is all great.

If I want to prepare something in preRun() for example, I have a problem though: Since the code that prepares the Module object lives outside of the MODULARIZEd function created by emscripten, the FS API is not available to it. The code can however access all of Module's properties, which at that stage are being enriched by the code in various `library_*.js` files. The code in preRun() thus has access to the `FS_*` properties. However, this is just a small subset of the API.

Currently that is:
```
  'FS_createFolder',
  'FS_createPath',
  'FS_createDataFile',
  'FS_createPreloadedFile',
  'FS_createLazyFile',
  'FS_createLink',
  'FS_createDevice',
  'FS_unlink',
```

In my use case, I need `FS.makedev()`, `FS.registerDevice()` and more. I think it's easiest to simply expose the FS object itself as a property of Module.

