### PR TITLE
update documentation for cwrap

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -213,4 +213,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Andrew Karpushin <reven86@gmail.com>
 * Felix Zimmermann <fzimmermann89@gmail.com>
 * Sven-Hendrik Haase <svenstaro@gmail.com>
+* Simon Sandström <simon@nikanor.nu>
 

--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -100,7 +100,7 @@ Calling compiled C functions from JavaScript
 				my_func(12)
 
 	:param ident: The name of the C function to be called.	
-	:param returnType: The return type of the function. This will be one of the JavaScript types ``number``, ``string`` or ``array`` (use ``number`` for any C pointer, and ``array`` for JavaScript arrays and typed arrays; note that arrays are 8-bit).
+	:param returnType: The return type of the function. This can be ``"number"``, ``"string"`` or ``"array"``, which correspond to the appropriate JavaScript types (use ``"number"`` for any C pointer, and ``"array"`` for JavaScript arrays and typed arrays; note that arrays are 8-bit), or for a void function it can be ``null`` (note: the JavaScript ``null`` value, not a string containing the word "null").
 	:param argTypes: An array of the types of arguments for the function (if there are no arguments, this can be omitted). Types are as in ``returnType``, except that ``array`` is not supported as there is no way for us to know the length of the array).
 	:returns: A JavaScript function that can be used for running the C function. 	
 


### PR DESCRIPTION
The documentation for `cwrap` does not mention how to specify the return type for a void function. There are also other differences between `ccall`'s and `cwrap`'s `returnType`-description. This change uses `ccall`'s `returnType`-decription for both of these functions.

(I did not update AUTHORS since this is a documentation only change. If it is needed anyway I will do it.)