### PR TITLE
functions for complex division, multiplication

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -226,3 +226,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nate Burr <nate.oo@gmail.com>
 * Paul "TBBle" Hampson <Paul.Hampson@Pobox.com>
 * Andreas Plesch <andreasplesch@gmail.com>
+* Brian Armstrong <brian.armstrong.ece+github@gmail.com>

--- a/system/lib/compiler-rt.symbols
+++ b/system/lib/compiler-rt.symbols
@@ -1,0 +1,4 @@
+         T __divdc3
+         T __divsc3
+         T __muldc3
+         T __mulsc3

--- a/system/lib/compiler-rt/CREDITS.TXT
+++ b/system/lib/compiler-rt/CREDITS.TXT
@@ -1,0 +1,36 @@
+This file is a partial list of people who have contributed to the LLVM/CompilerRT
+project.  If you have contributed a patch or made some other contribution to
+LLVM/CompilerRT, please submit a patch to this file to add yourself, and it will be
+done!
+
+The list is sorted by surname and formatted to allow easy grepping and
+beautification by scripts.  The fields are: name (N), email (E), web-address
+(W), PGP key ID and fingerprint (P), description (D), and snail-mail address
+(S).
+
+N: Craig van Vliet
+E: cvanvliet@auroraux.org
+W: http://www.auroraux.org
+D: Code style and Readability fixes.
+
+N: Edward O'Callaghan
+E: eocallaghan@auroraux.org
+W: http://www.auroraux.org
+D: CMake'ify Compiler-RT build system
+D: Maintain Solaris & AuroraUX ports of Compiler-RT
+
+N: Howard Hinnant
+E: hhinnant@apple.com
+D: Architect and primary author of compiler-rt
+
+N: Guan-Hong Liu
+E: koviankevin@hotmail.com
+D: IEEE Quad-precision functions
+
+N: Joerg Sonnenberger
+E: joerg@NetBSD.org
+D: Maintains NetBSD port.
+
+N: Matt Thomas
+E: matt@NetBSD.org
+D: ARM improvements.

--- a/system/lib/compiler-rt/LICENSE.TXT
+++ b/system/lib/compiler-rt/LICENSE.TXT
@@ -14,7 +14,7 @@ Full text of the relevant licenses is included below.
 University of Illinois/NCSA
 Open Source License
 
-Copyright (c) 2009-2013 by the contributors listed in CREDITS.TXT
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
 
 All rights reserved.
 
@@ -55,7 +55,7 @@ SOFTWARE.
 
 ==============================================================================
 
-Copyright (c) 2009-2013 by the contributors listed in CREDITS.TXT
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -89,9 +89,4 @@ other licenses gives permission to use the names of the LLVM Team or the
 University of Illinois to endorse or promote products derived from this
 Software.
 
-The following pieces of software have additional or alternate copyrights,
-licenses, and/or restrictions:
 
-Program             Directory
--------             ---------
-mach_override       lib/interception/mach_override

--- a/system/lib/compiler-rt/divdc3.c
+++ b/system/lib/compiler-rt/divdc3.c
@@ -1,0 +1,61 @@
+/* ===-- divdc3.c - Implement __divdc3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __divdc3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+#include "int_math.h"
+
+/* Returns: the quotient of (a + ib) / (c + id) */
+
+COMPILER_RT_ABI Dcomplex
+__divdc3(double __a, double __b, double __c, double __d)
+{
+    int __ilogbw = 0;
+    double __logbw = crt_logb(crt_fmax(crt_fabs(__c), crt_fabs(__d)));
+    if (crt_isfinite(__logbw))
+    {
+        __ilogbw = (int)__logbw;
+        __c = crt_scalbn(__c, -__ilogbw);
+        __d = crt_scalbn(__d, -__ilogbw);
+    }
+    double __denom = __c * __c + __d * __d;
+    Dcomplex z;
+    COMPLEX_REAL(z) = crt_scalbn((__a * __c + __b * __d) / __denom, -__ilogbw);
+    COMPLEX_IMAGINARY(z) = crt_scalbn((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z)))
+    {
+        if ((__denom == 0.0) && (!crt_isnan(__a) || !crt_isnan(__b)))
+        {
+            COMPLEX_REAL(z) = crt_copysign(CRT_INFINITY, __c) * __a;
+            COMPLEX_IMAGINARY(z) = crt_copysign(CRT_INFINITY, __c) * __b;
+        }
+        else if ((crt_isinf(__a) || crt_isinf(__b)) &&
+                 crt_isfinite(__c) && crt_isfinite(__d))
+        {
+            __a = crt_copysign(crt_isinf(__a) ? 1.0 : 0.0, __a);
+            __b = crt_copysign(crt_isinf(__b) ? 1.0 : 0.0, __b);
+            COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c + __b * __d);
+            COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__b * __c - __a * __d);
+        }
+        else if (crt_isinf(__logbw) && __logbw > 0.0 &&
+                 crt_isfinite(__a) && crt_isfinite(__b))
+        {
+            __c = crt_copysign(crt_isinf(__c) ? 1.0 : 0.0, __c);
+            __d = crt_copysign(crt_isinf(__d) ? 1.0 : 0.0, __d);
+            COMPLEX_REAL(z) = 0.0 * (__a * __c + __b * __d);
+            COMPLEX_IMAGINARY(z) = 0.0 * (__b * __c - __a * __d);
+        }
+    }
+    return z;
+}
+

