### PR TITLE
Fix some breakage from the fix for #3730

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -277,7 +277,7 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
       for i in range(arity):
         args.append('$' + str(i))
       const = 'function(' + ', '.join(args ) + ') ' + const
-      asm_consts[int(k)] = const
+      asm_consts[k] = const
 
     asm_const_funcs = []
     for arity in set(metadata['asmConstArities'].values()):


### PR DESCRIPTION
I'm a bit confused because I tried checking out the commit of the fix (c002379445706ef0) directly and the test added in that commit was broken. Not sure how this ever worked!? It

 - tried to use a string to index into a list (there's an `int(k)` elsewhere in the loop as evidence)
 - made no change to `metadata['asmConstArities']` at all but attempted to treat it as a dict!