### PR TITLE
Add missing GL_HALF_FLOAT to WebGL2

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -475,6 +475,9 @@ var LibraryGL = {
           sizePerPixel = numChannels*1;
           break;
         case 0x1403 /* GL_UNSIGNED_SHORT */:
+#if USE_WEBGL2
+        case 0x140B /* GL_HALF_FLOAT */:
+#endif
         case 0x8D61 /* GL_HALF_FLOAT_OES */:
           sizePerPixel = numChannels*2;
           break;
@@ -482,7 +485,7 @@ var LibraryGL = {
         case 0x1406 /* GL_FLOAT */:
           sizePerPixel = numChannels*4;
           break;
-        case 0x84FA /* UNSIGNED_INT_24_8_WEBGL */:
+        case 0x84FA /* UNSIGNED_INT_24_8_WEBGL/UNSIGNED_INT_24_8 */:
           sizePerPixel = 4;
           break;
         case 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */:


### PR DESCRIPTION
Add missing `GL_HALF_FLOAT` to WebGL2, and comment about `UNSIGNED_INT_24_8_WEBGL` and `UNSIGNED_INT_24_8` being the same.