### PR TITLE
Implement glfwSetInputMode when mode is GLFW_CURSOR and value is GLFW_CURSOR_NORMAL or GLFW_CURSOR_DISABLED

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -513,6 +513,58 @@ var LibraryGLFW = {
       win.windowRefreshFunc = cbfun;
     },
 
+    onClickRequestPointerLock: function(e) {
+      if (!Browser.pointerLock && Module['canvas'].requestPointerLock) {
+        Module['canvas'].requestPointerLock();
+        e.preventDefault();
+      }
+    },
+
+    setInputMode: function(winid, mode, value) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+
+      switch(mode) {
+        case 0x00033001: // GLFW_CURSOR
+        {
+          switch(value) {
+            case 0x00034001: // GLFW_CURSOR_NORMAL
+              win.inputModes[mode] = value;
+              Module['canvas'].removeEventListener('click', GLFW.onClickRequestPointerLock, true);
+              Module['canvas'].exitPointerLock();
+              break;
+
+            case 0x00034002: // GLFW_CURSOR_HIDDEN
+              console.log("glfwSetInputMode called with GLFW_CURSOR_HIDDEN value not implemented.");
+              break;
+
+            case 0x00034003: // GLFW_CURSOR_DISABLED
+              win.inputModes[mode] = value;
+              Module['canvas'].addEventListener('click', GLFW.onClickRequestPointerLock, true);
+              Module['canvas'].requestPointerLock();
+              break;
+            
+            default:
+              console.log("glfwSetInputMode called with unknown value parameter value: " + value + ".");
+              break;
+          }
+        }
+        break;
+
+        case 0x00033002: // GLFW_STICKY_KEYS
+          console.log("glfwSetInputMode called with GLFW_STICKY_KEYS mode not implemented.");
+          break;
+
+        case 0x00033003: // GLFW_STICKY_MOUSE_BUTTONS
+          console.log("glfwSetInputMode called with GLFW_STICKY_MOUSE_BUTTONS mode not implemented.");
+          break;
+
+        default:
+          console.log("glfwSetInputMode called with unknown mode parameter value: " + mode + ".");
+          break;
+      }
+    },
+
     getKey: function(winid, key) {
       var win = GLFW.WindowFromId(winid);
       if (!win) return 0;
@@ -588,14 +640,14 @@ var LibraryGLFW = {
         }
       }
 
-      if (!win.windowResizeFunc) return;
+      if (!win.windowSizeFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', win.windowResizeFunc, [width, height]);
+      Runtime.dynCall('vii', win.windowSizeFunc, [width, height]);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viii', win.windowResizeFunc, [win.id, width, height]);
+      Runtime.dynCall('viii', win.windowSizeFunc, [win.id, width, height]);
 #endif
     },
 
@@ -1004,11 +1056,9 @@ var LibraryGLFW = {
     return win.inputModes[mode];
   },
 
