### PR TITLE
get_clang_native_env

### DIFF
--- a/tests/benchmark_sse1.py
+++ b/tests/benchmark_sse1.py
@@ -25,7 +25,7 @@ if WINDOWS: out_file += '.exe'
 cmd = [CLANG_CPP] + get_clang_native_args() + [path_from_root('tests', 'benchmark_sse1.cpp'), '-O3', '-o', out_file]
 print 'Building native version of the benchmark:'
 print ' '.join(cmd)
-build = Popen(cmd)
+build = Popen(cmd, env=get_clang_native_env())
 out = build.communicate()
 if build.returncode != 0:
     sys.exit(1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5745,7 +5745,7 @@ return malloc(size);
   # Tests the full SSE1 API.
   @SIMD
   def test_sse1_full(self):
-    Popen([CLANG, path_from_root('tests', 'test_sse1_full.cpp'), '-o', 'test_sse1_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + get_clang_native_args(), stdout=PIPE).communicate()
+    Popen([CLANG, path_from_root('tests', 'test_sse1_full.cpp'), '-o', 'test_sse1_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
     native_result, err = Popen('./test_sse1_full', stdout=PIPE).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
@@ -5764,7 +5764,7 @@ return malloc(size);
 
     args = []
     if '-O0' in self.emcc_args: args += ['-D_DEBUG=1']
-    Popen([CLANG, path_from_root('tests', 'test_sse2_full.cpp'), '-o', 'test_sse2_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + args + get_clang_native_args(), stdout=PIPE).communicate()
+    Popen([CLANG, path_from_root('tests', 'test_sse2_full.cpp'), '-o', 'test_sse2_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + args + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
     native_result, err = Popen('./test_sse2_full', stdout=PIPE).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2793,7 +2793,7 @@ int main()
     assert 'asm.js' in output, 'spidermonkey should mention asm.js compilation: ' + output
 
   def test_bad_triple(self):
-    Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), stdout=PIPE, stderr=PIPE).communicate()
+    Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
     out, err = Popen([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
     assert 'warning' in err or 'WARNING' in err, err
     assert 'incorrect target triple' in err or 'different target triples' in err, err

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -44,7 +44,7 @@ class WebsockifyServerHarness:
     # NOTE empty filename support is a hack to support
     # the current test_enet
     if self.filename:
-      Popen([CLANG_CC, path_from_root('tests', self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + get_clang_native_args() + self.args).communicate()
+      Popen([CLANG_CC, path_from_root('tests', self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + get_clang_native_args() + self.args, env=get_clang_native_env()).communicate()
       process = Popen([os.path.abspath('server')])
       self.processes.append(process)
 


### PR DESCRIPTION
Add new function get_clang_native_env() which finds the required Visual Studio environment for Clang to locate the Visual Studio linker when building a native Windows executable. This fixes running `test_sse1_full` and `test_sse2_full` without needing to manually open up Visual Studio Command Prompt to run those tests. Add get_clang_native_env() and get_clang_native_args() to always be present in pairs to be idiomatic, even though the other locations don't strictly need it (since just building .bc and not linking).

@kripken: btw, how does one run the `test_sse1_full` from command line after the addition of the python decorators? `python tests/runner.py test_sse1_full` no longer works.