### PR TITLE
Parse spaces in `-l`/`-L`/`I` args correctly, default to no absolute path warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,4 +208,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Juha Järvi <befunge@gmail.com>
 * Louis Lagrange <lagrange.louis@gmail.com>
 * Ying-Ruei Liang <thumbd03803@gmail.com>
+* Stuart Geipel <lapimlu@gmail.com>
 

--- a/emcc
+++ b/emcc
@@ -437,13 +437,14 @@ try:
   def check_bad_eq(arg):
     assert '=' not in arg, 'Invalid parameter (do not use "=" with "--" options)'
 
-  absolute_warning_shown = False
+  # Defaults to not showing absolute path warnings
+  absolute_warning_shown = True
 
   for i in range(len(newargs)):
-    # Scan for warning suppression message in advance from other cmdline flags, so that it works even if -I or -L directives are present before this.
-    if newargs[i] == '-Wno-warn-absolute-paths':
+    # Scan for path warning flag in advance from other cmdline flags, so that it works even if -I or -L directives are present before this.
+    if newargs[i] == '-Wwarn-absolute-paths':
       newargs[i] = ''
-      absolute_warning_shown = True
+      absolute_warning_shown = False
     # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
     if newargs[i] in ['-l', '-L', '-I']:
       newargs[i] += newargs[i+1]
@@ -640,7 +641,7 @@ try:
     elif newargs[i].startswith(('-I', '-L')):
       path_name = newargs[i][2:]
       if not absolute_warning_shown and os.path.isabs(path_name) and not is_valid_abspath(path_name):
-        logging.warning('-I or -L of an absolute path "' + newargs[i] + '" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript). Pass \'-Wno-warn-absolute-paths\' to emcc to hide this warning.') # Of course an absolute path to a non-system-specific library or header is fine, and you can ignore this warning. The danger are system headers that are e.g. x86 specific and nonportable. The emscripten bundled headers are modified to be portable, local system ones are generally not
+        logging.warning('-I or -L of an absolute path "' + newargs[i] + '" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).') # Of course an absolute path to a non-system-specific library or header is fine, and you can ignore this warning. The danger are system headers that are e.g. x86 specific and nonportable. The emscripten bundled headers are modified to be portable, local system ones are generally not
         absolute_warning_shown = True
     elif newargs[i] == '--emrun':
       emrun = True

--- a/emcc
+++ b/emcc
@@ -439,11 +439,15 @@ try:
 
   absolute_warning_shown = False
 
-  # Scan for warning suppression message in advance from other cmdline flags, so that it works even if -I or -L directives are present before this.
   for i in range(len(newargs)):
+    # Scan for warning suppression message in advance from other cmdline flags, so that it works even if -I or -L directives are present before this.
     if newargs[i] == '-Wno-warn-absolute-paths':
       newargs[i] = ''
       absolute_warning_shown = True
+    # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
+    if newargs[i] in ['-l', '-L', '-I']:
+      newargs[i] += newargs[i+1]
+      newargs[i+1] = ''
 
   settings_changes = []
 
@@ -824,7 +828,7 @@ try:
             break
         if found: break
       if found: break
-    if not found and lib not in ['GL', 'GLU', 'glut', 'm', 'SDL', 'stdc++']: # whitelist our default libraries
+    if not found and lib not in ['GL', 'GLU', 'glut', 'm', 'c', 'SDL', 'stdc++']: # whitelist our default libraries
       logging.warning('emcc: cannot find library "%s"', lib)
 
   # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so

--- a/site/build/text/docs/api_reference/emscripten.h.txt
+++ b/site/build/text/docs/api_reference/emscripten.h.txt
@@ -41,8 +41,8 @@ Table of Contents
 Inline assembly/JavaScript
 ==========================
 
-Guide material for the following APIs can be found in *Calling
-JavaScript from C/C++*.
+Guide material for the following APIs can be found in Calling
+JavaScript from C/C++.
 
 
 Defines
@@ -119,8 +119,8 @@ EM_ASM_DOUBLE_V(code)
 Calling JavaScript From C/C++
 =============================
 
-Guide material for the following APIs can be found in *Calling
-JavaScript from C/C++*.
+Guide material for the following APIs can be found in Calling
+JavaScript from C/C++.
 
 
 Function pointer types for callbacks
