### PR TITLE
Allow multiple arities per EM_ASM block, fixes #3804.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -205,4 +205,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jan Bölsche <jan@lagomorph.de>
 * Sebastian Matthes <sebastianmatthes@outlook.com> (copyright owned by Volkswagen AG)
 * Robert Goulet <robert.goulet@autodesk.com> (copyright owned by Autodesk, Inc.)
-
+* Juha Järvi <befunge@gmail.com>

--- a/emscripten.py
+++ b/emscripten.py
@@ -273,14 +273,15 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
         const = const[1:-1]
       const = '{ ' + const + ' }'
       args = []
-      arity = metadata['asmConstArities'][k]
+      arity = metadata['asmConstArities'][k][-1]
       for i in range(arity):
         args.append('$' + str(i))
       const = 'function(' + ', '.join(args ) + ') ' + const
       asm_consts[int(k)] = const
 
+    join = lambda outer: (item for inner in outer for item in inner)
     asm_const_funcs = []
-    for arity in set(metadata['asmConstArities'].values()):
+    for arity in set(join(metadata['asmConstArities'].values())):
       forwarded_json['Functions']['libraryFunctions']['_emscripten_asm_const_%d' % arity] = 1
       args = ['a%d' % i for i in range(arity)]
       all_args = ['code'] + args

--- a/emscripten.py
+++ b/emscripten.py
@@ -273,15 +273,15 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
         const = const[1:-1]
       const = '{ ' + const + ' }'
       args = []
-      arity = metadata['asmConstArities'][k][-1]
+      arity = max(metadata['asmConstArities'][k])
       for i in range(arity):
         args.append('$' + str(i))
       const = 'function(' + ', '.join(args ) + ') ' + const
       asm_consts[int(k)] = const
 
-    join = lambda outer: (item for inner in outer for item in inner)
+    flatten_list_of_lists = lambda outer: (item for inner in outer for item in inner)
     asm_const_funcs = []
-    for arity in set(join(metadata['asmConstArities'].values())):
+    for arity in set(flatten_list_of_lists(metadata['asmConstArities'].values())):
       forwarded_json['Functions']['libraryFunctions']['_emscripten_asm_const_%d' % arity] = 1
       args = ['a%d' % i for i in range(arity)]
       all_args = ['code'] + args

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2155,6 +2155,30 @@ int main() {
     '''
     self.do_run(src, '''0+2=2''')
 
+  def test_em_asm_parameter_pack(self):
+    Building.COMPILER_TEST_OPTS += ['-std=c++11']
+    src = r'''
+      #include <emscripten.h>
+
+      template <typename... Args>
+      int call(Args... args) {
+        return(EM_ASM_INT(
+          {
+            console.log(Array.prototype.join.call(arguments, ','));
+          },
+          args...
+        ));
+      }
+
+      int main(int argc, char **argv) {
+        call(1);
+        call(1, 2);
+        call(1, 2, 3);
+        return 0;
+      }
+    '''
+    self.do_run(src, '''1\n1,2\n1,2,3''')
+
   def test_memorygrowth(self):
     if self.is_wasm(): return self.skip('wasm support for memory growth in the MVP is yet unclear')
     self.banned_js_engines = [V8_ENGINE] # stderr printing limitations in v8

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2155,6 +2155,10 @@ int main() {
     '''
     self.do_run(src, '''0+2=2''')
 
+  # Verify that EM_ASM macros support getting called with multiple arities.
+  # Maybe tests will later be joined into larger compilation units?
+  # Then this must still be compiled separately from other code using EM_ASM
+  # macros with arities 1-3. Otherwise this may incorrectly report a success.
   def test_em_asm_parameter_pack(self):
     Building.COMPILER_TEST_OPTS += ['-std=c++11']
     src = r'''


### PR DESCRIPTION
PR for kripken/emscripten#3804.
Create `_emscripten_asm_const` functions with arities matching all template expansions of all EM_ASM blocks and use the largest arity among template expansions for each `EM_ASM` macro expansion in `ASM_CONSTS`.