### PR TITLE
Actual emscripten and nodejs

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -138,7 +138,7 @@ for arg in sys.argv[2:]:
     try:
       from shared import CRUNCH
     except Exception, e:
-      print >> sys.stderr, 'could not import CRUNCH (make sure it is defined properly in ~/.emscripten)'
+      print >> sys.stderr, 'could not import CRUNCH (make sure it is defined properly in ' + shared.hint_config_file_location() + ')'
       raise e
     crunch = arg.split('=')[1] if '=' in arg else '128'
     leading = ''

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -224,7 +224,7 @@ else:
     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
     llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
-    node = find_executable('node') or find_executable('nodejs') or 'node'
+    node = find_executable('nodejs') or find_executable('node') or 'node'
     config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))
     if WINDOWS:
       tempdir = os.environ.get('TEMP') or os.environ.get('TMP') or 'c:\\temp'

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -18,7 +18,7 @@ import shared
 def validate_asmjs_jsfile(filename, muteOutput):
   cmd = shared.SPIDERMONKEY_ENGINE + ['-c', filename]
   if not shared.SPIDERMONKEY_ENGINE or cmd[0] == 'js-not-found' or len(cmd[0].strip()) == 0:
-    print >> sys.stderr, 'Could not find SpiderMonkey engine! Please set tis location to SPIDERMONKEY_ENGINE in your ~/.emscripten configuration file!'
+    print >> sys.stderr, 'Could not find SpiderMonkey engine! Please set tis location to SPIDERMONKEY_ENGINE in your ' + shared.hint_config_file_location() + ' configuration file!'
     return False
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)


### PR DESCRIPTION
Two minor fixes:
   1. Read user's `EM_CONFIG` variable to correctly point instructions to right location of `.emscripten`. E.g. emsdk's `--embedded` option routes `.emscripten` to a local directory, and not the user home directory. Also add debug prints of where `.emscripten` is being read from.
   2. When we need to resort to autodetecting node.js, always heuristically pick the executable "nodejs" over "node" first if it exists, since it is a more specific name. Fixes https://github.com/juj/emsdk/issues/20