### PR TITLE
Improve no eval

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -998,6 +998,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     assert not (bind and shared.Settings.NO_DYNAMIC_EXECUTION), 'NO_DYNAMIC_EXECUTION disallows embind'
 
+    assert not (shared.Settings.NO_DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both NO_DYNAMIC_EXECUTION and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
+
     if shared.Settings.RELOCATABLE:
       assert shared.Settings.GLOBAL_BASE < 1
       if shared.Settings.EMULATED_FUNCTION_POINTERS == 0:

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -110,7 +110,7 @@ Functions
 
 .. c:function:: void emscripten_run_script(const char *script)
 
-	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. 
+	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. Note: If -s NO_DYNAMIC_EXECUTION=1 is set, this function will not be available.
 
 	:param script: The script to evaluate.
 	:type script: const char* 
@@ -119,7 +119,7 @@ Functions
 	
 .. c:function:: int emscripten_run_script_int(const char *script)
 
-	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. 
+	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. Note: If -s NO_DYNAMIC_EXECUTION=1 is set, this function will not be available.
 
 	:param script: The script to evaluate.
 	:type script: const char* 
@@ -129,7 +129,7 @@ Functions
 	
 .. c:function:: char *emscripten_run_script_string(const char *script)
 
-	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. Note that this overload uses a single buffer shared between calls.
+	Interface to the underlying JavaScript engine. This function will ``eval()`` the given script. Note that this overload uses a single buffer shared between calls. Note: If -s NO_DYNAMIC_EXECUTION=1 is set, this function will not be available.
 
 	:param script: The script to evaluate.
 	:type script: const char* 

--- a/src/library.js
+++ b/src/library.js
@@ -3729,15 +3729,15 @@ LibraryManager.library = {
   // ==========================================================================
 
   emscripten_run_script: function(ptr) {
-    eval(Pointer_stringify(ptr));
+    globalEval(Pointer_stringify(ptr));
   },
 
   emscripten_run_script_int: function(ptr) {
-    return eval(Pointer_stringify(ptr))|0;
+    return globalEval(Pointer_stringify(ptr))|0;
   },
 
   emscripten_run_script_string: function(ptr) {
-    var s = eval(Pointer_stringify(ptr)) + '';
+    var s = globalEval(Pointer_stringify(ptr)) + '';
     var me = _emscripten_run_script_string;
     if (!me.bufferSize || me.bufferSize < s.length+1) {
       if (me.bufferSize) _free(me.buffer);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -124,12 +124,18 @@ var globalScope = this;
 function getCFunc(ident) {
   var func = Module['_' + ident]; // closure exported function
   if (!func) {
-#if NO_DYNAMIC_EXECUTION == 0
+#if NO_DYNAMIC_EXECUTION == 1
+    // Treat eval as error.
+    abort('NO_DYNAMIC_EXECUTION=1 was set, cannot eval - ccall/cwrap are not functional');
+#else
+#if NO_DYNAMIC_EXECUTION == 2
+    // Warn on evals, but proceed.
+    Module.printErr('Warning: NO_DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:');
+    Module.printErr(stackTrace());
+#endif
     try {
       func = eval('_' + ident); // explicit lookup
     } catch(e) {}
-#else
-    abort('NO_DYNAMIC_EXECUTION was set, cannot eval - ccall/cwrap are not functional');
 #endif
   }
   assert(func, 'Cannot call unknown function ' + ident + ' (perhaps LLVM optimizations or closure removed it?)');

--- a/src/settings.js
+++ b/src/settings.js
@@ -553,10 +553,27 @@ var EXPLICIT_ZEXT = 0; // If 1, generate an explicit conversion of zext i1 to i3
 var EXPORT_NAME = 'Module'; // Global variable to export the module as for environments without a standardized module
                             // loading system (e.g. the browser and SM shell).
 
-var NO_DYNAMIC_EXECUTION = 0; // When enabled, we do not emit eval() and new Function(), which disables some functionality
+var NO_DYNAMIC_EXECUTION = 0; // When set to 1, we do not emit eval() and new Function(), which disables some functionality
                               // (causing runtime errors if attempted to be used), but allows the emitted code to be
-                              // acceptable in places that disallow dynamic code execution (chrome packaged app, non-
-                              // privileged firefox app, etc.)
+                              // acceptable in places that disallow dynamic code execution (chrome packaged app,
+                              // privileged firefox app, etc.). Pass this flag when developing an Emscripten application
+                              // that is targeting a privileged or a certified execution environment, see
+                              // Firefox Content Security Policy (CSP) webpage for details:
+                              // https://developer.mozilla.org/en-US/Apps/Build/Building_apps_for_Firefox_OS/CSP
+                              // When this flag is set, the following features (linker flags) are unavailable:
+                              //  --closure 1: When using closure compiler, eval() would be needed to locate the Module object.
+                              //  -s RELOCATABLE=1: the function Runtime.loadDynamicLibrary would need to eval().
+                              //  --bind: Embind would need to eval().
+                              // Additionally, the following Emscripten runtime functions are unavailable when
+                              // NO_DYNAMIC_EXECUTION=1 is set, and an attempt to call them will throw an exception:
+                              // - emscripten_run_script(),
+                              // - emscripten_run_script_int(),
+                              // - emscripten_run_script_string(),
+                              // - dlopen(),
+                              // - the functions ccall() and cwrap() are still available, but they are restricted to only
+                              //   being able to call functions that have been exported in the Module object in advance.
+                              // When set to -s NO_DYNAMIC_EXECUTION=2 flag is set, attempts to call to eval() are demoted
+                              // to warnings instead of throwing an exception.
 
 var EMTERPRETIFY = 0; // Runs tools/emterpretify on the compiler output
 var EMTERPRETIFY_FILE = ''; // If defined, a file to write bytecode to, otherwise the default is to embed it in text JS arrays (which is less efficient).

--- a/src/shell.js
+++ b/src/shell.js
@@ -183,10 +183,16 @@ else {
 }
 
 function globalEval(x) {
-#if NO_DYNAMIC_EXECUTION == 0
-  eval.call(null, x);
+#if NO_DYNAMIC_EXECUTION == 1
+  // Treat eval as error.
+  throw 'NO_DYNAMIC_EXECUTION=1 was set, cannot eval';
 #else
-  throw 'NO_DYNAMIC_EXECUTION was set, cannot eval';
+#if NO_DYNAMIC_EXECUTION == 2
+    // Warn on evals, but proceed.
+    Module.printErr('Warning: NO_DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:');
+    Module.printErr(stackTrace());
+#endif
+  eval.call(null, x);
 #endif
 }
 if (!Module['load'] && Module['read']) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3069,6 +3069,28 @@ int main(int argc, char **argv) {
     assert 'eval(' not in src
     assert 'eval.' not in src
     assert 'new Function' not in src
+    try_delete('a.out.js')
+
+    # Test that --preload-file doesn't add an use of eval().
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '--preload-file', 'temp.txt']
+    stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+    self.assertContained('hello, world!', run_js('a.out.js'))
+    src = open('a.out.js').read()
+    assert 'eval(' not in src
+    assert 'eval.' not in src
+    assert 'new Function' not in src
+
+    # Test that -s NO_DYNAMIC_EXECUTION=1 and --closure 1 are not allowed together.
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '--closure', '1']
+    proc = Popen(cmd, stderr=PIPE)
+    proc.communicate()
+    assert proc.returncode != 0
+
+    # Test that -s NO_DYNAMIC_EXECUTION=1 and -s RELOCATABLE=1 are not allowed together.
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '-s', 'RELOCATABLE=1']
+    proc = Popen(cmd, stderr=PIPE)
+    proc.communicate()
+    assert proc.returncode != 0
 
   def test_init_file_at_offset(self):
     open('src.cpp', 'w').write(r'''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3079,18 +3079,40 @@ int main(int argc, char **argv) {
     assert 'eval(' not in src
     assert 'eval.' not in src
     assert 'new Function' not in src
+    try_delete('a.out.js')
 
     # Test that -s NO_DYNAMIC_EXECUTION=1 and --closure 1 are not allowed together.
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '--closure', '1']
     proc = Popen(cmd, stderr=PIPE)
     proc.communicate()
     assert proc.returncode != 0
+    try_delete('a.out.js')
 
     # Test that -s NO_DYNAMIC_EXECUTION=1 and -s RELOCATABLE=1 are not allowed together.
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '-s', 'RELOCATABLE=1']
     proc = Popen(cmd, stderr=PIPE)
     proc.communicate()
     assert proc.returncode != 0
+    try_delete('a.out.js')
+
+    open('test.c', 'w').write(r'''
+      #include <emscripten/emscripten.h>
+      int main() {
+        emscripten_run_script("console.log('hello from script');");
+        return 0;
+      }
+      ''')
+
+    # Test that emscripten_run_script() aborts when -s NO_DYNAMIC_EXECUTION=1
+    Popen([PYTHON, EMCC, 'test.c', '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1']).communicate()
+    self.assertContained('NO_DYNAMIC_EXECUTION=1 was set, cannot eval', run_js(os.path.join(self.get_dir(), 'a.out.js'), assert_returncode=None, full_output=True, stderr=PIPE))
+    try_delete('a.out.js')
+
+    # Test that emscripten_run_script() posts a warning when -s NO_DYNAMIC_EXECUTION=2
+    Popen([PYTHON, EMCC, 'test.c', '-O1', '-s', 'NO_DYNAMIC_EXECUTION=2']).communicate()
+    self.assertContained('Warning: NO_DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:', run_js(os.path.join(self.get_dir(), 'a.out.js'), assert_returncode=None, full_output=True, stderr=PIPE))
+    self.assertContained('hello from script', run_js(os.path.join(self.get_dir(), 'a.out.js'), assert_returncode=None, full_output=True, stderr=PIPE))
+    try_delete('a.out.js')
 
   def test_init_file_at_offset(self):
     open('src.cpp', 'w').write(r'''


### PR DESCRIPTION
Some improvements on the `-s NO_DYNAMIC_EXECUTION=1` related code handling:
   - clarify documentation that even though we write "When enabled, we do not emit eval() and new Function()", that we still do emit eval() like discussed in #3882. Document where that occurs.
   - mark build flags that are incompatible with `-s NO_DYNAMIC_EXECUTION=1`.
   - add new build mode `-s NO_DYNAMIC_EXECUTION=2` that demotes eval from error to warning, useful for profiling a codebase of its uses of eval and fixing them at one go, instead of halting on first error and having to rebuild after each fix.
   - adds a few tests.