### PR TITLE
throw an Error if assets.data is unavailable

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -425,7 +425,6 @@ If manually bisecting:
               window.onerror = null;
               var result = error.indexOf("test.data") >= 0 ? 1 : 0;
               var xhr = new XMLHttpRequest();
-              if (!result) alert(error);
               xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);
               xhr.send();
               setTimeout(function() { window.close() }, 1000);
@@ -464,7 +463,6 @@ If manually bisecting:
     test()
 
 
-    
     # TODO: CORS, test using a full url for filePackagePrefixURL
     #open(self.in_dir('shell.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { filePackagePrefixURL: "http:/localhost:8888/cdn/", '))
     #test()

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -690,8 +690,13 @@ if has_preloaded:
         }
       };
       xhr.onload = function(event) {
-        var packageData = xhr.response;
-        callback(packageData);
+        if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206) {
+          var packageData = xhr.response;
+          callback(packageData);
+        } else {
+          throw new Error(xhr.statusText + " : " + xhr.responseURL);
+        }
+        
       };
       xhr.send(null);
     };

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -689,6 +689,9 @@ if has_preloaded:
           if (Module['setStatus']) Module['setStatus']('Downloading data...');
         }
       };
+      xhr.onerror = function(event) {
+        throw new Error("NetworkError for: " + packageName);
+      }
       xhr.onload = function(event) {
         if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206) {
           var packageData = xhr.response;
@@ -696,7 +699,6 @@ if has_preloaded:
         } else {
           throw new Error(xhr.statusText + " : " + xhr.responseURL);
         }
-        
       };
       xhr.send(null);
     };


### PR DESCRIPTION
Currently game runs even if asset.data download failed what could lead to run-time errors connected to missing files. 

This error could be captured and handled by `windows.onerror`. 

