### PR TITLE
Update building_fastcomp_manually_from_source.rst

### DIFF
--- a/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
+++ b/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
@@ -16,10 +16,10 @@ This article explains how you can build Fastcomp's sources using a fully manual 
 What you'll need
 ================
 
-First follow the instructions for your platform showing how to :ref:`manually build Emscripten from source <installing-from-source>`.
+First verify you have :ref:'the compiler toolchain <compiler-toolchain>` for your platform, download and install them as  necessary. 
 
-Then :ref:`download and install the compiler toolchain <compiler-toolchain>` for your platform.
-
+Then follow the instructions for your platform showing how to :ref:`manually build Emscripten from source <installing-from-source>` steps 1-6, and return to this page at step 6. When you're done here return to those instructions.
+ 		 
 .. _building-fastcomp-from-source-building:
 
 Building Fastcomp

--- a/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
+++ b/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
@@ -18,8 +18,9 @@ What you'll need
 
 First verify you have :ref:'the compiler toolchain <compiler-toolchain>` for your platform, download and install them as  necessary. 
 
-Then follow the instructions for your platform showing how to :ref:`manually build Emscripten from source <installing-from-source>` steps 1-6, and return to this page at step 6. When you're done here return to those instructions.
- 		 
+Then follow the instructions for your platform showing how to :ref:`manually build Emscripten from source <installing-from-source>`. When you get to step "Build Fastcomp (LLVM + Clang) from source" return here and complete these instructions. When you're done here, resume building Emscripten from source.
+
+
 .. _building-fastcomp-from-source-building:
 
 Building Fastcomp


### PR DESCRIPTION
clarified confusing installation instructions that looped user between two pages
