### PR TITLE
Fix buffer length for copying image filename when using stb_image

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2162,7 +2162,7 @@ var LibrarySDL = {
         if (!raw) {
           if (raw === null) Module.printErr('Trying to reuse preloaded image, but freePreloadedMediaOnUse is set!');
 #if STB_IMAGE
-          var name = Module['_malloc'](filename.length+1);
+          var name = Module['_malloc'](lengthBytesUTF8(filename)+1);
           writeStringToMemory(filename, name);
           addCleanup(function() {
             Module['_free'](name);


### PR DESCRIPTION
When using the stb_image implementation for IMG_Load, the image filename is copied to a newly allocated bytes buffer.
As the filename can contain non ascii characters, lengthBytesUTF8(filename) must be used instead of filename.length to retrieve the number of bytes to allocated. Memory corruption can occur otherwise.