### PR TITLE
cxx11_atomics

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1282,14 +1282,6 @@ LibraryManager.library = {
     return -1; // 'indeterminable' for FLT_ROUNDS
   },
 
-  llvm_memory_barrier: function(){},
-
-  llvm_atomic_load_add_i32_p0i32: function(ptr, delta) {
-    var ret = {{{ makeGetValue('ptr', '0', 'i32') }}};
-    {{{ makeSetValue('ptr', '0', 'ret+delta', 'i32') }}};
-    return ret;
-  },
-
   llvm_expect_i32__inline: function(val, expected) {
     return '(' + val + ')';
   },
@@ -1311,89 +1303,6 @@ LibraryManager.library = {
   llvm_nacl_atomic_cmpxchg_i8__inline: true,
   llvm_nacl_atomic_cmpxchg_i16__inline: true,
   llvm_nacl_atomic_cmpxchg_i32__inline: true,
-
-  // gnu atomics
-
-  __atomic_is_lock_free: function(size, ptr) {
-    return size <= 4 && (ptr&(size-1)) == 0;
-  },
-
-  __atomic_load_8: function(ptr, memmodel) {
-    {{{ makeStructuralReturn([makeGetValue('ptr', 0, 'i32'), makeGetValue('ptr', 4, 'i32')]) }}};
-  },
-
-  __atomic_store_8: function(ptr, vall, valh, memmodel) {
-    {{{ makeSetValue('ptr', 0, 'vall', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'valh', 'i32') }}};
-  },
-
-  __atomic_exchange_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, 'vall', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'valh', 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
-  __atomic_compare_exchange_8: function(ptr, expected, desiredl, desiredh, weak, success_memmodel, failure_memmodel) {
-    var pl = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var ph = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    var el = {{{ makeGetValue('expected', 0, 'i32') }}};
-    var eh = {{{ makeGetValue('expected', 4, 'i32') }}};
-    if (pl === el && ph === eh) {
-      {{{ makeSetValue('ptr', 0, 'desiredl', 'i32') }}};
-      {{{ makeSetValue('ptr', 4, 'desiredh', 'i32') }}};
-      return 1;
-    } else {
-      {{{ makeSetValue('expected', 0, 'pl', 'i32') }}};
-      {{{ makeSetValue('expected', 4, 'ph', 'i32') }}};
-      return 0;
-    }
-  },
-
-  __atomic_fetch_add_8__deps: ['llvm_uadd_with_overflow_i64'],
-  __atomic_fetch_add_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, '_llvm_uadd_with_overflow_i64(l, h, vall, valh)', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, makeGetTempRet0(), 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
-  __atomic_fetch_sub_8__deps: ['i64Subtract'],
-  __atomic_fetch_sub_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, '_i64Subtract(l, h, vall, valh)', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, makeGetTempRet0(), 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
-  __atomic_fetch_and_8__deps: ['i64Subtract'],
-  __atomic_fetch_and_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, 'l&vall', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'h&valh', 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
-  __atomic_fetch_or_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, 'l|vall', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'h|valh', 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
-  __atomic_fetch_xor_8: function(ptr, vall, valh, memmodel) {
-    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
-    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
-    {{{ makeSetValue('ptr', 0, 'l^vall', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'h^valh', 'i32') }}};
-    {{{ makeStructuralReturn(['l', 'h']) }}};
-  },
-
 
   // ==========================================================================
   // llvm-mono integration

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -692,6 +692,10 @@ var LibraryPThread = {
     if (ret >= 0) return ret;
     throw 'Atomics.futexWakeOrRequeue returned an unexpected value ' + ret;
   },
+
+  __atomic_is_lock_free: function(size, ptr) {
+    return size <= 4 && (size & (size-1)) == 0 && (ptr&(size-1)) == 0;
+  }
 };
 
 autoAddDeps(LibraryPThread, '$PThread');

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -170,7 +170,97 @@ var LibraryPThreadStub = {
       }
     }
     return 0;