-  // TODO: implement
-  // GLFW_STICKY_KEYS == key stays pressed until pressed second time
-  // GLFW_STICKY_MOUSE_BUTTONS == same as above but for mouse buttons
-  // GLFW_CURSOR == NORMAL, HIDDEN (no pointer), DISABLED (hidden && always centered)
-  glfwSetInputMode: function(winid, mode, value) {},
+  glfwSetInputMode: function(winid, mode, value) {
+    GLFW.setInputMode(winid, mode, value);
+  },
 
   glfwGetKey: function(winid, key) {
     return GLFW.getKey(winid, key);

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -525,43 +525,43 @@ var LibraryGLFW = {
       if (!win) return;
 
       switch(mode) {
-        case 0x00033001: // GLFW_CURSOR
-        {
+        case 0x00033001: { // GLFW_CURSOR
           switch(value) {
-            case 0x00034001: // GLFW_CURSOR_NORMAL
+            case 0x00034001: { // GLFW_CURSOR_NORMAL
               win.inputModes[mode] = value;
               Module['canvas'].removeEventListener('click', GLFW.onClickRequestPointerLock, true);
               Module['canvas'].exitPointerLock();
               break;
-
-            case 0x00034002: // GLFW_CURSOR_HIDDEN
+            }
+            case 0x00034002: { // GLFW_CURSOR_HIDDEN
               console.log("glfwSetInputMode called with GLFW_CURSOR_HIDDEN value not implemented.");
               break;
-
-            case 0x00034003: // GLFW_CURSOR_DISABLED
+            }
+            case 0x00034003: { // GLFW_CURSOR_DISABLED
               win.inputModes[mode] = value;
               Module['canvas'].addEventListener('click', GLFW.onClickRequestPointerLock, true);
               Module['canvas'].requestPointerLock();
               break;
-            
-            default:
+            }
+            default: {
               console.log("glfwSetInputMode called with unknown value parameter value: " + value + ".");
               break;
+            }
           }
+          break;
         }
-        break;
-
-        case 0x00033002: // GLFW_STICKY_KEYS
+        case 0x00033002: { // GLFW_STICKY_KEYS
           console.log("glfwSetInputMode called with GLFW_STICKY_KEYS mode not implemented.");
           break;
-
-        case 0x00033003: // GLFW_STICKY_MOUSE_BUTTONS
+        }
+        case 0x00033003: { // GLFW_STICKY_MOUSE_BUTTONS
           console.log("glfwSetInputMode called with GLFW_STICKY_MOUSE_BUTTONS mode not implemented.");
           break;
-
-        default:
+        }
+        default: {
           console.log("glfwSetInputMode called with unknown mode parameter value: " + mode + ".");
           break;
+        }
       }
     },
 

--- a/tests/test_glfw_pointerlock.c
+++ b/tests/test_glfw_pointerlock.c
@@ -46,7 +46,7 @@ int main() {
   glfwSetInputMode(g_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
   // Main loop
-  printf("Click the canvas to enter pointer lock mode. The browser might offer to allow hidding mouse pointer. Make sure to accept it.\n");
+  printf("Click the canvas to enter pointer lock mode. The browser might offer to allow hiding mouse pointer. Make sure to accept it.\n");
   printf("Escaping the pointer lock mode should work again upon clicking the canvas.\n");
   emscripten_set_main_loop(render, 0, 1);
 

--- a/tests/test_glfw_pointerlock.c
+++ b/tests/test_glfw_pointerlock.c
@@ -42,12 +42,13 @@ int main() {
   }
   glfwMakeContextCurrent(g_window);
 
-  // Disable cursor: pointer lock
+  // Try to disable cursor by entering pointer lock. If pointer lock failed (because glfwSetInputMode wasn't called in a user event),
+  // then clicking the canvas should also try to lock the pointer, as long as the cursor mode is GLFW_CURSOR_DISABLED.
   glfwSetInputMode(g_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
   // Main loop
-  printf("Click the canvas to enter pointer lock mode. The browser might offer to allow hiding mouse pointer. Make sure to accept it.\n");
-  printf("Escaping the pointer lock mode should work again upon clicking the canvas.\n");
+  printf("Click the canvas to enter pointer lock mode. The browser should offer to hide the mouse pointer. Make sure to accept it.\n");
+  printf("If you exit pointer lock (such as pressing ESC on keyboard), clicking the canvas should lock the pointer again.\n");
   emscripten_set_main_loop(render, 0, 1);
 
   glfwTerminate();

--- a/tests/test_glfw_pointerlock.c
+++ b/tests/test_glfw_pointerlock.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+#define GLFW_INCLUDE_ES2
+#include <GLFW/glfw3.h>
+
+int result = 1;
+
+GLFWwindow* g_window;
+
+void render();
+void error_callback(int error, const char* description);
+
+void render() {
+  glClearColor(1.0f, 1.0f, 0.0f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+}
+
+int main() {
+  // Setup g_window
+  glfwSetErrorCallback(error_callback);
+  if (!glfwInit())
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    return -1;
+  }
+  glfwWindowHint(GLFW_RESIZABLE , 1);
+  g_window = glfwCreateWindow(600, 450, "GLFW pointerlock test", NULL, NULL);
+  if (!g_window)
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    glfwTerminate();
+    return -1;
+  }
+  glfwMakeContextCurrent(g_window);
+
+  // Disable cursor: pointer lock
+  glfwSetInputMode(g_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+
+  // Main loop
+  printf("Click the canvas to enter pointer lock mode. The browser might offer to allow hidding mouse pointer. Make sure to accept it.\n");
+  printf("Escaping the pointer lock mode should work again upon clicking the canvas.\n");
+  emscripten_set_main_loop(render, 0, 1);
+
+  glfwTerminate();
+
+  return 0;
+}

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -123,5 +123,8 @@ class interactive(BrowserCore):
   def test_glfw_fullscreen(self):
     self.btest('test_glfw_fullscreen.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
 
+  def test_glfw_pointerlock(self):
+    self.btest('test_glfw_pointerlock.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
+
   def test_cpuprofiler_memoryprofiler(self):
     self.btest('hello_world_gles.c', expected='0', args=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '-O2', '--cpuprofiler', '--memoryprofiler'])


### PR DESCRIPTION
This PR implements `glfwSetInputMode(window, mode, value)` when mode is `GLFW_CURSOR` and value is `GLFW_CURSOR_NORMAL` or `GLFW_CURSOR_DISABLED`.

Since browsers require requestPointerLock to be in user event, I believe it is perfectly legitimate to add an event listener on the canvas click, to properly respect the value of the mode, meaning that in `GLFW_CURSOR_DISABLED` mode, even if the user press escape to exit the pointer lock, clicking again the canvas should request the pointer lock again, while being in `GLFW_CURSOR_NORMAL` mode will keep the cursor visible.