### PR TITLE
Fix a bunch of clang warnings when using embind or stb_image

### DIFF
--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -37,7 +37,7 @@ extern "C" {
 #endif
         } else {
             char str[80];
-            sprintf(str, "%p", ti);
+            sprintf(str, "%p", reinterpret_cast<const void*>(ti));
             return strdup(str);
         }
     }


### PR DESCRIPTION
This PR fixes some compilation warnings when invoking emcc with flag -Wextra : 
  * -Wformat-pedantic is generated when using embind (--bind flag with emcc)
  * -Wself-assign, -Wmissing-field-initializers are generated when using stb_image (-s STB_IMAGE=1 flag with emcc)
