### PR TITLE
Support passing data by transferring ownership to or from Web Workers 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -214,4 +214,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Felix Zimmermann <fzimmermann89@gmail.com>
 * Sven-Hendrik Haase <svenstaro@gmail.com>
 * Simon Sandström <simon@nikanor.nu>
+* Khaled Sami <k.sami.mohammed@gmail.com>
+* Omar El-Mohandes <omar.elmohandes90@gmail.com>
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1340,11 +1340,16 @@ mergeInto(LibraryManager.library, {
       });
       info.awaited++;
     }
-    info.worker.postMessage({
+    var transferObject = {
       'funcName': funcName,
       'callbackId': callbackId,
-      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0 // XXX copy to a new typed array as a workaround for chrome bug 169705
-    });
+      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0  
+    };
+    if (data) {
+      info.worker.postMessage(transferObject,[transferObject.data.buffer]);
+    } else { 
+      info.worker.postMessage(transferObject);
+    }
   },
 
   emscripten_worker_respond_provisionally: function(data, size) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1354,21 +1354,31 @@ mergeInto(LibraryManager.library, {
 
   emscripten_worker_respond_provisionally: function(data, size) {
     if (workerResponded) throw 'already responded with final response!';
-    postMessage({
+    var transferObject = {
       'callbackId': workerCallbackId,
       'finalResponse': false,
-      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0 // XXX copy to a new typed array as a workaround for chrome bug 169705
-    });
+      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0
+    };
+    if (data) {
+      postMessage(transferObject,[transferObject.data.buffer]);
+    } else {
+      postMessage(transferObject);
+    }
   },
 
   emscripten_worker_respond: function(data, size) {
     if (workerResponded) throw 'already responded with final response!';
     workerResponded = true;
-    postMessage({
+    var transferObject = {
       'callbackId': workerCallbackId,
       'finalResponse': true,
-      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0 // XXX copy to a new typed array as a workaround for chrome bug 169705
-    });
+      'data': data ? new Uint8Array({{{ makeHEAPView('U8', 'data', 'data + size') }}}) : 0
+    };
+    if (data) {
+      postMessage(transferObject,[transferObject.data.buffer]);
+    } else {
+      postMessage(transferObject);
+    }
   },
 
   emscripten_get_worker_queue_size: function(id) {


### PR DESCRIPTION
This patch is solving this [issue] (https://github.com/kripken/emscripten/issues/3857). Basically it is allowing Emscripten to pass data by transferring ownership in the way that mentioned [here](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#Passing_data_by_transferring_ownership_(transferable_objects)).