### PR TITLE
remove useless call to console.log when using lz4 compression

### DIFF
--- a/src/library_lz4.js
+++ b/src/library_lz4.js
@@ -25,7 +25,6 @@ mergeInto(LibraryManager.library, {
                                                                       compressedData.cachedOffset + (i+1)*LZ4.CHUNK_SIZE);
         assert(compressedData.cachedChunks[i].length === LZ4.CHUNK_SIZE);
       }
-      console.log('loading package');
       pack['metadata'].files.forEach(function(file) {
         var dir = PATH.dirname(file.filename);
         var name = PATH.basename(file.filename);


### PR DESCRIPTION
When using emcc option -s LZ4=1 to compress application data, "loading package" is printed to the console output when loading the compiled script. So remove the corresponding call to console.log in src/library_lz4.js as the console output should not be polluted by useless messages.