### PR TITLE
Optimize optimizer eliminate stage

### DIFF
--- a/tools/optimizer/CMakeLists.txt
+++ b/tools/optimizer/CMakeLists.txt
@@ -11,9 +11,11 @@ else()
 	set(IS_GCC_LIKE FALSE)
 endif()
 
-# -DPROFILING will print crude timing information to stderr for initial
-# identification of areas to profile in more depth with
+# -DCMAKE_CXX_FLAGS=-DPROFILING will print crude timing information to stderr
+# for initial identification of areas to profile in more depth with
 # CALLGRIND_{START,STOP}_INSTRUMENTATION or similar
+# Don't forget to also pass -DCMAKE_BUILD_TYPE=Release to cmake or your build
+# won't be optimized by the compiler!
 
 if (IS_GCC_LIKE)
 	set(cFlags "-std=c++11 -fno-exceptions -fno-rtti")

--- a/tools/optimizer/optimizer-main.cpp
+++ b/tools/optimizer/optimizer-main.cpp
@@ -15,6 +15,12 @@ int main(int argc, char **argv) {
     else if (str == "last") last = true;
   }
 
+#ifdef PROFILING
+    std::string str("reading and parsing");
+    clock_t start = clock();
+    errv("starting %s", str.c_str());
+#endif
+
   // Read input file
   FILE *f = fopen(argv[1], "r");
   assert(f);
@@ -49,6 +55,10 @@ int main(int argc, char **argv) {
   }
   // do not free input, its contents are used as strings
 
