### PR TITLE
When WebGL contexts are lost the extension are invalidated

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -213,4 +213,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Andrew Karpushin <reven86@gmail.com>
 * Felix Zimmermann <fzimmermann89@gmail.com>
 * Sven-Hendrik Haase <svenstaro@gmail.com>
-
+* Owen Delahoy <owen.delahoy@gmail.com>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -993,6 +993,11 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
 
+        if(target.GLctxObject) {
+          if(eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST') }}}) target.GLctxObject.initExtensionsDone = false;
+          if(eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED') }}}) GL.initExtensions(target.GLctxObject);
+        }
+
         var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);
         if (shouldCancel) {
           e.preventDefault();

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -993,9 +993,9 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
 
-        if(target.GLctxObject) {
-          if(eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST') }}}) target.GLctxObject.initExtensionsDone = false;
-          if(eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED') }}}) GL.initExtensions(target.GLctxObject);
+        if (target.GLctxObject) {
+          if (eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTLOST') }}}) target.GLctxObject.initExtensionsDone = false;
+          if (eventTypeId == {{{ cDefine('EMSCRIPTEN_EVENT_WEBGLCONTEXTRESTORED') }}}) GL.initExtensions(target.GLctxObject);
         }
 
         var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);


### PR DESCRIPTION
When a [webgl context is lost extensions are invalidated](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14), and extensions such as 'OES_vertex_array_object' can not be reinitialized via `emscripten_webgl_enable_extension` since variables like `GLctx['createVertexArray']` must be reintialized.

In the webgl callback handler, I have marked extensions as not initialized for the webglcontextlost event and  added a call to `GL.initExtension` for the webglcontextrestored event.

This way extensions are correctly initialized like in context creation.