### PR TITLE
Clarifications on switch elimination and optimization assumptions

### DIFF
--- a/tests/optimizer/asm-eliminator-test.js
+++ b/tests/optimizer/asm-eliminator-test.js
@@ -130,11 +130,11 @@ function label() {
  }
 }
 function switchy() {
- var no = 0, yes = 0;
+ var yes1 = 0, yes = 0;
  var a = 0, b = 0;
  while (1) switch (label | 0) {
   case 1:
-   no = 100; // eliminatable in theory, but eliminator does not look into switch. must leave def above as well.
+   yes1 = 100;
    break;
   case 2:
    yes = 111;

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -4,8 +4,11 @@
 //==============================================================================
 // Optimizer tool. This is meant to be run after the emscripten compiler has
 // finished generating code. These optimizations are done on the generated
-// code to further improve it. Some of the modifications also work in
-// conjunction with closure compiler.
+// code to further improve it.
+//
+// Be aware that this is *not* a general JS optimizer. It assumes that the
+// input is valid asm.js and makes strong assumptions based on this. It may do
+// anything from crashing to optimizing incorrectly if the input is not valid!
 //
 // TODO: Optimize traverse to modify a node we want to replace, in-place,
 //       instead of returning it to the previous call frame where we check?
@@ -4066,7 +4069,9 @@ function eliminate(ast, memSafe) {
             for (var j = 0; j < stats.length; j++) {
               traverseInOrder(stats[j]);
             }
-            // We cannot track from one switch case into another, undo all new trackings TODO: general framework here, use in if-else as well
+            // We cannot track from one switch case into another if there are external dependencies, undo all new trackings
+            // Otherwise we can track, e.g. a var used in a case before assignment in another case is UB in asm.js, so no need for the assignment
+            // TODO: general framework here, use in if-else as well
             for (var t in tracked) {
               if (!(t in originalTracked)) {
                 var info = tracked[t];

--- a/tools/optimizer/optimizer-main.cpp
+++ b/tools/optimizer/optimizer-main.cpp
@@ -1,3 +1,10 @@
+//==============================================================================
+// Optimizer tool. This is meant to be run after the emscripten compiler has
+// finished generating code. These optimizations are done on the generated
+// code to further improve it. Some of the modifications also work in
+// conjunction with closure compiler.
+//==============================================================================
+
 #include "simple_ast.h"
 #include "optimizer.h"
 

--- a/tools/optimizer/optimizer-main.cpp
+++ b/tools/optimizer/optimizer-main.cpp
@@ -1,8 +1,11 @@
 //==============================================================================
 // Optimizer tool. This is meant to be run after the emscripten compiler has
 // finished generating code. These optimizations are done on the generated
-// code to further improve it. Some of the modifications also work in
-// conjunction with closure compiler.
+// code to further improve it.
+//
+// Be aware that this is *not* a general JS optimizer. It assumes that the
+// input is valid asm.js and makes strong assumptions based on this. It may do
+// anything from crashing to optimizing incorrectly if the input is not valid!
 //==============================================================================
 
 #include "simple_ast.h"

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -1331,7 +1331,9 @@ void eliminate(Ref ast, bool memSafe) {
             for (size_t j = 0; j < stats->size(); j++) {
               traverseInOrder(stats[j], false, false);
             }
-            // We cannot track from one switch case into another, undo all new trackings TODO: general framework here, use in if-else as well
+            // We cannot track from one switch case into another if there are external dependencies, undo all new trackings
+            // Otherwise we can track, e.g. a var used in a case before assignment in another case is UB in asm.js, so no need for the assignment
+            // TODO: general framework here, use in if-else as well
             std::vector<IString> toDelete;
             for (auto t : tracked) {
               if (!originalTracked.has(t.first)) {


### PR DESCRIPTION
This PR contains only *two* commits - please merge after #3732.

In #2003 @kripken stated that "The issue was we let variables be eliminated between switch cases, which is fine unless they have a dependency on a non-safe variable".

I'm not convinced this is true. In the testcase I came up with,
```
function testfn($in) {
 $in = $in | 0;
 var a = 0;
 switch ($in | 0) {
  case 0:
   a = 6;
   break;
  case 1:
   print(a);
   break;
 }
}
```
when optimised with `asm eliminate` is optimised to
```
function testfn($in) {
 $in = $in | 0;
 switch ($in | 0) {
 case 0:
  break;
 case 1:
  print(6);
  break;
 }
}
```

This may be valid when compiling from C (where the initial vars are likely UB) but someone handwriting asm.js may well be a little surprised.