### PR TITLE
Accept -O4 and larger values, clamping to 3 and warning

### DIFF
--- a/emcc
+++ b/emcc
@@ -445,10 +445,16 @@ try:
 
   settings_changes = []
 
-  def validate_arg_level(level_string, max_level, err_msg):
+  def validate_arg_level(level_string, max_level, err_msg, clamp=False):
     try:
       level = int(level_string)
-      assert 0 <= level <= max_level
+      assert 0 <= level
+      if clamp:
+        if level > max_level:
+          logging.warning(err_msg + '; clamped to ' + str(max_level))
+          level = max_level
+      else:
+        assert level <= max_level
     except:
       raise Exception(err_msg)
     return level
@@ -470,7 +476,7 @@ try:
         requested_level = 2
         shrink_level = 2
         settings_changes.append('INLINING_LIMIT=25')
-      opt_level = validate_arg_level(requested_level, 3, 'Invalid optimization level: ' + newargs[i])
+      opt_level = validate_arg_level(requested_level, 3, 'Invalid optimization level: ' + newargs[i], clamp=True)
       # We leave the -O option in place so that the clang front-end runs in that
       # optimization mode, but we disable the actual optimization passes, as we'll
       # run them separately.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5152,3 +5152,9 @@ main(int argc, char **argv)
     Popen([PYTHON, EMCC, 'src.c', '--embed-file', 'boot']).communicate()
     self.assertContained('Resolved: /boot/README.txt', run_js('a.out.js'))
 
+  def test_o_level_clamp(self):
+    for level in [3, 4, 20]:
+      out, err = Popen([PYTHON, EMCC, '-O' + str(level), path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE).communicate()
+      assert os.path.exists('a.out.js'), '-O' + str(level) + ' should produce output'
+      if level > 3:
+        self.assertContained('Invalid optimization level: -O' + str(level) + '; clamped to 3', err)


### PR DESCRIPTION
GCC and clang accept huge -O\* values like -O4 and -O20, silently
clamping them to a sensible -O3. Some packages rely on this and
specify -O20 as a default "REALLY FAST", such as libogg and libvorbis.

For compatibility, accept the large values, clamp them to 3, and
print a warning instead of throwing an exception and dying.

Test case added.

Fixes https://github.com/kripken/emscripten/issues/1499
Fixes https://github.com/kripken/emscripten/issues/264

Replaces stale pull request https://github.com/kripken/emscripten/pull/2954
