### PR TITLE
Slightly more detail on nonportable endianness

### DIFF
--- a/site/source/docs/porting/guidelines/portability_guidelines.rst
+++ b/site/source/docs/porting/guidelines/portability_guidelines.rst
@@ -17,7 +17,7 @@ The following types of code would need to be re-written in order to work with Em
 
 	.. note:: Should the JavaScript standards bodies add shared state to web workers, multithreaded code would become possible to support.
 	
--  Code that relies on endianness is non-portable (both on native builds on different CPUs and using Emscripten).
+-  Code relying on a big-endian architecture. Emscripten-compiled code currently requires a little-endian host to run on, which accounts for 99% of machines connected to the internet. This is because JavaScript typed arrays (used for views on memory) obey the host byte ordering and LLVM needs to know which endianness to target.
 -  Code that relies on x86 alignment behavior. x86 allows unaligned reads and writes (so for example you can read a 16-bit value from a non-even address), but other architectures do not (ARM will raise ``SIGILL``). For Emscripten-generated JavaScript the behavior is undefined. If you build your code with ``SAFE_HEAP=1`` then you will get a clear runtime exception, see :ref:`Debugging`.
 -  Code that uses low-level features of the native environment, for example native stack manipulation in conjunction with ``setjmp``/``longjmp`` (we support normal ``setjmp``/``longjmp``, but not with stack replacing, etc.)
 -  Code that scans registers or the stack. This won't work because a variable in a register or on the stack may be held in a JavaScript local variable (which cannot be scanned).


### PR DESCRIPTION
This is both a suggestion (as the current point is a bit vague) and a question (to check that what I've added is actually the reason for nonportability).

However, I wonder if this warning about endianness is still relevant given the assert below...
```
// Endianness check (note: assumes compiler arch was little-endian)
#if SAFE_SPLIT_MEMORY == 0
HEAP32[0] = 255;
assert(HEAPU8[0] === 255 && HEAPU8[3] === 0, 'Typed arrays 2 must be run on a little-endian system');
#endif
```