### PR TITLE
Add support for many exported functions via response file

### DIFF
--- a/emcc
+++ b/emcc
@@ -895,10 +895,8 @@ try:
       value = value.replace('\\', '\\\\')
     exec('shared.Settings.' + key + ' = ' + value)
     if key == 'EXPORTED_FUNCTIONS':
-      if original_exported_response:
-        shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = original_exported_response
-      else:
-        shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS[:] # used for warnings in emscripten.py
+      # used for warnings in emscripten.py
+      shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = original_exported_response or shared.Settings.EXPORTED_FUNCTIONS[:]
 
   try:
     assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'

--- a/emcc
+++ b/emcc
@@ -882,8 +882,12 @@ try:
   # Apply -s settings in newargs here (after optimization levels, so they can override them)
   for change in settings_changes:
     key, value = change.split('=')
+    original_exported_response = False
+
     if value[0] == '@':
       if key not in DEFERRED_REPONSE_FILES:
+        if key == 'EXPORTED_FUNCTIONS':
+          original_exported_response = value
         value = open(value[1:]).read()
       else:
         value = '"' + value + '"'
@@ -891,7 +895,10 @@ try:
       value = value.replace('\\', '\\\\')
     exec('shared.Settings.' + key + ' = ' + value)
     if key == 'EXPORTED_FUNCTIONS':
-      shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS[:] # used for warnings in emscripten.py
+      if original_exported_response:
+        shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = original_exported_response
+      else:
+        shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS[:] # used for warnings in emscripten.py
 
   try:
     assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'

--- a/emscripten.py
+++ b/emscripten.py
@@ -238,7 +238,8 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
 
     # merge forwarded data
     settings['EXPORTED_FUNCTIONS'] = forwarded_json['EXPORTED_FUNCTIONS']
-    all_exported_functions = set(settings['EXPORTED_FUNCTIONS']) # both asm.js and otherwise
+    all_exported_functions = set(shared.expand_response(settings['EXPORTED_FUNCTIONS'])) # both asm.js and otherwise
+
     for additional_export in settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE']: # additional functions to export from asm, if they are implemented
       all_exported_functions.add('_' + additional_export)
     if settings['EXPORT_FUNCTION_TABLES']:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-import glob, hashlib, os, re, shutil, subprocess, sys
+import glob, hashlib, os, re, shutil, subprocess, sys, json
 from textwrap import dedent
 import tools.shared
 from tools.shared import *
@@ -6383,6 +6383,42 @@ def process(filename):
     self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=@exps']
     self.do_run(src, '''waka 5!''')
     assert 'other_function' in open('src.cpp.o.js').read()
+
+  def test_large_exported_response(self):
+    src = r'''
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <emscripten.h>
+
+      extern "C" {
+      '''
+
+    js_funcs = []
+    num_exports = 5000
+    count = 0
+    while count < num_exports:
+        src += 'int exported_func_from_response_file_%d () { return %d;}\n' % (count, count)
+        js_funcs.append('_exported_func_from_response_file_%d' % count)
+        count += 1
+
+    src += r'''
+      }
+
+      int main() {
+        int x = EM_ASM_INT_V({ return Module._exported_func_from_response_file_4999() });
+        emscripten_run_script_string(""); // Add a reference to a symbol that exists in src/deps_info.json to uncover issue #2836 in the test suite.
+        printf("waka %d!\n", x);
+        return 0;
+      }
+    '''
+
+    js_funcs.append('_main')
+    exported_func_json_file = os.path.join(self.get_dir(), 'large_exported_response.json')
+    open(exported_func_json_file, 'wb').write(json.dumps(js_funcs))
+
+    self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=@' + exported_func_json_file]
+    self.do_run(src, '''waka 4999!''')
+    assert '_exported_func_from_response_file_1' in open('src.cpp.o.js').read()
 
   def test_add_function(self):
     Settings.INVOKE_RUN = 0


### PR DESCRIPTION
This spawned from forum post ['Argument list too long' from shared.Building.llvm_opt(final, link_opts)](https://groups.google.com/forum/#!topic/emscripten-discuss/wkJywgecrSI).

In order to support very large EXPORTED_FUNCTIONS lists, the following changes were made:
* Retain the response file in ORIGINAL_EXPORTED_FUNCTIONS and expand it later when it's needed in emscripten.py.
* Change the call to llvm-opt to use internalize-public-api-file instead of passing a list.
* Convert EXPORTED_FUNCTIONS back to a response file before calling emscripten.py.

I added a new test to core, "test_large_exported_response". I'm wondering if the contents of this test should replace test_exported_response or if this test should be moved out of test_core.py. 

Tests:
* python tests/runner.py test_large_exported_response
* python tests/runner.py test_dlfcn_qsort
* python tests/runner.py test_exported_response
* python tests/runner.py test_sixtyfour_bit_return_value
* python tests/runner.py test_dlfcn_data_and_fptr
* python tests/runner.py... still running but everything looks ok so far.
