### PR TITLE
[WIP] WORKERFS prototype

### DIFF
--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -51,7 +51,6 @@ This file system lets a program in *node* directly access files on the local fil
 
 See `this test <https://github.com/kripken/emscripten/blob/master/tests/fs/test_nodefs_rw.c>`_ for an example.
 
-
 .. _filesystem-api-idbfs:
 
 IDBFS
@@ -63,6 +62,14 @@ The *IDBFS* file system implements the :js:func:`FS.syncfs` interface, which whe
 
 This is provided to overcome the limitation that browsers do not offer synchronous APIs for persistent storage, and so (by default) all writes exist only temporarily in-memory. 
 
+.. _filesystem-api-workerfs:
+
+WORKERFS
+-----
+
+.. note:: This file system is only for use when running code inside a worker.
+
+This file system provides read-only access to ``File`` and ``Blob`` objects inside a worker without copying the entire data into memory and can potentially be used for huge files.
 
 Devices
 =======
@@ -133,6 +140,17 @@ File system API
 		
 				FS.mkdir('/working');
 				FS.mount(NODEFS, { root: '.' }, '/working');
+
+        ``WORKERFS`` accepts `files` and `blobs` parameters to map provided flat list of files into the ``mountpoint`` directory:
+
+			::
+
+				var blob = new Blob(['blob data']);
+				FS.mkdir('/working');
+				FS.mount(NODEFS, {
+				  blobs: [{ name: 'blob.txt', data: blob }],
+				  files: files, // Array of File objects or FileList
+				}, '/working');
 
 	:param string mountpoint: A path to an existing local Emscripten directory where the file system is to be mounted. It can be either an absolute path, or something relative to the current directory.
 	

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
-  $FS__deps: ['$ERRNO_CODES', '$ERRNO_MESSAGES', '__setErrNo', '$PATH', '$TTY', '$MEMFS', '$IDBFS', '$NODEFS', 'stdin', 'stdout', 'stderr'],
+  $FS__deps: ['$ERRNO_CODES', '$ERRNO_MESSAGES', '__setErrNo', '$PATH', '$TTY', '$MEMFS', '$IDBFS', '$NODEFS', '$WORKERFS', 'stdin', 'stdout', 'stderr'],
   $FS__postset: 'FS.staticInit();' +
                 '__ATINIT__.unshift(function() { if (!Module["noFSInit"] && !FS.init.initialized) FS.init() });' +
                 '__ATMAIN__.push(function() { FS.ignorePermissions = false });' +

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -1,0 +1,114 @@
+mergeInto(LibraryManager.library, {
+  $WORKERFS__deps: ['$FS'],
+  $WORKERFS: {
+    DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
+    FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
+    reader: null,
+    mount: function (mount) {
+      assert(ENVIRONMENT_IS_WORKER);
+      if (!WORKERFS.reader) WORKERFS.reader = new FileReaderSync();
+      var root = WORKERFS.createNode(null, '/', WORKERFS.DIR_MODE, 0);
+      // We also accept FileList here.
+      Array.prototype.forEach.call(mount.opts["files"] || [], function(file) {
+        WORKERFS.createNode(root, file.name, WORKERFS.FILE_MODE, 0, file, file.lastModifiedDate);
+      });
+      (mount.opts["blobs"] || []).forEach(function(obj) {
+        WORKERFS.createNode(root, obj["name"], WORKERFS.FILE_MODE, 0, obj["data"]);
+      });
+      return root;
+    },
+    createNode: function (parent, name, mode, dev, contents, mtime) {
+      var node = FS.createNode(parent, name, mode);
+      node.mode = mode;
+      node.node_ops = WORKERFS.node_ops;
+      node.stream_ops = WORKERFS.stream_ops;
+      node.timestamp = (mtime || new Date).getTime();
+      if (parent) {
+        node.size = contents.size;
+        node.contents = contents;
+        parent.contents[name] = node;
+      } else {
+        node.size = 4096;
+        node.contents = {};
+      }
+      return node;
+    },
+    node_ops: {
+      getattr: function(node) {
+        return {
+          dev: 1,
+          ino: undefined,
+          mode: node.mode,
+          nlink: 1,
+          uid: 0,
+          gid: 0,
+          rdev: undefined,
+          size: node.size,
+          atime: new Date(node.timestamp),
+          mtime: new Date(node.timestamp),
+          ctime: new Date(node.timestamp),
+          blksize: 4096,
+          blocks: Math.ceil(node.size / 4096),
+        };
+      },
+      setattr: function(node, attr) {
+        if (attr.mode !== undefined) {
+          node.mode = attr.mode;
+        }
+        if (attr.timestamp !== undefined) {
+          node.timestamp = attr.timestamp;
+        }
+      },
+      lookup: function(parent, name) {
+        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+      },
+      mknod: function (parent, name, mode, dev) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      rename: function (oldNode, newDir, newName) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      unlink: function(parent, name) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      rmdir: function(parent, name) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      readdir: function(node) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      symlink: function(parent, newName, oldPath) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+      readlink: function(node) {
+        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+      },
+    },
+    stream_ops: {
+      read: function (stream, buffer, offset, length, position) {
+        if (position >= stream.node.size) return 0;
+        var chunk = stream.node.contents.slice(position, position + length);
+        var ab = WORKERFS.reader.readAsArrayBuffer(chunk);
+        buffer.set(new Uint8Array(ab), offset);
+        return chunk.size;
+      },
+      write: function (stream, buffer, offset, length, position) {
+        throw new FS.ErrnoError(ERRNO_CODES.EIO);
+      },
+      llseek: function (stream, offset, whence) {
+        var position = offset;
+        if (whence === 1) {  // SEEK_CUR.
+          position += stream.position;
+        } else if (whence === 2) {  // SEEK_END.
+          if (FS.isFile(stream.node.mode)) {
+            position += stream.node.size;
+          }
+        }
+        if (position < 0) {
+          throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        }
+        return position;
+      },
+    },
+  },
+});

