### PR TITLE
Fast safe heap

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -991,10 +991,9 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned) {
   if (unsigned) return HEAPU16[dest>>1] | 0;
   return HEAP16[dest>>1] | 0;
 }
-function SAFE_HEAP_LOAD_D(dest, bytes, unsigned) {
+function SAFE_HEAP_LOAD_D(dest, bytes) {
   dest = dest | 0;
   bytes = bytes | 0;
-  unsigned = unsigned | 0;
   if ((dest|0) <= 0) segfault();
   if ((dest + bytes|0) > (DYNAMICTOP|0)) segfault();
   if ((bytes|0) == 8) {

--- a/emscripten.py
+++ b/emscripten.py
@@ -530,7 +530,7 @@ function _emscripten_asm_const_%d(%s) {
              '"); ' + extra
 
     basic_funcs = ['abort', 'assert'] + [m.replace('.', '_') for m in math_envs]
-    if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_FT_MASK']
+    if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
     if settings['ASSERTIONS']:
       if settings['ASSERTIONS'] >= 2: import difflib
       for sig in last_forwarded_json['Functions']['tables'].iterkeys():

--- a/emscripten.py
+++ b/emscripten.py
@@ -1036,6 +1036,11 @@ Runtime.stackSave = asm['stackSave'];
 Runtime.stackRestore = asm['stackRestore'];
 Runtime.establishStackSpace = asm['establishStackSpace'];
 ''')
+      if settings['SAFE_HEAP']:
+        funcs_js.append('''
+Runtime.setDynamicTop = asm['setDynamicTop'];
+''')
+
     if not settings['RELOCATABLE']:
       funcs_js.append('''
 Runtime.setTempRet0 = asm['setTempRet0'];

--- a/emscripten.py
+++ b/emscripten.py
@@ -533,7 +533,11 @@ function _emscripten_asm_const_%d(%s) {
 
     asm_safe_heap = settings['SAFE_HEAP'] and not settings['SAFE_HEAP_LOG'] and not settings['RELOCATABLE'] # optimized safe heap in asm, when we can
 
-    if settings['SAFE_HEAP'] and not asm_safe_heap: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
+    if settings['SAFE_HEAP']:
+      if asm_safe_heap:
+        basic_funcs += ['segfault', 'alignfault', 'ftfault']
+      else:
+        basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
     if settings['ASSERTIONS']:
       if settings['ASSERTIONS'] >= 2: import difflib
       for sig in last_forwarded_json['Functions']['tables'].iterkeys():
@@ -941,15 +945,15 @@ function SAFE_HEAP_STORE(dest, value, bytes) {
   dest = dest | 0;
   value = value | 0;
   bytes = bytes | 0;
-  if ((dest|0) <= 0) abort(-1);
-  if (((dest + bytes)|0) > (DYNAMICTOP|0)) abort(-2);
+  if ((dest|0) <= 0) segfault();
+  if (((dest + bytes)|0) > (DYNAMICTOP|0)) segfault();
   if ((bytes|0) == 4) {
-    if ((dest&3)) abort(-3);
+    if ((dest&3)) alignfault();
     HEAP32[dest>>2] = value;
   } else if ((bytes|0) == 1) {
     HEAP8[dest>>0] = value;
   } else {
-    if ((dest&1)) abort(-4);
+    if ((dest&1)) alignfault();
     HEAP16[dest>>1] = value;
   }
 }
@@ -957,13 +961,13 @@ function SAFE_HEAP_STORE_D(dest, value, bytes) {
   dest = dest | 0;
   value = +value;
   bytes = bytes | 0;
-  if ((dest|0) <= 0) abort(-5);
-  if (((dest + bytes)|0) > (DYNAMICTOP|0)) abort(-6);
+  if ((dest|0) <= 0) segfault();
+  if (((dest + bytes)|0) > (DYNAMICTOP|0)) segfault();
   if ((bytes|0) == 8) {
-    if ((dest&7)) abort(-7);
+    if ((dest&7)) alignfault();
     HEAPF64[dest>>3] = value;
   } else {
-    if ((dest&3)) abort(-8);
+    if ((dest&3)) alignfault();
     HEAPF32[dest>>2] = value;
   }
 }
@@ -971,10 +975,10 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned) {
   dest = dest | 0;
   bytes = bytes | 0;
   unsigned = unsigned | 0;
-  if ((dest|0) <= 0) abort(-9);
-  if ((dest + bytes|0) > (DYNAMICTOP|0)) abort(-10);
+  if ((dest|0) <= 0) segfault();
+  if ((dest + bytes|0) > (DYNAMICTOP|0)) segfault();
   if ((bytes|0) == 4) {
-    if ((dest&3)) abort(-11);
+    if ((dest&3)) alignfault();
     return HEAP32[dest>>2] | 0;
   } else if ((bytes|0) == 1) {
     if (unsigned) {
@@ -983,7 +987,7 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned) {
       return HEAP8[dest>>0] | 0;
     }
   }
-  if ((dest&1)) abort(-12);
+  if ((dest&1)) alignfault();
   if (unsigned) return HEAPU16[dest>>1] | 0;
   return HEAP16[dest>>1] | 0;
 }
@@ -991,13 +995,13 @@ function SAFE_HEAP_LOAD_D(dest, bytes, unsigned) {
   dest = dest | 0;
   bytes = bytes | 0;
   unsigned = unsigned | 0;
-  if ((dest|0) <= 0) abort(-13);
-  if ((dest + bytes|0) > (DYNAMICTOP|0)) abort(-14);
+  if ((dest|0) <= 0) segfault();
+  if ((dest + bytes|0) > (DYNAMICTOP|0)) segfault();
   if ((bytes|0) == 8) {
-    if ((dest&7)) abort(-15);
+    if ((dest&7)) alignfault();
     return +HEAPF64[dest>>3];
   }
-  if ((dest&3)) abort(-16);
+  if ((dest&3)) alignfault();
   return +HEAPF32[dest>>2];
 }
 function SAFE_FT_MASK(value, mask) {
@@ -1005,7 +1009,7 @@ function SAFE_FT_MASK(value, mask) {
   mask = mask | 0;
   var ret = 0;
   ret = value & mask;
-  if ((ret|0) != (value|0)) abort(-7);
+  if ((ret|0) != (value|0)) ftfault();
   return ret | 0;
 }
 '''] + ['''

--- a/emscripten.py
+++ b/emscripten.py
@@ -530,7 +530,10 @@ function _emscripten_asm_const_%d(%s) {
              '"); ' + extra
 
     basic_funcs = ['abort', 'assert'] + [m.replace('.', '_') for m in math_envs]
-    if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
+
+    asm_safe_heap = settings['SAFE_HEAP'] and not settings['SAFE_HEAP_LOG'] and not settings['RELOCATABLE'] # optimized safe heap in asm, when we can
+
+    if settings['SAFE_HEAP'] and not asm_safe_heap: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
     if settings['ASSERTIONS']:
       if settings['ASSERTIONS'] >= 2: import difflib
       for sig in last_forwarded_json['Functions']['tables'].iterkeys():
@@ -539,6 +542,8 @@ function _emscripten_asm_const_%d(%s) {
 
     basic_vars = ['STACKTOP', 'STACK_MAX', 'tempDoublePtr', 'ABORT']
     basic_float_vars = []
+
+    if settings['SAFE_HEAP']: basic_vars += ['DYNAMICTOP']
 
     if metadata.get('preciseI64MathUsed'):
       basic_vars += ['cttz_i8']
@@ -569,6 +574,9 @@ function _emscripten_asm_const_%d(%s) {
       asm_runtime_funcs += ['emterpret']
       if settings.get('EMTERPRETIFY_ASYNC'):
         asm_runtime_funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore']
+
+    if settings['SAFE_HEAP']:
+      asm_runtime_funcs += ['setDynamicTop']
 
     # function tables
     if not settings['EMULATED_FUNCTION_POINTERS']:
@@ -922,6 +930,83 @@ function copyTempDouble(ptr) {
   HEAP8[tempDoublePtr+5>>0] = HEAP8[ptr+5>>0];
   HEAP8[tempDoublePtr+6>>0] = HEAP8[ptr+6>>0];
   HEAP8[tempDoublePtr+7>>0] = HEAP8[ptr+7>>0];
+}
+'''] + ['' if not settings['SAFE_HEAP'] else '''
+function setDynamicTop(value) {
+  value = value | 0;
+  DYNAMICTOP = value;
+}
+'''] + ['' if not asm_safe_heap else '''
+function SAFE_HEAP_STORE(dest, value, bytes) {
+  dest = dest | 0;
+  value = value | 0;
+  bytes = bytes | 0;
+  if ((dest|0) <= 0) abort(-1);
+  if (((dest + bytes)|0) > (DYNAMICTOP|0)) abort(-2);
+  if ((bytes|0) == 4) {
+    if ((dest&3)) abort(-3);
+    HEAP32[dest>>2] = value;
+  } else if ((bytes|0) == 1) {
+    HEAP8[dest>>0] = value;
+  } else {
+    if ((dest&1)) abort(-4);
+    HEAP16[dest>>1] = value;
+  }
+}
+function SAFE_HEAP_STORE_D(dest, value, bytes) {
+  dest = dest | 0;
+  value = +value;
+  bytes = bytes | 0;
+  if ((dest|0) <= 0) abort(-5);
+  if (((dest + bytes)|0) > (DYNAMICTOP|0)) abort(-6);
+  if ((bytes|0) == 8) {
+    if ((dest&7)) abort(-7);
+    HEAPF64[dest>>3] = value;
+  } else {
+    if ((dest&3)) abort(-8);
+    HEAPF32[dest>>2] = value;
+  }
+}
+function SAFE_HEAP_LOAD(dest, bytes, unsigned) {
+  dest = dest | 0;
+  bytes = bytes | 0;
+  unsigned = unsigned | 0;
+  if ((dest|0) <= 0) abort(-9);
+  if ((dest + bytes|0) > (DYNAMICTOP|0)) abort(-10);
+  if ((bytes|0) == 4) {
+    if ((dest&3)) abort(-11);
+    return HEAP32[dest>>2] | 0;
+  } else if ((bytes|0) == 1) {
+    if (unsigned) {
+      return HEAPU8[dest>>0] | 0;
+    } else {
+      return HEAP8[dest>>0] | 0;
+    }
+  }
+  if ((dest&1)) abort(-12);
+  if (unsigned) return HEAPU16[dest>>1] | 0;
+  return HEAP16[dest>>1] | 0;
+}
+function SAFE_HEAP_LOAD_D(dest, bytes, unsigned) {
+  dest = dest | 0;
+  bytes = bytes | 0;
+  unsigned = unsigned | 0;
+  if ((dest|0) <= 0) abort(-13);
+  if ((dest + bytes|0) > (DYNAMICTOP|0)) abort(-14);
+  if ((bytes|0) == 8) {
+    if ((dest&7)) abort(-15);
+    return +HEAPF64[dest>>3];
+  }
+  if ((dest&3)) abort(-16);
+  return +HEAPF32[dest>>2];
+}
+function SAFE_FT_MASK(value, mask) {
+  value = value | 0;
+  mask = mask | 0;
+  var ret = 0;
+  ret = value & mask;
+  if ((ret|0) != (value|0)) abort(-7);
+  return ret | 0;
 }
 '''] + ['''
 function setTempRet0(value) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -883,7 +883,7 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
     if (printType !== 'null' && printType[0] !== '#') printType = '"' + safeQuote(printType) + '"';
     if (printType[0] === '#') printType = printType.substr(1);
     if (!ignore) {
-      return asmCoercion('SAFE_HEAP_LOAD(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + ((type in Compiletime.FLOAT_TYPES)|0) + ', ' + (!!unsigned+0) + ')', type);
+      return asmCoercion('SAFE_HEAP_LOAD' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + (!!unsigned+0) + ')', type);
     }
   }
   var ret = makeGetSlabs(ptr, type, false, unsigned)[0] + '[' + getHeapOffset(offset, type) + ']';
@@ -971,7 +971,7 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
     if (printType !== 'null' && printType[0] !== '#') printType = '"' + safeQuote(printType) + '"';
     if (printType[0] === '#') printType = printType.substr(1);
     if (!ignore) {
-      return asmCoercion('SAFE_HEAP_STORE(' + asmCoercion(offset, 'i32') + ', ' + asmCoercion(value, type) + ', ' + Runtime.getNativeTypeSize(type) + ', ' + ((type in Compiletime.FLOAT_TYPES)|0) + ')', type);
+      return 'SAFE_HEAP_STORE' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + asmCoercion(value, type) + ', ' + Runtime.getNativeTypeSize(type) + ')';
     }
   }
   return makeGetSlabs(ptr, type, true).map(function(slab) { return slab + '[' + getHeapOffset(offset, type) + ']=' + value }).join(sep);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -54,9 +54,11 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
   assert(DYNAMICTOP <= TOTAL_MEMORY);
   setValue(dest, value, getSafeHeapType(bytes, isFloat), 1);
 }
-var SAFE_HEAP_STORE_D = SAFE_HEAP_STORE;
+function SAFE_HEAP_STORE_D(dest, value, bytes) {
+  SAFE_HEAP_STORE(dest, value, bytes, true);
+}
 
-function SAFE_HEAP_LOAD(dest, bytes, isFloat, unsigned) {
+function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
   if (dest <= 0) abort('segmentation fault loading ' + bytes + ' bytes from address ' + dest);
   if (dest % bytes !== 0) abort('alignment error loading from address ' + dest + ', which was expected to be aligned to a multiple of ' + bytes);
   if (dest + bytes > Math.max(DYNAMICTOP, STATICTOP)) abort('segmentation fault, exceeded the top of the available heap when loading ' + bytes + ' bytes from address ' + dest + '. STATICTOP=' + STATICTOP + ', DYNAMICTOP=' + DYNAMICTOP);
@@ -69,7 +71,9 @@ function SAFE_HEAP_LOAD(dest, bytes, isFloat, unsigned) {
 #endif
   return ret;
 }
-var SAFE_HEAP_LOAD_D = SAFE_HEAP_LOAD;
+function SAFE_HEAP_LOAD_D(dest, bytes, unsigned) {
+  return SAFE_HEAP_LOAD(dest, bytes, unsigned, true);
+}
 
 function SAFE_FT_MASK(value, mask) {
   var ret = value & mask;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -54,6 +54,7 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
   assert(DYNAMICTOP <= TOTAL_MEMORY);
   setValue(dest, value, getSafeHeapType(bytes, isFloat), 1);
 }
+var SAFE_HEAP_STORE_D = SAFE_HEAP_STORE;
 
 function SAFE_HEAP_LOAD(dest, bytes, isFloat, unsigned) {
   if (dest <= 0) abort('segmentation fault loading ' + bytes + ' bytes from address ' + dest);
@@ -68,6 +69,7 @@ function SAFE_HEAP_LOAD(dest, bytes, isFloat, unsigned) {
 #endif
   return ret;
 }
+var SAFE_HEAP_LOAD_D = SAFE_HEAP_LOAD;
 
 function SAFE_FT_MASK(value, mask) {
   var ret = value & mask;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -82,6 +82,16 @@ function SAFE_FT_MASK(value, mask) {
   }
   return ret;
 }
+
+function segfault() {
+  abort('segmentation fault');
+}
+function alignfault() {
+  abort('alignment fault');
+}
+function ftfault() {
+  abort('Function table mask error');
+}
 #endif
 
 //========================================

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -64,9 +64,9 @@ var RuntimeGenerator = {
     if (typeof ENVIRONMENT_IS_PTHREAD !== 'undefined' && ENVIRONMENT_IS_PTHREAD) throw 'Runtime.dynamicAlloc is not available in pthreads!'; // This is because each worker has its own copy of DYNAMICTOP, of which main thread is authoritative.
 #endif
     var ret = RuntimeGenerator.alloc(size, 'DYNAMIC');
-    if (SAFE_HEAP) ret += '; if (asm) { asm.setDynamicTop(DYNAMICTOP); }';
+    if (SAFE_HEAP) ret += '; if (asm) { Runtime.setDynamicTop(DYNAMICTOP); }';
     ret += '; if (DYNAMICTOP >= TOTAL_MEMORY) { var success = enlargeMemory(); if (!success) { DYNAMICTOP = ret; ';
-    if (SAFE_HEAP) ret += 'if (asm) { asm.setDynamicTop(DYNAMICTOP); }';
+    if (SAFE_HEAP) ret += 'if (asm) { Runtime.setDynamicTop(DYNAMICTOP); }';
     ret += ' return 0; } }'
     return ret;
   },

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -64,7 +64,10 @@ var RuntimeGenerator = {
     if (typeof ENVIRONMENT_IS_PTHREAD !== 'undefined' && ENVIRONMENT_IS_PTHREAD) throw 'Runtime.dynamicAlloc is not available in pthreads!'; // This is because each worker has its own copy of DYNAMICTOP, of which main thread is authoritative.
 #endif
     var ret = RuntimeGenerator.alloc(size, 'DYNAMIC');
-    ret += '; if (DYNAMICTOP >= TOTAL_MEMORY) { var success = enlargeMemory(); if (!success) { DYNAMICTOP = ret; return 0; } }'
+    if (SAFE_HEAP) ret += '; if (asm) { asm.setDynamicTop(DYNAMICTOP); }';
+    ret += '; if (DYNAMICTOP >= TOTAL_MEMORY) { var success = enlargeMemory(); if (!success) { DYNAMICTOP = ret; ';
+    if (SAFE_HEAP) ret += 'if (asm) { asm.setDynamicTop(DYNAMICTOP); }';
+    ret += ' return 0; } }'
     return ret;
   },
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2929,13 +2929,7 @@ int main() {
               if emulate_casts:
                 assert 'Hello, world.' in output, output
               elif safe:
-                if relocate:
-                  assert 'Function table mask error' in output, output
-                else:
-                  if opts < 2:
-                    assert 'Function table mask error' in output or 'SAFE_FT_MASK' in output, output # less nice error message when optimized safe heap
-                  else: # minified is less nice
-                    assert 'Function table mask error' in output or 'abort(-7)' in output, output # less nice error message when optimized safe heap
+                assert 'Function table mask error' in output, output
               else:
                 if opts == 0:
                   assert 'Invalid function pointer called' in output, output

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2915,23 +2915,32 @@ int main() {
       for safe in [0, 1]:
         for emulate_casts in [0, 1]:
           for emulate_fps in [0, 1]:
-            cmd = [PYTHON, EMCC, 'src.cpp', '-O' + str(opts), '-s', 'SAFE_HEAP=' + str(safe)]
-            if emulate_casts:
-              cmd += ['-s', 'EMULATE_FUNCTION_POINTER_CASTS=1']
-            if emulate_fps:
-              cmd += ['-s', 'EMULATED_FUNCTION_POINTERS=1']
-            print cmd
-            Popen(cmd).communicate()
-            output = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None)
-            if emulate_casts:
-              assert 'Hello, world.' in output, output
-            elif safe:
-              assert 'Function table mask error' in output, output
-            else:
-              if opts == 0:
-                assert 'Invalid function pointer called' in output, output
+            for relocate in [0, 1]:
+              cmd = [PYTHON, EMCC, 'src.cpp', '-O' + str(opts), '-s', 'SAFE_HEAP=' + str(safe)]
+              if emulate_casts:
+                cmd += ['-s', 'EMULATE_FUNCTION_POINTER_CASTS=1']
+              if emulate_fps:
+                cmd += ['-s', 'EMULATED_FUNCTION_POINTERS=1']
+              if relocate:
+                cmd += ['-s', 'RELOCATABLE=1'] # disables asm-optimized safe heap
+              print cmd
+              Popen(cmd).communicate()
+              output = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None)
+              if emulate_casts:
+                assert 'Hello, world.' in output, output
+              elif safe:
+                if relocate:
+                  assert 'Function table mask error' in output, output
+                else:
+                  if opts < 2:
+                    assert 'Function table mask error' in output or 'SAFE_FT_MASK' in output, output # less nice error message when optimized safe heap
+                  else: # minified is less nice
+                    assert 'Function table mask error' in output or 'abort(-7)' in output, output # less nice error message when optimized safe heap
               else:
-                assert 'abort()' in output, output
+                if opts == 0:
+                  assert 'Invalid function pointer called' in output, output
+                else:
+                  assert 'abort()' in output, output
 
   def test_aliased_func_pointers(self):
     open('src.cpp', 'w').write(r'''

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -5660,10 +5660,10 @@ function safeHeap(ast) {
             return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 4], ['num', 0]]];
           }
           case 'HEAPF32': {
-            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 4], ['num', 1]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 4], ['num', 1]]];
           }
           case 'HEAPF64': {
-            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 8], ['num', 1]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 8], ['num', 1]]];
           }
           default: throw 'bad heap ' + heap;
         }
@@ -5695,10 +5695,10 @@ function safeHeap(ast) {
             return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 0], ['num', 1]]], ASM_INT);
           }
           case 'HEAPF32': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 1], ['num', 0]]], ASM_DOUBLE);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 4], ['num', 1], ['num', 0]]], ASM_DOUBLE);
           }
           case 'HEAPF64': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 8], ['num', 1], ['num', 0]]], ASM_DOUBLE);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 8], ['num', 1], ['num', 0]]], ASM_DOUBLE);
           }
           default: throw 'bad heap ' + heap;
         }

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -5698,10 +5698,10 @@ function safeHeap(ast) {
               return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 1]]], ASM_INT);
             }
             case 'HEAPF32': {
-              return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 4], ['num', 0]]], ASM_DOUBLE);
+              return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 4]]], ASM_DOUBLE);
             }
             case 'HEAPF64': {
-              return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 8], ['num', 0]]], ASM_DOUBLE);
+              return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 8]]], ASM_DOUBLE);
             }
             default: throw 'bad heap ' + heap;
           }

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -5651,19 +5651,19 @@ function safeHeap(ast) {
         // SAFE_HEAP_STORE(ptr, value, bytes, isFloat) 
         switch (heap) {
           case 'HEAP8':   case 'HEAPU8': {
-            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 1], ['num', 0]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 1]]];
           }
           case 'HEAP16':  case 'HEAPU16': {
-            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 2], ['num', 0]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 2]]];
           }
           case 'HEAP32':  case 'HEAPU32': {
-            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 4], ['num', 0]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE'], [ptr, makeAsmCoercion(value, ASM_INT), ['num', 4]]];
           }
           case 'HEAPF32': {
-            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 4], ['num', 1]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 4]]];
           }
           case 'HEAPF64': {
-            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 8], ['num', 1]]];
+            return ['call', ['name', 'SAFE_HEAP_STORE_D'], [ptr, makeAsmCoercion(value, ASM_DOUBLE), ['num', 8]]];
           }
           default: throw 'bad heap ' + heap;
         }
@@ -5677,28 +5677,28 @@ function safeHeap(ast) {
         // SAFE_HEAP_LOAD(ptr, bytes, isFloat) 
         switch (heap) {
           case 'HEAP8': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 1], ['num', 0], ['num', 0]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 1], ['num', 0]]], ASM_INT);
           }
           case 'HEAPU8': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 1], ['num', 0], ['num', 1]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 1], ['num', 1]]], ASM_INT);
           }
           case 'HEAP16': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 2], ['num', 0], ['num', 0]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 2], ['num', 0]]], ASM_INT);
           }
           case 'HEAPU16': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 2], ['num', 0], ['num', 1]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 2], ['num', 1]]], ASM_INT);
           }
           case 'HEAP32': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 0], ['num', 0]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 0]]], ASM_INT);
           }
           case 'HEAPU32': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 0], ['num', 1]]], ASM_INT);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD'], [ptr, ['num', 4], ['num', 1]]], ASM_INT);
           }
           case 'HEAPF32': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 4], ['num', 1], ['num', 0]]], ASM_DOUBLE);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 4], ['num', 0]]], ASM_DOUBLE);
           }
           case 'HEAPF64': {
-            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 8], ['num', 1], ['num', 0]]], ASM_DOUBLE);
+            return makeAsmCoercion(['call', ['name', 'SAFE_HEAP_LOAD_D'], [ptr, ['num', 8], ['num', 0]]], ASM_DOUBLE);
           }
           default: throw 'bad heap ' + heap;
         }


### PR DESCRIPTION
This optimizes `SAFE_HEAP` so it runs fully inside asm.js. This makes the code a little more complex, but makes it much faster, for example bullet is 92x slower (!) without this, and "just" 8x slower with it. Also Unity (Angry Bots) becomes very playable with this optimization.

Tradeoff seems worth it to me. Thoughts?