### PR TITLE
64-bit c++11 atomics do not behave correctly when high bits are set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -219,3 +219,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Florian Rival <florian.rival@gmail.com>
 * Mark Achée <mark@achee.com>
 * Piotr Paczkowski <kontakt@trzeci.eu>
+* Braden MacDonald <braden@bradenmacdonald.com>

--- a/tests/core/test_atomic_cxx.cpp
+++ b/tests/core/test_atomic_cxx.cpp
@@ -1,9 +1,9 @@
 //------------------------------------------------------------------------------
 //  test C++11 atomics
 //  compile native version with:
-//  clang -std=c++11 -Wno-format atomic_test.cpp 
+//  clang -std=c++11 -Wno-format test_atomic_cxx.cpp
 //  compile emscripten version with:
-//  emcc -std=c++11 -Wno-format atomic_test.cpp
+//  emcc -std=c++11 -Wno-format test_atomic_cxx.cpp
 //------------------------------------------------------------------------------
 #include <atomic>
 #include <cstdio>
@@ -51,16 +51,16 @@ template<typename TYPE, typename UNSIGNED_TYPE> void test(TYPE mask0, TYPE mask1
     }
 
     // fetch_add
-    atomicDog = 0;
+    atomicDog = mask2;
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         TYPE old = atomicDog.fetch_add(1, memoryOrder[i]);
-        printf("fetch_add %lld: old=%lld new=%lld\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
+        printf("fetch_add %lld: old=%llx new=%llx\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
     }
 
     // fetch_sub
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         TYPE old = atomicDog.fetch_sub(1, memoryOrder[i]);
-        printf("fetch_sub %lld: old=%lld new=%lld\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
+        printf("fetch_sub %lld: old=%llx new=%llx\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
     }
 
     // fetch_and

--- a/tests/core/test_atomic_cxx.txt
+++ b/tests/core/test_atomic_cxx.txt
@@ -17,18 +17,18 @@ exchange 4: old=3 new=4
 exchange 5: old=4 new=5
 compare_exchange_weak 5: success = false
 compare_exchange_strong 5: success = false
-fetch_add 0: old=0 new=1
-fetch_add 1: old=1 new=2
-fetch_add 2: old=2 new=3
-fetch_add 3: old=3 new=4
-fetch_add 4: old=4 new=5
-fetch_add 5: old=5 new=6
-fetch_sub 0: old=6 new=5
-fetch_sub 1: old=5 new=4
-fetch_sub 2: old=4 new=3
-fetch_sub 3: old=3 new=2
-fetch_sub 4: old=2 new=1
-fetch_sub 5: old=1 new=0
+fetch_add 0: old=f new=10
+fetch_add 1: old=10 new=11
+fetch_add 2: old=11 new=12
+fetch_add 3: old=12 new=13
+fetch_add 4: old=13 new=14
+fetch_add 5: old=14 new=15
+fetch_sub 0: old=15 new=14
+fetch_sub 1: old=14 new=13
+fetch_sub 2: old=13 new=12
+fetch_sub 3: old=12 new=11
+fetch_sub 4: old=11 new=10
+fetch_sub 5: old=10 new=f
 fetch_and 0: old=ff, new=1
 fetch_and 1: old=ff, new=2
 fetch_and 2: old=ff, new=4
@@ -73,18 +73,18 @@ exchange 4: old=3 new=4
 exchange 5: old=4 new=5
 compare_exchange_weak 5: success = false
 compare_exchange_strong 5: success = false
-fetch_add 0: old=0 new=1
-fetch_add 1: old=1 new=2
-fetch_add 2: old=2 new=3
-fetch_add 3: old=3 new=4
-fetch_add 4: old=4 new=5
-fetch_add 5: old=5 new=6
-fetch_sub 0: old=6 new=5
-fetch_sub 1: old=5 new=4
-fetch_sub 2: old=4 new=3
-fetch_sub 3: old=3 new=2
-fetch_sub 4: old=2 new=1
-fetch_sub 5: old=1 new=0
+fetch_add 0: old=f0f new=f10
+fetch_add 1: old=f10 new=f11
+fetch_add 2: old=f11 new=f12
+fetch_add 3: old=f12 new=f13
+fetch_add 4: old=f13 new=f14
+fetch_add 5: old=f14 new=f15
+fetch_sub 0: old=f15 new=f14
+fetch_sub 1: old=f14 new=f13
+fetch_sub 2: old=f13 new=f12
+fetch_sub 3: old=f12 new=f11
+fetch_sub 4: old=f11 new=f10
+fetch_sub 5: old=f10 new=f0f
 fetch_and 0: old=ffff, new=1
 fetch_and 1: old=ffff, new=2
 fetch_and 2: old=ffff, new=4
@@ -129,18 +129,18 @@ exchange 4: old=3 new=4
 exchange 5: old=4 new=5
 compare_exchange_weak 5: success = false
 compare_exchange_strong 5: success = false
-fetch_add 0: old=0 new=1
-fetch_add 1: old=1 new=2
-fetch_add 2: old=2 new=3
-fetch_add 3: old=3 new=4
-fetch_add 4: old=4 new=5
-fetch_add 5: old=5 new=6
-fetch_sub 0: old=6 new=5
-fetch_sub 1: old=5 new=4
-fetch_sub 2: old=4 new=3
-fetch_sub 3: old=3 new=2
-fetch_sub 4: old=2 new=1
-fetch_sub 5: old=1 new=0
+fetch_add 0: old=f0f0f0f new=f0f0f10
+fetch_add 1: old=f0f0f10 new=f0f0f11
+fetch_add 2: old=f0f0f11 new=f0f0f12
+fetch_add 3: old=f0f0f12 new=f0f0f13
+fetch_add 4: old=f0f0f13 new=f0f0f14
+fetch_add 5: old=f0f0f14 new=f0f0f15
+fetch_sub 0: old=f0f0f15 new=f0f0f14
+fetch_sub 1: old=f0f0f14 new=f0f0f13
+fetch_sub 2: old=f0f0f13 new=f0f0f12
+fetch_sub 3: old=f0f0f12 new=f0f0f11
+fetch_sub 4: old=f0f0f11 new=f0f0f10
+fetch_sub 5: old=f0f0f10 new=f0f0f0f
 fetch_and 0: old=ffffffff, new=1
 fetch_and 1: old=ffffffff, new=2
 fetch_and 2: old=ffffffff, new=4
@@ -185,18 +185,18 @@ exchange 4: old=3 new=4
 exchange 5: old=4 new=5
 compare_exchange_weak 5: success = false
 compare_exchange_strong 5: success = false
-fetch_add 0: old=0 new=1
-fetch_add 1: old=1 new=2
-fetch_add 2: old=2 new=3
-fetch_add 3: old=3 new=4
-fetch_add 4: old=4 new=5
-fetch_add 5: old=5 new=6
-fetch_sub 0: old=6 new=5
-fetch_sub 1: old=5 new=4
-fetch_sub 2: old=4 new=3
-fetch_sub 3: old=3 new=2
-fetch_sub 4: old=2 new=1
-fetch_sub 5: old=1 new=0
+fetch_add 0: old=f0f0f0f0f0f0f0f new=f0f0f0f0f0f0f10
+fetch_add 1: old=f0f0f0f0f0f0f10 new=f0f0f0f0f0f0f11
+fetch_add 2: old=f0f0f0f0f0f0f11 new=f0f0f0f0f0f0f12
+fetch_add 3: old=f0f0f0f0f0f0f12 new=f0f0f0f0f0f0f13
+fetch_add 4: old=f0f0f0f0f0f0f13 new=f0f0f0f0f0f0f14
+fetch_add 5: old=f0f0f0f0f0f0f14 new=f0f0f0f0f0f0f15
+fetch_sub 0: old=f0f0f0f0f0f0f15 new=f0f0f0f0f0f0f14
+fetch_sub 1: old=f0f0f0f0f0f0f14 new=f0f0f0f0f0f0f13
+fetch_sub 2: old=f0f0f0f0f0f0f13 new=f0f0f0f0f0f0f12
+fetch_sub 3: old=f0f0f0f0f0f0f12 new=f0f0f0f0f0f0f11
+fetch_sub 4: old=f0f0f0f0f0f0f11 new=f0f0f0f0f0f0f10
+fetch_sub 5: old=f0f0f0f0f0f0f10 new=f0f0f0f0f0f0f0f
 fetch_and 0: old=ffffffffffffffff, new=1
 fetch_and 1: old=ffffffffffffffff, new=2
 fetch_and 2: old=ffffffffffffffff, new=4


### PR DESCRIPTION
Addition/subtraction/increment/decrement operations on 64-bit c++11 atomics seem to truncate the value to 32 bits. I have included an updated test case that reveals this bug, but I'm not sure how to fix it.

The relevant portion of the revised test case can be reduced to:

```c++
std::atomic<int64_t> atomicDog = 0x0F0F0F0F0F0F0F0F;
int64_t old = atomicDog.fetch_add(1, ...);
printf("fetch_add: old=%llx new=%llx\n", old, (int64_t)atomicDog);
```

Output as generated by clang:
```
fetch_add: old=f0f0f0f0f0f0f0f new=f0f0f0f0f0f0f10
```

Output as generated by emcc:
```
fetch_add: old=f0f0f0f0f0f0f0f new=f0f0f10
```

My environment is:
```
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 1.35.2
clang version 3.8.0 
Target: x86_64-apple-darwin15.0.0
Thread model: posix
```