### PR TITLE
Gracefully no threads - second try.

### DIFF
--- a/emcc
+++ b/emcc
@@ -1702,7 +1702,7 @@ try:
       if debug_level >= 4:
         generate_source_map(target)
       shutil.move(final, js_target)
-      need_mods = shared.Settings.PRECISE_F32 == 2
+      need_mods = shared.Settings.PRECISE_F32 == 2 or shared.Settings.USE_PTHREADS == 2
       if not need_mods:
         # Non-modifiable code, just load the code directly
         script_src = base_js_target
@@ -1725,7 +1725,7 @@ code = code.replace(/Math_fround\(/g, '(').replace("'use asm'", "'almost asm'").
             mods.append('''
 try {
   console.log('optimizing out Math.fround calls');
-  var m = /var ([^=]+)=global\.Math\.fround;/.exec(code);
+  var m = /var\s+([^=]+?)\s*=\s*global\.Math\.fround;/.exec(code);
   var minified = m[1];
   if (!minified) throw 'fail';
   var startAsm = code.indexOf('// EMSCRIPTEN_START_FUNCS');
@@ -1738,6 +1738,137 @@ try {
   code = code.substring(0, startAsm) + asm + code.substring(endAsm);
   code = code.replace("'use asm'", "'almost asm'").replace('"use asm"', '"almost asm"');
 } catch(e) { console.log('failed to optimize out Math.fround calls ' + e) }
+''')
+
+        if shared.Settings.USE_PTHREADS == 2:
+          checks.append('typeof SharedInt8Array === "undefined"')
+          mods.append('''
+try {
+  console.log('This browser does not support SharedArrayBuffer/Atomics/pthreads! Patching out SharedArrayBuffer usage...');
+  var t0 = performance.now();
+  // "new global.SharedInt8Array(buffer)" -> "new global.Int8Array(buffer)" and likewise for other buffer types.
+  code = code.replace(/new\s+global\.Shared(.*?)Array\(buffer\);/g, "new global.$1Array(buffer);");
+
+  // In minified builds the interesting symbol names are mangled, so we have to first find what they are.
+  var math_fround = /var\s+([^=]+?)\s*=\s*global\.Math\.fround;/.exec(code);
+  var cp;
+  var zero;
+  if (math_fround && math_fround.length >= 2) {
+    math_fround = math_fround[1] + '(';
+    cp = ')';
+    zero = math_fround + '0)';
+  } else {
+    math_fround = "+";
+    cp = '';
+    zero = '0.0';
+  }
+  var heap8 = /var\s+([^=]+?)\s*=\s*new global\.Int8Array\(buffer\);/.exec(code)[1];
+  var heap16 = /var\s+([^=]+?)\s*=\s*new global\.Int16Array\(buffer\);/.exec(code)[1];
+  var heap32 = /var\s+([^=]+?)\s*=\s*new global\.Int32Array\(buffer\);/.exec(code)[1];
+  var heapf32 = /var\s+([^=]+?)\s*=\s*new global\.Float32Array\(buffer\);/.exec(code)[1];
+  var heapf64 = /var\s+([^=]+?)\s*=\s*new global\.Float64Array\(buffer\);/.exec(code)[1];
+  var atomics_load = /var\s+([^=]+?)\s*=\s*global\.Atomics\.load;/.exec(code)[1];
+  var atomics_store = /var\s+([^=]+?)\s*=\s*global\.Atomics\.store;/.exec(code)[1];
+  var atomics_compareExchange = /var\s+([^=]+?)\s*=\s*global\.Atomics\.compareExchange;/.exec(code)[1];
+  var atomics_add = /var\s+([^=]+?)\s*=\s*global\.Atomics\.add;/.exec(code)[1];
+  var atomics_sub = /var\s+([^=]+?)\s*=\s*global\.Atomics\.sub;/.exec(code)[1];
+  var atomics_and = /var\s+([^=]+?)\s*=\s*global\.Atomics\.and;/.exec(code)[1];
+  var atomics_or = /var\s+([^=]+?)\s*=\s*global\.Atomics\.or;/.exec(code)[1];
+  var atomics_xor = /var\s+([^=]+?)\s*=\s*global\.Atomics\.xor;/.exec(code)[1];
+  var atomics_fence = /var\s+([^=]+?)\s*=\s*global\.Atomics\.fence;/.exec(code)[1];
+
+  // "Atomics_load(HEAP32, index)" -> "HEAP32[index]|0" and same for other heap types.
+  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\((' + heap8 + ')\w*,(.*?)\\\\\)', 'g'), "($1[$2]|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\((' + heap16 + ')\w*,(.*?)\\\\\)', 'g'), "($1[$2]|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\((' + heap32 + ')\w*,(.*?)\\\\\)', 'g'), "($1[$2]|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\((' + heapf32 + ')\w*,(.*?)\\\\\)', 'g'), math_fround + "$1[$2]"+cp);
+  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\((' + heapf64 + ')\w*,(.*?)\\\\\)', 'g'), "(+$1[$2])");
+
+  // "Atomics_store(HEAP32, index, value)" -> "HEAP32[index] = value" and same for other heap types.
+  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\((.*?),(.*?),(.*?)\\\\\)', 'g'), "($1[$2] = $3)");
+
+  // The Atomics built-ins take as first parameter the heap object, however when replacing those with
+  // polyfill versions, it is not possible to pass a heap object as the first parameter. Therefore
+  // route each call to Atomics to a polyfill function for each type, e.g. "Atomics_add(HEAP32, index, val)" -> "Atomics_add_32(index, val)"
+  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap8+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_add + "_8($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap16+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_add + "_16($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap32+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_add + "_32($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heapf32+',(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_add + "_f32($1,$2)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heapf64+',(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_add + "_f64($1,$2)|0)");
+
+  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap8+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_sub + "_8($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap16+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_sub + "_16($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap32+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_sub + "_32($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heapf32+',(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_sub + "_f32($1,$2)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heapf64+',(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_sub + "_f64($1,$2)|0)");
+
+  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap8+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_and + "_8($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap16+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_and + "_16($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap32+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_and + "_32($1,$2)|0)|0)");
+
+  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap8+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_or + "_8($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap16+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_or + "_16($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap32+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_or + "_32($1,$2)|0)|0)");
+
+  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap8+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_xor + "_8($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap16+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_xor + "_16($1,$2)|0)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap32+',(.*?),(.*?)\\\\\)', 'g'), '((' + atomics_xor + "_32($1,$2)|0)|0)");
+
+  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap8+',(.*?),(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_compareExchange + "_8($1,$2,$3)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap16+',(.*?),(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_compareExchange + "_16($1,$2,$3)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap32+',(.*?),(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_compareExchange + "_32($1,$2,$3)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heapf32+',(.*?),(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_compareExchange + "_f32($1,$2,$3)|0)");
+  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heapf64+',(.*?),(.*?),(.*?)\\\\\)', 'g'), '(' + atomics_compareExchange + "_f64($1,$2,$3)|0)");
+
+  // Remove the import statements of Atomics built-ins.
+  code = code.replace(new RegExp("var " + atomics_load + "\\\\s*=\\\\s*global\\.Atomics\\.load;"), "");
+  code = code.replace(new RegExp("var " + atomics_store + "\\\\s*=\\\\s*global\\.Atomics\\.store;"), "");
+  code = code.replace(new RegExp("var " + atomics_compareExchange + "\\\\s*=\\\\s*global\\.Atomics\\.compareExchange;"), "");
+  code = code.replace(new RegExp("var " + atomics_add + "\\\\s*=\\\\s*global\\.Atomics\\.add;"), "");
+  code = code.replace(new RegExp("var " + atomics_sub + "\\\\s*=\\\\s*global\\.Atomics\\.sub;"), "");
+  code = code.replace(new RegExp("var " + atomics_and + "\\\\s*=\\\\s*global\\.Atomics\\.and;"), "");
+  code = code.replace(new RegExp("var " + atomics_or + "\\\\s*=\\\\s*global\\.Atomics\\.or;"), "");
+  code = code.replace(new RegExp("var " + atomics_xor + "\\\\s*=\\\\s*global\\.Atomics\\.xor;"), "");
+  code = code.replace(new RegExp("var " + atomics_fence + "\\\\s*=\\\\s*global\\.Atomics\\.fence;"), "");
+
+  // Implement polyfill versions of Atomics intrinsics inside the asm.js scope.
+  code = code.replace("// EMSCRIPTEN_START_FUNCS", "// EMSCRIPTEN_START_FUNCS\\n"
+    + "function " + atomics_add + "_8(i,v) { i=i|0; v=v|0; var w=0; w="+heap8+"[i>>0]|0; "+heap8+"[i>>0]=("+heap8+"[i>>0]|0)+(v|0); return w|0; }\\n"
+    + "function " + atomics_add + "_16(i,v) { i=i|0; v=v|0; var w=0; w="+heap16+"[i<<1>>1]|0; "+heap16+"[i<<1>>1]=("+heap16+"[i<<1>>1]|0)+(v|0); return w|0; }\\n"
+    + "function " + atomics_add + "_32(i,v) { i=i|0; v=v|0; var w=0; w="+heap32+"[i<<2>>2]|0; "+heap32+"[i<<2>>2]=("+heap32+"[i<<2>>2]|0)+(v|0); return w|0; }\\n"
+    + "function " + atomics_add + "_f32(i,v) { i=i|0; v="+math_fround+"v"+cp+"; var w="+zero+"; w="+math_fround+heapf32+"[i<<2>>2]"+cp+"; "+heapf32+"[i<<2>>2]="+math_fround+heapf32+"[i<<2>>2]"+cp+"+v; return w; }\\n"
+    + "function " + atomics_add + "_f64(i,v) { i=i|0; v=+v; var w=0.0; w=+"+heapf64+"[i<<3>>3]; "+heapf64+"[i<<3>>3]="+heapf64+"[i<<3>>3]+v; return w; }\\n"
+
+    + "function " + atomics_sub + "_8(i,v) { i=i|0; v=v|0; var w=0; w="+heap8+"[i>>0]|0; "+heap8+"[i>>0]=("+heap8+"[i>>0]|0)-(v|0); return w|0; }\\n"
+    + "function " + atomics_sub + "_16(i,v) { i=i|0; v=v|0; var w=0; w="+heap16+"[i<<1>>1]|0; "+heap16+"[i<<1>>1]=("+heap16+"[i<<1>>1]|0)-(v|0); return w|0; }\\n"
+    + "function " + atomics_sub + "_32(i,v) { i=i|0; v=v|0; var w=0; w="+heap32+"[i<<2>>2]|0; "+heap32+"[i<<2>>2]=("+heap32+"[i<<2>>2]|0)-(v|0); return w|0; }\\n"
+    + "function " + atomics_sub + "_f32(i,v) { i=i|0; v="+math_fround+"v"+cp+"; var w="+zero+"; w="+math_fround+heapf32+"[i<<2>>2]"+cp+"; "+heapf32+"[i<<2>>2]="+math_fround+heapf32+"[i<<2>>2]"+cp+"-v; return w; }\\n"
+    + "function " + atomics_sub + "_f64(i,v) { i=i|0; v=+v; var w=0.0; w=+"+heapf64+"[i<<3>>3]; "+heapf64+"[i<<3>>3]="+heapf64+"[i<<3>>3]-v; return w; }\\n"
+
+    + "function " + atomics_and + "_8(i,v) { i=i|0; v=v|0; var w=0; w="+heap8+"[i>>0]|0; "+heap8+"[i>>0]=("+heap8+"[i>>0]|0)&(v|0); return w|0; }\\n"
+    + "function " + atomics_and + "_16(i,v) { i=i|0; v=v|0; var w=0; w="+heap16+"[i<<1>>1]|0; "+heap16+"[i<<1>>1]=("+heap16+"[i<<1>>1]|0)&(v|0); return w|0; }\\n"
+    + "function " + atomics_and + "_32(i,v) { i=i|0; v=v|0; var w=0; w="+heap32+"[i<<2>>2]|0; "+heap32+"[i<<2>>2]=("+heap32+"[i<<2>>2]|0)&(v|0); return w|0; }\\n"
+
+    + "function " + atomics_or + "_8(i,v) { i=i|0; v=v|0; var w=0; w="+heap8+"[i>>0]|0; "+heap8+"[i>>0]=("+heap8+"[i>>0]|0)|(v|0); return w|0; }\\n"
+    + "function " + atomics_or + "_16(i,v) { i=i|0; v=v|0; var w=0; w="+heap16+"[i<<1>>1]|0; "+heap16+"[i<<1>>1]=("+heap16+"[i<<1>>1]|0)|(v|0); return w|0; }\\n"
+    + "function " + atomics_or + "_32(i,v) { i=i|0; v=v|0; var w=0; w="+heap32+"[i<<2>>2]|0; "+heap32+"[i<<2>>2]=("+heap32+"[i<<2>>2]|0)|(v|0); return w|0; }\\n"
+
+    + "function " + atomics_xor + "_8(i,v) { i=i|0; v=v|0; var w=0; w="+heap8+"[i>>0]|0; "+heap8+"[i>>0]=("+heap8+"[i>>0]|0)^(v|0); return w|0; }\\n"
+    + "function " + atomics_xor + "_16(i,v) { i=i|0; v=v|0; var w=0; w="+heap16+"[i<<1>>1]|0; "+heap16+"[i<<1>>1]=("+heap16+"[i<<1>>1]|0)^(v|0); return w|0; }\\n"
+    + "function " + atomics_xor + "_32(i,v) { i=i|0; v=v|0; var w=0; w="+heap32+"[i<<2>>2]|0; "+heap32+"[i<<2>>2]=("+heap32+"[i<<2>>2]|0)^(v|0); return w|0; }\\n"
+
+    + "function " + atomics_compareExchange + "_8(i,e,r) { i=i|0; e=e|0; r=r|0; var w=0; w="+heap8+"[i>>0]|0; if ((w|0) == (e|0)) "+heap8+"[i>>0]=r; return w|0; }\\n"
+    + "function " + atomics_compareExchange + "_16(i,e,r) { i=i|0; e=e|0; r=r|0; var w=0; w="+heap16+"[i<<1>>1]|0; if ((w|0) == (e|0)) "+heap16+"[i<<1>>1]=r; return w|0; }\\n"
+    + "function " + atomics_compareExchange + "_32(i,e,r) { i=i|0; e=e|0; r=r|0; var w=0; w="+heap32+"[i<<2>>2]|0; if ((w|0) == (e|0)) "+heap32+"[i<<2>>2]=r; return w|0; }\\n"
+    + "function " + atomics_compareExchange + "_f32(i,e,r) { i=i|0; e="+math_fround+"e"+cp+"; r="+math_fround+"r"+cp+"; var w="+zero+"; w="+math_fround+heapf32+"[i<<2>>2]"+cp+"; if (w == e) "+heapf32+"[i<<2>>2]=r; return w; }\\n"
+    + "function " + atomics_compareExchange + "_f64(i,e,r) { i=i|0; e=+e; r=+r; var w=0.0; w=+"+heapf64+"[i<<3>>3]; if (+w == +e) "+heapf64+"[i<<3>>3]=r; return w; }\\n"
+
+    + "function " + atomics_fence + "() {}\\n"
+    );
+
+  var t1 = performance.now();
+  console.log('SAB+Atomics removed in ' + (t1-t0) + ' msecs.');
+} catch(e) { console.log('Failed to optimize out SharedArrayBuffer calls ' + e); }
 ''')
 
         fixes = ''

--- a/emscripten.py
+++ b/emscripten.py
@@ -484,10 +484,7 @@ function _emscripten_asm_const_%d(%s) {
     simdtypes = simdfloattypes + simdinttypes
 
     fundamentals = ['Math']
-    if settings['USE_PTHREADS']:
-      fundamentals += ['I8Array', 'I16Array', 'I32Array', 'U8Array', 'U16Array', 'U32Array', 'F32Array', 'F64Array', 'Atomics']
-    else:
-      fundamentals += ['Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Float32Array', 'Float64Array']
+    fundamentals += ['Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Float32Array', 'Float64Array']
     fundamentals += ['NaN', 'Infinity']
     if metadata['simd']:
         fundamentals += ['SIMD']
@@ -778,19 +775,23 @@ Module['NAMED_GLOBALS'] = NAMED_GLOBALS;
       receiving += ''.join(["Module['%s'] = Module['%s']\n" % (k, v) for k, v in metadata['aliases'].iteritems()])
 
     if settings['USE_PTHREADS']:
-      asm_setup += '''
-var I8Array = typeof SharedInt8Array !== 'undefined' ? SharedInt8Array : Int8Array;
-var I16Array = typeof SharedInt16Array !== 'undefined' ? SharedInt16Array : Int16Array;
-var I32Array = typeof SharedInt32Array !== 'undefined' ? SharedInt32Array : Int32Array;
-var U8Array = typeof SharedUint8Array !== 'undefined' ? SharedUint8Array : Uint8Array;
-var U16Array = typeof SharedUint16Array !== 'undefined' ? SharedUint16Array : Uint16Array;
-var U32Array = typeof SharedUint32Array !== 'undefined' ? SharedUint32Array : Uint32Array;
-var F32Array = typeof SharedFloat32Array !== 'undefined' ? SharedFloat32Array : Float32Array;
-var F64Array = typeof SharedFloat64Array !== 'undefined' ? SharedFloat64Array : Float64Array;
+      shared_array_buffer = '''if (typeof SharedArrayBuffer !== 'undefined') Module.asmGlobalArg['Atomics'] = Atomics;
+if (typeof SharedInt8Array !== 'undefined') Module.asmGlobalArg['SharedInt8Array'] = SharedInt8Array;
+if (typeof SharedInt16Array !== 'undefined') Module.asmGlobalArg['SharedInt16Array'] = SharedInt16Array;
+if (typeof SharedInt32Array !== 'undefined') Module.asmGlobalArg['SharedInt32Array'] = SharedInt32Array;
+if (typeof SharedUint8Array !== 'undefined') Module.asmGlobalArg['SharedUint8Array'] = SharedUint8Array;
+if (typeof SharedUint16Array !== 'undefined') Module.asmGlobalArg['SharedUint16Array'] = SharedUint16Array;
+if (typeof SharedUint32Array !== 'undefined') Module.asmGlobalArg['SharedUint32Array'] = SharedUint32Array;
+if (typeof SharedFloat32Array !== 'undefined') Module.asmGlobalArg['SharedFloat32Array'] = SharedFloat32Array;
+if (typeof SharedFloat64Array !== 'undefined') Module.asmGlobalArg['SharedFloat64Array'] = SharedFloat64Array;
 '''
+    else:
+      shared_array_buffer = ''
+
     funcs_js = ['''
 %s
 Module%s = %s;
+%s
 Module%s = %s;
 // EMSCRIPTEN_START_ASM
 var asm = (function(global, env, buffer) {
@@ -798,6 +799,7 @@ var asm = (function(global, env, buffer) {
   %s
 ''' % (asm_setup,
        access_quote('asmGlobalArg'), the_global,
+       shared_array_buffer,
        access_quote('asmLibraryArg'), sending,
        "'use asm';" if not metadata.get('hasInlineJS') and settings['ASM_JS'] == 1 else "'almost asm';", '''
   var HEAP8 = new global%s(buffer);
@@ -808,14 +810,14 @@ var asm = (function(global, env, buffer) {
   var HEAPU32 = new global%s(buffer);
   var HEAPF32 = new global%s(buffer);
   var HEAPF64 = new global%s(buffer);
-''' % (access_quote('I8Array' if settings['USE_PTHREADS'] else 'Int8Array'),
-     access_quote('I16Array' if settings['USE_PTHREADS'] else 'Int16Array'),
-     access_quote('I32Array' if settings['USE_PTHREADS'] else 'Int32Array'),
-     access_quote('U8Array' if settings['USE_PTHREADS'] else 'Uint8Array'),
-     access_quote('U16Array' if settings['USE_PTHREADS'] else 'Uint16Array'),
-     access_quote('U32Array' if settings['USE_PTHREADS'] else 'Uint32Array'),
-     access_quote('F32Array' if settings['USE_PTHREADS'] else 'Float32Array'),
-     access_quote('F64Array' if settings['USE_PTHREADS'] else 'Float64Array'))
+''' % (access_quote('SharedInt8Array' if settings['USE_PTHREADS'] else 'Int8Array'),
+     access_quote('SharedInt16Array' if settings['USE_PTHREADS'] else 'Int16Array'),
+     access_quote('SharedInt32Array' if settings['USE_PTHREADS'] else 'Int32Array'),
+     access_quote('SharedUint8Array' if settings['USE_PTHREADS'] else 'Uint8Array'),
+     access_quote('SharedUint16Array' if settings['USE_PTHREADS'] else 'Uint16Array'),
+     access_quote('SharedUint32Array' if settings['USE_PTHREADS'] else 'Uint32Array'),
+     access_quote('SharedFloat32Array' if settings['USE_PTHREADS'] else 'Float32Array'),
+     access_quote('SharedFloat64Array' if settings['USE_PTHREADS'] else 'Float64Array'))
      if not settings['ALLOW_MEMORY_GROWTH'] else '''
   var Int8View = global%s;
   var Int16View = global%s;

--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -24,6 +24,8 @@ Special considerations
 
 The Emscripten implementation for the pthreads API should follow the POSIX standard closely, but some behavioral differences do exist:
 
+- If a page is built with the -s USE_PTHREADS=1 flag, then it will not run backwards compatibly in a non-supporting browser. In order to enable backwards compatibility so that multithreaded pages can run in non-supporting browsers (except with pthread_create() disabled), pass the flag -s USE_PTHREADS=2 instead. At runtime, you can use the emscripten_has_threading_support() function to test whether the current browser does have the capability to launch pthreads with pthread_create(). If a browser does not support threads, calls to pthread_create() will fail with error code EAGAIN.
+
 - When -s PTHREAD_POOL_SIZE=<integer> is not specified and pthread_create() is called, the new thread will not actually start to run immediately, but the main JS thread must yield execution back to browser first. This behavior is a result of `#1049079 <https://bugzilla.mozilla.org/show_bug.cgi?id=1049079>`.
 
 - Currently several of the functions in the C runtime, such as filesystem functions like fopen(), fread(), printf(), fprintf() etc. are not multithreaded, but instead their execution is proxied over to the main application thread. Memory allocation via malloc() and free() is fully multithreaded though. This proxying can generate a deadlock in a special situation that native code running pthreads does not have. See `bug 3495 <https://github.com/kripken/emscripten/issues/3495>` for more information and how to work around this until proxying is no longer needed in Emscripten.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1163,9 +1163,9 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
        'JS engine does not provide full typed array support');
 
 var buffer;
-#if USE_PTHREADS
 
 #if IN_TEST_HARNESS
+#if USE_PTHREADS == 1
 if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
   xhr = new XMLHttpRequest();
   xhr.open('GET', 'http://localhost:8888/report_result?skipped:%20SharedArrayBuffer%20is%20not%20supported!');
@@ -1173,8 +1173,9 @@ if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') 
   setTimeout(function() { window.close() }, 2000);
 }
 #endif
+#endif
 
-
+#if USE_PTHREADS
 if (typeof SharedArrayBuffer !== 'undefined') {
   if (!ENVIRONMENT_IS_PTHREAD) buffer = new SharedArrayBuffer(TOTAL_MEMORY);
   // Currently SharedArrayBuffer does not have a slice() operation, so polyfill it in.

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -132,7 +132,16 @@ int main()
 {
 	globalDouble = 5.0;
 	globalU64 = 5;
-	malloc(4); // Work around bug https://github.com/kripken/emscripten/issues/2621
+
+	int result = 0;
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT();
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
 
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
@@ -151,7 +160,6 @@ int main()
 	else
 		printf("64-bit CAS test failed! totalRead != totalWritten (%llu != %llu)\n", totalRead, totalWritten);
 #ifdef REPORT_RESULT
-	int result = 0;
 	if (totalRead != totalWritten) result = 1;
 	REPORT_RESULT();
 #else

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -147,7 +147,17 @@ int main()
 	globalFloat = 5.0f;
 	globalDouble = 5.0;
 	globalU64 = 5;
-	malloc(4); // Work around bug https://github.com/kripken/emscripten/issues/2621
+
+	int result = 0;
+
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT();
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
 
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
@@ -166,7 +176,6 @@ int main()
 	else
 		printf("32-bit CAS test failed! totalRead != totalWritten (%llu != %llu)\n", totalRead, totalWritten);
 #ifdef REPORT_RESULT
-	int result = 0;
 	if (totalRead != totalWritten) result = 1;
 	REPORT_RESULT();
 #else

--- a/tests/pthread/test_pthread_barrier.cpp
+++ b/tests/pthread/test_pthread_barrier.cpp
@@ -1,5 +1,6 @@
 // This file tests pthread barrier usage.
 
+#include <emscripten/threading.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -66,11 +67,14 @@ int main(int argc, char **argv)
     assert(ret == 0); 
 
     for(int i = 0; i < THREADS; ++i) pthread_create(&thr[i], NULL, &thread_main, (void*)i);
-    for(int i = 0; i < THREADS; ++i)
+    if (emscripten_has_threading_support())
     {
-        int totalSum = 0;
-        pthread_join(thr[i], (void**)&totalSum);
-        assert(totalSum == expectedTotalSum);
+        for(int i = 0; i < THREADS; ++i)
+        {
+            int totalSum = 0;
+            pthread_join(thr[i], (void**)&totalSum);
+            assert(totalSum == expectedTotalSum);
+        }
     }
 
 #ifdef REPORT_RESULT

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -32,6 +32,17 @@ pthread_t thr;
 
 int main()
 {
+  int result;
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    result = 1;
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
   EM_ASM(Module['print']('Canceling thread..'););
@@ -40,7 +51,7 @@ int main()
 
   for(;;)
   {
-    int result = emscripten_atomic_load_u32((const void*)&res);
+    result = emscripten_atomic_load_u32((const void*)&res);
     if (result == 1)
     {
       EM_ASM_INT( { Module['print']('After canceling, shared variable = ' + $0 + '.'); }, result);

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <emscripten.h>
+#include <emscripten/threading.h>
 
 // Stores/encodes the results of calling to cleanup handlers.
 int cleanupState = 1;
@@ -63,6 +64,18 @@ pthread_t thr[4];
 
 int main()
 {
+   int result = 0;
+
+   if (!emscripten_has_threading_support())
+   {
+#ifdef REPORT_RESULT
+      result = 907640832;
+      REPORT_RESULT();
+#endif
+      printf("Skipped: Threading is not supported.\n");
+      return 0;
+   }
+
    pthread_cleanup_push(cleanup_handler1, (void*)9998);
    pthread_cleanup_push(cleanup_handler1, (void*)9999);
 
@@ -84,7 +97,7 @@ int main()
    EM_ASM_INT( { console.log('Cleanup state variable: ' + $0); }, cleanupState);
 
 #ifdef REPORT_RESULT
-   int result = cleanupState;
+   result = cleanupState;
    REPORT_RESULT();
 #endif
 

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <emscripten/emscripten.h>
+#include <emscripten/threading.h>
 
 #define NUM_THREADS  3
 #define TCOUNT 10
@@ -87,11 +88,14 @@ int main (int argc, char *argv[])
   pthread_create(&threads[1], &attr, inc_count, (void *)t2);
   pthread_create(&threads[2], &attr, inc_count, (void *)t3);
 
-  /* Wait for all threads to complete */
-  for (i=0; i<NUM_THREADS; i++) {
-    pthread_join(threads[i], NULL);
+  if (emscripten_has_threading_support())
+  {
+    /* Wait for all threads to complete */
+    for (i=0; i<NUM_THREADS; i++) {
+      pthread_join(threads[i], NULL);
+    }
+    printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
   }
-  printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
 
   /* Clean up and exit */
   pthread_attr_destroy(&attr);

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <emscripten.h>
+#include <emscripten/threading.h>
 #include <assert.h>
 
 #define NUM_THREADS 8
@@ -68,7 +69,16 @@ void CreateThread(int i)
 
 int main()
 {
-	malloc(4); // Work around bug https://github.com/kripken/emscripten/issues/2621
+	int result = 0;
+
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT();
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
 
 	// Create initial threads.
 	for(int i = 0; i < NUM_THREADS; ++i)
@@ -93,7 +103,6 @@ int main()
 		}
 	}
 #ifdef REPORT_RESULT
-	int result = 0;
 	REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -25,6 +25,16 @@ static void *thread1_start(void *arg)
 
 int main()
 {
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    result = 1;
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
   pthread_t thr;
   pthread_create(&thr, NULL, thread1_start, 0);
 

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -25,6 +25,16 @@ static void *thread1_start(void *arg)
 
 int main()
 {
+  int result = 0;
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
   FILE *handle = fopen("file1.txt", "w");
   fputs("hello!", handle);
   fclose(handle);
@@ -39,7 +49,6 @@ int main()
   assert(!strcmp(str, "hello2!"));
 
 #ifdef REPORT_RESULT
-  int result = 0;
   REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
@@ -91,10 +91,13 @@ int main()
 		assert(y == HILO(6, 4));
 		assert(x == HILO(6, 4));
 		volatile T n = HILO(2, 1);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		printf("n: %llx\n", n);
-		assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			printf("n: %llx\n", n);
+			assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
+		}
 	}
 	{
 		T x = HILO(15, 13);
@@ -102,10 +105,13 @@ int main()
 		assert(y == HILO(5, 3));
 		assert(x == HILO(5, 3));
 		volatile T n = HILO(NUM_THREADS*10000ULL+5ULL, NUM_THREADS*10000ULL+3ULL);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		printf("n: %llx\n", n);
-		assert(n == HILO(5,3));
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			printf("n: %llx\n", n);
+			assert(n == HILO(5,3));
+		}
 	}
 	{
 		T x = HILO(32768 + 5, 5);
@@ -115,13 +121,16 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			or_and_fetch_data = HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-			for(int i = 0; i < NUM_THREADS; ++i)
+			if (emscripten_has_threading_support())
 			{
-				threadArg[i] = DUP(1 << i);
-				pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)&threadArg[i]);
+				for(int i = 0; i < NUM_THREADS; ++i)
+				{
+					threadArg[i] = DUP(1 << i);
+					pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)&threadArg[i]);
+				}
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(or_and_fetch_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
 			}
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(or_and_fetch_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
 		}
 	}
 	{
@@ -129,16 +138,19 @@ int main()
 		T y = __sync_and_and_fetch(&x, HILO(32768 + 9, 9));
 		assert(y == HILO(32768 + 1, 1));
 		assert(x == HILO(32768 + 1, 1));
-		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+		if (emscripten_has_threading_support())
 		{
-			and_and_fetch_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
-			for(int i = 0; i < NUM_THREADS; ++i)
+			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 			{
-				threadArg[i] = DUP(~(1UL<<i));
-				pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)&threadArg[i]);
+				and_and_fetch_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
+				for(int i = 0; i < NUM_THREADS; ++i)
+				{
+					threadArg[i] = DUP(~(1UL<<i));
+					pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)&threadArg[i]);
+				}
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(and_and_fetch_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
 			}
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(and_and_fetch_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
 		}
 	}
 	{
@@ -146,16 +158,19 @@ int main()
 		T y = __sync_xor_and_fetch(&x, HILO(16384 + 9, 9));
 		assert(y == HILO(32768 + 16384 + 12, 12));
 		assert(x == HILO(32768 + 16384 + 12, 12));
-		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+		if (emscripten_has_threading_support())
 		{
-			xor_and_fetch_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-			for(int i = 0; i < NUM_THREADS; ++i)
+			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 			{
-				threadArg[i] = DUP(~(1UL<<i));
-				pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)&threadArg[i]);
+				xor_and_fetch_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
+				for(int i = 0; i < NUM_THREADS; ++i)
+				{
+					threadArg[i] = DUP(~(1UL<<i));
+					pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)&threadArg[i]);
+				}
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(xor_and_fetch_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
 			}
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(xor_and_fetch_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
@@ -87,9 +87,12 @@ int main()
 		assert(y == 5);
 		assert(x == 15);
 		volatile int n = 1;
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		assert(n == NUM_THREADS*10000+1);
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(n == NUM_THREADS*10000+1);
+		}
 	}
 	{
 		T x = 5;
@@ -97,9 +100,12 @@ int main()
 		assert(y == 5);
 		assert(x == -5);
 		volatile int n = 1;
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		assert(n == 1-NUM_THREADS*10000);
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(n == 1-NUM_THREADS*10000);
+		}
 	}
 	{
 		T x = 5;
@@ -109,9 +115,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_or_data = (1<<NUM_THREADS);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)(1<<i));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(fetch_and_or_data == (1<<(NUM_THREADS+1))-1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)(1<<i));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(fetch_and_or_data == (1<<(NUM_THREADS+1))-1);
+			}
 		}
 	}
 	{
@@ -122,9 +131,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_and_data = (1<<(NUM_THREADS+1))-1;
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)(~(1<<i)));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(fetch_and_and_data == 1<<NUM_THREADS);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)(~(1<<i)));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(fetch_and_and_data == 1<<NUM_THREADS);
+			}
 		}
 	}
 	{
@@ -135,9 +147,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_xor_data = 1<<NUM_THREADS;
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)(~(1<<i)));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(fetch_and_xor_data == (1<<(NUM_THREADS+1))-1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)(~(1<<i)));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(fetch_and_xor_data == (1<<(NUM_THREADS+1))-1);
+			}
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
@@ -87,9 +87,12 @@ int main()
 		assert(y == 15);
 		assert(x == 15);
 		volatile int n = 1;
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		assert(n == NUM_THREADS*10000+1);
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(n == NUM_THREADS*10000+1);
+		}
 	}
 	{
 		T x = 5;
@@ -97,9 +100,12 @@ int main()
 		assert(y == -5);
 		assert(x == -5);
 		volatile int n = 1;
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		assert(n == 1-NUM_THREADS*10000);
+		if (emscripten_has_threading_support())
+		{
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(n == 1-NUM_THREADS*10000);
+		}
 	}
 	{
 		T x = 5;
@@ -109,9 +115,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			or_and_fetch_data = (1<<NUM_THREADS);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)(1<<i));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(or_and_fetch_data == (1<<(NUM_THREADS+1))-1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)(1<<i));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(or_and_fetch_data == (1<<(NUM_THREADS+1))-1);
+			}
 		}
 	}
 	{
@@ -122,9 +131,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			and_and_fetch_data = (1<<(NUM_THREADS+1))-1;
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)(~(1<<i)));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(and_and_fetch_data == 1<<NUM_THREADS);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)(~(1<<i)));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(and_and_fetch_data == 1<<NUM_THREADS);
+			}
 		}
 	}
 	{
@@ -135,9 +147,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			xor_and_fetch_data = 1<<NUM_THREADS;
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)(~(1<<i)));
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(xor_and_fetch_data == (1<<(NUM_THREADS+1))-1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)(~(1<<i)));
+				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+				assert(xor_and_fetch_data == (1<<(NUM_THREADS+1))-1);
+			}
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_atomics.cpp
+++ b/tests/pthread/test_pthread_gcc_atomics.cpp
@@ -77,9 +77,12 @@ int main()
 		{
 			nand_and_fetch_data = 0;
 			__sync_synchronize(); // This has no effect in this code, but called in here just to test that the compiler generates a valid expression for this.
-			for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch, (void*)-1);
-			for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
-			assert(nand_and_fetch_data == -1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch, (void*)-1);
+				for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
+				assert(nand_and_fetch_data == -1);
+			}
 		}
 	}
 	{
@@ -91,9 +94,12 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			nand_and_fetch_data = 0;
-			for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch_bool, (void*)-1);
-			for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
-			assert(nand_and_fetch_data == -1);
+			if (emscripten_has_threading_support())
+			{
+				for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch_bool, (void*)-1);
+				for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
+				assert(nand_and_fetch_data == -1);
+			}
 		}
 	}
 

--- a/tests/pthread/test_pthread_gcc_spinlock.cpp
+++ b/tests/pthread/test_pthread_gcc_spinlock.cpp
@@ -41,6 +41,17 @@ void *ThreadMain(void *arg)
 
 int main()
 {
+	int result = 0;
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		result = 800;
+		REPORT_RESULT();
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
+
 	pthread_t thread[NUM_THREADS];
 
 	for(int i = 0; i < NUM_THREADS; ++i)
@@ -62,7 +73,7 @@ int main()
 
 	printf("counter: %d\n", counter);
 #ifdef REPORT_RESULT
-	int result = counter;
+	result = counter;
 	REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_iostream.cpp
+++ b/tests/pthread/test_pthread_iostream.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <emscripten.h>
+#include <emscripten/threading.h>
 #include <assert.h>
 #include <iostream>
 
@@ -16,7 +17,15 @@ int numThreadsToCreate = 1000;
 
 int main()
 {
-	malloc(4); // Work around bug https://github.com/kripken/emscripten/issues/2621
+  int result = 0;
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
 
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
@@ -28,7 +37,6 @@ int main()
 	std::cout << "The thread should print 'Hello from thread'" << std::endl;
 
 #ifdef REPORT_RESULT
-	int result = 0;
 	REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -33,6 +33,17 @@ void BusySleep(double msecs)
 
 int main()
 {
+  int result;
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    result = 0;
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
   sharedVar = 0;
   int s = pthread_create(&thr, NULL, thread_start, 0);
   assert(s == 0);
@@ -65,7 +76,7 @@ int main()
   assert(emscripten_atomic_load_u32((void*)&sharedVar) == 0);
   EM_ASM_INT( { Module['print']('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'); }, sharedVar);
 #ifdef REPORT_RESULT
-  int result = sharedVar;
+  result = sharedVar;
   REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_malloc.cpp
+++ b/tests/pthread/test_pthread_malloc.cpp
@@ -35,10 +35,18 @@ static void *thread_start(void *arg)
 
 int main()
 {
+  int result = 0;
+  if (!emscripten_has_threading_support()) {
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    printf("Skipped: threading support is not available!\n");
+    return 0;
+  }
+
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
     pthread_create(&thr[i], NULL, thread_start, (void*)(i*N));
-  int result = 0;
   for(int i = 0; i < NUM_THREADS; ++i) {
     int res = 0;
     pthread_join(thr[i], (void**)&res);

--- a/tests/pthread/test_pthread_malloc_free.cpp
+++ b/tests/pthread/test_pthread_malloc_free.cpp
@@ -26,6 +26,14 @@ static void *thread_start(void *arg)
 
 int main()
 {
+  int result = 0;
+  if (!emscripten_has_threading_support()) {
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    printf("Skipped: threading support is not available!\n");
+    return 0;
+  }
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
   {
@@ -33,7 +41,7 @@ int main()
     if (rc != 0)
     {
 #ifdef REPORT_RESULT
-      int result = (rc != EAGAIN);
+      result = (rc != EAGAIN);
       REPORT_RESULT();
       return 0;
 #endif
@@ -58,7 +66,6 @@ int main()
   }
   printf("Test finished successfully!\n");
 #ifdef REPORT_RESULT
-  int result = 0;
   REPORT_RESULT();
 #endif
 }

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <emscripten.h>
+#include <emscripten/threading.h>
 #include <unistd.h>
 
 #define NUM_THREADS 8
@@ -91,9 +92,18 @@ int main()
 {
 	pthread_mutex_init(&lock, NULL);
 
-	// Create new threads in parallel.
-	for(int i = 0; i < NUM_THREADS; ++i)
-		CreateThread(i, threadNum++);
+	if (emscripten_has_threading_support()) {
+		// Create new threads in parallel.
+		for(int i = 0; i < NUM_THREADS; ++i)
+			CreateThread(i, threadNum++);
 
-	emscripten_set_main_loop(WaitToJoin, 0, 0);
+		emscripten_set_main_loop(WaitToJoin, 0, 0);
+	} else {
+		pthread_mutex_lock(&lock);
+		pthread_mutex_unlock(&lock);
+#ifdef REPORT_RESULT
+		int result = 50;
+		REPORT_RESULT();
+#endif
+	}
 }

--- a/tests/pthread/test_pthread_nested_spawns.cpp
+++ b/tests/pthread/test_pthread_nested_spawns.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <pthread.h>
+#include <emscripten/threading.h>
 
 int result = 0;
 
@@ -21,7 +22,11 @@ int main(void) {
   pthread_t thread;
   puts("a");
   pthread_create(&thread, NULL, thread_func, NULL);
-  pthread_join(thread, NULL);
+  if (emscripten_has_threading_support()) {
+    pthread_join(thread, NULL);
+  } else {
+    result = 1;
+  }
 
 #ifdef REPORT_RESULT
   REPORT_RESULT();

--- a/tests/pthread/test_pthread_once.cpp
+++ b/tests/pthread/test_pthread_once.cpp
@@ -27,8 +27,11 @@ int main()
 {
 	assert(numInitialized == 0);
 	for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_main, 0);
-	for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-	assert(numInitialized == 1);
+
+	if (emscripten_has_threading_support()) {
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		assert(numInitialized == 1);
+	}
 
 #ifdef REPORT_RESULT
 	int result = 0;

--- a/tests/pthread/test_pthread_printf.cpp
+++ b/tests/pthread/test_pthread_printf.cpp
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <emscripten.h>
+#include <emscripten/threading.h>
+#include <errno.h>
 #include <assert.h>
 
 void *ThreadMain(void *arg)
@@ -13,16 +15,18 @@ int numThreadsToCreate = 1000;
 
 int main()
 {
-	malloc(4); // Work around bug https://github.com/kripken/emscripten/issues/2621
-
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
-	assert(rc == 0);
+	if (emscripten_has_threading_support()) {
+		assert(rc == 0);
 
-	rc = pthread_join(thread, NULL);
-	assert(rc == 0);
+		rc = pthread_join(thread, NULL);
+		assert(rc == 0);
 
-	printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
+		printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
+	} else {
+		assert(rc == EAGAIN);
+	}
 
 #ifdef REPORT_RESULT
 	int result = 0;

--- a/tests/pthread/test_pthread_spawns.cpp
+++ b/tests/pthread/test_pthread_spawns.cpp
@@ -1,4 +1,5 @@
 #include <pthread.h>
+#include <emscripten/threading.h>
 
 #define NUM_THREADS 2
 
@@ -14,7 +15,8 @@ int main()
 	for(int x = 0; x < 1000; ++x)
 	{
 		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_main, 0);
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		if (emscripten_has_threading_support())
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
 	}
 #ifdef REPORT_RESULT
 	int result = 0;

--- a/tests/pthread/test_pthread_supported.cpp
+++ b/tests/pthread/test_pthread_supported.cpp
@@ -21,10 +21,8 @@ int main()
 	pthread_attr_destroy(&attr);
 	pthread_join(thread, 0);
 
-	if (emscripten_has_threading_support())
-		assert(rc == 0);
-	else
-		assert(rc == EAGAIN);
+	if (emscripten_has_threading_support()) assert(rc == 0);
+	else assert(rc == EAGAIN);
 
 #ifdef REPORT_RESULT
 	int result = 0;

--- a/tests/pthread/test_pthread_volatile.cpp
+++ b/tests/pthread/test_pthread_volatile.cpp
@@ -21,6 +21,17 @@ static void *thread_start(void *arg) // thread: just flip the shared flag and qu
 
 int main()
 {
+  int result;
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    result = 1;
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
   pthread_t thr;
   int rc = pthread_create(&thr, NULL, thread_start, (void*)0);
   if (rc != 0)
@@ -40,7 +51,7 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-  int result = sharedVar;
+  result = sharedVar;
   REPORT_RESULT();
 #endif
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2676,130 +2676,135 @@ window.close = function() {
 
   # Test that the emscripten_ atomics api functions work.
   def test_aaa_aaa_pthread_atomics(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=120) # extra time on first test, to be sure to build all libraries
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=120) # extra time on first test, to be sure to build all libraries
 
   # Test 64-bit atomics.
   def test_aaa_pthread_64bit_atomics(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_64bit_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_64bit_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test the old GCC atomic __sync_fetch_and_op builtin operations.
   def test_aaa_pthread_gcc_atomic_fetch_and_op(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomic_fetch_and_op.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    # We need to resort to using regexes to optimize out SharedArrayBuffer when pthreads are not supported, which is brittle!
+    # Therefore perform very extensive testing of different codegen modes to catch any problems.
+    for opt in [[], ['-O1'], ['-O2'], ['-O3'], ['-Os'], ['-Oz']]:
+      for debug in [[], ['-g1'], ['-g2'], ['-g4']]:
+        for f32 in [[], ['-s', 'PRECISE_F32=1']]:
+          self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomic_fetch_and_op.cpp'), expected='0', args=opt+debug+f32+['-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # 64 bit version of the above test.
   def test_aaa_pthread_gcc_64bit_atomic_fetch_and_op(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_64bit_atomic_fetch_and_op.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_64bit_atomic_fetch_and_op.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test the old GCC atomic __sync_op_and_fetch builtin operations.
   def test_aaa_pthread_gcc_atomic_op_and_fetch(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomic_op_and_fetch.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomic_op_and_fetch.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # 64 bit version of the above test.
   def test_aaa_pthread_gcc_64bit_atomic_op_and_fetch(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_64bit_atomic_op_and_fetch.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_64bit_atomic_op_and_fetch.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Tests the rest of the remaining GCC atomics after the two above tests.
   def test_aaa_pthread_gcc_atomics(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test the __sync_lock_test_and_set and __sync_lock_release primitives.
   def test_aaa_pthread_gcc_spinlock(self):
     for arg in [[], ['-DUSE_EMSCRIPTEN_INTRINSICS']]:
-      self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_spinlock.cpp'), expected='800', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=30)
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_gcc_spinlock.cpp'), expected='800', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=30)
 
   # Test that basic thread creation works.
   def test_aaa_pthread_create(self):
-    print '0'
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=['-O0', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
-    print '3'
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    for opt in [['-O0'], ['-O3']]:
+      for pthreads in [['-s', 'USE_PTHREADS=1'], ['-s', 'USE_PTHREADS=2']]:
+        print str(opt) + ' ' + str(pthreads)
+        self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=opt + pthreads + ['-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test that a pthread can spawn another pthread of its own.
   def test_aaa_pthread_create_pthread(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create_pthread.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'NO_EXIT_RUNTIME=1'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create_pthread.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'NO_EXIT_RUNTIME=1'], timeout=30)
 
   # Test another case of pthreads spawning pthreads, but this time the callers immediately join on the threads they created.
   def test_aaa_pthread_nested_spawns(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_nested_spawns.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_nested_spawns.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=2'], timeout=30)
 
   # Test that main thread can wait for a pthread to finish via pthread_join().
   def test_aaa_pthread_join(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_join.cpp'), expected='6765', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_join.cpp'), expected='6765', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test pthread_cancel() operation
   def test_aaa_pthread_cancel(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_cancel.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_cancel.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test pthread_kill() operation
   def test_aaa_pthread_kill(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_kill.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_kill.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test that pthread cleanup stack (pthread_cleanup_push/_pop) works.
   def test_aaa_pthread_cleanup(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_cleanup.cpp'), expected='907640832', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_cleanup.cpp'), expected='907640832', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Tests the pthread mutex api.
   def test_aaa_pthread_mutex(self):
     for arg in [[], ['-DSPINLOCK_TEST']]:
-      self.btest(path_from_root('tests', 'pthread', 'test_pthread_mutex.cpp'), expected='50', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=20)
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_mutex.cpp'), expected='50', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=20)
 
   # Test that memory allocation is thread-safe.
   def test_aaa_pthread_malloc(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_malloc.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_malloc.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Stress test pthreads allocating memory that will call to sbrk(), and main thread has to free up the data.
   def test_aaa_pthread_malloc_free(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_malloc_free.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8', '-s', 'TOTAL_MEMORY=268435456'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_malloc_free.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8', '-s', 'TOTAL_MEMORY=268435456'], timeout=30)
 
   # Test that the pthread_barrier API works ok.
   def test_aaa_pthread_barrier(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_barrier.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_barrier.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test the pthread_once() function.
   def test_aaa_pthread_once(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_once.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_once.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test against a certain thread exit time handling bug by spawning tons of threads.
   def test_aaa_pthread_spawns(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_spawns.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_spawns.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # It is common for code to flip volatile global vars for thread control. This is a bit lax, but nevertheless, test whether that
   # kind of scheme will work with Emscripten as well.
   def test_aaa_pthread_volatile(self):
     for arg in [[], ['-DUSE_C_VOLATILE']]:
-      self.btest(path_from_root('tests', 'pthread', 'test_pthread_volatile.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=30)
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_volatile.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'] + arg, timeout=30)
 
   # Test thread-specific data (TLS).
   def test_aaa_pthread_thread_local_storage(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_thread_local_storage.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_thread_local_storage.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test the pthread condition variable creation and waiting.
   def test_aaa_pthread_condition_variable(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_condition_variable.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_condition_variable.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test that pthreads are able to do printf.
   def test_aaa_pthread_printf(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_printf.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_printf.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
 
   # Test that pthreads are able to do cout. Failed due to https://bugzilla.mozilla.org/show_bug.cgi?id=1154858.
   def test_aaa_pthread_iostream(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_iostream.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_iostream.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
 
   # Test that the main thread is able to use pthread_set/getspecific.
   def test_aaa_pthread_setspecific_mainthread(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_setspecific_mainthread.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_setspecific_mainthread.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2'], timeout=30)
 
   # Test the -s PTHREAD_HINT_NUM_CORES=x command line variable.
   def test_aaa_pthread_num_logical_cores(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_num_logical_cores.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_HINT_NUM_CORES=2'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_num_logical_cores.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_HINT_NUM_CORES=2'], timeout=30)
 
   # Test that pthreads have access to filesystem.
   def test_aaa_pthread_file_io(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_file_io.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_file_io.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=1'], timeout=30)
 
   # Test that the pthread_create() function operates benignly in the case that threading is not supported.
   def test_aaa_pthread_supported(self):
-    for args in [[], ['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8']]:
+    for args in [[], ['-s', 'USE_PTHREADS=2', '-s', 'PTHREAD_POOL_SIZE=8']]:
       self.btest(path_from_root('tests', 'pthread', 'test_pthread_supported.cpp'), expected='0', args=['-O3'] + args, timeout=30)
 
   def test_aaa_separate_asm_pthreads(self):


### PR DESCRIPTION
Fixes the asm.js validation issues with -s USE_PTHREADS=1 in #3719. Adds a new build mode -s USE_PTHREADS=2 to mean 'build with threads enabled in a backwards compatible fashion.' Closes #3719.