### PR TITLE
Treat js-libraries as libraries in cmake

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -186,18 +186,11 @@ set(link_js_counter 1)
 
 # Internal function: Do not call from user CMakeLists.txt files. Use one of em_link_js_library()/em_link_pre_js()/em_link_post_js() instead.
 function(em_add_tracked_link_flag target flagname)
-	get_target_property(props ${target} LINK_FLAGS)
-	if(NOT props)
-	    set(props "")
-	endif()
 
 	# User can input list of JS files either as a single list, or as variable arguments to this function, so iterate over varargs, and treat each
 	# item in varargs as a list itself, to support both syntax forms.
 	foreach(jsFileList ${ARGN})
 		foreach(jsfile ${jsFileList})
-			# Add link command to the given JS file.
-			set(props "${props} ${flagname} \"${jsfile}\"")
-			
 			# If the user edits the JS file, we want to relink the emscripten application, but unfortunately it is not possible to make a link step
 			# depend directly on a source file. Instead, we must make a dummy no-op build target on that source file, and make the project depend on
 			# that target.
@@ -215,10 +208,16 @@ function(em_add_tracked_link_flag target flagname)
 			add_custom_command(OUTPUT ${dummy_c_name} COMMAND ${CMAKE_COMMAND} -E touch ${dummy_c_name} DEPENDS ${jsfile})
 			target_link_libraries(${target} ${dummy_lib_name})
 
+			# Link the js-library to the target
+			# When a linked library starts with a "-" cmake will just add it to the linker command line as it is.
+			# The advantage of doing it this way is that the js-library will also be automatically linked to targets
+			# that depend on this target.
+			get_filename_component(js_file_absolute_path "${jsfile}" ABSOLUTE )
+			target_link_libraries(${target} "${flagname} \"${js_file_absolute_path}\"")
+
 			math(EXPR link_js_counter "${link_js_counter} + 1")
 		endforeach()
 	endforeach()
-	set_target_properties(${target} PROPERTIES LINK_FLAGS "${props}")
 endfunction()
 
 # This function links a (list of ) .js library file(s) to the given CMake project.

--- a/tests/cmake/cpp_lib/CMakeLists.txt
+++ b/tests/cmake/cpp_lib/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(cpp_library)
+
+SET(CPP_LIBRARY_TYPE "SHARED" CACHE STRING "Library type to build")
+SET_PROPERTY(CACHE CPP_LIBRARY_TYPE PROPERTY STRINGS STATIC SHARED)
+
+add_library( cpp_lib ${CPP_LIBRARY_TYPE} lib.cpp)
+em_link_js_library(cpp_lib "lib.js")

--- a/tests/cmake/cpp_lib/lib.cpp
+++ b/tests/cmake/cpp_lib/lib.cpp
@@ -1,0 +1,8 @@
+extern "C" {
+  int js_library_function();
+}
+
+int cpp_library_function()
+{
+	return js_library_function();
+}

--- a/tests/cmake/cpp_lib/lib.js
+++ b/tests/cmake/cpp_lib/lib.js
@@ -1,0 +1,6 @@
+mergeInto(LibraryManager.library, {
+		js_library_function: function() {
+			return 0;
+		}
+}
+);

--- a/tests/cmake/target_html/CMakeLists.txt
+++ b/tests/cmake/target_html/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(hello_world_gles)
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp_lib ${CMAKE_CURRENT_BINARY_DIR}/cpp_lib)
+
 file(GLOB sourceFiles ../../hello_world_gles.c)
 
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
@@ -84,6 +86,7 @@ if (NOT HAVE_MATH_H)
 endif()
 
 add_executable(hello_world_gles ${sourceFiles})
+target_link_libraries(hello_world_gles cpp_lib)
 set_target_properties(hello_world_gles PROPERTIES LINK_FLAGS "${linkFlags}")
 
 # Validating asm.js requires SpiderMonkey JS VM - detect its presence via the SPIDERMONKEY environment variable.

--- a/tests/cmake/target_js/CMakeLists.txt
+++ b/tests/cmake/target_js/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(test_cmake)
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp_lib ${CMAKE_CURRENT_BINARY_DIR}/cpp_lib)
+
 file(GLOB sourceFiles main.cpp)
 
 file(GLOB preJsFiles pre*.js)
