### PR TITLE
Fix race condition under windows for cmake tests

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -468,7 +468,12 @@ f.close()
                 self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt', 'r').read().strip(), ret.strip())
             finally:
               os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
-              shutil.rmtree(tempdirname)
+              #there is a race condition under windows here causing an exception in shutil.rmtree because the directory is not empty yet
+              try:
+                shutil.rmtree(tempdirname)
+              except:
+                time.sleep(0.1)
+                shutil.rmtree(tempdirname)
 
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:


### PR DESCRIPTION
When running the cmake tests under windows I noticed that they sometimes fail because they cannot remove a temp folder. The exception states that it is not empty. But when looking at the folder it seemed to be empty. I think this is a windows issue. I found some threads regarding similar issues:
https://mail.python.org/pipermail/python-dev/2013-September/128345.html

So I added this workaround.