### PR TITLE
Work around Chrome memory leak/crash by disabling IndexedDB

### DIFF
--- a/tests/fs/test_idbfs_sync.c
+++ b/tests/fs/test_idbfs_sync.c
@@ -115,6 +115,17 @@ void test() {
 
 #endif
 
+#if EXTRA_WORK
+  EM_ASM(
+    for (var i = 0; i < 100; i++) {
+      FS.syncfs(function (err) {
+        assert(!err);
+        console.log('extra work');
+      });
+    }
+  );
+#endif
+
   // sync from memory state to persisted and then
   // run 'success'
   EM_ASM(

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -900,9 +900,10 @@ keydown(100);keyup(100); // trigger the end
 
   def test_fs_idbfs_sync(self):
     for mode in [[], ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1']]:
-      secret = str(time.time())
-      self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DFIRST', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
-      self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
+      for extra in [[], ['-DEXTRA_WORK']]:
+        secret = str(time.time())
+        self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DFIRST', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
+        self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''] + extra)
 
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -566,6 +566,10 @@ if has_preloaded:
   if use_preload_cache:
     code += r'''
       var indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
+      if (navigator.userAgent.indexOf('Chrome') >= 0) { // XXX
+        console.log('not using IndexedDB caching in Chrome due to a severe memory leak in that browser https://code.google.com/p/chromium/issues/detail?id=533648');
+        indexedDB = null;
+      }
       var IDB_RO = "readonly";
       var IDB_RW = "readwrite";
       var DB_NAME = 'EM_PRELOAD_CACHE';


### PR DESCRIPTION
Background: https://code.google.com/p/chromium/issues/detail?id=533648

This is a very severe memory leak, causing some Unity games to crash all of Chrome (not just a tab, but the whole browser). Testing locally, it looks like it is an IndexedDB bug in that browser, and disabling IndexedDB caching works around it. This patch does so, just in Chrome, so that other browsers are not negatively affected.

However, to just apply the workaround in Chrome, it checks the user agent, which is horrible of course. But I don't see a better solution here:

 * The bug is very severe, as mentioned before, games literally bring down the entire browser in a matter of seconds by runaway memory usage. On some systems this leads to thrashing memory to swap before the crash, during which the entire system is unresponsive.
 * The bug affects Chrome from stable to canary.
 * The bug was filed a month ago, but so far there is little progress on it.
 * Disabling IndexedDB in all browsers would avoid checking the user agent, but means duplicate downloads in some cases of quite large files, e.g., in the testcase in the linked bug, the data file is 80MB.

Given those, I think checking the user agent is the least of all evils. Thoughts?
