### PR TITLE
[optimizer] Use a 10M stack size on Windows.

### DIFF
--- a/tools/optimizer/CMakeLists.txt
+++ b/tools/optimizer/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 if (MSVC)
 	set(cFlags "${cFlags} -D_CRT_SECURE_NO_WARNINGS=1")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
 endif()
 
 set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} ${cFlags}")


### PR DESCRIPTION
The default is 1M and this has been reported to crash for people
in the past, so bumping it to 10M by default hurts no one and
avoids a possible problem.