@@ -83,6 +85,7 @@ if(${CMAKE_VERSION} VERSION_GREATER 3.2.20150502)
 endif()
 
 add_executable(test_cmake ${sourceFiles})
+target_link_libraries( test_cmake cpp_lib)
 
 # GOTCHA: If your project has custom link flags, these must be set *before* calling any of the em_link_xxx functions!
 set_target_properties(test_cmake PROPERTIES LINK_FLAGS "${linkFlags}")

--- a/tests/cmake/target_js/main.cpp
+++ b/tests/cmake/target_js/main.cpp
@@ -3,8 +3,11 @@ extern "C" {
   void lib_function2();
 }
 
+int cpp_library_function();
+
 int main()
 {
   lib_function();
   lib_function2();
+  cpp_library_function();
 }

--- a/tests/cmake/target_library/CMakeLists.txt
+++ b/tests/cmake/target_library/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(test_cmake)
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp_lib ${CMAKE_CURRENT_BINARY_DIR}/cpp_lib)
+
 option(BUILD_SHARED_LIBS "Build with shared libraries." OFF) 
 
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
@@ -22,6 +24,7 @@ foreach(i RANGE ${MAX_SRC_FILE_INDEX})
 endforeach()
 
 add_library(test_cmake ${TEST_SOURCES})
+target_link_libraries(test_cmake cpp_lib)
 
 if (WIN32)
 	message(FATAL_ERROR "WIN32 should not be defined when cross-compiling!")

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -415,65 +415,66 @@ f.close()
           # CMake can be invoked in two ways, using 'emconfigure cmake', or by directly running 'cmake'.
           # Test both methods.
           for invoke_method in ['cmake', 'emconfigure']:
-
-            # Create a temp workspace folder
-            cmakelistsdir = path_from_root('tests', 'cmake', cmake_cases[i])
-            tempdirname = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=TEMP_DIR)
-            try:
-              os.chdir(tempdirname)
-
-              # Run Cmake
-              if invoke_method == 'cmake':
-                # Test invoking cmake directly.
-                cmd = ['cmake', '-DCMAKE_TOOLCHAIN_FILE='+path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'),
-                                '-DCMAKE_CROSSCOMPILING_EMULATOR="' + ' '.join(NODE_JS) + '"',
-                                '-DCMAKE_BUILD_TYPE=' + configuration, cmake_arguments[i], '-G', generator, cmakelistsdir]
-                env = tools.shared.Building.remove_sh_exe_from_path(os.environ)
-              else:
-                # Test invoking via 'emconfigure cmake'
-                cmd = [emconfigure, 'cmake', '-DCMAKE_BUILD_TYPE=' + configuration, cmake_arguments[i], '-G', generator, cmakelistsdir]
-                env = os.environ.copy()
-
-              print str(cmd)
-              ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else PIPE, env=env).communicate()
-              if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
-                logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
-              if len(ret) > 1 and ret[1] != None and 'error' in ret[1].lower():
-                logging.error('Failed command: ' + ' '.join(cmd))
-                logging.error('Result:\n' + ret[1])
-                raise Exception('cmake call failed!')
-
-              if prebuild:
-                prebuild(configuration, tempdirname)
-
-              # Build
-              cmd = make
-              if EM_BUILD_VERBOSE_LEVEL >= 3 and 'Ninja' not in generator:
-                cmd += ['VERBOSE=1']
-              ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE).communicate()
-              if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
-                logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
-              if len(ret) > 0 and ret[0] != None and 'error' in ret[0].lower() and not '0 error(s)' in ret[0].lower():
-                logging.error('Failed command: ' + ' '.join(cmd))
-                logging.error('Result:\n' + ret[0])
-                raise Exception('make failed!')
-              assert os.path.exists(tempdirname + '/' + cmake_outputs[i]), 'Building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + cmake_outputs[i]
-
-              if postbuild:
-                postbuild(configuration, tempdirname)
-
-              # Run through node, if CMake produced a .js file.
-              if cmake_outputs[i].endswith('.js'):
-                ret = Popen(NODE_JS + [tempdirname + '/' + cmake_outputs[i]], stdout=PIPE).communicate()[0]
-                self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt', 'r').read().strip(), ret.strip())
-            finally:
-              os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
-              #there is a race condition under windows here causing an exception in shutil.rmtree because the directory is not empty yet
+            for cpp_lib_type in ['STATIC', 'SHARED']:
+              # Create a temp workspace folder
+              cmakelistsdir = path_from_root('tests', 'cmake', cmake_cases[i])
+              tempdirname = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=TEMP_DIR)
               try:
