### PR TITLE
Gracefully no threads

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -471,7 +471,7 @@ function _emscripten_asm_const_%d(%s) {
                                 'shiftLeftByScalar'];
     fundamentals = ['Math']
     if settings['USE_PTHREADS']:
-      fundamentals += ['SharedInt8Array', 'SharedInt16Array', 'SharedInt32Array', 'SharedUint8Array', 'SharedUint16Array', 'SharedUint32Array', 'SharedFloat32Array', 'SharedFloat64Array', 'Atomics']
+      fundamentals += ['I8Array', 'I16Array', 'I32Array', 'U8Array', 'U16Array', 'U32Array', 'F32Array', 'F64Array', 'Atomics']
     else:
       fundamentals += ['Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Float32Array', 'Float64Array']
     fundamentals += ['NaN', 'Infinity']
@@ -735,6 +735,17 @@ Module['NAMED_GLOBALS'] = NAMED_GLOBALS;
 
       receiving += ''.join(["Module['%s'] = Module['%s']\n" % (k, v) for k, v in metadata['aliases'].iteritems()])
 
+    if settings['USE_PTHREADS']:
+      asm_setup += '''
+var I8Array = typeof SharedInt8Array !== 'undefined' ? SharedInt8Array : Int8Array;
+var I16Array = typeof SharedInt16Array !== 'undefined' ? SharedInt16Array : Int16Array;
+var I32Array = typeof SharedInt32Array !== 'undefined' ? SharedInt32Array : Int32Array;
+var U8Array = typeof SharedUint8Array !== 'undefined' ? SharedUint8Array : Uint8Array;
+var U16Array = typeof SharedUint16Array !== 'undefined' ? SharedUint16Array : Uint16Array;
+var U32Array = typeof SharedUint32Array !== 'undefined' ? SharedUint32Array : Uint32Array;
+var F32Array = typeof SharedFloat32Array !== 'undefined' ? SharedFloat32Array : Float32Array;
+var F64Array = typeof SharedFloat64Array !== 'undefined' ? SharedFloat64Array : Float64Array;
+'''
     funcs_js = ['''
 %s
 Module%s = %s;
@@ -755,14 +766,14 @@ var asm = (function(global, env, buffer) {
   var HEAPU32 = new global%s(buffer);
   var HEAPF32 = new global%s(buffer);
   var HEAPF64 = new global%s(buffer);
-''' % (access_quote('SharedInt8Array' if settings['USE_PTHREADS'] else 'Int8Array'),
-     access_quote('SharedInt16Array' if settings['USE_PTHREADS'] else 'Int16Array'),
-     access_quote('SharedInt32Array' if settings['USE_PTHREADS'] else 'Int32Array'),
-     access_quote('SharedUint8Array' if settings['USE_PTHREADS'] else 'Uint8Array'),
-     access_quote('SharedUint16Array' if settings['USE_PTHREADS'] else 'Uint16Array'),
-     access_quote('SharedUint32Array' if settings['USE_PTHREADS'] else 'Uint32Array'),
-     access_quote('SharedFloat32Array' if settings['USE_PTHREADS'] else 'Float32Array'),
-     access_quote('SharedFloat64Array' if settings['USE_PTHREADS'] else 'Float64Array'))
+''' % (access_quote('I8Array' if settings['USE_PTHREADS'] else 'Int8Array'),
+     access_quote('I16Array' if settings['USE_PTHREADS'] else 'Int16Array'),
+     access_quote('I32Array' if settings['USE_PTHREADS'] else 'Int32Array'),
+     access_quote('U8Array' if settings['USE_PTHREADS'] else 'Uint8Array'),
+     access_quote('U16Array' if settings['USE_PTHREADS'] else 'Uint16Array'),
+     access_quote('U32Array' if settings['USE_PTHREADS'] else 'Uint32Array'),
+     access_quote('F32Array' if settings['USE_PTHREADS'] else 'Float32Array'),
+     access_quote('F64Array' if settings['USE_PTHREADS'] else 'Float64Array'))
      if not settings['ALLOW_MEMORY_GROWTH'] else '''
   var Int8View = global%s;
   var Int16View = global%s;

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -3,6 +3,10 @@ var LibraryPThreadStub = {
   // Stub implementation for pthread.h when not compiling with pthreads support enabled.
   // ===================================================================================
 
+  emscripten_has_threading_support: function() {
+    return 0;
+  },
+
   pthread_mutex_init: function() {},
   pthread_mutex_destroy: function() {},
   pthread_mutexattr_init: function() {},
@@ -115,6 +119,13 @@ var LibraryPThreadStub = {
   pthread_rwlock_init: function() {
     return 0; // XXX
   },
+
+  pthread_attr_setdetachstate: function() {},
+
+  pthread_create: function() {
+    return {{{ cDefine('EAGAIN') }}};
+  },
+  pthread_exit: function() {},
 
   pthread_cond_signal: function() {},
   pthread_equal: function() {},

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1142,53 +1142,83 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 var buffer;
 #if USE_PTHREADS
 
-if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
 #if IN_TEST_HARNESS
+if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
   xhr = new XMLHttpRequest();
   xhr.open('GET', 'http://localhost:8888/report_result?skipped:%20SharedArrayBuffer%20is%20not%20supported!');
   xhr.send();
   setTimeout(function() { window.close() }, 2000);
+}
 #endif
-  abort('Your browser does not support the SharedArrayBuffer and Atomics specification! Try running in Firefox Nightly.');
+
+
+if (typeof SharedArrayBuffer !== 'undefined') {
+  if (!ENVIRONMENT_IS_PTHREAD) buffer = new SharedArrayBuffer(TOTAL_MEMORY);
+  // Currently SharedArrayBuffer does not have a slice() operation, so polyfill it in.
+  // Adapted from https://github.com/ttaubert/node-arraybuffer-slice, (c) 2014 Tim Taubert <tim@timtaubert.de>
+  // arraybuffer-slice may be freely distributed under the MIT license.
+  (function (undefined) {
+    "use strict";
+    function clamp(val, length) {
+      val = (val|0) || 0;
+      if (val < 0) return Math.max(val + length, 0);
+      return Math.min(val, length);
+    }
+    if (typeof SharedArrayBuffer !== 'undefined' && !SharedArrayBuffer.prototype.slice) {
+      SharedArrayBuffer.prototype.slice = function (from, to) {
+        var length = this.byteLength;
+        var begin = clamp(from, length);
+        var end = length;
+        if (to !== undefined) end = clamp(to, length);
+        if (begin > end) return new ArrayBuffer(0);
+        var num = end - begin;
+        var target = new ArrayBuffer(num);
+        var targetArray = new Uint8Array(target);
+        var sourceArray = new SharedUint8Array(this, begin, num);
+        targetArray.set(sourceArray);
+        return target;
+      };
+    }
+  })();
+
+  HEAP8 = new SharedInt8Array(buffer);
+  HEAP16 = new SharedInt16Array(buffer);
+  HEAP32 = new SharedInt32Array(buffer);
+  HEAPU8 = new SharedUint8Array(buffer);
+  HEAPU16 = new SharedUint16Array(buffer);
+  HEAPU32 = new SharedUint32Array(buffer);
+  HEAPF32 = new SharedFloat32Array(buffer);
+  HEAPF64 = new SharedFloat64Array(buffer);
+} else {
+  if (!ENVIRONMENT_IS_PTHREAD) buffer = new ArrayBuffer(TOTAL_MEMORY);
+  HEAP8 = new Int8Array(buffer);
+  HEAP16 = new Int16Array(buffer);
+  HEAP32 = new Int32Array(buffer);
+  HEAPU8 = new Uint8Array(buffer);
+  HEAPU16 = new Uint16Array(buffer);
+  HEAPU32 = new Uint32Array(buffer);
+  HEAPF32 = new Float32Array(buffer);
+  HEAPF64 = new Float64Array(buffer);
 }
 
-if (!ENVIRONMENT_IS_PTHREAD) buffer = new SharedArrayBuffer(TOTAL_MEMORY);
+if (typeof Atomics === 'undefined') {
+  // Polyfill singlethreaded atomics ops from http://lars-t-hansen.github.io/ecmascript_sharedmem/shmem.html#Atomics.add
+  // No thread-safety needed since we don't have multithreading support.
+  Atomics = {};
+  Atomics['add'] = function(t, i, v) { var w = t[i]; t[i] += v; return w; }
+  Atomics['and'] = function(t, i, v) { var w = t[i]; t[i] &= v; return w; }
+  Atomics['compareExchange'] = function(t, i, e, r) { var w = t[i]; if (w == e) t[i] = r; return w; }
+  Atomics['futexWait'] = function(t, i, v, o) { if (t[i] != v) abort('Multithreading is not supported, cannot sleep to wait for futex!'); }
+  Atomics['futexWake'] = function(t, i, c) {}
+  Atomics['futexWakeOrRequeue'] = function(t, i1, c, i2, v) {}
+  Atomics['isLockFree'] = function(s) { return true; }
+  Atomics['load'] = function(t, i) { return t[i]; }
+  Atomics['or'] = function(t, i, v) { var w = t[i]; t[i] |= v; return w; }
+  Atomics['store'] = function(t, i, v) { t[i] = v; return v; }
+  Atomics['sub'] = function(t, i, v) { var w = t[i]; t[i] -= v; return w; }
+  Atomics['xor'] = function(t, i, v) { var w = t[i]; t[i] ^= v; return w; }
+}
 
-// Currently SharedArrayBuffer does not have a slice() operation, so polyfill it in.
-// Adapted from https://github.com/ttaubert/node-arraybuffer-slice, (c) 2014 Tim Taubert <tim@timtaubert.de>
-// arraybuffer-slice may be freely distributed under the MIT license.
-(function (undefined) {
-  "use strict";
-  function clamp(val, length) {
-    val = (val|0) || 0;
-    if (val < 0) return Math.max(val + length, 0);
-    return Math.min(val, length);
-  }
-  if (!SharedArrayBuffer.prototype.slice) {
-    SharedArrayBuffer.prototype.slice = function (from, to) {
-      var length = this.byteLength;
-      var begin = clamp(from, length);
-      var end = length;
-      if (to !== undefined) end = clamp(to, length);
-      if (begin > end) return new ArrayBuffer(0);
-      var num = end - begin;
-      var target = new ArrayBuffer(num);
-      var targetArray = new Uint8Array(target);
-      var sourceArray = new SharedUint8Array(this, begin, num);
-      targetArray.set(sourceArray);
-      return target;
-    };
-  }
-})();
-
-HEAP8 = new SharedInt8Array(buffer);
-HEAP16 = new SharedInt16Array(buffer);
-HEAP32 = new SharedInt32Array(buffer);
-HEAPU8 = new SharedUint8Array(buffer);
-HEAPU16 = new SharedUint16Array(buffer);
-HEAPU32 = new SharedUint32Array(buffer);
-HEAPF32 = new SharedFloat32Array(buffer);
-HEAPF64 = new SharedFloat64Array(buffer);
 #else // USE_PTHREADS
 buffer = new ArrayBuffer(TOTAL_MEMORY);
 HEAP8 = new Int8Array(buffer);
@@ -1640,7 +1670,7 @@ if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() {
 
 #if PTHREAD_POOL_SIZE > 0
 // To work around https://bugzilla.mozilla.org/show_bug.cgi?id=1049079, warm up a worker pool before starting up the application.
-if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() { addRunDependency('pthreads'); PThread.allocateUnusedWorkers({{{PTHREAD_POOL_SIZE}}}, function() { removeRunDependency('pthreads'); }); });
+if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() { if (typeof SharedArrayBuffer !== 'undefined') { addRunDependency('pthreads'); PThread.allocateUnusedWorkers({{{PTHREAD_POOL_SIZE}}}, function() { removeRunDependency('pthreads'); }); }});
 #endif
 
 // === Body ===

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -7,6 +7,11 @@
 extern "C" {
 #endif
 
+// Returns true if the current browser is able to spawn threads with pthread_create(), and the compiled page was built with
+// threading support enabled. If this returns 0, calls to pthread_create() will fail with return code EAGAIN.
+int emscripten_has_threading_support();
+
+// Returns the number of logical cores on the system.
 int emscripten_num_logical_cores();
 
 // Configures the number of logical cores on the system. This can be called at startup

--- a/tests/pthread/test_pthread_supported.cpp
+++ b/tests/pthread/test_pthread_supported.cpp
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/threading.h>
+#include <assert.h>
+#include <errno.h>
+
+void *ThreadMain(void *arg)
+{
+	pthread_exit(0);
+}
+
+int main()
+{
+	pthread_t thread;
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+	int rc = pthread_create(&thread, &attr, ThreadMain, 0);
+	pthread_attr_destroy(&attr);
+	pthread_join(thread, 0);
+
+	if (emscripten_has_threading_support())
+		assert(rc == 0);
+	else
+		assert(rc == EAGAIN);
+
+#ifdef REPORT_RESULT
+	int result = 0;
+	REPORT_RESULT();
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2693,6 +2693,11 @@ window.close = function() {
   def test_aaa_pthread_file_io(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_file_io.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
 
+  # Test that the pthread_create() function operates benignly in the case that threading is not supported.
+  def test_aaa_pthread_supported(self):
+    for args in [[], ['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8']]:
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_supported.cpp'), expected='0', args=['-O3'] + args, timeout=30)
+
   # Test that it is possible to send a signal via calling alarm(timeout), which in turn calls to the signal handler set by signal(SIGALRM, func);
   def test_sigalrm(self):
     self.btest(path_from_root('tests', 'sigalrm.cpp'), expected='0', args=['-O3'])


### PR DESCRIPTION
Add graceful fallback path to enable running pthreads-enabled code even on browser that don't support pthreads, by allowing code to examine emscripten_has_threading_support() or the return value of pthread_create() to detect whether threads are available or not, and fall back on a singlethreaded path if no threads are supported. This implements #3493.