### PR TITLE
Correct DST calculations in mktime

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1643,10 +1643,10 @@ LibraryManager.library = {
     var winterOffset = start.getTimezoneOffset();
     var dstOffset = Math.min(winterOffset, summerOffset); // DST is in December in South
     if (dst < 0) {
-      {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_isdst, 'Number(winterOffset != guessedOffset)', 'i32') }}};
-    } else if ((dst > 0) != (winterOffset != guessedOffset)) {
-      var summerOffset = new Date(date.getFullYear(), 6, 1).getTimezoneOffset();
-      var trueOffset = dst > 0 ? summerOffset : winterOffset;
+      {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_isdst, 'Number(dstOffset == guessedOffset)', 'i32') }}};
+    } else if ((dst > 0) != (dstOffset == guessedOffset)) {
+      var nonDstOffset = Math.max(winterOffset, summerOffset);
+      var trueOffset = dst > 0 ? dstOffset : nonDstOffset;
       // Don't try setMinutes(date.getMinutes() + ...) -- it's messed up.
       date.setTime(date.getTime() + (trueOffset - guessedOffset)*60000);
     }

--- a/tests/time/src.c
+++ b/tests/time/src.c
@@ -74,7 +74,7 @@ int main() {
   // ones to watch, but we don't where they are since the zoneinfo could be US or
   // European)
   int mktimeOk = 1;
-  for (int i = 0; i < 2*24*266; ++i) {
+  for (int i = 0; i < 2*24*366; ++i) {
     struct tm tmp;
     time_t test = xmas2002 + 30*60*i;
     if (localtime_r(&test, &tmp) != &tmp) printf("localtime_r failed\n");


### PR DESCRIPTION
I've tested this with the `test_time` test (the one failing in #4001), but only in the Southern Hemisphere. It _looks_ rational to me for Northern Hemisphere though, where `dstOffset == summerOffset`.

The guessing of tm_dst is now the same as localtime_r, which was already working correctly.