### PR TITLE
Move to legalization in the JS backend (emscripten)

### DIFF
--- a/emcc
+++ b/emcc
@@ -870,8 +870,6 @@ try:
   # Set ASM_JS default here so that we can override it from the command line.
   shared.Settings.ASM_JS = 1 if opt_level > 0 else 2
 
-  pre_fastcomp_opts = []
-
   # Apply -s settings in newargs here (after optimization levels, so they can override them)
   for change in settings_changes:
     key, value = change.split('=')
@@ -901,20 +899,6 @@ try:
   except Exception, e:
     logging.error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
     raise e
-
-  fastcomp_opts = []
-  if shared.Settings.NO_EXIT_RUNTIME:
-    pre_fastcomp_opts += ['-emscripten-no-exit-runtime']
-    if not llvm_lto: fastcomp_opts += ['-globalopt', '-globaldce']
-  fastcomp_opts += ['-pnacl-abi-simplify-preopt', '-pnacl-abi-simplify-postopt']
-  if shared.Settings.DISABLE_EXCEPTION_CATCHING != 1:
-    fastcomp_opts += ['-enable-emscripten-cxx-exceptions']
-    if shared.Settings.DISABLE_EXCEPTION_CATCHING == 2:
-      fastcomp_opts += ['-emscripten-cxx-exceptions-whitelist=' + ','.join(shared.Settings.EXCEPTION_CATCHING_WHITELIST or ['fake'])]
-  if shared.Settings.ASYNCIFY:
-    fastcomp_opts += ['-emscripten-asyncify']
-    fastcomp_opts += ['-emscripten-asyncify-functions=' + ','.join(shared.Settings.ASYNCIFY_FUNCTIONS)]
-    fastcomp_opts += ['-emscripten-asyncify-whitelist=' + ','.join(shared.Settings.ASYNCIFY_WHITELIST)]
 
   assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
 
@@ -1278,7 +1262,7 @@ try:
     if not shared.Settings.ASSERTIONS:
       link_opts += ['-disable-verify']
 
-    if llvm_lto >= 2:
+    if llvm_lto >= 2 and llvm_opts > 0:
       logging.debug('running LLVM opts as pre-LTO')
       final = shared.Building.llvm_opt(final, llvm_opts, DEFAULT_FINAL)
       if DEBUG: save_intermediate('opt', 'bc')
@@ -1289,9 +1273,8 @@ try:
       # add a manual internalize with the proper things we need to be kept alive during lto
       link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
       # execute it now, so it is done entirely before we get to the stage of legalization etc.
-      final = shared.Building.llvm_opt(final, pre_fastcomp_opts + link_opts, DEFAULT_FINAL)
+      final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
       if DEBUG: save_intermediate('lto', 'bc')
-      pre_fastcomp_opts = []
       link_opts = []
     else:
       # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
@@ -1303,15 +1286,11 @@ try:
       final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
       if DEBUG: save_intermediate('linktime', 'll')
     else:
-      if not save_bc:
-        # Simplify LLVM bitcode for fastcomp
-        link_opts = pre_fastcomp_opts + link_opts + fastcomp_opts
-      final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-      if DEBUG: save_intermediate('linktime', 'bc')
+      if len(link_opts) > 0:
+        final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+        if DEBUG: save_intermediate('linktime', 'bc')
       if save_bc:
         shutil.copyfile(final, save_bc)
-        final = shared.Building.llvm_opt(final, fastcomp_opts, get_final() + '.adsimp.bc')
-        if DEBUG: save_intermediate('adsimp', 'bc')
 
   # Prepare .ll for Emscripten
   if LEAVE_INPUTS_RAW:
@@ -1324,11 +1303,6 @@ try:
     execute([shared.PYTHON, shared.AUTODEBUGGER, final, next])
     final = next
     if DEBUG: save_intermediate('autodebug', 'll')
-
-  # Simplify bitcode after autodebug
-  if AUTODEBUG or LEAVE_INPUTS_RAW:
-    final = shared.Building.llvm_opt(final, fastcomp_opts, get_final() + '.adsimp.bc')
-    if DEBUG: save_intermediate('adsimp', 'bc')
 
   assert type(final) == str, 'we must have linked the final files, if linking was deferred, by this point'
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -83,6 +83,17 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
     elif settings['GLOBAL_BASE'] >= 0:
       backend_args += ['-emscripten-global-base=%d' % settings['GLOBAL_BASE']]
     backend_args += ['-O' + str(settings['OPT_LEVEL'])]
+    if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
+      backend_args += ['-enable-emscripten-cxx-exceptions']
+      if settings['DISABLE_EXCEPTION_CATCHING'] == 2:
+        backend_args += ['-emscripten-cxx-exceptions-whitelist=' + ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['fake'])]
+    if settings['ASYNCIFY']:
+      backend_args += ['-emscripten-asyncify']
+      backend_args += ['-emscripten-asyncify-functions=' + ','.join(settings['ASYNCIFY_FUNCTIONS'])]
+      backend_args += ['-emscripten-asyncify-whitelist=' + ','.join(settings['ASYNCIFY_WHITELIST'])]
+    if settings['NO_EXIT_RUNTIME']:
+      backend_args += ['-emscripten-no-exit-runtime']
+
     if DEBUG:
       logging.debug('emscript: llvm backend: ' + ' '.join(backend_args))
       t = time.time()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1472,6 +1472,7 @@ class Building:
       assert out, 'must provide out if llvm_opt on a list of inputs'
     if type(opts) is int:
       opts = Building.pick_llvm_opts(opts)
+    assert len(opts) > 0, 'should not call opt with nothing to do'
     opts = opts[:]
     #opts += ['-debug-pass=Arguments']
     if get_clang_version() >= '3.4':


### PR DESCRIPTION
This is part of 3 pulls that move us to performing legalization in the backend. This moves the PNaCl passes from `lib/Transform` to the backend dir.

Benefits:

1. Smaller/more focused diff against upstream LLVM, as more of our different code is in our target dir.
2. Simpler compilation process. Instead of telling `opt` to legalize, we just call the backend and it does it all for us.
3. Puts us within striking distance of doing everything in the backend, i.e., avoiding any call to `opt` beforehand. This should give a significant speedup to compile times.

Downsides:

1. Apparently doing the PNaCl passes in the backend leads to different results in some cases. This seems like an LLVM oddity - you would think that save/load of an LLVM module would have no effect, but it does. This led to different IR being run through the backend, which uncovered a few real bugs. They should all be fixed, but apparently this change does come with risks.