### PR TITLE
fix_string_meminit_windows

### DIFF
--- a/tools/eliminator/node_modules/uglify-js/lib/process.js
+++ b/tools/eliminator/node_modules/uglify-js/lib/process.js
@@ -1365,7 +1365,8 @@ function make_string(str, ascii_only) {
 };
 
 function to_ascii(str) {
-        return str.replace(/[\u0080-\uffff]/g, function(ch) {
+        // Escape the ^Z (= 0x1a = substitute) ASCII character and all characters higher than 7-bit ASCII.
+        return str.replace(/[\u001a\u0080-\uffff]/g, function(ch) {
                 var code = ch.charCodeAt(0).toString(16);
                 while (code.length < 4) code = "0" + code;
                 return "\\u" + code;

--- a/tools/eliminator/node_modules/uglify-js/lib/process.js
+++ b/tools/eliminator/node_modules/uglify-js/lib/process.js
@@ -1365,7 +1365,8 @@ function make_string(str, ascii_only) {
 };
 
 function to_ascii(str) {
-        // Escape the ^Z (= 0x1a = substitute) ASCII character and all characters higher than 7-bit ASCII.
+        // XXX Emscripten: escape the ^Z (= 0x1a = substitute) ASCII character in addition to the extended ASCII characters,
+        // since otherwise opening the generated file on Windows in ASCII mode gives trouble.
         return str.replace(/[\u001a\u0080-\uffff]/g, function(ch) {
                 var code = ch.charCodeAt(0).toString(16);
                 while (code.length < 4) code = "0" + code;

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -24,16 +24,30 @@ def check_line_endings(filename, print_errors=True):
 
   has_dos_line_endings = False
   has_unix_line_endings = False
+  dos_line_ending_example = ''
+  dos_line_ending_count = 0
+  unix_line_ending_example = ''
+  unix_line_ending_count = 0
   if '\r\n' in data:
+    dos_line_ending_example = data[max(0, data.find('\r\n') - 50):min(len(data), data.find('\r\n')+50)].replace('\r', '\\r').replace('\n', '\\n')
+    dos_line_ending_count = data.count('\r\n')
     has_dos_line_endings = True
     data = data.replace('\r\n', 'A') # Replace all DOS line endings with some other character, and continue testing what's left.
   if '\n' in data:
+    unix_line_ending_example = data[max(0, data.find('\n') - 50):min(len(data), data.find('\n')+50)].replace('\r', '\\r').replace('\n', '\\n')
+    unix_line_ending_count = data.count('\n')
     has_unix_line_endings = True
   if '\r' in data:
-    if print_errors: print >> sys.stderr, 'File \'' + filename + '\' contains OLD OSX line endings "\\r"'
+    old_osx_line_ending_example = data[max(0, data.find('\r') - 50):min(len(data), data.find('\r')+50)].replace('\r', '\\r').replace('\n', '\\n')
+    if print_errors:
+      print >> sys.stderr, 'File \'' + filename + '\' contains OLD OSX line endings "\\r"'
+      print >> sys.stderr, "Content around an OLD OSX line ending location: '" + old_osx_line_ending_example + "'"
     return 1 # Return a non-zero process exit code since we don't want to use the old OSX (9.x) line endings anywhere.
   if has_dos_line_endings and has_unix_line_endings:
-    if print_errors: print >> sys.stderr, 'File \'' + filename + '\' contains both DOS "\\r\\n" and UNIX "\\n" line endings!'
+    if print_errors:
+      print >> sys.stderr, 'File \'' + filename + '\' contains both DOS "\\r\\n" and UNIX "\\n" line endings! (' + str(dos_line_ending_count) + ' DOS line endings, ' + str(unix_line_ending_count) + ' UNIX line endings)'
+      print >> sys.stderr, "Content around a DOS line ending location: '" + dos_line_ending_example + "'"
+      print >> sys.stderr, "Content around an UNIX line ending location: '" + unix_line_ending_example + "'"
     return 1 # Mixed line endings
   else: return 0
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1938,8 +1938,9 @@ class JS:
     s = ''.join(map(chr, s))
     s = s.replace('\\', '\\\\').replace("'", "\\'")
     s = s.replace('\n', '\\n').replace('\r', '\\r')
+    # Escape the ^Z (= 0x1a = substitute) ASCII character and all characters higher than 7-bit ASCII.
     def escape(x): return '\\x{:02x}'.format(ord(x.group()))
-    return re.sub('[\x80-\xff]', escape, s)
+    return re.sub('[\x1a\x80-\xff]', escape, s)
 
 def execute(cmd, *args, **kw):
   try:


### PR DESCRIPTION
Fix memory string initializer to generate format that is safe for text files. Perform Emscripten optimizer cleanup pass in binary file read and write mode to not get confused by the special characters in the string initializer. Skip closure compiler when memory string initializer is used on Windows, since closure trips over when presented with such input. Related to #3326. cc @gagern .