### PR TITLE
Accept HTTP status 0 in packager, so file:// URLs work in Chrome

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -693,7 +693,7 @@ if has_preloaded:
         throw new Error("NetworkError for: " + packageName);
       }
       xhr.onload = function(event) {
-        if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206) {
+        if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
           var packageData = xhr.response;
           callback(packageData);
         } else {


### PR DESCRIPTION
I run Chrome with --allow-file-access-from-files so Emscripten programs can load data from the local file system, without needing a web server. This works fine with old packager output, but fails with new packager output because Chrome returns status 0. This fix is similar to [xhrLoad() in library_browser](https://github.com/kripken/emscripten/blob/incoming/src/library_browser.js#L628).

This was observed with Chrome 47.0.2526.80 (64-bit) in Ubuntu.