### PR TITLE
Prevent Building.link from forcing absolute paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -221,3 +221,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Piotr Paczkowski <kontakt@trzeci.eu>
 * Braden MacDonald <braden@bradenmacdonald.com>
 * Kevin Cheung <kevin.cheung@autodesk.com> (copyright owned by Autodesk, Inc.)
+* Josh Peterson <petersonjm1@gmail.com>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7307,6 +7307,34 @@ Module.printErr = Module['printErr'] = function(){};
       # This test *should* fail, by throwing this exception
       assert 'Assertion failed: Load-store consistency assumption failure!' in str(e), str(e)
 
+  def test_link_response_file_does_not_force_absolute_paths(self):
+    with_space = 'with space'
+    directory_with_space_name = os.path.join(self.get_dir(), with_space)
+    if not os.path.exists(directory_with_space_name):
+      os.makedirs(directory_with_space_name)
+
+    main = '''
+      int main() {
+        return 0;
+      }
+    '''
+    main_file_name = 'main.cpp'
+    main_path_name = os.path.join(directory_with_space_name, main_file_name)
+    open(main_path_name, 'w').write(main)
+    main_object_file_name = 'main.cpp.o'
+
+    Building.emcc(main_path_name, ['-g'])
+
+    current_directory = os.getcwd()
+    os.chdir(os.path.join(current_directory, with_space))
+
+    link_args = Building.link([main_object_file_name], os.path.join(self.get_dir(), 'all.bc'), just_calculate=True)
+
+    os.chdir(current_directory)
+
+    # We want only the relative path to be in the linker args, it should not be converted to an absolute path.
+    self.assertItemsEqual(link_args, [main_object_file_name])
+
   @no_emterpreter
   def test_source_map(self):
     if NODE_JS not in JS_ENGINES: return self.skip('sourcemapper requires Node to run')


### PR DESCRIPTION
For this PR I've run the core tests via tests/parallel_tests_core.py and the "other" tests. I see some failures and errors in both suites, but no new failures or errors that don't occur locally for me with a clean checkout. So I'm not sure what to make of that. Maybe I have some local setup incorrect?

I've also added a new core test: test_link_response_file_does_not_force_absolute_paths

This one fails without the associated change in shared.py and succeeds with that change.