### PR TITLE
Cast WebIDL returned values to real JS booleans

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -216,4 +216,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Simon Sandström <simon@nikanor.nu>
 * Khaled Sami <k.sami.mohammed@gmail.com>
 * Omar El-Mohandes <omar.elmohandes90@gmail.com>
-
+* Florian Rival <florian.rival@gmail.com>

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -4,6 +4,8 @@ Parent:42
 object
 object
 8
+boolean
+true
 c1
 Parent:7
 Child1:7
@@ -13,6 +15,7 @@ Child1:7
 588
 14
 28
+true
 Child1::parentFunc(90)
 c1 v2
 Parent:16
@@ -21,6 +24,7 @@ Child1:15
 30
 900
 2700
+true
 c2
 Parent:9
 Child2:9

--- a/tests/webidl/output_DEFAULT.txt
+++ b/tests/webidl/output_DEFAULT.txt
@@ -4,6 +4,8 @@ Parent:42
 object
 object
 8
+boolean
+true
 c1
 Parent:7
 Child1:7
@@ -13,6 +15,7 @@ Child1:7
 588
 14
 28
+true
 Child1::parentFunc(90)
 c1 v2
 Parent:16
@@ -21,6 +24,7 @@ Child1:15
 30
 900
 2700
+true
 c2
 Parent:9
 Child2:9

--- a/tests/webidl/output_FAST.txt
+++ b/tests/webidl/output_FAST.txt
@@ -4,6 +4,8 @@ Parent:42
 object
 object
 8
+boolean
+true
 c1
 Parent:7
 Child1:7
@@ -13,6 +15,7 @@ Child1:7
 588
 14
 28
+true
 Child1::parentFunc(90)
 c1 v2
 Parent:16
@@ -21,6 +24,7 @@ Child1:15
 30
 900
 2700
+true
 c2
 Parent:9
 Child2:9

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -9,6 +9,8 @@ sme.parentFunc(90);
 TheModule.print(typeof sme.getAsConst());
 TheModule.print(typeof sme.voidStar(sme));
 TheModule.print(sme.get_immutableAttr());
+TheModule.print(typeof sme.getBoolean());
+TheModule.print(sme.getBoolean());
 
 TheModule.print('c1');
 
@@ -20,6 +22,7 @@ TheModule.print(c1.getValSqr());
 TheModule.print(c1.getValSqr(3));
 TheModule.print(c1.getValTimes()); // default argument should be 1
 TheModule.print(c1.getValTimes(2));
+TheModule.print(sme.getBoolean());
 c1.parentFunc(90);
 
 TheModule.print('c1 v2');
@@ -30,6 +33,7 @@ c1.mulVal(2);
 TheModule.print(c1.getVal());
 TheModule.print(c1.getValSqr());
 TheModule.print(c1.getValSqr(3));
+TheModule.print(sme.getBoolean());
 
 TheModule.print('c2')
 

--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -14,6 +14,7 @@ public:
   void parentFunc() {}
   const Parent *getAsConst() { return NULL; }
   void *voidStar(void *something) { return something; }
+  bool getBoolean() {return true; }
 
   const int immutableAttr;
 };

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -8,6 +8,7 @@ interface Parent {
   void parentFunc();
   [Const] Parent getAsConst();
   VoidPtr voidStar(VoidPtr something);
+  boolean getBoolean();
 
   readonly attribute long immutableAttr;
 };

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -296,6 +296,9 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
     elif return_type == 'String':
       call_prefix += 'Pointer_stringify('
       call_postfix += ')'
+    elif return_type == 'Boolean':
+      call_prefix += '!!('
+      call_postfix += ')'
 
   args = ['arg%d' % i for i in range(max_args)]
   if not constructor:


### PR DESCRIPTION
This patch allow functions generated by the WebIDL binder and declared as returning a boolean:

```
interface MyClass {
    boolean GetBool();
}
```

to return a Javascript boolean (instead of `0` for `false`, and any other value for `true`). It's just a "cast", but it is useful, in particular for test suites of libraries that are expecting to see false/true and not values that are falsy/truthy (see the test suite of [my library](https://github.com/4ian/GDevelop.js)).

Sorry I've not yet managed to run the automatic test suite for now! Will keep trying :)