### PR TITLE
locate_pthread_main_js

### DIFF
--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -42,7 +42,7 @@ The Emscripten implementation for the pthreads API should follow the POSIX stand
 
 - One particular note to pay attention to when porting is that sometimes in existing codebases the callback function pointers to pthread_create() and pthread_cleanup_push() omit the void* argument, which strictly speaking is undefined behavior in C/C++, but works in several x86 calling conventions. Doing this in Emscripten will issue a compiler warning, and can abort at runtime when attempting to call a function pointer with incorrect signature, so in the presence of such errors, it is good to check the signatures of the thread callback functions.
 
-Also note that when compiling code that uses pthreads, an additional JavaScript file `pthread-main.js` is generated alongside the output .js file. That file must be deployed with the rest of the generated code files.
+Also note that when compiling code that uses pthreads, an additional JavaScript file `pthread-main.js` is generated alongside the output .js file. That file must be deployed with the rest of the generated code files. By default, `pthread-main.js` will be loaded relative to the main HTML page URL. If it is desirable to load the file from a different location e.g. in a CDN environment, then one can define the `Module.locateFile(filename)` function in the main HTML `Module` object to return the URL of the target location of the `pthread-main.js` entry point. If this function is not defined in `Module`, then the relative location specified by `Module.pthreadMainPrefixURL + '/pthread-main.js'` will be used instead. If this is prefix URL is not specified either, then the default location relative to the main HTML file is used.
 
 Running code and tests
 ======================

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -130,7 +130,13 @@ var LibraryPThread = {
 
       var numWorkersLoaded = 0;
       for (var i = 0; i < numWorkers; ++i) {
-        var worker = new Worker('pthread-main.js');
+        var pthreadMainJs = 'pthread-main.js';
+        // Allow HTML module to configure the location where the 'pthread-main.js' file will be loaded from,
+        // either via Module.locateFile() function, or via Module.pthreadMainPrefixURL string. If neither
+        // of these are passed, then the default URL 'pthread-main.js' relative to the main html file is loaded.
+        if (typeof Module['locateFile'] === 'function') pthreadMainJs = Module['locateFile'](pthreadMainJs);
+        else if (Module['pthreadMainPrefixURL']) pthreadMainJs = Module['pthreadMainPrefixURL'] + pthreadMainJs;
+        var worker = new Worker(pthreadMainJs);
 
         worker.onmessage = function(e) {
           if (e.data.cmd === 'processQueuedMainThreadWork') {


### PR DESCRIPTION
Add support for using `Module.locateFile(filename)` function to locate `pthread-main.js`, and add new field `Module.pthreadMainPrefixURL` to locate the file if `Module.locateFile` is not being used. Replaces #3919. Closes #3500.