-  }
+  },
+
+  llvm_memory_barrier: function(){},
+
+  llvm_atomic_load_add_i32_p0i32: function(ptr, delta) {
+    var ret = {{{ makeGetValue('ptr', '0', 'i32') }}};
+    {{{ makeSetValue('ptr', '0', 'ret+delta', 'i32') }}};
+    return ret;
+  },
+
+  // gnu atomics
+
+  __atomic_is_lock_free: function(size, ptr) {
+    return true;
+  },
+
+  __atomic_load_8: function(ptr, memmodel) {
+    {{{ makeStructuralReturn([makeGetValue('ptr', 0, 'i32'), makeGetValue('ptr', 4, 'i32')]) }}};
+  },
+
+  __atomic_store_8: function(ptr, vall, valh, memmodel) {
+    {{{ makeSetValue('ptr', 0, 'vall', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'valh', 'i32') }}};
+  },
+
+  __atomic_exchange_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, 'vall', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'valh', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
+
+  __atomic_compare_exchange_8: function(ptr, expected, desiredl, desiredh, weak, success_memmodel, failure_memmodel) {
+    var pl = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var ph = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    var el = {{{ makeGetValue('expected', 0, 'i32') }}};
+    var eh = {{{ makeGetValue('expected', 4, 'i32') }}};
+    if (pl === el && ph === eh) {
+      {{{ makeSetValue('ptr', 0, 'desiredl', 'i32') }}};
+      {{{ makeSetValue('ptr', 4, 'desiredh', 'i32') }}};
+      return 1;
+    } else {
+      {{{ makeSetValue('expected', 0, 'pl', 'i32') }}};
+      {{{ makeSetValue('expected', 4, 'ph', 'i32') }}};
+      return 0;
+    }
+  },
+
+  __atomic_fetch_add_8__deps: ['llvm_uadd_with_overflow_i64'],
+  __atomic_fetch_add_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, '_llvm_uadd_with_overflow_i64(l, h, vall, valh)', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'asm["getTempRet0"]()', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
+
+  __atomic_fetch_sub_8__deps: ['i64Subtract'],
+  __atomic_fetch_sub_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, '_i64Subtract(l, h, vall, valh)', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'asm["getTempRet0"]()', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
+
+  __atomic_fetch_and_8__deps: ['i64Subtract'],
+  __atomic_fetch_and_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, 'l&vall', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'h&valh', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
+
+  __atomic_fetch_or_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, 'l|vall', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'h|valh', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
+
+  __atomic_fetch_xor_8: function(ptr, vall, valh, memmodel) {
+    var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
+    var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
+    {{{ makeSetValue('ptr', 0, 'l^vall', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'h^valh', 'i32') }}};
+    {{{ makeStructuralReturn(['l', 'h']) }}};
+  },
 };
 
 mergeInto(LibraryManager.library, LibraryPThreadStub);

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -642,3 +642,58 @@ uint64_t EMSCRIPTEN_KEEPALIVE _emscripten_atomic_fetch_and_xor_u64(void *addr, u
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
 	return oldVal;
 }
+
+int llvm_memory_barrier()
+{
+	emscripten_atomic_fence();
+}
+
+int llvm_atomic_load_add_i32_p0i32(int *ptr, int delta)
+{
+	return emscripten_atomic_add_u32(ptr, delta) - delta;
+}
+
+uint64_t __atomic_load_8(void *ptr, int memmodel)
+{
+	return emscripten_atomic_load_u64(ptr);
+}
+
+uint64_t __atomic_store_8(void *ptr, uint64_t value, int memmodel)
+{
+	return emscripten_atomic_store_u64(ptr, value);
+}
+
+uint64_t __atomic_exchange_8(void *ptr, uint64_t value, int memmodel)
+{
+	return emscripten_atomic_exchange_u64(ptr, value);
+}
+
+uint64_t __atomic_compare_exchange_8(void *ptr, uint64_t *expected, uint64_t desired, int weak, int success_memmodel, int failure_memmodel)
+{
+	return emscripten_atomic_cas_u64(ptr, *expected, desired);
+}
+
+uint64_t __atomic_fetch_add_8(void *ptr, uint64_t value, int memmodel)
+{
+	return _emscripten_atomic_fetch_and_add_u64(ptr, value);
+}
+
+uint64_t __atomic_fetch_sub_8(void *ptr, uint64_t value, int memmodel)
+{
+	return _emscripten_atomic_fetch_and_sub_u64(ptr, value);
+}
+
+uint64_t __atomic_fetch_and_8(void *ptr, uint64_t value, int memmodel)
+{
+	return _emscripten_atomic_fetch_and_and_u64(ptr, value);
+}
+
+uint64_t __atomic_fetch_or_8(void *ptr, uint64_t value, int memmodel)
+{
+	return _emscripten_atomic_fetch_and_or_u64(ptr, value);
+}
+
+uint64_t __atomic_fetch_xor_8(void *ptr, uint64_t value, int memmodel)
+{
+	return _emscripten_atomic_fetch_and_xor_u64(ptr, value);
+}