@@ -251,8 +251,8 @@ void emscripten_async_load_script(const char *script, em_callback_func onload,
 Browser Execution Environment
 =============================
 
-Guide material for the following APIs can be found in *Emscripten
-Runtime Environment*.
+Guide material for the following APIs can be found in Emscripten
+Runtime Environment.
 
 
 Functions
@@ -1199,7 +1199,7 @@ EMSCRIPTEN_KEEPALIVE
    Forces LLVM to not dead-code-eliminate a function.
 
    This also exports the function, as if you added it to
-   *EXPORTED_FUNCTIONS*.
+   EXPORTED_FUNCTIONS.
 
    For example:
 
@@ -1286,7 +1286,7 @@ void emscripten_call_worker(worker_handle worker, const char *funcname, char 
 
       * **funcname** (*const char**) -- The name of the function in
         the worker. The function must be a C function (so no C++ name
-        mangling), and must be exported (*EXPORTED_FUNCTIONS*).
+        mangling), and must be exported (EXPORTED_FUNCTIONS).
 
       * **data** (*char**) -- The address of a block of memory to
         copy over.
@@ -1537,6 +1537,29 @@ char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *
    Return type:
       char*
 
+int emscripten_print_double(double x, char *to, signed max)
+
+   Prints a double as a string, including a null terminator. This is
+   useful because JS engines have good support for printing out a
+   double in a way that takes the least possible size, but preserves
+   all the information in the double, i.e., it can then be parsed back
+   in a perfectly reversible manner (snprintf etc. do not do so,
+   sadly).
+
+   Parameters:
+      * **x** (*double*) -- The double.
+
+      * **to** (*char**) -- A pre-allocated buffer of sufficient
+        size, or NULL if no output is requested (useful to get the
+        necessary size).
+
+      * **max** (*signed*) -- The maximum number of characters to
+        write
+
+   Return type:
+      The number of necessary bytes, not including the null terminator
+      (actually written, if "to" is not NULL).
+
 
 Socket event registration
 =========================
@@ -1633,7 +1656,7 @@ void emscripten_set_socket_error_callback(void *userData, em_socket_error_callb
 
    Triggered by a "WebSocket" error.
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1648,7 +1671,7 @@ void emscripten_set_socket_open_callback(void *userData, em_socket_callback ca
 
    Triggered when the "WebSocket" has opened.
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1662,7 +1685,7 @@ void emscripten_set_socket_listen_callback(void *userData, em_socket_callback 
 
    Triggered when "listen" has been called (synthetic event).
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1676,7 +1699,7 @@ void emscripten_set_socket_connection_callback(void *userData, em_socket_callba
 
    Triggered when the connection has been established.
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1690,7 +1713,7 @@ void emscripten_set_socket_message_callback(void *userData, em_socket_callback�
 
    Triggered when data is available to be read from the socket.
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1704,7 +1727,7 @@ void emscripten_set_socket_close_callback(void *userData, em_socket_callback c
 
    Triggered when the "WebSocket" has closed.
 
-   See *Socket event registration* for more information.
+   See Socket event registration for more information.
 
    Parameters:
       * **userData** (*void**) -- Arbitrary user data to be passed
@@ -1732,7 +1755,7 @@ emscripten_align2_double
 emscripten_align1_double
 
    Unaligned types. These may be used to force LLVM to emit unaligned
-   loads/stores in places in your code where *SAFE_HEAP* found an
+   loads/stores in places in your code where SAFE_HEAP found an
    unaligned operation.
 
    For usage examples see tests/core/test_set_align.c.

--- a/site/build/text/docs/api_reference/html5.h.txt
+++ b/site/build/text/docs/api_reference/html5.h.txt
@@ -5,10 +5,10 @@ html5.h
 The C++ APIs in html5.h define the Emscripten low-level glue bindings
 to interact with HTML5 events from native code.
 
-Tip: The C++ APIs map closely to their *equivalent HTML5 JavaScript
-  APIs*. The HTML5 specifications listed below provide additional
+Tip: The C++ APIs map closely to their equivalent HTML5 JavaScript
+  APIs. The HTML5 specifications listed below provide additional
   detailed reference "over and above" the information provided in this
-  document.In addition, the *Test/Example code* can be reviewed to see
+  document.In addition, the Test/Example code can be reviewed to see
   how the code is used.
 
 The HTML5 specifications for APIs that are mapped by **html5.h**
@@ -258,9 +258,9 @@ EMSCRIPTEN_RESULT
 
    EMSCRIPTEN_RESULT_DEFERRED
 
-      The requested operation cannot be completed now for *web
-      security reasons*, and has been deferred for completion in the
-      next event handler.
+      The requested operation cannot be completed now for web security
+      reasons, and has been deferred for completion in the next event
+      handler.
 
    EMSCRIPTEN_RESULT_NOT_SUPPORTED
 
@@ -270,8 +270,8 @@ EMSCRIPTEN_RESULT
 
    EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED
 
-      The requested operation could not be completed now for *web
-      security reasons*. It failed because the user requested the
+      The requested operation could not be completed now for web
+      security reasons. It failed because the user requested the
       operation not be deferred.
 
    EMSCRIPTEN_RESULT_INVALID_TARGET
@@ -441,7 +441,7 @@ em_key_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -458,12 +458,12 @@ EMSCRIPTEN_RESULT emscripten_set_keyup_callback(const char *target, void *user
    keyboard input events.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_key_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -597,7 +597,7 @@ em_mouse_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -618,12 +618,12 @@ EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback(const char *target, void 
    input events.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_mouse_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -735,7 +735,7 @@ em_wheel_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -750,12 +750,12 @@ EMSCRIPTEN_RESULT emscripten_set_wheel_callback(const char *target, void *user
    mousewheel events.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_wheel_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -837,7 +837,7 @@ em_ui_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -863,12 +863,12 @@ EMSCRIPTEN_RESULT emscripten_set_scroll_callback(const char *target, void *use
        to fire "resize" events for these.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_ui_callback_func*) -- A callback function.
         The function is called with the type of event, information
@@ -941,7 +941,7 @@ em_focus_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -959,12 +959,12 @@ EMSCRIPTEN_RESULT emscripten_set_focusout_callback(const char *target, void *u
    focus, focusin and focusout events.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_focus_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -1051,7 +1051,7 @@ em_deviceorientation_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1066,10 +1066,10 @@ EMSCRIPTEN_RESULT emscripten_set_deviceorientation_callback(void *userData, EM_
    event.
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_deviceorientation_callback_func*) -- A
         callback function. The function is called with the type of
@@ -1167,7 +1167,7 @@ em_devicemotion_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1181,10 +1181,10 @@ EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback(void *userData, EM_BOOL�
    Registers a callback function for receiving the devicemotion event.
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_devicemotion_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -1291,7 +1291,7 @@ em_orientationchange_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1306,10 +1306,10 @@ EMSCRIPTEN_RESULT emscripten_set_orientationchange_callback(void *userData, EM_
    event.
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_orientationchange_callback_func*) -- A
         callback function. The function is called with the type of
@@ -1578,7 +1578,7 @@ em_fullscreenchange_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1593,12 +1593,12 @@ EMSCRIPTEN_RESULT emscripten_set_fullscreenchange_callback(const char *target, 
    event.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_fullscreenchange_callback_func*) -- A
         callback function. The function is called with the type of
@@ -1635,8 +1635,8 @@ EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target, EM_BOOL de
      reasons its associated *request* can only be raised inside the
      event handler for a user-generated event (for example a key,
      mouse or touch press/release). This has implications for porting
-     and the value of "deferUntilInEventHandler"  — see *Functions
-     affected by web security* for more information.
+     and the value of "deferUntilInEventHandler"  — see Functions
+     affected by web security for more information.
 
    Note: This function only performs a fullscreen request without
      changing any parameters of the DOM element that is to be
@@ -1652,7 +1652,7 @@ EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target, EM_BOOL de
      with the developer's use case in some way.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
       * **deferUntilInEventHandler** (*EM_BOOL*) -- If "true"
         requests made outside of a user-generated event handler are
@@ -1786,7 +1786,7 @@ em_pointerlockchange_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1805,12 +1805,12 @@ EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback(const char *target,
    event.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_pointerlockchange_callback_func*) -- A
         callback function. The function is called with the type of
@@ -1846,11 +1846,11 @@ EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target, EM_BOOL d
      reasons its associated *request* can only be raised inside the
      event handler for a user-generated event (for example a key,
      mouse or touch press/release). This has implications for porting
-     and the value of "deferUntilInEventHandler"  — see *Functions
-     affected by web security* for more information.
+     and the value of "deferUntilInEventHandler"  — see Functions
+     affected by web security for more information.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
       * **deferUntilInEventHandler** (*EM_BOOL*) -- If "true"
         requests made outside of a user-generated event handler are
@@ -1944,7 +1944,7 @@ em_visibilitychange_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -1959,10 +1959,10 @@ EMSCRIPTEN_RESULT emscripten_set_visibilitychange_callback(void *userData, EM_B
    event.
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_visibilitychange_callback_func*) -- A
         callback function. The function is called with the type of
@@ -2098,7 +2098,7 @@ em_touch_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -2116,12 +2116,12 @@ EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback(const char *target, void�
    touchstart, touchend, touchmove and touchcancel.
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_touch_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -2227,7 +2227,7 @@ em_gamepad_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -2243,10 +2243,10 @@ EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback(void *userData, E
    gamepadconnected and gamepaddisconnected.
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_gamepad_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -2354,7 +2354,7 @@ em_battery_callback_func
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -2370,10 +2370,10 @@ EMSCRIPTEN_RESULT emscripten_set_batterylevelchange_callback(void *userData, em
    events: "chargingchange" and "levelchange".
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_battery_callback_func*) -- A callback
         function. The function is called with the type of event,
@@ -2495,8 +2495,8 @@ EMSCRIPTEN_RESULT emscripten_set_beforeunload_callback(void *userData, em_befor
    really wants to leave the page).
 
    Parameters:
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
       * **callback** (*em_beforeunload_callback*) -- A callback
         function. The function is called with the type of event,
@@ -2631,7 +2631,7 @@ em_webgl_context_callback
 
    Returns:
       "true" (non zero) to indicate that the event was consumed by the
-      *callback handler*.
+      callback handler.
 
    Return type:
       "EM_BOOL"
@@ -2647,12 +2647,12 @@ EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback(const char *targ
    "webglcontextlost" and "webglcontextrestored".
 
    Parameters:
-      * **target** (*const char**) -- *Target HTML element id*.
+      * **target** (*const char**) -- Target HTML element id.
 
-      * **userData** (*void**) -- *User-defined data* to be passed
-        to the callback (opaque to the API).
+      * **userData** (*void**) -- User-defined data to be passed to
+        the callback (opaque to the API).
 
-      * **useCapture** (*EM_BOOL*) -- Set "true" to *use capture*.
+      * **useCapture** (*EM_BOOL*) -- Set "true" to use capture.
 
       * **callback** (*em_webgl_context_callback*) -- A callback
         function. The function is called with the type of event,

--- a/site/build/text/docs/api_reference/preamble.js.txt
+++ b/site/build/text/docs/api_reference/preamble.js.txt
@@ -8,7 +8,7 @@ functions, accessing memory, converting pointers to JavaScript
 "Strings" and "Strings" to pointers (with different
 encodings/formats), and other convenience functions.
 
-Note: All functions should be called though the *Module* object (for
+Note: All functions should be called though the Module object (for
   example: "Module.functionName"). At optimisation "-O2" (and higher)
   function names are minified by the closure compiler, and calling
   them directly will fail.
@@ -256,6 +256,33 @@ Pointer_stringify(ptr[, length])
    Return type:
       String
 
+UTF8ToString(ptr)
+
+   Given a pointer "ptr" to a null-terminated UTF8-encoded string in
+   the Emscripten HEAP, returns a copy of that string as a JavaScript
+   "String" object.
+
+   Arguments:
+      * **ptr** -- A pointer to a null-terminated UTF8-encoded
+        string in the Emscripten HEAP.
+
+   Returns:
+      A JavaScript "String" object
+
+stringToUTF8(str, outPtr[, maxBytesToWrite])
+
+   Copies the given JavaScript "String" object "str" to the Emscripten
+   HEAP at address "outPtr", null-terminated and encoded in UTF8 form.
+
+   Arguments:
+      * **str** (*String*) -- A JavaScript "String" object.
+
+      * **outPtr** -- Pointer to data copied from "str", encoded in
+        UTF8 format and null-terminated.
+
+      * **maxBytesToWrite** -- A limit on the number of bytes to
+        write out.
+
 UTF16ToString(ptr)
 
    Given a pointer "ptr" to a null-terminated UTF16LE-encoded string
@@ -269,7 +296,7 @@ UTF16ToString(ptr)
    Returns:
       A JavaScript "String" object
 
-stringToUTF16(str, outPtr)
+stringToUTF16(str, outPtr[, maxBytesToWrite])
 
    Copies the given JavaScript "String" object "str" to the Emscripten
    HEAP at address "outPtr", null-terminated and encoded in UTF16LE
@@ -284,6 +311,9 @@ stringToUTF16(str, outPtr)
       * **outPtr** -- Pointer to data copied from "str", encoded in
         UTF16LE format and null-terminated.
 
+      * **maxBytesToWrite** -- A limit on the number of bytes to
+        write out.
+
 UTF32ToString(ptr)
 
    Given a pointer "ptr" to a null-terminated UTF32LE-encoded string
@@ -297,7 +327,7 @@ UTF32ToString(ptr)
    Returns:
       A JavaScript "String" object.
 
-stringToUTF32(str, outPtr)
+stringToUTF32(str, outPtr[, maxBytesToWrite])
 
    Copies the given JavaScript "String" object "str" to the Emscripten
    HEAP at address "outPtr", null-terminated and encoded in UTF32LE
@@ -313,6 +343,9 @@ stringToUTF32(str, outPtr)
 
       * **outPtr** -- Pointer to data copied from "str", encoded in
         encoded in UTF32LE format and null-terminated.
+
+      * **maxBytesToWrite** -- A limit on the number of bytes to
+        write out.
 
 intArrayFromString(stringy, dontAddNull[, length])
 
@@ -442,7 +475,7 @@ stackTrace()
 Type accessors for the memory model
 ===================================
 
-The *Emscripten memory representation* uses a typed array buffer
+The Emscripten memory representation uses a typed array buffer
 ("ArrayBuffer") to represent memory, with different views into it
 giving access to the different types. The views for accessing
 different types of memory are listed below.

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -54,8 +54,8 @@ Options that are modified or new in *emcc* are listed below:
        see "apply_opt_level()" in tools/shared.py and also
        src/settings.js.
 
-     * To re-enable C++ exception catching, use *-s
-       DISABLE_EXCEPTION_CATCHING=0*.
+     * To re-enable C++ exception catching, use -s
+       DISABLE_EXCEPTION_CATCHING=0.
 
 "-O2"
    Like "-O1", but with various JavaScript-level optimizations and
@@ -85,8 +85,7 @@ Options that are modified or new in *emcc* are listed below:
      JavaScript- specific, so you can run "-Os" on your source files
      for example, and "-O3" during JavaScript generation if you want.
 
-   Note: For more tips on optimizing your code, see *Optimizing
-     Code*.
+   Note: For more tips on optimizing your code, see Optimizing Code.
 
 "-s OPTION=VALUE"
    JavaScript code generation option passed into the Emscripten
@@ -120,9 +119,9 @@ Options that are modified or new in *emcc* are listed below:
      *gcc* (it adds debug information to the object files).
 
    * When compiling from source to JavaScript or bitcode to
-     JavaScript, it is equivalent to *-g3* (discards LLVM debug info
+     JavaScript, it is equivalent to -g3 (discards LLVM debug info
      including C/C++ line numbers, but otherwise keeps as much debug
-     information as possible). Use *-g4* to get line number debugging
+     information as possible). Use -g4 to get line number debugging
      information in JavaScript.
 
 "-g<level>"
@@ -130,7 +129,7 @@ Options that are modified or new in *emcc* are listed below:
    bitcode to JavaScript. Each level builds on the previous level:
 
       * "-g0": Make no effort to keep code debuggable. Will discard
-        LLVM debug information (this is done by default in *-01* and
+        LLVM debug information (this is done by default in -01 and
         higher).
 
       * "-g1": Preserve whitespace (do not minify).
@@ -149,7 +148,7 @@ Options that are modified or new in *emcc* are listed below:
                       _printAnInteger(a + b | 0); // _printAnInteger is human readable.
               }
 
-      * "-g3": Preserve variable names (this is the same as *-g*).
+      * "-g3": Preserve variable names (this is the same as -g).
 
               function _addAndPrint($left, $right) {
                       $left = $left | 0;
@@ -169,9 +168,9 @@ Options that are modified or new in *emcc* are listed below:
 
            Note: * This debugging level may make compilation at
 
-               optimization level *-O1* and above significantly
-               slower, because JavaScript optimization will be limited
-               to one core (the default in "-O0").
+               optimization level -O1 and above significantly slower,
+               because JavaScript optimization will be limited to one
+               core (the default in "-O0").
 
              * Source maps allow you to view and debug the *C/C++
                source code* in your browser's debugger! This works in
@@ -191,7 +190,7 @@ Options that are modified or new in *emcc* are listed below:
    names, but do *not* intend to read the emitted code.
 
 "--tracing"
-   Enable the *Emscripten Tracing API*.
+   Enable the Emscripten Tracing API.
 
 "--emit-symbol-map"
    Save a map file between the minified global names and the original
@@ -305,12 +304,12 @@ Options that are modified or new in *emcc* are listed below:
    then "dir/file.dat" must exist relative to the directory where you
    run *emcc*.
 
-   Note: Embedding files is much less efficient than *preloading*
+   Note: Embedding files is much less efficient than preloading
      them. You should only use it for small files, in small numbers.
      Instead use "--preload-file", which emits efficient binary data.
 
    For more information about the "--embed-file" options, see
-   *Packaging Files*.
+   Packaging Files.
 
 "--preload-file <name>"
    Specify a file to preload before running the compiled code
@@ -322,23 +321,22 @@ Options that are modified or new in *emcc* are listed below:
    **filename.html** is the main file you are compiling to. To run
    your code, you will need both the **.html** and the **.data**.
 
-   Note: This option is similar to *--embed-file*, except that it is
+   Note: This option is similar to --embed-file, except that it is
      only relevant when generating HTML (it uses asynchronous binary
      *XHRs*), or JavaScript that will be used in a web page.
 
    *emcc* runs tools/file_packager.py to do the actual packaging of
    embedded and preloaded files. You can run the file packager
-   yourself if you want (see *Packaging using the file packager
-   tool*). You should then put the output of the file packager in an
-   emcc "--pre-js", so that it executes before your main compiled
-   code.
+   yourself if you want (see Packaging using the file packager tool).
+   You should then put the output of the file packager in an emcc "--
+   pre-js", so that it executes before your main compiled code.
 
    For more information about the "--preload-file" options, see
-   *Packaging Files*.
+   Packaging Files.
 
 "--exclude-file <name>"
-   Files and directories to be excluded from *--embed-file* and
-   *--preload-file*. Wildcards (*) are supported.
+   Files and directories to be excluded from --embed-file and
+   --preload-file. Wildcards (*) are supported.
 
 "--shell-file <path>"
    The path name to a skeleton HTML file used when generating HTML
@@ -351,28 +349,6 @@ Options that are modified or new in *emcc* are listed below:
 
      * This argument is ignored if a target other than HTML is
        specified using the "-o" option.
-
-"--compression <codec>"
-   Compress both the compiled code and embedded/ preloaded files.
-
-   Warning: This option is deprecated.
-
-   "<codec>" should be a triple:
-   "<native_encoder>,<js_decoder>,<js_name>", where:
-
-      * "native_encoder" is a native executable that compresses
-        "stdin" to "stdout" (the simplest possible interface).
-
-      * "js_decoder" is a JavaScript file that implements a decoder.
-
-      * "js_name" is the name of the function to call in the decoder
-        file (which should receive an array/typed array and return an
-        array/typed array.
-
-   Compression only works when generating HTML. When compression is
-   on, all files specified to be preloaded are compressed in one big
-   archive, which is given the same name as the output HTML but with
-   suffix **.data.compress**.
 
 "--minify 0"
    Identical to "-g1".
@@ -392,8 +368,8 @@ Options that are modified or new in *emcc* are listed below:
    script to be run.
 
 "--bind"
-   Compiles the source code using the *Embind* bindings to connect
-   C/C++ and JavaScript.
+   Compiles the source code using the Embind bindings to connect C/C++
+   and JavaScript.
 
 "--ignore-dynamic-linking"
    Tells the compiler to ignore dynamic linking (the user will need to
@@ -478,9 +454,9 @@ Options that are modified or new in *emcc* are listed below:
         and applied; you cannot call any C functions until it arrives.
         This is the default setting when compiling with -O2 or higher.
 
-           Note: The *safest way* to ensure that it is safe to call
-             C functions (the initialisation file has loaded) is to
-             call a notifier function from "main()".
+           Note: The safest way to ensure that it is safe to call C
+             functions (the initialisation file has loaded) is to call
+             a notifier function from "main()".
 
            Note: If you assign a network request to
              "Module.memoryInitializerRequest" (before the script
@@ -494,10 +470,11 @@ Options that are modified or new in *emcc* are listed below:
              all it must provide is a ".response" property containing
              an ArrayBuffer.)
 
-"-Wno-warn-absolute-paths"
-   Suppress warnings about the use of absolute paths in "-I" and "-L"
-   command line directives. This is used to hide the warnings and
-   acknowledge that the explicit use of absolute paths is intentional.
+"-Wwarn-absolute-paths"
+   Enables warnings about the use of absolute paths in "-I" and "-L"
+   command line directives. This is used to warn against unintentional
+   use of absolute paths, which is sometimes dangerous when referring
+   to nonportable local system headers.
 
 "--proxy-to-worker"
    Runs the main application code in a worker, proxying events to it
@@ -508,9 +485,17 @@ Options that are modified or new in *emcc* are listed below:
    suffix ".worker.js" will contain the worker portion.
 
 "--emrun"
-   Enables the generated output to be aware of the *emrun* command
-   line tool. This allows "stdout", "stderr" and "exit(returncode)"
-   capture when running the generated application through *emrun*.
+   Enables the generated output to be aware of the emrun command line
+   tool. This allows "stdout", "stderr" and "exit(returncode)" capture
+   when running the generated application through *emrun*.
+
+"--cpuprofiler"
+   Embeds a simple CPU profiler onto the generated page. Use this to
+   perform cursory interactive performance profiling.
+
+"--memoryprofiler"
+   Embeds a memory allocation tracker onto the generated page. Use
+   this to profile the application usage of the Emscripten HEAP.
 
 "--em-config"
    Specifies the location of the **.emscripten** configuration file
@@ -558,8 +543,8 @@ Options that are modified or new in *emcc* are listed below:
 "--separate-asm"
    Emits asm.js in one file, and the rest of the code in another, and
    emits HTML that loads the asm.js first, in order to reduce memory
-   load during startup. See *Avoid memory spikes by separating out
-   asm.js*.
+   load during startup. See Avoid memory spikes by separating out
+   asm.js.
 
 
 Environment variables

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -378,8 +378,8 @@ Options that are modified or new in *emcc* are listed below:
 			.. note:: If you assign a network request to ``Module.memoryInitializerRequest`` (before the script runs), then it will use that request instead of automatically starting a download for you. This is beneficial in that you can, in your HTML, fire off a request for the memory init file before the script actually arrives. For this to work, the network request should be an XMLHttpRequest with responseType set to ``'arraybuffer'``. (You can also put any other object here, all it must provide is a ``.response`` property containing an ArrayBuffer.) 
 
 	
-``-Wno-warn-absolute-paths``
-	Suppress warnings about the use of absolute paths in ``-I`` and ``-L`` command line directives. This is used to hide the warnings and acknowledge that the explicit use of absolute paths is intentional.
+``-Wwarn-absolute-paths``
+  Enables warnings about the use of absolute paths in ``-I`` and ``-L`` command line directives. This is used to warn against unintentional use of absolute paths, which is sometimes dangerous when referring to nonportable local system headers.
 	 
 ``--proxy-to-worker``
 	Runs the main application code in a worker, proxying events to it and output from it. If emitting HTML, this emits a **.html** file, and a separate **.js** file containing the JavaScript to be run in a worker. If emitting JavaScript, the target file name contains the part to be run on the main thread, while a second **.js** file with suffix ".worker.js" will contain the worker portion.

--- a/tests/lib_include_flags.c
+++ b/tests/lib_include_flags.c
@@ -1,0 +1,5 @@
+#include "test.h"
+
+int main(int argc, char** argv) {
+  return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5949,7 +5949,7 @@ return malloc(size);
     self.do_run_from_file(src, output)
 
   def test_gcc_unmangler(self):
-    Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('third_party'), '-Wno-warn-absolute-paths']
+    Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('third_party')]
 
     self.do_run(open(path_from_root('third_party', 'gcc_demangler.c')).read(), '*d_demangle(char const*, int, unsigned int*)*', args=['_ZL10d_demanglePKciPj'])
 
@@ -6124,8 +6124,7 @@ def process(filename):
 
     Building.COMPILER_TEST_OPTS += [
       '-I' + path_from_root('tests', 'freetype', 'include'),
-      '-I' + path_from_root('tests', 'poppler', 'include'),
-      '-Wno-warn-absolute-paths'
+      '-I' + path_from_root('tests', 'poppler', 'include')
     ]
 
     Settings.INVOKE_RUN = 0 # We append code that does run() ourselves
@@ -6385,7 +6384,7 @@ def process(filename):
       self.emcc_args = emcc_args
 
   def test_fuzz(self):
-    Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('tests', 'fuzz', 'include'), '-Wno-warn-absolute-paths', '-w']
+    Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('tests', 'fuzz', 'include'), '-w']
 
     def run_all(x):
       print x

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5332,3 +5332,7 @@ main(int argc, char **argv)
     assert "low = 5678" in out
     assert "high = 1234" in out
 
+  def test_lib_include_flags(self):
+    process = Popen([PYTHON, EMCC] + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')], stdout=PIPE, stderr=PIPE)
+    process.communicate()
+    assert process.returncode is 0, 'Empty -l/-L/-I flags should read the next arg as a param'

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -78,7 +78,7 @@ def get(ports, settings, shared):
         commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-DFT2_BUILD_LIBRARY', '-O2', '-o', o, '-I' + dest_path + '/include',
                          '-I' + dest_path + '/truetype', '-I' + dest_path + '/sfnt', '-I' + dest_path + '/autofit', '-I' + dest_path + '/smooth', 
                          '-I' + dest_path + '/raster', '-I' + dest_path + '/psaux', '-I' + dest_path + '/psnames', '-I' + dest_path + '/truetype', 
-                         '-Wno-warn-absolute-paths', '-w',])
+                         '-w',])
         o_s.append(o)
 
       ports.run_commands(commands)

--- a/tools/ports/sdl.py
+++ b/tools/ports/sdl.py
@@ -40,7 +40,7 @@ def get(ports, settings, shared):
       for src in srcs:
         o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
         shared.safe_ensure_dirs(os.path.dirname(o))
-        commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', 'SDL2-' + TAG, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-Wno-warn-absolute-paths', '-w'])
+        commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', 'SDL2-' + TAG, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w'])
         o_s.append(o)
       ports.run_commands(commands)
       final = os.path.join(ports.get_build_dir(), 'sdl2', 'libsdl2.bc')

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -33,8 +33,7 @@ def get(ports, settings, shared):
       for src in srcs:
         o = os.path.join(ports.get_build_dir(), 'zlib', src + '.o')
         shared.safe_ensure_dirs(os.path.dirname(o))
-        commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path,
-                         '-Wno-warn-absolute-paths', '-w',])
+        commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path,'-w',])
         o_s.append(o)
 
       ports.run_commands(commands)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -151,7 +151,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       'regex.cpp',
       'strstream.cpp'
     ]
-    return build_libcxx(os.path.join('system', 'lib', 'libcxx'), libname, libcxx_files, ['-Oz', '-Wno-warn-absolute-paths', '-I' + shared.path_from_root('system', 'lib', 'libcxxabi', 'include')], has_noexcept_version=True)
+    return build_libcxx(os.path.join('system', 'lib', 'libcxx'), libname, libcxx_files, ['-Oz', '-I' + shared.path_from_root('system', 'lib', 'libcxxabi', 'include')], has_noexcept_version=True)
 
   # libcxxabi - just for dynamic_cast for now
   def create_libcxxabi(libname):
@@ -170,7 +170,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       'private_typeinfo.cpp',
       os.path.join('..', '..', 'libcxx', 'new.cpp'),
     ]
-    return build_libcxx(os.path.join('system', 'lib', 'libcxxabi', 'src'), libname, libcxxabi_files, ['-Oz', '-Wno-warn-absolute-paths', '-I' + shared.path_from_root('system', 'lib', 'libcxxabi', 'include')])
+    return build_libcxx(os.path.join('system', 'lib', 'libcxxabi', 'src'), libname, libcxxabi_files, ['-Oz', '-I' + shared.path_from_root('system', 'lib', 'libcxxabi', 'include')])
 
   # gl
   def create_gl(libname): # libname is ignored, this is just one .o file
@@ -352,7 +352,7 @@ class Ports:
       objects = []
       for src in srcs:
         obj = src + '.o'
-        commands.append([shared.PYTHON, shared.EMCC, src, '-O2', '-o', obj, '-Wno-warn-absolute-paths', '-w'] + include_commands + flags)
+        commands.append([shared.PYTHON, shared.EMCC, src, '-O2', '-o', obj, '-w'] + include_commands + flags)
         objects.append(obj)
 
       run_commands(commands)


### PR DESCRIPTION
Fixes #3777 and #2713.  This includes changes to the documentation (and a rebuild of the docs) to reflect #2713.  Let me know if anything is out of place – it may be easier to read the first four commits without the clutter aa3c1b7 throws in in the PR diff.

This fails two tests in `other`; however, these both fail on incoming and master for me as well, so I believe something is wrong with my development environment rather than the PR.  Do you recognize these errors?  I'm running relatively fresh Linux Mint 17.2 with the latest packages.

```
======================================================================
ERROR: test_crunch (test_other.other)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pimlu/Documents/emscripten/tests/test_other.py", line 2131, in test_crunch
    assert os.stat('test.data').st_size < 0.25*os.stat('ship.dds').st_size, 'Compressed should be much smaller than dds'
OSError: [Errno 2] No such file or directory: 'test.data'

======================================================================
FAIL: test_llvm_lit (test_other.other)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pimlu/Documents/emscripten/tests/test_other.py", line 2764, in test_llvm_lit
    assert p.returncode == 0, 'LLVM tests must pass with exit code 0'
AssertionError: LLVM tests must pass with exit code 0

----------------------------------------------------------------------
Ran 172 tests in 1910.554s

FAILED (failures=1, errors=1)
```