--- a/system/lib/compiler-rt/divsc3.c
+++ b/system/lib/compiler-rt/divsc3.c
@@ -1,0 +1,61 @@
+/*===-- divsc3.c - Implement __divsc3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __divsc3 for the compiler_rt library.
+ *
+ *===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+#include "int_math.h"
+
+/* Returns: the quotient of (a + ib) / (c + id) */
+
+COMPILER_RT_ABI Fcomplex
+__divsc3(float __a, float __b, float __c, float __d)
+{
+    int __ilogbw = 0;
+    float __logbw = crt_logbf(crt_fmaxf(crt_fabsf(__c), crt_fabsf(__d)));
+    if (crt_isfinite(__logbw))
+    {
+        __ilogbw = (int)__logbw;
+        __c = crt_scalbnf(__c, -__ilogbw);
+        __d = crt_scalbnf(__d, -__ilogbw);
+    }
+    float __denom = __c * __c + __d * __d;
+    Fcomplex z;
+    COMPLEX_REAL(z) = crt_scalbnf((__a * __c + __b * __d) / __denom, -__ilogbw);
+    COMPLEX_IMAGINARY(z) = crt_scalbnf((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z)))
+    {
+        if ((__denom == 0) && (!crt_isnan(__a) || !crt_isnan(__b)))
+        {
+            COMPLEX_REAL(z) = crt_copysignf(CRT_INFINITY, __c) * __a;
+            COMPLEX_IMAGINARY(z) = crt_copysignf(CRT_INFINITY, __c) * __b;
+        }
+        else if ((crt_isinf(__a) || crt_isinf(__b)) &&
+                 crt_isfinite(__c) && crt_isfinite(__d))
+        {
+            __a = crt_copysignf(crt_isinf(__a) ? 1 : 0, __a);
+            __b = crt_copysignf(crt_isinf(__b) ? 1 : 0, __b);
+            COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c + __b * __d);
+            COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__b * __c - __a * __d);
+        }
+        else if (crt_isinf(__logbw) && __logbw > 0 &&
+                 crt_isfinite(__a) && crt_isfinite(__b))
+        {
+            __c = crt_copysignf(crt_isinf(__c) ? 1 : 0, __c);
+            __d = crt_copysignf(crt_isinf(__d) ? 1 : 0, __d);
+            COMPLEX_REAL(z) = 0 * (__a * __c + __b * __d);
+            COMPLEX_IMAGINARY(z) = 0 * (__b * __c - __a * __d);
+        }
+    }
+    return z;
+}
+

--- a/system/lib/compiler-rt/int_types.h
+++ b/system/lib/compiler-rt/int_types.h
@@ -136,5 +136,12 @@ typedef union
     long double f;
 } long_double_bits;
 
+typedef float _Complex Fcomplex;
+typedef double _Complex Dcomplex;
+typedef long double _Complex Lcomplex;
+
+#define COMPLEX_REAL(x) __real__(x)
+#define COMPLEX_IMAGINARY(x) __imag__(x)
+
 #endif /* INT_TYPES_H */
 

