### PR TITLE
getpeername implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,3 +224,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Josh Peterson <petersonjm1@gmail.com>
 * eska <eska@eska.me>
 * Nate Burr <nate.oo@gmail.com>
+* Paul "TBBle" Hampson <Paul.Hampson@Pobox.com>

--- a/src/library.js
+++ b/src/library.js
@@ -3183,11 +3183,11 @@ LibraryManager.library = {
     lookup_name: function (name) {
       // If the name is already a valid ipv4 / ipv6 address, don't generate a fake one.
       var res = __inet_pton4_raw(name);
-      if (res) {
+      if (res !== null) {
         return name;
       }
       res = __inet_pton6_raw(name);
-      if (res) {
+      if (res !== null) {
         return name;
       }
 

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -448,7 +448,18 @@ var SyscallsLibrary = {
       }
       case 6: { // getsockname
         var sock = SYSCALLS.getSocketFromFD(), addr = SYSCALLS.get(), addrlen = SYSCALLS.get();
-        var res = __write_sockaddr(addr, sock.family, DNS.lookup_name(sock.daddr || '0.0.0.0'), sock.dport);
+        // TODO: sock.saddr should never be undefined, see TODO in websocket_sock_ops.getname
+        var res = __write_sockaddr(addr, sock.family, DNS.lookup_name(sock.saddr || '0.0.0.0'), sock.sport);
+        assert(!res.errno);
+        return 0;
+      }
+      case 7: { // getpeername
+        var sock = SYSCALLS.getSocketFromFD(), addr = SYSCALLS.get(), addrlen = SYSCALLS.get();
+        if (!sock.daddr)
+        {
+          return -ERRNO_CODES.ENOTCONN; // The socket is not connected.
+        }
+        var res = __write_sockaddr(addr, sock.family, DNS.lookup_name(sock.daddr), sock.dport);
         assert(!res.errno);
         return 0;
       }

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -455,8 +455,7 @@ var SyscallsLibrary = {
       }
       case 7: { // getpeername
         var sock = SYSCALLS.getSocketFromFD(), addr = SYSCALLS.get(), addrlen = SYSCALLS.get();
-        if (!sock.daddr)
-        {
+        if (!sock.daddr) {
           return -ERRNO_CODES.ENOTCONN; // The socket is not connected.
         }
         var res = __write_sockaddr(addr, sock.family, DNS.lookup_name(sock.daddr), sock.dport);

--- a/tests/sockets/test_sockets_echo_client.c
+++ b/tests/sockets/test_sockets_echo_client.c
@@ -198,10 +198,30 @@ int main() {
       finish(EXIT_FAILURE);
     }
     char buffer[1000];
-    sprintf(buffer, "%s:%u\n", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
-    char *correct = "127.0.0.1:49161\n";
+    sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
+    // TODO: This is not the correct result: We should have a auto-bound address
+    char *correct = "0.0.0.0:0";
     printf("got (expected) socket: %s (%s), size %d (%d)\n", buffer, correct, strlen(buffer), strlen(correct));
-    assert(strncmp(buffer, correct, 10) == 0);
+    assert(strlen(buffer) == strlen(correct));
+    assert(strcmp(buffer, correct) == 0);
+  }
+
+  {
+    int z;
+    struct sockaddr_in adr_inet;
+    socklen_t len_inet = sizeof adr_inet;
+    z = getpeername(server.fd, (struct sockaddr *)&adr_inet, &len_inet);
+    if (z != 0) {
+      perror("getpeername");
+      finish(EXIT_FAILURE);
+    }
+    char buffer[1000];
+    sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
+    char correct[1000];
+    sprintf(correct, "127.0.0.1:%u", SOCKK);
+    printf("got (expected) socket: %s (%s), size %d (%d)\n", buffer, correct, strlen(buffer), strlen(correct));
+    assert(strlen(buffer) == strlen(correct));
+    assert(strcmp(buffer, correct) == 0);
   }
 
 #ifdef __EMSCRIPTEN__

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -264,7 +264,7 @@ ok.
       #include <assert.h>
       #include <sys/socket.h>
       #include <netinet/in.h>
-      #include <arpa/inet.h> 
+      #include <arpa/inet.h>
       #include <string.h>
       int main() {
         int fd;
@@ -278,12 +278,38 @@ ok.
           return 1;
         }
         char buffer[1000];
-        sprintf(buffer, "%s:%u\n", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
-        const char *correct = "0.0.0.0:0\n";
+        sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
+        const char *correct = "0.0.0.0:0";
         printf("got (expected) socket: %s (%s), size %d (%d)\n", buffer, correct, strlen(buffer), strlen(correct));
+        assert(strlen(buffer) == strlen(correct));
+        assert(strcmp(buffer, correct) == 0);
         puts("success.");
       }
     ''', 'success.')
+
+  def test_getpeername_null(self):
+    self.do_run(r'''
+      #include <sys/socket.h>
+      #include <stdio.h>
+      #include <assert.h>
+      #include <sys/socket.h>
+      #include <netinet/in.h>
+      #include <arpa/inet.h>
+      #include <string.h>
+      int main() {
+        int fd;
+        int z;
+        fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+        struct sockaddr_in adr_inet;
+        socklen_t len_inet = sizeof adr_inet;
+        z = getpeername(fd, (struct sockaddr *)&adr_inet, &len_inet);
+        if (z != 0) {
+          perror("getpeername error");
+          return 1;
+        }
+        puts("unexpected success.");
+      }
+    ''', 'getpeername error: Socket not connected')
 
   def test_getaddrinfo(self):
     self.emcc_args=[]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -257,7 +257,7 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff - ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff
 ok.
 ''')
 
-  def test_getsockname_null(self):
+  def test_getsockname_unconnected_socket(self):
     self.do_run(r'''
       #include <sys/socket.h>
       #include <stdio.h>
@@ -287,7 +287,7 @@ ok.
       }
     ''', 'success.')
 
-  def test_getpeername_null(self):
+  def test_getpeername_unconnected_socket(self):
     self.do_run(r'''
       #include <sys/socket.h>
       #include <stdio.h>


### PR DESCRIPTION
This pulls in the fixes for issues described in #3997
The following tests pass:
* sockets.test_nodejs_sockets_echo
* sockets.test_getsockname_null
* *new* sockets.test_getpeername_null

The latter two tests should probably be renamed from 'null' to 'unconnected' as that is what they are actually testing. But I'm not sure if renaming tests would cause issues, so I haven't done so.

I'm developing on an SSH connection to a remove Linux machine, so I didn't seem to be able to run
* sockets.test_sockets_echo
* sockets.test_sockets_echo_bigdata

as they appear to depend on access to a local web browser?

I have the default tests ran with 11 failures, but the above tests are the only ones that reference getsockname. Hopefully no one is relying on the behaviour of `DNS.lookup_name( '0.0.0.0' )` not returning `'0.0.0.0'`.