### PR TITLE
embed_pthread_main_js

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -130,7 +130,22 @@ var LibraryPThread = {
 
       var numWorkersLoaded = 0;
       for (var i = 0; i < numWorkers; ++i) {
+#if EMBED_PTHREAD_MAIN_JS
+        var pthreadMainCode = {{{ PTHREAD_MAIN_CODE }}};
+        if (!PThread.pthreadMainBlobURL) {
+          try {
+            PThread.pthreadMainBlobURL = URL.createObjectURL(new Blob([pthreadMainCode], {type: 'application/javascript'}));
+          } catch (e) {
+            window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
+            var blob = new BlobBuilder();
+            blob.append(pthreadMainCode);
+            PThread.pthreadMainBlobURL = URL.createObjectURL(blob.getBlob());
+          }
+        }
+        var worker = new Worker(PThread.pthreadMainBlobURL);
+#else
         var worker = new Worker('pthread-main.js');
+#endif
 
         worker.onmessage = function(e) {
           if (e.data.cmd === 'processQueuedMainThreadWork') {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1031,7 +1031,9 @@ var DYNAMIC_BASE = 0, DYNAMICTOP = 0; // dynamic area handled by sbrk
 if (ENVIRONMENT_IS_PTHREAD) {
   staticSealed = true; // The static memory area has been initialized already in the main thread, pthreads skip this.
 #if SEPARATE_ASM != 0
-  importScripts('{{{ SEPARATE_ASM }}}'); // load the separated-out asm.js
+  // Specify the script to import by absolute URL, or otherwise it won't be located since the pthread may have been
+  // constructed via a blob url, and importing via a relative url won't work.
+  importScripts(currentScriptUrl.split('/').slice(0, -1).join('/') + '/{{{ SEPARATE_ASM }}}'); // load the separated-out asm.js
 #endif
 }
 #endif

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -19,6 +19,9 @@ var STACK_MAX = 0;
 
 var ENVIRONMENT_IS_PTHREAD = true;
 
+// Will be initialized at the 'load' message.
+var currentScriptUrl;
+
 // Cannot use console.log or console.error in a web worker, since that would risk a browser deadlock! https://bugzilla.mozilla.org/show_bug.cgi?id=1049091
 // Therefore implement custom logging facility for threads running in a worker, which queue the messages to main thread to print.
 var Module = {};
@@ -46,6 +49,7 @@ this.onmessage = function(e) {
     buffer = e.data.buffer;
     tempDoublePtr = e.data.tempDoublePtr;
     PthreadWorkerInit = e.data.PthreadWorkerInit;
+    currentScriptUrl = e.data.url;
     importScripts(e.data.url);
     FS.createStandardStreams();
     postMessage({ cmd: 'loaded' });

--- a/src/settings.js
+++ b/src/settings.js
@@ -654,6 +654,15 @@ var PTHREAD_POOL_SIZE = 0; // Specifies the number of web workers that are preal
 // to show a popup dialog at startup so the user can configure this dynamically.
 var PTHREAD_HINT_NUM_CORES = 4;
 
+// If 1 (default), the contents of the pthread bootstrap script "src/pthread-main.js" is embedded to the final generated output
+// to avoid needing to host a separate file for this on the web server. If 0, then the pthread main script is  deployed alongside
+// the generated output file. Generally set only to 0 if you need to debug something regarding the pthread internals.
+var EMBED_PTHREAD_MAIN_JS = 1;
+
+// A dummy placeholder that will contain the contents of src/pthread-main.js at link. Specified
+// here to quieten a false positive warning message.
+var PTHREAD_MAIN_CODE = '';
+
 var MAX_GLOBAL_ALIGN = -1; // received from the backend
 
 // Reserved: variables containing POINTER_MASKING.

--- a/src/shell.js
+++ b/src/shell.js
@@ -43,10 +43,13 @@ var ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
 var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
 #if USE_PTHREADS
 var ENVIRONMENT_IS_PTHREAD;
-if (!ENVIRONMENT_IS_PTHREAD) ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
 var PthreadWorkerInit; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
-if (!ENVIRONMENT_IS_PTHREAD) PthreadWorkerInit = {};
-var currentScriptUrl = ENVIRONMENT_IS_WORKER ? undefined : document.currentScript.src;
+var currentScriptUrl;
+if (!ENVIRONMENT_IS_PTHREAD) {
+  ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
+  PthreadWorkerInit = {};
+  currentScriptUrl = document.currentScript.src;
+}
 #endif
 var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2677,10 +2677,11 @@ window.close = function() {
 
   # Test that basic thread creation works.
   def test_zzz_pthread_create(self):
-    for opt in [['-O0'], ['-O3']]:
-      for pthreads in [['-s', 'USE_PTHREADS=1'], ['-s', 'USE_PTHREADS=2', '--separate-asm']]:
-        print str(opt) + ' ' + str(pthreads)
-        self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=opt + pthreads + ['-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
+    for embed in [[], ['-s', 'EMBED_PTHREAD_MAIN_JS=0']]:
+      for opt in [['-O0'], ['-O3']]:
+        for pthreads in [['-s', 'USE_PTHREADS=1'], ['-s', 'USE_PTHREADS=2', '--separate-asm']]:
+          print str(opt) + ' ' + str(pthreads)
+          self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=embed + opt + pthreads + ['-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
   # Test that a pthread can spawn another pthread of its own.
   def test_zzz_pthread_create_pthread(self):


### PR DESCRIPTION
Embed src/pthread-main.js as a string into the main generated output file so that one does not need to host an extra pthread-main.js. Make the embedding a build option (default on) so that it can be disabled when debugging pthreads internals.