--- a/system/lib/compiler-rt/muldc3.c
+++ b/system/lib/compiler-rt/muldc3.c
@@ -1,0 +1,75 @@
+/* ===-- muldc3.c - Implement __muldc3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __muldc3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+#include "int_math.h"
+
+/* Returns: the product of a + ib and c + id */
+
+COMPILER_RT_ABI Dcomplex
+__muldc3(double __a, double __b, double __c, double __d)
+{
+    double __ac = __a * __c;
+    double __bd = __b * __d;
+    double __ad = __a * __d;
+    double __bc = __b * __c;
+    Dcomplex z;
+    COMPLEX_REAL(z) = __ac - __bd;
+    COMPLEX_IMAGINARY(z) = __ad + __bc;
+    if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z)))
+    {
+        int __recalc = 0;
+        if (crt_isinf(__a) || crt_isinf(__b))
+        {
+            __a = crt_copysign(crt_isinf(__a) ? 1 : 0, __a);
+            __b = crt_copysign(crt_isinf(__b) ? 1 : 0, __b);
+            if (crt_isnan(__c))
+                __c = crt_copysign(0, __c);
+            if (crt_isnan(__d))
+                __d = crt_copysign(0, __d);
+            __recalc = 1;
+        }
+        if (crt_isinf(__c) || crt_isinf(__d))
+        {
+            __c = crt_copysign(crt_isinf(__c) ? 1 : 0, __c);
+            __d = crt_copysign(crt_isinf(__d) ? 1 : 0, __d);
+            if (crt_isnan(__a))
+                __a = crt_copysign(0, __a);
+            if (crt_isnan(__b))
+                __b = crt_copysign(0, __b);
+            __recalc = 1;
+        }
+        if (!__recalc && (crt_isinf(__ac) || crt_isinf(__bd) ||
+                          crt_isinf(__ad) || crt_isinf(__bc)))
+        {
+            if (crt_isnan(__a))
+                __a = crt_copysign(0, __a);
+            if (crt_isnan(__b))
+                __b = crt_copysign(0, __b);
+            if (crt_isnan(__c))
+                __c = crt_copysign(0, __c);
+            if (crt_isnan(__d))
+                __d = crt_copysign(0, __d);
+            __recalc = 1;
+        }
+        if (__recalc)
+        {
+            COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c - __b * __d);
+            COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__a * __d + __b * __c);
+        }
+    }
+    return z;
+}
+
+

--- a/system/lib/compiler-rt/mulsc3.c
+++ b/system/lib/compiler-rt/mulsc3.c
@@ -1,0 +1,75 @@
+/* ===-- mulsc3.c - Implement __mulsc3 -------------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __mulsc3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+#include "int_math.h"
+
+/* Returns: the product of a + ib and c + id */
+
+COMPILER_RT_ABI Fcomplex
+__mulsc3(float __a, float __b, float __c, float __d)
+{
+    float __ac = __a * __c;
+    float __bd = __b * __d;
+    float __ad = __a * __d;
+    float __bc = __b * __c;
+    Fcomplex z;
+    COMPLEX_REAL(z) = __ac - __bd;
+    COMPLEX_IMAGINARY(z) = __ad + __bc;
+    if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z)))
+    {
+        int __recalc = 0;
+        if (crt_isinf(__a) || crt_isinf(__b))
+        {
+            __a = crt_copysignf(crt_isinf(__a) ? 1 : 0, __a);
+            __b = crt_copysignf(crt_isinf(__b) ? 1 : 0, __b);
+            if (crt_isnan(__c))
+                __c = crt_copysignf(0, __c);
+            if (crt_isnan(__d))
+                __d = crt_copysignf(0, __d);
+            __recalc = 1;
+        }
+        if (crt_isinf(__c) || crt_isinf(__d))
+        {
+            __c = crt_copysignf(crt_isinf(__c) ? 1 : 0, __c);
+            __d = crt_copysignf(crt_isinf(__d) ? 1 : 0, __d);
+            if (crt_isnan(__a))
+                __a = crt_copysignf(0, __a);
+            if (crt_isnan(__b))
+                __b = crt_copysignf(0, __b);
+            __recalc = 1;
+        }
+        if (!__recalc && (crt_isinf(__ac) || crt_isinf(__bd) ||
+                          crt_isinf(__ad) || crt_isinf(__bc)))
+        {
+            if (crt_isnan(__a))
+                __a = crt_copysignf(0, __a);
+            if (crt_isnan(__b))
+                __b = crt_copysignf(0, __b);
+            if (crt_isnan(__c))
+                __c = crt_copysignf(0, __c);
+            if (crt_isnan(__d))
+                __d = crt_copysignf(0, __d);
+            __recalc = 1;
+        }
+        if (__recalc)
+        {
+            COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c - __b * __d);
+            COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__a * __d + __b * __c);
+        }
+    }
+    return z;
+}
+
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1634,6 +1634,12 @@ int main(int argc, char**argv)
    printf("value = real %.2f imag %.2f\n",creal(z4),cimag(z4));
    float complex z5 =  cargf(z1); 
    printf("value = real %.2f imag %.2f\n",creal(z5),cimag(z5));