--- a/system/lib/pthreads.symbols
+++ b/system/lib/pthreads.symbols
@@ -21,6 +21,18 @@
          T _pthread_getcanceltype
          T _pthread_isduecanceled
          T _pthread_msecs_until
+         T ___atomic_is_lock_free
+         T ___atomic_load_8
+         T ___atomic_store_8
+         T ___atomic_exchange_8
+         T ___atomic_compare_exchange_8
+         T ___atomic_fetch_add_8
+         T ___atomic_fetch_sub_8
+         T ___atomic_fetch_and_8
+         T ___atomic_fetch_or_8
+         T ___atomic_fetch_xor_8
+         T _llvm_atomic_load_add_i32_p0i32
+         T _llvm_memory_barrier
          U accept
          U access
          U atexit

--- a/tests/pthread/test_pthread_64bit_cxx11_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_cxx11_atomics.cpp
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <assert.h>
+#include <atomic>
+
+int main(void)
+{
+    std::atomic<int64_t> a(0x0F0F0F0F0F0F0F0FULL);
+    int64_t old = a.fetch_add(1, std::memory_order_relaxed);
+    printf("%llx\n", old);
+    assert(old == 0x0F0F0F0F0F0F0F0FULL);
+    assert(a.load(std::memory_order_relaxed) == 0x0F0F0F0F0F0F0F10ULL);
+
+    old = a.fetch_sub(1, std::memory_order_relaxed);
+    printf("%llx\n", old);
+    assert(old == 0x0F0F0F0F0F0F0F10ULL);
+    assert(a.load(std::memory_order_relaxed) == 0x0F0F0F0F0F0F0F0FULL);
+
+    old = a.fetch_and(0x0770077007700070ULL, std::memory_order_relaxed);
+    printf("%llx\n", old);
+    assert(old == 0x0F0F0F0F0F0F0F0FULL);
+    assert(a.load(std::memory_order_relaxed) == 0x0700070007000000ULL);
+
+    old = a.fetch_or(0x3003300330033000ULL, std::memory_order_relaxed);
+    printf("%llx\n", old);
+    assert(old == 0x0700070007000000ULL);
+    assert(a.load(std::memory_order_relaxed) == 0x3703370337033000ULL);
+
+    old = a.fetch_xor(0xFF00FF0000FF00FFULL, std::memory_order_relaxed);
+    printf("%llx\n", old);
+    assert(old == 0x3703370337033000ULL);
+    assert(a.load(std::memory_order_relaxed) == 0xC803C80337FC30FFULL);
+
+#ifdef REPORT_RESULT
+    int result = 0;
+    REPORT_RESULT();
+#endif
+
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2706,6 +2706,12 @@ window.close = function() {
   def test_zzz_pthread_64bit_atomics(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_64bit_atomics.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '--separate-asm', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)
 
+  # Test 64-bit C++11 atomics.
+  def test_zzz_pthread_64bit_cxx11_atomics(self):
+    for opt in [['-O0'], ['-O3']]:
+      for pthreads in [[], ['-s', 'USE_PTHREADS=1']]:
+        self.btest(path_from_root('tests', 'pthread', 'test_pthread_64bit_cxx11_atomics.cpp'), expected='0', args=opt + pthreads + ['-std=c++11'], timeout=30)
+
   # Test the old GCC atomic __sync_fetch_and_op builtin operations.
   def test_zzz_pthread_gcc_atomic_fetch_and_op(self):
     # We need to resort to using regexes to optimize out SharedArrayBuffer when pthreads are not supported, which is brittle!


### PR DESCRIPTION
Fix __atomic_fetch_add_8() and __atomic_fetch_sub_8() when pthreads are disabled, by replacing makeGetTempRet0() in those functions with asm["getTempRet0"]() - these both call an asm.js function _llvm_uadd_with_overflow_i64(). Also fix the atomicity of the 64 bit primitives when targeting pthreads. Fixes the underlying issue reported in #3892.