### PR TITLE
SDL2 image formats

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -604,6 +604,8 @@ var USE_VORBIS = 0; // 1 = use vorbis from emscripten-ports
 var USE_OGG = 0; // 1 = use ogg from emscripten-ports
 var USE_FREETYPE = 0; // 1 = use freetype from emscripten-ports
 
+var SDL2_IMAGE_FORMATS = []; // Formats to support in SDL2_image. Valid values: bmp, gif, lbm, pcx, png, pnm, tga, xcf, xpm, xv
+
 
 // Compiler debugging options
 var DEBUG_TAGS_SHOWING = [];

--- a/tests/sdl2_image.c
+++ b/tests/sdl2_image.c
@@ -18,12 +18,14 @@ int testImage(SDL_Renderer* renderer, const char* fileName) {
   assert(image->pitch == 4*image->w);
   int result = image->w;
 
+#ifndef NO_PRELOADED
   int w, h;
   char *data = emscripten_get_preloaded_image_data(fileName, &w, &h);
 
   assert(data);
   assert(w == image->w);
   assert(h == image->h);
+#endif
 
   SDL_Texture *tex = SDL_CreateTextureFromSurface(renderer, image);
 
@@ -32,7 +34,10 @@ int testImage(SDL_Renderer* renderer, const char* fileName) {
   SDL_DestroyTexture (tex);
 
   SDL_FreeSurface (image);
+
+#ifndef NO_PRELOADED
   free(data);
+#endif
 
   return result;
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2107,6 +2107,11 @@ Module['_main'] = function() {
     ]).communicate()
     self.run_browser('page.html', '', '/report_result?600')
 
+  def test_sdl2_image_formats(self):
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    self.btest('sdl2_image.c', expected='512', args=['--preload-file', 'screenshot.png', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.png"',
+                                                     '-DNO_PRELOADED','-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
+
   def test_sdl2_key(self):
     for defines in [[]]:
       open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''


### PR DESCRIPTION
Allow specifying image formats to enable when using SDL2_image. Previously we were enabling none, so only preloaded images could be loaded. Handles every format supported by SDL2_image except jpeg, tiff and webp (external libs not in ports). (Related to #3605 )