-                shutil.rmtree(tempdirname)
-              except:
-                time.sleep(0.1)
-                shutil.rmtree(tempdirname)
+                os.chdir(tempdirname)
+
+                # Run Cmake
+                if invoke_method == 'cmake':
+                  # Test invoking cmake directly.
+                  cmd = ['cmake', '-DCMAKE_TOOLCHAIN_FILE='+path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'),
+                                  '-DCPP_LIBRARY_TYPE='+cpp_lib_type,
+                                  '-DCMAKE_CROSSCOMPILING_EMULATOR="' + ' '.join(NODE_JS) + '"',
+                                  '-DCMAKE_BUILD_TYPE=' + configuration, cmake_arguments[i], '-G', generator, cmakelistsdir]
+                  env = tools.shared.Building.remove_sh_exe_from_path(os.environ)
+                else:
+                  # Test invoking via 'emconfigure cmake'
+                  cmd = [emconfigure, 'cmake', '-DCMAKE_BUILD_TYPE=' + configuration, cmake_arguments[i], '-G', generator, cmakelistsdir]
+                  env = os.environ.copy()
+
+                print str(cmd)
+                ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else PIPE, env=env).communicate()
+                if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
+                  logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
+                if len(ret) > 1 and ret[1] != None and 'error' in ret[1].lower():
+                  logging.error('Failed command: ' + ' '.join(cmd))
+                  logging.error('Result:\n' + ret[1])
+                  raise Exception('cmake call failed!')
+
+                if prebuild:
+                  prebuild(configuration, tempdirname)
+
+                # Build
+                cmd = make
+                if EM_BUILD_VERBOSE_LEVEL >= 3 and 'Ninja' not in generator:
+                  cmd += ['VERBOSE=1']
+                ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE).communicate()
+                if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
+                  logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
+                if len(ret) > 0 and ret[0] != None and 'error' in ret[0].lower() and not '0 error(s)' in ret[0].lower():
+                  logging.error('Failed command: ' + ' '.join(cmd))
+                  logging.error('Result:\n' + ret[0])
+                  raise Exception('make failed!')
+                assert os.path.exists(tempdirname + '/' + cmake_outputs[i]), 'Building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + cmake_outputs[i]
+
+                if postbuild:
+                  postbuild(configuration, tempdirname)
+
+                # Run through node, if CMake produced a .js file.
+                if cmake_outputs[i].endswith('.js'):
+                  ret = Popen(NODE_JS + [tempdirname + '/' + cmake_outputs[i]], stdout=PIPE).communicate()[0]
+                  self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt', 'r').read().strip(), ret.strip())
+              finally:
+                os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
+                #there is a race condition under windows here causing an exception in shutil.rmtree because the directory is not empty yet
+                try:
+                  shutil.rmtree(tempdirname)
+                except:
+                  time.sleep(0.1)
+                  shutil.rmtree(tempdirname)
 
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:


### PR DESCRIPTION
For C++ stuff cmake tracks the link dependencies of libraries and automatically adds them to targets that use a library. This change will treat js-libraries the same way as native libraries to make the cmake link dependency tracking work. 

Example CMakeLists.txt
add_library( foo STATIC "foo.cpp")
em_link_js_library( foo "foo.js")
add_executable(bar "bar.cpp")
target_link_libraries(bar foo) #this will automatically add "--js-library foo.js" now

The change relies on the special behavior of target_link_libraries:
"Item names starting with '-', but not '-l' or '-framework', are treated as linker flags."
https://cmake.org/cmake/help/v2.8.12/cmake.html#command:target_link_libraries

So this should work for all the special linker flags as the start with "--"

It ran the cmake tests under windows and it seemed to work fine.