+#ifdef PROFILING
+    errv("    %s took %lu milliseconds", str.c_str(), (clock() - start)/1000);
+#endif
+
   // Run passes on the Document
   for (int i = 2; i < argc; i++) {
     std::string str(argv[i]);
@@ -78,7 +88,7 @@ int main(int argc, char **argv) {
       abort();
     }
 #ifdef PROFILING
-    errv("    %s took %lu microseconds", str.c_str(), clock() - start);
+    errv("    %s took %lu milliseconds", str.c_str(), (clock() - start)/1000);
 #endif
 #ifdef DEBUGGING
     if (worked) {

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -105,7 +105,7 @@ AsmType detectType(Ref node, AsmData *asmData=nullptr, bool inVarDef=false);
 Ref makeEmpty();
 bool isEmpty(Ref node);
 Ref makeAsmVarDef(const IString& v, AsmType type);
-Ref makeArray();
+Ref makeArray(int size_hint);
 Ref makeBool(bool b);
 Ref makeNum(double x);
 Ref makeName(IString str);
@@ -219,7 +219,7 @@ struct AsmData {
       }
     }
     // calculate variable definitions
-    Ref varDefs = makeArray();
+    Ref varDefs = makeArray(vars.size());
     for (auto v : vars) {
       varDefs->push_back(makeAsmVarDef(v, locals[v].type));
     }
@@ -403,8 +403,8 @@ AsmType detectType(Ref node, AsmData *asmData, bool inVarDef) {
 
 // Constructions TODO: share common constructions, and assert they remain frozen
 
-Ref makeArray() {
-  return &arena.alloc()->setArray();
+Ref makeArray(int size_hint=0) {
+  return &arena.alloc()->setArray(size_hint);
 }
 
 Ref makeBool(bool b) {
@@ -432,14 +432,14 @@ Ref makeBlock() {
 }
 
 Ref make1(IString s1, Ref a) {
-  Ref ret(makeArray());
+  Ref ret(makeArray(2));
   ret->push_back(makeString(s1));
   ret->push_back(a);
   return ret;
 }
 
 Ref make2(IString s1, IString s2, Ref a) {
-  Ref ret(makeArray());
+  Ref ret(makeArray(2));
   ret->push_back(makeString(s1));
   ret->push_back(makeString(s2));
   ret->push_back(a);
@@ -447,7 +447,7 @@ Ref make2(IString s1, IString s2, Ref a) {
 }
 
 Ref make2(IString s1, Ref a, Ref b) {
-  Ref ret(makeArray());
+  Ref ret(makeArray(3));
   ret->push_back(makeString(s1));
   ret->push_back(a);
   ret->push_back(b);
@@ -455,7 +455,7 @@ Ref make2(IString s1, Ref a, Ref b) {
 }
 
 Ref make3(IString type, IString a, Ref b, Ref c) {
-  Ref ret(makeArray());
+  Ref ret(makeArray(4));
   ret->push_back(makeString(type));
   ret->push_back(makeString(a));
   ret->push_back(b);
@@ -464,7 +464,7 @@ Ref make3(IString type, IString a, Ref b, Ref c) {
 }
 
 Ref make3(IString type, Ref a, Ref b, Ref c) {
-  Ref ret(makeArray());
+  Ref ret(makeArray(4));
   ret->push_back(makeString(type));
   ret->push_back(a);
   ret->push_back(b);
@@ -481,28 +481,28 @@ Ref makeAsmVarDef(const IString& v, AsmType type) {
       if (!ASM_FLOAT_ZERO.isNull()) {
         val = makeName(ASM_FLOAT_ZERO);
       } else {
-        val = make2(CALL, makeName(MATH_FROUND), &(makeArray())->push_back(makeNum(0)));
+        val = make2(CALL, makeName(MATH_FROUND), &(makeArray(1))->push_back(makeNum(0)));
       }
       break;
     }
     case ASM_FLOAT32X4: {
-      val = make2(CALL, makeName(SIMD_FLOAT32X4), &(makeArray())->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
+      val = make2(CALL, makeName(SIMD_FLOAT32X4), &(makeArray(4))->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
       break;
     }
     case ASM_FLOAT64X2: {
-      val = make2(CALL, makeName(SIMD_FLOAT64X2), &(makeArray())->push_back(makeNum(0)).push_back(makeNum(0)));
+      val = make2(CALL, makeName(SIMD_FLOAT64X2), &(makeArray(2))->push_back(makeNum(0)).push_back(makeNum(0)));
       break;
     }
     case ASM_INT8X16: {
-      val = make2(CALL, makeName(SIMD_INT8X16), &(makeArray())->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
+      val = make2(CALL, makeName(SIMD_INT8X16), &(makeArray(16))->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
       break;
     }
     case ASM_INT16X8: {
-      val = make2(CALL, makeName(SIMD_INT16X8), &(makeArray())->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
+      val = make2(CALL, makeName(SIMD_INT16X8), &(makeArray(8))->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
       break;
     }
     case ASM_INT32X4: {
-      val = make2(CALL, makeName(SIMD_INT32X4), &(makeArray())->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
+      val = make2(CALL, makeName(SIMD_INT32X4), &(makeArray(4))->push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)).push_back(makeNum(0)));
       break;
     }
     default: assert(0);
@@ -514,12 +514,12 @@ Ref makeAsmCoercion(Ref node, AsmType type) {
   switch (type) {
     case ASM_INT: return make3(BINARY, OR, node, makeNum(0));
     case ASM_DOUBLE: return make2(UNARY_PREFIX, PLUS, node);
-    case ASM_FLOAT: return make2(CALL, makeName(MATH_FROUND), &(makeArray())->push_back(node));
-    case ASM_FLOAT32X4: return make2(CALL, makeName(SIMD_FLOAT32X4_CHECK), &(makeArray())->push_back(node));
-    case ASM_FLOAT64X2: return make2(CALL, makeName(SIMD_FLOAT64X2_CHECK), &(makeArray())->push_back(node));
-    case ASM_INT8X16: return make2(CALL, makeName(SIMD_INT8X16_CHECK), &(makeArray())->push_back(node));
-    case ASM_INT16X8: return make2(CALL, makeName(SIMD_INT16X8_CHECK), &(makeArray())->push_back(node));
-    case ASM_INT32X4: return make2(CALL, makeName(SIMD_INT32X4_CHECK), &(makeArray())->push_back(node));
+    case ASM_FLOAT: return make2(CALL, makeName(MATH_FROUND), &(makeArray(1))->push_back(node));
+    case ASM_FLOAT32X4: return make2(CALL, makeName(SIMD_FLOAT32X4_CHECK), &(makeArray(1))->push_back(node));
+    case ASM_FLOAT64X2: return make2(CALL, makeName(SIMD_FLOAT64X2_CHECK), &(makeArray(1))->push_back(node));
+    case ASM_INT8X16: return make2(CALL, makeName(SIMD_INT8X16_CHECK), &(makeArray(1))->push_back(node));
+    case ASM_INT16X8: return make2(CALL, makeName(SIMD_INT16X8_CHECK), &(makeArray(1))->push_back(node));
+    case ASM_INT32X4: return make2(CALL, makeName(SIMD_INT32X4_CHECK), &(makeArray(1))->push_back(node));
     case ASM_NONE:
     default: return node; // non-validating code, emit nothing XXX this is dangerous, we should only allow this when we know we are not validating
   }
@@ -716,12 +716,12 @@ void removeAllUselessSubNodes(Ref ast) {
 }
 
 Ref unVarify(Ref vars) { // transform var x=1, y=2 etc. into (x=1, y=2), i.e., the same assigns, but without a var definition
-  Ref ret = makeArray();
+  Ref ret = makeArray(1);
   ret->push_back(makeString(STAT));
   if (vars->size() == 1) {
     ret->push_back(make3(ASSIGN, makeBool(true), makeName(vars[0][0]->getIString()), vars[0][1]));
   } else {
-    ret->push_back(makeArray());
+    ret->push_back(makeArray(vars->size()-1));
     Ref curr = ret[1];
     for (size_t i = 0; i+1 < vars->size(); i++) {
       curr->push_back(makeString(SEQ));
@@ -1400,7 +1400,7 @@ void eliminate(Ref ast, bool memSafe) {
       // Look for statements, including while-switch pattern
       Ref stats = getStatements(block);
       if (!stats && (block[0] == WHILE && block[2][0] == SWITCH)) {
-        stats = &(makeArray()->push_back(block[2]));
+        stats = &(makeArray(1)->push_back(block[2]));
       }
       if (!stats) return;
       tracked.clear();
@@ -2173,7 +2173,7 @@ void simplifyIfs(Ref ast) {
               Ref curr = deStat(stats[i]);
               other[1] = make2(SEQ, curr, other[1]);
             }
-            Ref temp = makeArray();
+            Ref temp = makeArray(1);
             temp->push_back(other);
             stats = body[1] = temp;
           }
@@ -2339,7 +2339,7 @@ void registerize(Ref ast) {
       Ref assign = makeNum(0);
       // TODO: will be an isEmpty here, can reuse it.
       fun[3]->insert(0, make1(VAR, fun[2]->map([&assign](Ref param) {
-        return &(makeArray()->push_back(param).push_back(assign));
+        return &(makeArray(2)->push_back(param).push_back(assign));
       })));
     }
     // Replace all var definitions with assignments; we will add var definitions at the top after we registerize
@@ -4062,7 +4062,7 @@ void eliminateDeadFuncs(Ref ast) {
     }
     AsmData asmData(fun);
     fun[3]->setSize(1);
-    fun[3][0] = make1(STAT, make2(CALL, makeName(ABORT), &(makeArray())->push_back(makeNum(-1))));
+    fun[3][0] = make1(STAT, make2(CALL, makeName(ABORT), &(makeArray(1))->push_back(makeNum(-1))));
     asmData.vars.clear();
     asmData.denormalize();
   });

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -983,8 +983,10 @@ void eliminate(Ref ast, bool memSafe) {
           Ref value;
           if (node1i->size() > 1 && !!(value = node1i[1])) {
             IString name = node1i[0]->getIString();
-            definitions[name]++;
-            if (!values.has(name)) values[name] = value;
+            // values is only used if definitions is 1
+            if (definitions[name]++ == 0) {
+              values[name] = value;
+            }
           }
         }
       } else if (type == NAME) {
@@ -995,8 +997,10 @@ void eliminate(Ref ast, bool memSafe) {
         Ref target = node[2];
         if (target[0] == NAME) {
           IString& name = target[1]->getIString();
-          definitions[name]++;
-          if (!values.has(name)) values[name] = node[3];
+          // values is only used if definitions is 1
+          if (definitions[name]++ == 0) {
+            values[name] = node[3];
+          }
           assert(node[1]->isBool(true)); // not +=, -= etc., just =
           uses[name]--; // because the name node will show up by itself in the previous case
         }

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -1138,9 +1138,9 @@ void eliminate(Ref ast, bool memSafe) {
           ignoreName = false;
         }
       });
-      globalsInvalidated = false;
-      memoryInvalidated = false;
-      callsInvalidated = false;
+      if (track.usesGlobals) globalsInvalidated = false;
+      if (track.usesMemory) memoryInvalidated = false;
+      if (track.doesCall) callsInvalidated = false;
     };
 
     // TODO: invalidate using a sequence number for each type (if you were tracked before the last invalidation, you are cancelled). remove for.in loops

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -192,7 +192,6 @@ class Parser {
     }
 
     explicit Frag(char* src) {
-      assert(!isSpace(*src));
       char *start = src;
       if (isIdentInit(*src)) {
         // read an identifier or a keyword
@@ -252,8 +251,8 @@ class Parser {
           case '^': str = XOR; break;
           case '|': str = OR; break;
           case '~': str = B_NOT; break;
+          default: abort();
         }
-        assert(!str.isNull());
         size = strlen(str.str);
 #ifndef NDEBUG
         char temp = start[size];
@@ -326,7 +325,6 @@ class Parser {
       case STRING:
       case INT:
       case DOUBLE: {
-        skipSpace(src);
         if (frag.type == IDENT) return parseAfterIdent(frag, src, seps);
         else return parseExpression(parseFrag(frag), src, seps);
       }
@@ -550,7 +548,7 @@ class Parser {
   }
 
   NodeRef parseAfterIdent(Frag& frag, char*& src, const char* seps) {
-    assert(!isSpace(*src));
+    skipSpace(src);
     if (*src == '(') return parseExpression(parseCall(parseFrag(frag), src), src, seps);
     if (*src == '[') return parseExpression(parseIndexing(parseFrag(frag), src), src, seps);
     if (*src == ':' && expressionPartsStack.back().size() == 0) {
@@ -789,7 +787,7 @@ class Parser {
   NodeRef parseBlock(char*& src, const char* seps=";", IString keywordSep1=IString(), IString keywordSep2=IString()) {
     NodeRef block = Builder::makeBlock();
     //dump("parseBlock", src);
-    while (*src) {
+    while (1) {
       skipSpace(src);
       if (*src == 0) break;
       if (*src == ';') {

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -391,14 +391,13 @@ class Parser {
       src += arg.size;
       Builder::appendArgumentToFunction(ret, arg.str);
       skipSpace(src);
-      if (*src && *src == ')') break;
-      if (*src && *src == ',') {
+      if (*src == ')') break;
+      if (*src == ',') {
         src++;
         continue;
       }
       abort();
     }
-    assert(*src == ')');
     src++;
     Builder::setBlockContent(ret, parseBracketedBlock(src));
     // TODO: parse expression?
@@ -422,14 +421,13 @@ class Parser {
       }
       Builder::appendToVar(ret, name.str, value);
       skipSpace(src);
-      if (*src && *src == ';') break;
-      if (*src && *src == ',') {
+      if (*src == ';') break;
+      if (*src == ',') {
         src++;
         continue;
       }
       abort();
     }
-    assert(*src == ';');
     src++;
     return ret;
   }
@@ -448,7 +446,7 @@ class Parser {
     NodeRef ifTrue = parseMaybeBracketed(src, seps);
     skipSpace(src);
     NodeRef ifFalse;
-    if (*src && !hasChar(seps, *src)) {
+    if (!hasChar(seps, *src)) {
       Frag next(src);
       if (next.type == KEYWORD && next.str == ELSE) {
         src += next.size;
@@ -576,8 +574,8 @@ class Parser {
       if (*src == ')') break;
       Builder::appendToCall(ret, parseElement(src, ",)"));
       skipSpace(src);
-      if (*src && *src == ')') break;
-      if (*src && *src == ',') {
+      if (*src == ')') break;
+      if (*src == ',') {
         src++;
         continue;
       }
@@ -633,12 +631,13 @@ class Parser {
       NodeRef element = parseElement(src, ",]");
       Builder::appendToArray(ret, element);
       skipSpace(src);
+      if (*src == ']') break;
       if (*src == ',') {
         src++;
         continue;
-      } else assert(*src == ']');
+      }
+      abort();
     }
-    assert(*src == ']');
     src++;
     return ret;
   }
@@ -659,12 +658,13 @@ class Parser {
       NodeRef value = parseElement(src, ",}");
       Builder::appendToObject(ret, key.str, value);
       skipSpace(src);
+      if (*src == '}') break;
       if (*src == ',') {
         src++;
         continue;
-      } else assert(*src == '}');
+      }
+      abort();
     }
-    assert(*src == '}');
     src++;
     return ret;
   }

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -330,23 +330,23 @@ class Parser {
 
   NodeRef parseAfterKeyword(Frag& frag, char*& src, const char* seps) {
     src = skipSpace(src);
-    if (frag.str == FUNCTION) return parseFunction(frag, src, seps);
-    else if (frag.str == VAR) return parseVar(frag, src, seps);
-    else if (frag.str == CONST) return parseVar(frag, src, seps);
-    else if (frag.str == RETURN) return parseReturn(frag, src, seps);
-    else if (frag.str == IF) return parseIf(frag, src, seps);
-    else if (frag.str == DO) return parseDo(frag, src, seps);
-    else if (frag.str == WHILE) return parseWhile(frag, src, seps);
-    else if (frag.str == BREAK) return parseBreak(frag, src, seps);
-    else if (frag.str == CONTINUE) return parseContinue(frag, src, seps);
-    else if (frag.str == SWITCH) return parseSwitch(frag, src, seps);
-    else if (frag.str == NEW) return parseNew(frag, src, seps);
+    if (frag.str == FUNCTION) return parseFunction(src, seps);
+    else if (frag.str == VAR) return parseVar(src, seps, false);
+    else if (frag.str == CONST) return parseVar(src, seps, true);
+    else if (frag.str == RETURN) return parseReturn(src, seps);
+    else if (frag.str == IF) return parseIf(src, seps);
+    else if (frag.str == DO) return parseDo(src, seps);
+    else if (frag.str == WHILE) return parseWhile(src, seps);
+    else if (frag.str == BREAK) return parseBreak(src, seps);
+    else if (frag.str == CONTINUE) return parseContinue(src, seps);
+    else if (frag.str == SWITCH) return parseSwitch(src, seps);
+    else if (frag.str == NEW) return parseNew(src, seps);
     dump(frag.str.str, src);
     abort();
     return nullptr;
   }
 
-  NodeRef parseFunction(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseFunction(char*& src, const char* seps) {
     Frag name(src);
     if (name.type == IDENT) {
       src += name.size;
@@ -380,8 +380,8 @@ class Parser {
     return ret;
   }
 
-  NodeRef parseVar(Frag& frag, char*& src, const char* seps) {
-    NodeRef ret = Builder::makeVar(frag.str == CONST);
+  NodeRef parseVar(char*& src, const char* seps, bool is_const) {
+    NodeRef ret = Builder::makeVar(is_const);
     while (1) {
       src = skipSpace(src);
       if (*src == ';') break;
@@ -409,7 +409,7 @@ class Parser {
     return ret;
   }
 
-  NodeRef parseReturn(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseReturn(char*& src, const char* seps) {
     src = skipSpace(src);
     NodeRef value = !hasChar(seps, *src) ? parseElement(src, seps) : nullptr;
     src = skipSpace(src);
@@ -418,7 +418,7 @@ class Parser {
     return Builder::makeReturn(value);
   }
 
-  NodeRef parseIf(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseIf(char*& src, const char* seps) {
     NodeRef condition = parseParenned(src);
     NodeRef ifTrue = parseMaybeBracketed(src, seps);
     src = skipSpace(src);
@@ -433,7 +433,7 @@ class Parser {
     return Builder::makeIf(condition, ifTrue, ifFalse);
   }
 
-  NodeRef parseDo(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseDo(char*& src, const char* seps) {
     NodeRef body = parseMaybeBracketed(src, seps);
     src = skipSpace(src);
     Frag next(src);
@@ -443,27 +443,27 @@ class Parser {
     return Builder::makeDo(body, condition);
   }
 
-  NodeRef parseWhile(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseWhile(char*& src, const char* seps) {
     NodeRef condition = parseParenned(src);
     NodeRef body = parseMaybeBracketed(src, seps);
     return Builder::makeWhile(condition, body);
   }
 
-  NodeRef parseBreak(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseBreak(char*& src, const char* seps) {
     src = skipSpace(src);
     Frag next(src);
     if (next.type == IDENT) src += next.size;
     return Builder::makeBreak(next.type == IDENT ? next.str : IString());
   }
 
-  NodeRef parseContinue(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseContinue(char*& src, const char* seps) {
     src = skipSpace(src);
     Frag next(src);
     if (next.type == IDENT) src += next.size;
     return Builder::makeContinue(next.type == IDENT ? next.str : IString());
   }
 
-  NodeRef parseSwitch(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseSwitch(char*& src, const char* seps) {
     NodeRef ret = Builder::makeSwitch(parseParenned(src));
     src = skipSpace(src);
     assert(*src == '{');
@@ -518,7 +518,7 @@ class Parser {
     return ret;
   }
 
-  NodeRef parseNew(Frag& frag, char*& src, const char* seps) {
+  NodeRef parseNew(char*& src, const char* seps) {
     return Builder::makeNew(parseElement(src, seps));
   }
 

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -321,12 +321,13 @@ class Parser {
       case KEYWORD: {
         return parseAfterKeyword(frag, src, seps);
       }
-      case IDENT:
+      case IDENT: {
+        return parseAfterIdent(frag, src, seps);
+      }
       case STRING:
       case INT:
       case DOUBLE: {
-        if (frag.type == IDENT) return parseAfterIdent(frag, src, seps);
-        else return parseExpression(parseFrag(frag), src, seps);
+        return parseExpression(parseFrag(frag), src, seps);
       }
       case SEPARATOR: {
         if (frag.str == OPEN_PAREN) return parseExpression(parseAfterParen(src), src, seps);
@@ -533,7 +534,8 @@ class Parser {
       // not case X: or default: or }, so must be some code
       skipSpace(src);
       bool explicitBlock = *src == '{';
-      Builder::appendCodeToSwitch(ret, parseMaybeBracketedBlock(src, ";}", CASE, DEFAULT), explicitBlock);
+      NodeRef subBlock = explicitBlock ? parseBracketedBlock(src) : parseBlock(src, ";}", CASE, DEFAULT);
+      Builder::appendCodeToSwitch(ret, subBlock, explicitBlock);
     }
     skipSpace(src);
     assert(*src == '}');
@@ -837,11 +839,6 @@ class Parser {
   NodeRef parseMaybeBracketed(char*& src, const char *seps) {
     skipSpace(src);
     return *src == '{' ? parseBracketedBlock(src) : parseElementOrStatement(src, seps);
-  }
-
-  NodeRef parseMaybeBracketedBlock(char*& src, const char *seps, IString keywordSep1=IString(), IString keywordSep2=IString()) {
-    skipSpace(src);
-    return *src == '{' ? parseBracketedBlock(src) : parseBlock(src, seps, keywordSep1, keywordSep2);
   }
 
   NodeRef parseParenned(char*& src) {

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -210,12 +210,6 @@ class Parser {
           *src = temp;
         }
         type = keywords.has(str) ? KEYWORD : IDENT;
-      } else if (*src == '"' || *src == '\'') {
-        char *end = strchr(src+1, *src);
-        *end = 0;
-        str.set(src+1);
-        src = end+1;
-        type = STRING;
       } else if (isDigit(*src) || (src[0] == '.' && isDigit(src[1]))) {
         if (src[0] == '0' && (src[1] == 'x' || src[1] == 'X')) {
           // Explicitly parse hex numbers of form "0x...", because strtod
@@ -277,6 +271,12 @@ class Parser {
         str.set(src, false);
         src[1] = temp;
         src++;
+      } else if (*src == '"' || *src == '\'') {
+        char *end = strchr(src+1, *src);
+        *end = 0;
+        str.set(src+1);
+        src = end+1;
+        type = STRING;
       } else {
         dump("frag parsing", src);
         abort();

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -62,8 +62,9 @@ void dump(const char *str, Ref node, bool pretty) {
 
 struct TraverseInfo {
   TraverseInfo() {}
-  TraverseInfo(Ref node) : node(node), index(0) {}
+  TraverseInfo(Ref node, ArrayStorage& arr) : node(node), arr(&arr), index(0) {}
   Ref node;
+  ArrayStorage* arr;
   int index;
 };
 
@@ -123,15 +124,15 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
   if (!visitable(node)) return;
   visit(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node));
+  stack.push_back(TraverseInfo(node, node->getArray()));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
-    if (top.index < (int)top.node->size()) {
-      Ref sub = top.node[top.index];
+    if (top.index < (int)top.arr->size()) {
+      Ref sub = (*top.arr)[top.index];
       top.index++;
       if (visitable(sub)) {
         visit(sub);
-        stack.push_back(TraverseInfo(sub));
+        stack.push_back(TraverseInfo(sub, sub->getArray()));
       }
     } else {
       stack.pop_back();
@@ -144,15 +145,15 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
   if (!visitable(node)) return;
   visitPre(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node));
+  stack.push_back(TraverseInfo(node, node->getArray()));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
-    if (top.index < (int)top.node->size()) {
-      Ref sub = top.node[top.index];
+    if (top.index < (int)top.arr->size()) {
+      Ref sub = (*top.arr)[top.index];
       top.index++;
       if (visitable(sub)) {
         visitPre(sub);
-        stack.push_back(TraverseInfo(sub));
+        stack.push_back(TraverseInfo(sub, sub->getArray()));
       }
     } else {
       visitPost(top.node);
@@ -166,15 +167,15 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
   if (!visitable(node)) return;
   if (!visitPre(node)) return;
   StackedStack<TraverseInfo, TRAV_STACK> stack;
-  stack.push_back(TraverseInfo(node));
+  stack.push_back(TraverseInfo(node, node->getArray()));
   while (stack.size() > 0) {
     TraverseInfo& top = stack.back();
-    if (top.index < (int)top.node->size()) {
-      Ref sub = top.node[top.index];
+    if (top.index < (int)top.arr->size()) {
+      Ref sub = (*top.arr)[top.index];
       top.index++;
       if (visitable(sub)) {
         if (visitPre(sub)) {
-          stack.push_back(TraverseInfo(sub));
+          stack.push_back(TraverseInfo(sub, sub->getArray()));
         }
       }
     } else {

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -133,7 +133,7 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
   visit(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   stack.push_back(TraverseInfo(node, node->getArray()));
-  while (stack.size() > 0) {
+  while (1) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.arr->size()) {
       Ref sub = (*top.arr)[top.index];
@@ -144,6 +144,7 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
       }
     } else {
       stack.pop_back();
+      if (stack.size() == 0) break;
     }
   }
 }
@@ -154,7 +155,7 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
   visitPre(node);
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   stack.push_back(TraverseInfo(node, node->getArray()));
-  while (stack.size() > 0) {
+  while (1) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.arr->size()) {
       Ref sub = (*top.arr)[top.index];
@@ -166,6 +167,7 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
     } else {
       visitPost(top.node);
       stack.pop_back();
+      if (stack.size() == 0) break;
     }
   }
 }
@@ -176,7 +178,7 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
   if (!visitPre(node)) return;
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   stack.push_back(TraverseInfo(node, node->getArray()));
-  while (stack.size() > 0) {
+  while (1) {
     TraverseInfo& top = stack.back();
     if (top.index < (int)top.arr->size()) {
       Ref sub = (*top.arr)[top.index];
@@ -189,6 +191,7 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
     } else {
       visitPost(top.node);
       stack.pop_back();
+      if (stack.size() == 0) break;
     }
   }
 }

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -47,6 +47,14 @@ Ref Arena::alloc() {
   return &chunks.back()[index++];
 }
 
+ArrayStorage* Arena::allocArr() {
+  if (arr_chunks.size() == 0 || arr_index == CHUNK_SIZE) {
+    arr_chunks.push_back(new ArrayStorage[CHUNK_SIZE]);
+    arr_index = 0;
+  }
+  return &arr_chunks.back()[arr_index++];
+}
+
 // dump
 
 void dump(const char *str, Ref node, bool pretty) {

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -134,16 +134,20 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   int index = 0;
   ArrayStorage* arr = &node->getArray();
+  int arrsize = (int)arr->size();
+  Ref* arrdata = arr->data();
   stack.push_back(TraverseInfo(node, arr));
   while (1) {
-    if (index < (int)arr->size()) {
-      Ref sub = (*arr)[index];
+    if (index < arrsize) {
+      Ref sub = *(arrdata+index);
       index++;
       if (visitable(sub)) {
         stack.back().index = index;
         index = 0;
         visit(sub);
         arr = &sub->getArray();
+        arrsize = (int)arr->size();
+        arrdata = arr->data();
         stack.push_back(TraverseInfo(sub, arr));
       }
     } else {
@@ -152,6 +156,8 @@ void traversePre(Ref node, std::function<void (Ref)> visit) {
       TraverseInfo& back = stack.back();
       index = back.index;
       arr = back.arr;
+      arrsize = (int)arr->size();
+      arrdata = arr->data();
     }
   }
 }
@@ -163,16 +169,20 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   int index = 0;
   ArrayStorage* arr = &node->getArray();
+  int arrsize = (int)arr->size();
+  Ref* arrdata = arr->data();
   stack.push_back(TraverseInfo(node, arr));
   while (1) {
-    if (index < (int)arr->size()) {
-      Ref sub = (*arr)[index];
+    if (index < arrsize) {
+      Ref sub = *(arrdata+index);
       index++;
       if (visitable(sub)) {
         stack.back().index = index;
         index = 0;
         visitPre(sub);
         arr = &sub->getArray();
+        arrsize = (int)arr->size();
+        arrdata = arr->data();
         stack.push_back(TraverseInfo(sub, arr));
       }
     } else {
@@ -182,6 +192,8 @@ void traversePrePost(Ref node, std::function<void (Ref)> visitPre, std::function
       TraverseInfo& back = stack.back();
       index = back.index;
       arr = back.arr;
+      arrsize = (int)arr->size();
+      arrdata = arr->data();
     }
   }
 }
@@ -193,16 +205,20 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
   StackedStack<TraverseInfo, TRAV_STACK> stack;
   int index = 0;
   ArrayStorage* arr = &node->getArray();
+  int arrsize = (int)arr->size();
+  Ref* arrdata = arr->data();
   stack.push_back(TraverseInfo(node, arr));
   while (1) {
-    if (index < (int)arr->size()) {
-      Ref sub = (*arr)[index];
+    if (index < arrsize) {
+      Ref sub = *(arrdata+index);
       index++;
       if (visitable(sub)) {
         if (visitPre(sub)) {
           stack.back().index = index;
           index = 0;
           arr = &sub->getArray();
+          arrsize = (int)arr->size();
+          arrdata = arr->data();
           stack.push_back(TraverseInfo(sub, arr));
         }
       }
@@ -213,6 +229,8 @@ void traversePrePostConditional(Ref node, std::function<bool (Ref)> visitPre, st
       TraverseInfo& back = stack.back();
       index = back.index;
       arr = back.arr;
+      arrsize = (int)arr->size();
+      arrdata = arr->data();
     }
   }
 }

--- a/tools/optimizer/simple_ast.cpp
+++ b/tools/optimizer/simple_ast.cpp
@@ -47,7 +47,7 @@ Ref Arena::alloc() {
   return &chunks.back()[index++];
 }
 
-ArrayStorage* Arena::allocArr() {
+ArrayStorage* Arena::allocArray() {
   if (arr_chunks.size() == 0 || arr_index == CHUNK_SIZE) {
     arr_chunks.push_back(new ArrayStorage[CHUNK_SIZE]);
     arr_index = 0;

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -67,6 +67,8 @@ struct Arena {
 
 extern Arena arena;
 
+typedef std::vector<Ref> ArrayStorage;
+
 // Main value type
 struct Value {
   enum Type {
@@ -80,7 +82,6 @@ struct Value {
 
   Type type;
 
-  typedef std::vector<Ref> ArrayStorage;
   typedef std::unordered_map<IString, Ref> ObjectStorage;
 
 #ifdef _MSC_VER // MSVC does not allow unrestricted unions: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -1301,12 +1301,17 @@ public:
                            .push_back(makeRawString(name));
   }
 
-  static void appendToBlock(Ref block, Ref element) {
-    if (block[0] == BLOCK || block[0] == TOPLEVEL) {
-      block[1]->push_back(element);
-    } else if (block[0] == DEFUN) {
-      block[3]->push_back(element);
+  static void setBlockContent(Ref target, Ref block) {
+    if (target[0] == TOPLEVEL) {
+      target[1]->setArray(block[1]->getArray());
+    } else if (target[0] == DEFUN) {
+      target[3]->setArray(block[1]->getArray());
     } else abort();
+  }
+
+  static void appendToBlock(Ref block, Ref element) {
+    assert(block[0] == BLOCK);
+    block[1]->push_back(element);
   }
 
   static Ref makeCall(Ref target) {

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -147,10 +147,11 @@ struct Value {
     *arr = a;
     return *this;
   }
-  Value& setArray() {
+  Value& setArray(int size_hint=0) {
     free();
     type = Array;
     arr = new ArrayStorage();
+    arr->reserve(size_hint);
     return *this;
   }
   Value& setNull() {
@@ -1272,8 +1273,8 @@ class ValueBuilder {
     return &arena.alloc()->setString(s);
   }
 
-  static Ref makeRawArray() {
-    return &arena.alloc()->setArray();
+  static Ref makeRawArray(int size_hint=0) {
+    return &arena.alloc()->setArray(size_hint);
   }
 
   static Ref makeNull() {
@@ -1282,23 +1283,23 @@ class ValueBuilder {
 
 public:
   static Ref makeToplevel() {
-    return &makeRawArray()->push_back(makeRawString(TOPLEVEL))
-                           .push_back(makeRawArray());
+    return &makeRawArray(2)->push_back(makeRawString(TOPLEVEL))
+                            .push_back(makeRawArray());
   }
 
   static Ref makeString(IString str) {
-    return &makeRawArray()->push_back(makeRawString(STRING))
-                           .push_back(makeRawString(str));
+    return &makeRawArray(2)->push_back(makeRawString(STRING))
+                            .push_back(makeRawString(str));
   }
 
   static Ref makeBlock() {
-    return &makeRawArray()->push_back(makeRawString(BLOCK))
-                           .push_back(makeRawArray());
+    return &makeRawArray(2)->push_back(makeRawString(BLOCK))
+                            .push_back(makeRawArray());
   }
 
   static Ref makeName(IString name) {
-    return &makeRawArray()->push_back(makeRawString(NAME))
-                           .push_back(makeRawString(name));
+    return &makeRawArray(2)->push_back(makeRawString(NAME))
+                            .push_back(makeRawString(name));
   }
 
   static void setBlockContent(Ref target, Ref block) {
@@ -1315,9 +1316,9 @@ public:
   }
 
   static Ref makeCall(Ref target) {
-    return &makeRawArray()->push_back(makeRawString(CALL))
-                           .push_back(target)
-                           .push_back(makeRawArray());
+    return &makeRawArray(3)->push_back(makeRawString(CALL))
+                            .push_back(target)
+                            .push_back(makeRawArray());
   }
 
   static void appendToCall(Ref call, Ref element) {
@@ -1327,16 +1328,16 @@ public:
 
   static Ref makeStatement(Ref contents) {
     if (statable.has(contents[0]->getIString())) {
-      return &makeRawArray()->push_back(makeRawString(STAT))
-                             .push_back(contents);
+      return &makeRawArray(2)->push_back(makeRawString(STAT))
+                              .push_back(contents);
     } else {
       return contents; // only very specific things actually need to be stat'ed
     }
   }
 
   static Ref makeDouble(double num) {
-    return &makeRawArray()->push_back(makeRawString(NUM))
-                           .push_back(&arena.alloc()->setNumber(num));
+    return &makeRawArray(2)->push_back(makeRawString(NUM))
+                            .push_back(&arena.alloc()->setNumber(num));
   }
   static Ref makeInt(uint32_t num) {
     return makeDouble(double(num));
@@ -1344,33 +1345,33 @@ public:
 
   static Ref makeBinary(Ref left, IString op, Ref right) {
     if (op == SET) {
-      return &makeRawArray()->push_back(makeRawString(ASSIGN))
-                             .push_back(&arena.alloc()->setBool(true))
-                             .push_back(left)
-                             .push_back(right);
+      return &makeRawArray(4)->push_back(makeRawString(ASSIGN))
+                              .push_back(&arena.alloc()->setBool(true))
+                              .push_back(left)
+                              .push_back(right);
     } else if (op == COMMA) {
-      return &makeRawArray()->push_back(makeRawString(SEQ))
-                             .push_back(left)
-                             .push_back(right);
+      return &makeRawArray(3)->push_back(makeRawString(SEQ))
+                              .push_back(left)
+                              .push_back(right);
     } else {
-      return &makeRawArray()->push_back(makeRawString(BINARY))
-                             .push_back(makeRawString(op))
-                             .push_back(left)
-                             .push_back(right);
+      return &makeRawArray(4)->push_back(makeRawString(BINARY))
+                              .push_back(makeRawString(op))
+                              .push_back(left)
+                              .push_back(right);
     }
   }
 
   static Ref makePrefix(IString op, Ref right) {
-    return &makeRawArray()->push_back(makeRawString(UNARY_PREFIX))
-                           .push_back(makeRawString(op))
-                           .push_back(right);
+    return &makeRawArray(3)->push_back(makeRawString(UNARY_PREFIX))
+                            .push_back(makeRawString(op))
+                            .push_back(right);
   }
 
   static Ref makeFunction(IString name) {
-    return &makeRawArray()->push_back(makeRawString(DEFUN))
-                           .push_back(makeRawString(name))
-                           .push_back(makeRawArray())
-                           .push_back(makeRawArray());
+    return &makeRawArray(4)->push_back(makeRawString(DEFUN))
+                            .push_back(makeRawString(name))
+                            .push_back(makeRawArray())
+                            .push_back(makeRawArray());
   }
 
   static void appendArgumentToFunction(Ref func, IString arg) {
@@ -1379,81 +1380,86 @@ public:
   }
 
   static Ref makeVar(bool is_const) {
-    return &makeRawArray()->push_back(makeRawString(VAR))
-                           .push_back(makeRawArray());
+    return &makeRawArray(2)->push_back(makeRawString(VAR))
+                            .push_back(makeRawArray());
   }
 
   static void appendToVar(Ref var, IString name, Ref value) {
     assert(var[0] == VAR);
-    Ref array = &makeRawArray()->push_back(makeRawString(name));
+    Ref array = &makeRawArray(1)->push_back(makeRawString(name));
     if (!!value) array->push_back(value);
     var[1]->push_back(array);
   }
 
   static Ref makeReturn(Ref value) {
-    return &makeRawArray()->push_back(makeRawString(RETURN)).push_back(!!value ? value : makeNull());
+    return &makeRawArray(2)->push_back(makeRawString(RETURN))
+                            .push_back(!!value ? value : makeNull());
   }
 
   static Ref makeIndexing(Ref target, Ref index) {
-    return &makeRawArray()->push_back(makeRawString(SUB))
-                           .push_back(target)
-                           .push_back(index);
+    return &makeRawArray(3)->push_back(makeRawString(SUB))
+                            .push_back(target)
+                            .push_back(index);
   }
 
   static Ref makeIf(Ref condition, Ref ifTrue, Ref ifFalse) {
-    return &makeRawArray()->push_back(makeRawString(IF))
-                           .push_back(condition)
-                           .push_back(ifTrue)
-                           .push_back(!!ifFalse ? ifFalse : makeNull());
+    return &makeRawArray(4)->push_back(makeRawString(IF))
+                            .push_back(condition)
+                            .push_back(ifTrue)
+                            .push_back(!!ifFalse ? ifFalse : makeNull());
   }
 
   static Ref makeConditional(Ref condition, Ref ifTrue, Ref ifFalse) {
-    return &makeRawArray()->push_back(makeRawString(CONDITIONAL))
-                           .push_back(condition)
-                           .push_back(ifTrue)
-                           .push_back(ifFalse);
+    return &makeRawArray(4)->push_back(makeRawString(CONDITIONAL))
+                            .push_back(condition)
+                            .push_back(ifTrue)
+                            .push_back(ifFalse);
   }
 
   static Ref makeDo(Ref body, Ref condition) {
-    return &makeRawArray()->push_back(makeRawString(DO))
-                           .push_back(condition)
-                           .push_back(body);
+    return &makeRawArray(3)->push_back(makeRawString(DO))
+                            .push_back(condition)
+                            .push_back(body);
   }
 
   static Ref makeWhile(Ref condition, Ref body) {
-    return &makeRawArray()->push_back(makeRawString(WHILE))
-                           .push_back(condition)
-                           .push_back(body);
+    return &makeRawArray(3)->push_back(makeRawString(WHILE))
+                            .push_back(condition)
+                            .push_back(body);
   }
 
   static Ref makeBreak(IString label) {
-    return &makeRawArray()->push_back(makeRawString(BREAK)).push_back(!!label ? makeRawString(label) : makeNull());
+    return &makeRawArray(2)->push_back(makeRawString(BREAK))
+                            .push_back(!!label ? makeRawString(label) : makeNull());
   }
 
   static Ref makeContinue(IString label) {
-    return &makeRawArray()->push_back(makeRawString(CONTINUE)).push_back(!!label ? makeRawString(label) : makeNull());
+    return &makeRawArray(2)->push_back(makeRawString(CONTINUE))
+                            .push_back(!!label ? makeRawString(label) : makeNull());
   }
 
   static Ref makeLabel(IString name, Ref body) {
-    return &makeRawArray()->push_back(makeRawString(LABEL))
-                           .push_back(makeRawString(name))
-                           .push_back(body);
+    return &makeRawArray(3)->push_back(makeRawString(LABEL))
+                            .push_back(makeRawString(name))
+                            .push_back(body);
   }
 
   static Ref makeSwitch(Ref input) {
-    return &makeRawArray()->push_back(makeRawString(SWITCH))
-                           .push_back(input)
-                           .push_back(makeRawArray());
+    return &makeRawArray(3)->push_back(makeRawString(SWITCH))
+                            .push_back(input)
+                            .push_back(makeRawArray());
   }
 
   static void appendCaseToSwitch(Ref switch_, Ref arg) {
     assert(switch_[0] == SWITCH);
-    switch_[2]->push_back(&makeRawArray()->push_back(arg).push_back(makeRawArray()));
+    switch_[2]->push_back(&makeRawArray(2)->push_back(arg)
+                                           .push_back(makeRawArray()));
   }
 
   static void appendDefaultToSwitch(Ref switch_) {
     assert(switch_[0] == SWITCH);
-    switch_[2]->push_back(&makeRawArray()->push_back(makeNull()).push_back(makeRawArray()));
+    switch_[2]->push_back(&makeRawArray(2)->push_back(makeNull())
+                                           .push_back(makeRawArray()));
   }
 
   static void appendCodeToSwitch(Ref switch_, Ref code, bool explicitBlock) {
@@ -1469,9 +1475,9 @@ public:
   }
 
   static Ref makeDot(Ref obj, IString key) {
-    return &makeRawArray()->push_back(makeRawString(DOT))
-                           .push_back(obj)
-                           .push_back(makeRawString(key));
+    return &makeRawArray(3)->push_back(makeRawString(DOT))
+                            .push_back(obj)
+                            .push_back(makeRawString(key));
   }
 
   static Ref makeDot(Ref obj, Ref key) {
@@ -1480,13 +1486,13 @@ public:
   }
 
   static Ref makeNew(Ref call) {
-    return &makeRawArray()->push_back(makeRawString(NEW))
-                           .push_back(call);
+    return &makeRawArray(2)->push_back(makeRawString(NEW))
+                            .push_back(call);
   }
 
   static Ref makeArray() {
-    return &makeRawArray()->push_back(makeRawString(ARRAY))
-                           .push_back(makeRawArray());
+    return &makeRawArray(2)->push_back(makeRawString(ARRAY))
+                            .push_back(makeRawArray());
   }
 
   static void appendToArray(Ref array, Ref element) {
@@ -1495,14 +1501,14 @@ public:
   }
 
   static Ref makeObject() {
-    return &makeRawArray()->push_back(makeRawString(OBJECT))
-                           .push_back(makeRawArray());
+    return &makeRawArray(2)->push_back(makeRawString(OBJECT))
+                            .push_back(makeRawArray());
   }
 
   static void appendToObject(Ref array, IString key, Ref value) {
     assert(array[0] == OBJECT);
-    array[1]->push_back(&makeRawArray()->push_back(makeRawString(key))
-                                        .push_back(value));
+    array[1]->push_back(&makeRawArray(2)->push_back(makeRawString(key))
+                                         .push_back(value));
   }
 };
 

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -65,10 +65,10 @@ struct Arena {
   std::vector<ArrayStorage*> arr_chunks;
   int arr_index;
 
-  Arena() : index(0), arr_index{0} {}
+  Arena() : index(0), arr_index(0) {}
 
   Ref alloc();
-  ArrayStorage* allocArr();
+  ArrayStorage* allocArray();
 };
 
 extern Arena arena;
@@ -147,14 +147,14 @@ struct Value {
   Value& setArray(ArrayStorage &a) {
     free();
     type = Array;
-    arr = arena.allocArr();
+    arr = arena.allocArray();
     *arr = a;
     return *this;
   }
   Value& setArray(int size_hint=0) {
     free();
     type = Array;
-    arr = arena.allocArr();
+    arr = arena.allocArray();
     arr->reserve(size_hint);
     return *this;
   }

--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -444,8 +444,7 @@ struct Value {
 
   Ref& operator[](unsigned x) {
     assert(isArray());
-    assert(x < arr->size());
-    return (*arr)[x];
+    return arr->at(x);
   }
 
   Value& push_back(Ref r) {


### PR DESCRIPTION
These are just speed and style changes - there should be no output difference at all.

Using the .bc file from #3718, before:
```
# EMCC_DEBUG=1 emcc -O3 -o out.js slow/libemscripten_worker.bc 2>&1 | grep 'emcc step\|total time'
DEBUG    root: emcc step "parse arguments and setup" took 0.01 seconds
DEBUG    root: emcc step "bitcodeize inputs" took 0.00 seconds
DEBUG    root: emcc step "process inputs" took 0.00 seconds
DEBUG    root: emcc step "calculate system libraries" took 0.43 seconds
DEBUG    root: emcc step "link" took 0.63 seconds
DEBUG    root: emcc step "post-link" took 10.19 seconds
DEBUG    root: emcc step "emscript (llvm=>js)" took 8.62 seconds
DEBUG    root: emcc step "source transforms" took 0.34 seconds
DEBUG    root: emcc step "js opts" took 88.50 seconds
DEBUG    root: emcc step "final emitting" took 0.04 seconds
DEBUG    root: total time: 108.75 seconds
```

After:
```
# EMCC_DEBUG=1 emcc -O3 -o out.js slow/libemscripten_worker.bc 2>&1 | grep 'emcc step\|total time'
DEBUG    root: emcc step "parse arguments and setup" took 0.01 seconds
DEBUG    root: emcc step "bitcodeize inputs" took 0.00 seconds
DEBUG    root: emcc step "process inputs" took 0.00 seconds
DEBUG    root: emcc step "calculate system libraries" took 0.43 seconds
DEBUG    root: emcc step "link" took 0.63 seconds
DEBUG    root: emcc step "post-link" took 10.35 seconds
DEBUG    root: emcc step "emscript (llvm=>js)" took 9.11 seconds
DEBUG    root: emcc step "source transforms" took 0.78 seconds
DEBUG    root: emcc step "js opts" took 67.66 seconds
DEBUG    root: emcc step "final emitting" took 0.05 seconds
DEBUG    root: total time: 89.01 seconds
```

So 20-25% optimisation speedup, 15-20% overall speedup. The optimizer tests pass, I've not yet run any others, will do so now.

I've got a few other optimisations, but want to get these and the switch optimisation (#3733) fix done first.