--- a/src/modules.js
+++ b/src/modules.js
@@ -109,6 +109,7 @@ var LibraryManager = {
         'library_memfs.js',
         'library_nodefs.js',
         'library_sockfs.js',
+        'library_workerfs.js',
         'library_tty.js'
       ]);
     }

--- a/tests/fs/test_workerfs_read.c
+++ b/tests/fs/test_workerfs_read.c
@@ -1,0 +1,71 @@
+#include <emscripten.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#define SECRET_LEN 10
+
+int result = 1;
+
+int main() {
+  int fd;
+  int fd2;
+  struct stat st;
+  struct stat st2;
+  char buf[100];
+  char secret2[] = SECRET2;
+  int len2 = SECRET_LEN / 2;
+
+  if (stat("/work/notexist.txt", &st) != -1 || errno != ENOENT) {
+    result = -1000 - errno;
+    goto exit;
+  }
+
+  if (stat("/work/blob.txt", &st) != 0) {
+    result = -2000 - errno;
+    goto exit;
+  }
+
+  fd = open("/work/blob.txt", O_RDWR, 0666);
+  if (fd == -1) {
+    result = -3000 - errno;
+    goto exit;
+  }
+
+  if (read(fd, buf, 1000) != SECRET_LEN ||
+      strncmp(buf, SECRET, SECRET_LEN) != 0) {
+    result = -4000 - errno;
+    goto exit;
+  }
+
+  fd2 = open("/work/file.txt", O_RDONLY, 0666);
+  if (fd == -1) {
+    result = -5000 - errno;
+    goto exit;
+  }
+
+  if (lseek(fd2, len2, SEEK_SET) != len2) {
+    result = -6000 - errno;
+    goto exit;
+  }
+
+  if (read(fd2, buf, len2) != len2 ||
+      strncmp(buf, secret2 + len2, len2) != 0) {
+    result = -7000 - errno;
+    goto exit;
+  }
+
+  stat("/work/file.txt", &st);
+  chmod("/work/file.txt", 0640);
+  stat("/work/file.txt", &st2);
+  if (st.st_mode != (0777 | S_IFREG) || st2.st_mode != (0640 | S_IFREG)) {
+    result = -8000 - errno;
+    goto exit;
+  }
+
+exit:
+  REPORT_RESULT();
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1007,6 +1007,23 @@ keydown(100);keyup(100); // trigger the end
       secret = str(time.time())
       self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
 
+  def test_fs_workerfs_read(self):
+    secret = 'a' * 10;
+    secret2 = 'b' * 10;
+    open(self.in_dir('pre.js'), 'w').write('''
+      var Module = {};
+      Module.preRun = function() {
+        var blob = new Blob(['%s']);
+        var file = new File(['%s'], 'file.txt');
+        FS.mkdir('/work');
+        FS.mount(WORKERFS, {
+          blobs: [{ name: 'blob.txt', data: blob }],
+          files: [file],
+        }, '/work');
+      };
+    ''' % (secret, secret2))
+    self.btest(path_from_root('tests', 'fs', 'test_workerfs_read.c'), '1', force_c=True, args=['--pre-js', 'pre.js', '-DSECRET=\"' + secret + '\"', '-DSECRET2=\"' + secret2 + '\"', '--proxy-to-worker'])
+
   def test_idbstore(self):
     secret = str(time.time())
     for stage in [0, 1, 2, 3, 0, 1, 2, 0, 0, 1, 4, 2, 5]:


### PR DESCRIPTION
As discussed earlier in #3641, I implemented some basic prototype of `WORKERFS`. Creating PR just to be sure I'm going in the right direction and to ask some questions.

* Are you ok with the API? I think people may want to work with multiple Blobs/Files at the same time and it will be convenient to make them available inside application with single mount call.
* I haven't implemented `setattr` and `llseek` yet. Is it ok to throw EPERM for all other calls? Or it's better to implement part of them in MEMFS-way too (rename, mkdir, unlink)?
* Also it may be worth to add some validation to `mount` (slashes in names, etc) and `read` (ranges, overlapping). Are you ok with the rest?
* I will add few other tests (files, unsupported calls, etc). Will it be enough?
* What about docs?

Thanks for your help and hints. Also, while digging through the code, I noticed that it's possible to provide device with your own read/write implementations. So all of this should be possible even without FS. But available by default FS is much more convenient to use of course.