### PR TITLE
separate_asm_warning

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -828,6 +828,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     js_target = unsuffixed(target) + '.js'
 
     asm_target = js_target[:-3] + '.asm.js' # might not be used, but if it is, this is the name
+    if not separate_asm and 'PRECISE_F32=2' in settings_changes or 'USE_PTHREADS=2' in settings_changes:
+      separate_asm = True
+      logging.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 or -s USE_PTHREADS=2 was passed.')
     if separate_asm:
       shared.Settings.SEPARATE_ASM = asm_target
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5832,3 +5832,15 @@ int main() {
     size = os.stat('a.out.js.mem').st_size
     assert size < 4096, size
 
+  def test_separate_asm_warning(self):
+    # Test that -s PRECISE_F32=2 raises a warning that --separate-asm is implied.
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2'], stderr=PIPE).communicate()
+    self.assertContained('forcing separate asm output', stderr)
+
+    # Test that -s PRECISE_F32=2 --separate-asm should not post a warning.
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2', '--separate-asm'], stderr=PIPE).communicate()
+    self.assertNotContained('forcing separate asm output', stderr)
+
+    # Test that -s PRECISE_F32=1 should not post a warning.
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=1'], stderr=PIPE).communicate()
+    self.assertNotContained('forcing separate asm output', stderr)


### PR DESCRIPTION
Change -s USE_PTHREADS=2 and -s PRECISE_F32=2 to imply --separate-asm, instead of aborting when it is not specified. Closes #3829.