### PR TITLE
webidl test: fix compiler warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -225,3 +225,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * eska <eska@eska.me>
 * Nate Burr <nate.oo@gmail.com>
 * Paul "TBBle" Hampson <Paul.Hampson@Pobox.com>
+* Andreas Plesch <andreasplesch@gmail.com>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7216,7 +7216,7 @@ def process(filename):
 // test purposes: remove printErr output, whose order is unpredictable when compared to print
 Module.printErr = Module['printErr'] = function(){};
 ''')
-      self.emcc_args += ['--post-js', 'glue.js', '--post-js', 'export.js']
+      self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=["_malloc"]', '--post-js', 'glue.js', '--post-js', 'export.js']
       shutil.copyfile(path_from_root('tests', 'webidl', 'test.h'), self.in_dir('test.h'))
       shutil.copyfile(path_from_root('tests', 'webidl', 'test.cpp'), self.in_dir('test.cpp'))
       src = open('test.cpp').read()


### PR DESCRIPTION
addresses #3994. Replaces #4014 to hopefully conform to contribution standards.