### PR TITLE
Fix test warnings

### DIFF
--- a/tests/core/test_ccall.in
+++ b/tests/core/test_ccall.in
@@ -5,7 +5,7 @@
 extern "C" {
 int get_int() { return 5; }
 float get_float() { return 3.14; }
-char *get_string() { return "hello world"; }
+const char *get_string() { return "hello world"; }
 void print_int(int x) { printf("%d\n", x); }
 void print_float(float x) { printf("%.2f\n", x); }
 void print_string(char *x) { printf("%s\n", x); }
@@ -32,6 +32,7 @@ int uses_stack(test_struct* t1) {
   *stackChecker = get_stack();
   EM_ASM(Module['ccall']('get_int', 'number'));
   printf("stack is %s.\n", *stackChecker == get_stack() ? "ok" : "messed up");
+  return 0;
 }
 void call_ccall_again() {
   test_struct t1 = { 1, 2, 3 };

--- a/tests/core/test_exceptions_typed.in
+++ b/tests/core/test_exceptions_typed.in
@@ -24,7 +24,7 @@ public:
 class ExChild : public ExQuux {
 public:
   ExChild(int x) : ExQuux(x) { printf("*CREATING A CHILD\n"); }
-  ExChild(const ExChild& other) : ExQuux(x)  { x=other.x; printf("*COPYING CHILD\n"); }
+  ExChild(const ExChild& other) : ExQuux(other.x)  { printf("*COPYING CHILD\n"); }
   ~ExChild() { printf("*DESTROYING A CHILD (%d)\n", x); }
 } ExChildInstance(44);
 

--- a/tests/core/test_linked_list.in
+++ b/tests/core/test_linked_list.in
@@ -32,7 +32,7 @@ int main() {
     c = c->next;
   } while (c != chunk);
 
-  printf("*%d,%d*\n", total, b.next);
+  printf("*%d,%p*\n", total, b.next);
   // NULL *is* 0, in C/C++. No JS null! (null == 0 is false, etc.)
 
   return 0;

--- a/tests/core/test_printf_2.in
+++ b/tests/core/test_printf_2.in
@@ -8,7 +8,7 @@ int main() {
   float f = 5.5;
   double d = 6.6;
 
-  printf("%c,%hd,%d,%lld,%.1f,%.1Lf\n", c, s, i, l, f, d);
+  printf("%c,%hd,%d,%lld,%.1f,%.1f\n", c, s, i, l, f, d);
   printf("%#x,%#x\n", 1, 0);
 
   return 0;

--- a/tests/core/test_sscanf_6.in
+++ b/tests/core/test_sscanf_6.in
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 int main() {
-  char *date = "18.07.2013w";
+  const char *date = "18.07.2013w";
   char c[10];
   memset(c, 0, 10);
   int y, m, d, i;
@@ -13,7 +13,8 @@ int main() {
          y, c, i);
 
   {
-    char *date = "18.07.2013", c;
+    const char *date = "18.07.2013";
+    char c;
     int y, m, d, i;
     if ((i = sscanf(date, "%d.%d.%4d%c", &d, &m, &y, &c)) == 3)
     {

--- a/tests/core/test_sscanf_n.in
+++ b/tests/core/test_sscanf_n.in
@@ -1,6 +1,6 @@
 #include <stdio.h>
 int main() {
-  char *line = "version 1.0";
+  const char *line = "version 1.0";
   int i, l, lineno;
   char word[80];
   if (sscanf(line, "%s%n", word, &l) != 1) {

--- a/tests/core/test_sscanf_skip.in
+++ b/tests/core/test_sscanf_skip.in
@@ -8,8 +8,8 @@ int main() {
 
   int64_t large, val2;
   printf("%d\n", sscanf("1000000 -1125899906842620 -123 -1073741823",
-                        "%lld %*lld %ld %*d", &large, &val2));
-  printf("%lld,%d\n", large, val2);
+                        "%lld %*lld %lld %*d", &large, &val2));
+  printf("%lld,%lld\n", large, val2);
 
   return 0;
 }

--- a/tests/core/test_strtok.in
+++ b/tests/core/test_strtok.in
@@ -3,7 +3,7 @@
 
 int main() {
   char test[80], blah[80];
-  char *sep = "\\/:;=-";
+  const char *sep = "\\/:;=-";
   char *word, *phrase, *brkt, *brkb;
 
   strcpy(test, "This;is.a:test:of=the/string\\tokenizer-function.");

--- a/tests/core/test_transtrcase.in
+++ b/tests/core/test_transtrcase.in
@@ -5,7 +5,7 @@ int main() {
   char szTolwr[] = "EMSCRIPTEN";
   strupr(szToupr);
   strlwr(szTolwr);
-  printf(szToupr);
-  printf(szTolwr);
+  puts(szToupr);
+  puts(szTolwr);
   return 0;
 }

--- a/tests/core/test_transtrcase.out
+++ b/tests/core/test_transtrcase.out
@@ -1,1 +1,2 @@
-HELLO, emscripten
+HELLO, 
+emscripten

--- a/tests/core/test_vprintf.in
+++ b/tests/core/test_vprintf.in
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-void print(char* format, ...) {
+void print(const char* format, ...) {
   va_list args;
   va_start(args, format);
   vprintf(format, args);

--- a/tests/parseInt/src.c
+++ b/tests/parseInt/src.c
@@ -10,7 +10,7 @@ void check_error() {
 }
 
 int main() {
-  char* test_values[] = {
+  const char* test_values[] = {
     "-9223372036854775809",
     "-9223372036854775808",
     "-9223372036854775807",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4837,7 +4837,7 @@ def process(filename):
       char buf[32];
       int main()
       {
-        char *r = "SUCCESS";
+        const char *r = "SUCCESS";
         FILE *f = fopen("eol.txt", "r");
         while (fgets(buf, 32, f) != NULL) {
           if (buf[0] == '\0') {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3543,6 +3543,7 @@ ok
     self.prep_dlfcn_lib()
     lib_src = r'''
       #include <setjmp.h>
+      #include <stdio.h>
 
       void jumpy(jmp_buf buf) {
         static int i = 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1154,7 +1154,7 @@ base align: 0, 0, 0, 0'''])
       #include <stdio.h>
       #include <setjmp.h>
 
-      int main(int argc) {
+      int main(int argc, char** argv) {
         jmp_buf buf;
         for (int i = 0; i < NUM; i++) printf("%d\n", setjmp(buf));
         if (argc-- == 1131) longjmp(buf, 11);

--- a/tests/unistd/confstr.c
+++ b/tests/unistd/confstr.c
@@ -21,7 +21,7 @@ int main() {
     _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
     _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS
   };
-  char* names[] = {
+  const char* names[] = {
     "_CS_PATH",
     "_CS_POSIX_V6_WIDTH_RESTRICTED_ENVS",
     "_CS_GNU_LIBC_VERSION",

--- a/tests/unistd/io.c
+++ b/tests/unistd/io.c
@@ -109,7 +109,7 @@ int main() {
   printf("errno: %d\n\n", errno);
   errno = 0;
 
-  printf("pread past end of file: %d\n", pread(f, readBuffer, sizeof readBuffer, 99999999999));
+  printf("pread past end of file: %d\n", pread(f, readBuffer, sizeof readBuffer, 999999999));
   printf("data: %s\n", readBuffer);
   memset(readBuffer, 0, sizeof readBuffer);
   printf("errno: %d\n\n", errno);

--- a/tests/unistd/misc.c
+++ b/tests/unistd/misc.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>

--- a/tests/unistd/pathconf.c
+++ b/tests/unistd/pathconf.c
@@ -26,7 +26,7 @@ int main() {
     _PC_SYMLINK_MAX,
     _PC_FILESIZEBITS
   };
-  char* names[] = {
+  const char* names[] = {
     "_PC_LINK_MAX",
     "_PC_MAX_CANON",
     "_PC_MAX_INPUT",

--- a/tests/unistd/symlink_on_nodefs.c
+++ b/tests/unistd/symlink_on_nodefs.c
@@ -21,7 +21,7 @@ int main() {
   );
 
   {
-    char* path = "/working/symlink/test";
+    const char* path = "/working/symlink/test";
     printf("reading %s\n", path);
 
     FILE* fd = fopen(path, "r");
@@ -39,7 +39,7 @@ int main() {
   printf("\n");
 
   {
-    char* path = "/direct-link/test";
+    const char* path = "/direct-link/test";
     printf("reading %s\n", path);
 
     FILE* fd = fopen(path, "r");

--- a/tests/whets.cpp
+++ b/tests/whets.cpp
@@ -195,7 +195,7 @@ void whetstones(long xtra, long x100, int calibrate);
 void pa(SPDP e[4], SPDP t, SPDP t2);
 void po(SPDP e1[4], long j, long k, long l);
 void p3(SPDP *x, SPDP *y, SPDP *z, SPDP t, SPDP t1, SPDP t2);
-void pout(char title[22], float ops, int type, SPDP checknum,
+void pout(const char title[22], float ops, int type, SPDP checknum,
   	  SPDP time, int calibrate, int section);
 
 


### PR DESCRIPTION
For some reason, when I run tests, clang is doing warnings ...

With all of the warnings, the tests are unusable, so here are some fixes.