+   float complex z6 = 0.5 + 0.5 * I;
+   float complex z7 = 0.5 - 0.5 * I;
+   float complex z8 = z6 * z7;
+   float complex z9 = z6 / z7;
+   printf("value = real %.2f imag %.2f\n",creal(z8),cimag(z8));
+   printf("value = real %.2f imag %.2f\n",creal(z9),cimag(z9));
    return 0;
 }
 ''', '''value = real 1.00 imag 3.00
@@ -1641,7 +1647,9 @@ abs = 3.16
 value = real 1.00 imag -3.00
 value = real -2.69 imag 0.38
 value = real 1.00 imag -3.00
-value = real 1.25 imag 0.00''', force_c=True)
+value = real 1.25 imag 0.00
+value = real 0.50 imag 0.00
+value = real 0.00 imag 1.00''', force_c=True)
 
   def test_segfault(self):
     Settings.SAFE_HEAP = 1

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -47,6 +47,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   libcxx_symbols = read_symbols(shared.path_from_root('system', 'lib', 'libcxx', 'symbols'), exclude=libc_symbols)
   libcxxabi_symbols = read_symbols(shared.path_from_root('system', 'lib', 'libcxxabi', 'symbols'), exclude=libc_symbols)
   gl_symbols = read_symbols(shared.path_from_root('system', 'lib', 'gl.symbols'))
+  compiler_rt_symbols = read_symbols(shared.path_from_root('system', 'lib', 'compiler-rt.symbols'))
   pthreads_symbols = read_symbols(shared.path_from_root('system', 'lib', 'pthreads.symbols'))
 
   # XXX we should disable EMCC_DEBUG when building libs, just like in the relooper
@@ -178,6 +179,21 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     check_call([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', 'gl.c'), '-o', o])
     return o
 
+  def create_compiler_rt(libname):
+    srcdir = shared.path_from_root('system', 'lib', 'compiler-rt')
+    filenames = ['divdc3.c', 'divsc3.c', 'muldc3.c', 'mulsc3.c']
+    files = (os.path.join(srcdir, f) for f in filenames)
+
+    o_s = []
+    commands = []
+    for src in files:
+      o = in_temp(os.path.basename(src) + '.o')
+      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o])
+      o_s.append(o)
+    run_commands(commands)
+    shared.Building.link(o_s, in_temp(libname))
+    return in_temp(libname)
+
   def create_dlmalloc(out_name, clflags):
     o = in_temp(out_name)
     check_call([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', 'dlmalloc.c'), '-o', o] + clflags)
@@ -271,9 +287,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   for symbols in symbolses:
     all_needed.difference_update(symbols.defs)
 
-  system_libs = [('libcxx',    'a',  create_libcxx,    libcxx_symbols,    ['libcxxabi'], True),
-                 ('libcxxabi', 'bc', create_libcxxabi, libcxxabi_symbols, ['libc'],      False),
-                 ('gl',        'bc', create_gl,        gl_symbols,        ['libc'],      False)]
+  system_libs = [('libcxx',      'a',  create_libcxx,      libcxx_symbols,      ['libcxxabi'], True),
+                 ('libcxxabi',   'bc', create_libcxxabi,   libcxxabi_symbols,   ['libc'],      False),
+                 ('gl',          'bc', create_gl,          gl_symbols,          ['libc'],      False),
+                 ('compiler-rt', 'bc', create_compiler_rt, compiler_rt_symbols, ['libc'],      False)]
 
   # malloc dependency is force-added, so when using pthreads, it must be force-added
   # as well, since malloc needs to be thread-safe, so it depends on mutexes.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -188,7 +188,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     commands = []
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o])
+      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-O2', '-o', o])
       o_s.append(o)
     run_commands(commands)
     shared.Building.link(o_s, in_temp(libname))


### PR DESCRIPTION
I couldn't remember what had happened with merges on this branch before, so I resorted to the nuclear option rather than trying to fix it.

This creates a new compiler-rt lib. It appears to resolve the symbols on my machine. As far as the license goes, the compiler-rt dir already had the correct LICENSE file in it (possibly a previous attempt to resolve these missing symbols?), so I don't think there's anything to do there.