### PR TITLE
optimize_pthread_self

### DIFF
--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -51,6 +51,7 @@ this.onmessage = function(e) {
     postMessage({ cmd: 'loaded' });
   } else if (e.data.cmd === 'run') { // This worker was idle, and now should start executing its pthread entry point.
     threadInfoStruct = e.data.threadInfoStruct;
+    __register_pthread_ptr(threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0); // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
     assert(threadInfoStruct);
     selfThreadId = e.data.selfThreadId;
     assert(selfThreadId);


### PR DESCRIPTION
Optimize potentially hot functions pthread_self(), emscripten_is_main_runtime_thread() and emscripten_is_main_browser_thread() to run inside the asm.js scope to avoid a FFI transition. Implements #3504.