### PR TITLE
The header is copied into the sdl2 include path

### DIFF
--- a/tools/ports/sdl_image.py
+++ b/tools/ports/sdl_image.py
@@ -51,7 +51,6 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL_IMAGE == 2:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2-image', 'include')]
   return args
 
 def show():


### PR DESCRIPTION
You will note there is no include directory in https://github.com/emscripten-ports/SDL2_image

Instead what happens (further up in this file) is the header file gets copied into the SDL2 include directory. `emcc -v` supports this:
```
[...]
clang -cc1 version 3.8.0 based upon LLVM 3.8.0svn default target x86_64-unknown-linux-gnu
ignoring nonexistent directory "/myhome/.emscripten_cache/ports-builds/sdl2-image/include"
#include "..." search starts here:
[...]
```