### PR TITLE
python2_wrappers

### DIFF
--- a/emar
+++ b/emar
@@ -1,56 +1,17 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-'''
-emar - ar helper script
-=======================
+# This script should work in python 2 *or* 3. It loads emar.py, which needs python 2.
 
-This script acts as a frontend replacement for ar. See emcc.
-'''
 
-import os, subprocess, sys
-from tools import shared
+import sys
 
-DEBUG = os.environ.get('EMCC_DEBUG')
-if DEBUG == "0":
-  DEBUG = None
 
-newargs = [shared.LLVM_AR] + sys.argv[1:]
 
-if DEBUG:
-  print >> sys.stderr, 'emar:', sys.argv, '  ==>  ', newargs
-
-if len(newargs) > 2:
-  to_delete = []
-  if 'r' in newargs[1]:
-    # we are adding files to the archive.
-    # find the .a; everything after it is an input file.
-    # we add a hash to each input, to make them unique as
-    # possible, as llvm-ar cannot extract duplicate names
-    # (and only the basename is used!)
-    i = 1
-    while i < len(newargs):
-      if newargs[i].endswith('.a'):
-        import hashlib, shutil
-        for j in range(i+1, len(newargs)):
-          orig_name = newargs[j]
-          full_name = os.path.abspath(orig_name)
-          dir_name = os.path.dirname(full_name)
-          base_name = os.path.basename(full_name)
-          h = hashlib.md5(full_name).hexdigest()[:8]
-          parts = base_name.split('.')
-          parts[0] += '_' + h
-          newname = '.'.join(parts)
-          full_newname = os.path.join(dir_name, newname)
-          if not os.path.exists(full_newname):
-            try: # it is ok to fail here, we just don't get hashing
-              shutil.copyfile(orig_name, full_newname)
-              newargs[j] = full_newname
-              to_delete.append(full_newname)
-            except:
-              pass
-        break
-      i += 1
-  subprocess.call(newargs)
-  for d in to_delete:
-    shared.try_delete(d)
-
+if sys.version_info.major == 2:
+  import emar
+  if __name__ == '__main__':
+    emar.run()
+else:
+  import os, subprocess
+  if __name__ == '__main__':
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emar.py')] + sys.argv[1:]))

--- a/emar.py
+++ b/emar.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python2
+
+'''
+emar - ar helper script
+=======================
+
+This script acts as a frontend replacement for ar. See emcc.
+'''
+
+import os, subprocess, sys
+from tools import shared
+
+#
+# Main run() function
+#
+def run():
+  DEBUG = os.environ.get('EMCC_DEBUG')
+  if DEBUG == "0":
+    DEBUG = None
+
+  newargs = [shared.LLVM_AR] + sys.argv[1:]
+
+  if DEBUG:
+    print >> sys.stderr, 'emar:', sys.argv, '  ==>  ', newargs
+
+  if len(newargs) > 2:
+    to_delete = []
+    if 'r' in newargs[1]:
+      # we are adding files to the archive.
+      # find the .a; everything after it is an input file.
+      # we add a hash to each input, to make them unique as
+      # possible, as llvm-ar cannot extract duplicate names
+      # (and only the basename is used!)
+      i = 1
+      while i < len(newargs):
+        if newargs[i].endswith('.a'):
+          import hashlib, shutil
+          for j in range(i+1, len(newargs)):
+            orig_name = newargs[j]
+            full_name = os.path.abspath(orig_name)
+            dir_name = os.path.dirname(full_name)
+            base_name = os.path.basename(full_name)
+            h = hashlib.md5(full_name).hexdigest()[:8]
+            parts = base_name.split('.')
+            parts[0] += '_' + h
+            newname = '.'.join(parts)
+            full_newname = os.path.join(dir_name, newname)
+            if not os.path.exists(full_newname):
+              try: # it is ok to fail here, we just don't get hashing
+                shutil.copyfile(orig_name, full_newname)
+                newargs[j] = full_newname
+                to_delete.append(full_newname)
+              except:
+                pass
+          break
+        i += 1
+    subprocess.call(newargs)
+    for d in to_delete:
+      shared.try_delete(d)
+
+if __name__ == '__main__':
+  run()

--- a/emcmake
+++ b/emcmake
@@ -1,8 +1,17 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-import os, subprocess, sys
-from tools import shared
+# This script should work in python 2 *or* 3. It loads emcmake.py, which needs python 2.
 
-configure_path = shared.path_from_root('emconfigure')
 
-exit(subprocess.call([shared.PYTHON, configure_path] + sys.argv[1:]))
+import sys
+
+
+
+if sys.version_info.major == 2:
+  import emcmake
+  if __name__ == '__main__':
+    emcmake.run()
+else:
+  import os, subprocess
+  if __name__ == '__main__':
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emcmake.py')] + sys.argv[1:]))

--- a/emcmake.py
+++ b/emcmake.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python2
+
+import os, subprocess, sys
+from tools import shared
+
+#
+# Main run() function
+#
+def run():
+  configure_path = shared.path_from_root('emconfigure')
+
+  exit(subprocess.call([shared.PYTHON, configure_path] + sys.argv[1:]))
+
+if __name__ == '__main__':
+  run()

--- a/emconfigure
+++ b/emconfigure
@@ -1,44 +1,17 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-'''
-This is a helper script. It runs ./configure (or cmake,
-etc.) for you, setting the environment variables to use
-emcc and so forth. Usage:
+# This script should work in python 2 *or* 3. It loads emconfigure.py, which needs python 2.
 
-  emconfigure ./configure [FLAGS]
 
-You can also use this for cmake and other configure-like
-stages. What happens is that all compilations done during
-this command are to native code, not JS, so that configure
-tests will work properly.
+import sys
 
-Relevant defines:
 
-  CONFIGURE_CC - see emcc
-'''
 
-import os, sys
-from tools import shared
-from subprocess import CalledProcessError
-
-if len(sys.argv) < 2 or ('configure' not in sys.argv[1] and 'cmake' not in sys.argv[1]):
-  print >> sys.stderr, '''
-emconfigure is a helper for configure, setting various environment
-variables so that emcc etc. are used. Typical usage:
-
-  emconfigure ./configure [FLAGS]
-
-(but you can run any command instead of configure)
-
-'''
-elif 'cmake' in sys.argv[1]:
-  node_js = shared.NODE_JS
-  if type(node_js) is list: node_js = ' '.join(node_js)
-  node_js = node_js.replace('"', '\"')
-  sys.argv = sys.argv[:2] + ['-DCMAKE_CROSSCOMPILING_EMULATOR="' + node_js +'"'] + sys.argv[2:]
-
-try:
-  shared.Building.configure(sys.argv[1:])
-except CalledProcessError, e:
-  sys.exit(e.returncode)
-
+if sys.version_info.major == 2:
+  import emconfigure
+  if __name__ == '__main__':
+    emconfigure.run()
+else:
+  import os, subprocess
+  if __name__ == '__main__':
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emconfigure.py')] + sys.argv[1:]))

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python2
+
+'''
+This is a helper script. It runs ./configure (or cmake,
+etc.) for you, setting the environment variables to use
+emcc and so forth. Usage:
+
+  emconfigure ./configure [FLAGS]
+
+You can also use this for cmake and other configure-like
+stages. What happens is that all compilations done during
+this command are to native code, not JS, so that configure
+tests will work properly.
+
+Relevant defines:
+
+  CONFIGURE_CC - see emcc
+'''
+
+import os, sys
+from tools import shared
+from subprocess import CalledProcessError
+
+#
+# Main run() function
+#
+def run():
+  if len(sys.argv) < 2 or ('configure' not in sys.argv[1] and 'cmake' not in sys.argv[1]):
+    print >> sys.stderr, '''
+  emconfigure is a helper for configure, setting various environment
+  variables so that emcc etc. are used. Typical usage:
+
+    emconfigure ./configure [FLAGS]
+
+  (but you can run any command instead of configure)
+
+  '''
+  elif 'cmake' in sys.argv[1]:
+    node_js = shared.NODE_JS
+    if type(node_js) is list: node_js = ' '.join(node_js)
+    node_js = node_js.replace('"', '\"')
+    sys.argv = sys.argv[:2] + ['-DCMAKE_CROSSCOMPILING_EMULATOR="' + node_js +'"'] + sys.argv[2:]
+
+  try:
+    shared.Building.configure(sys.argv[1:])
+  except CalledProcessError, e:
+    sys.exit(e.returncode)
+
+if __name__ == '__main__':
+  run()

--- a/emmake
+++ b/emmake
@@ -1,40 +1,17 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-'''
-This is a helper script. It runs make for you, setting
-the environment variables to use emcc and so forth. Usage:
+# This script should work in python 2 *or* 3. It loads emmake.py, which needs python 2.
 
-  emmake make [FLAGS]
 
-Note that if you ran configure with emconfigure, then
-the environment variables have already been detected
-and set. This script is useful if you have no configure
-step, and your Makefile uses the environment vars
-directly.
+import sys
 
-The difference between this and emconfigure is that
-emconfigure runs compilation into native code, so
-that configure tests pass. emmake uses Emscripten to
-generate JavaScript.
-'''
 
-import os, sys
-from tools import shared
-from subprocess import CalledProcessError
 
-if len(sys.argv) < 2 or sys.argv[1] != 'make':
-  print >> sys.stderr, '''
-emmake is a helper for make, setting various environment
-variables so that emcc etc. are used. Typical usage:
-
-  emmake make [FLAGS]
-
-(but you can run any command instead of make)
-
-'''
-
-try:
-	shared.Building.make(sys.argv[1:])
-except CalledProcessError, e:
-	sys.exit(e.returncode)
-
+if sys.version_info.major == 2:
+  import emmake
+  if __name__ == '__main__':
+    emmake.run()
+else:
+  import os, subprocess
+  if __name__ == '__main__':
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emmake.py')] + sys.argv[1:]))

--- a/emmake.py
+++ b/emmake.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python2
+
+'''
+This is a helper script. It runs make for you, setting
+the environment variables to use emcc and so forth. Usage:
+
+  emmake make [FLAGS]
+
+Note that if you ran configure with emconfigure, then
+the environment variables have already been detected
+and set. This script is useful if you have no configure
+step, and your Makefile uses the environment vars
+directly.
+
+The difference between this and emconfigure is that
+emconfigure runs compilation into native code, so
+that configure tests pass. emmake uses Emscripten to
+generate JavaScript.
+'''
+
+import os, sys
+from tools import shared
+from subprocess import CalledProcessError
+
+#
+# Main run() function
+#
+def run():
+  if len(sys.argv) < 2 or sys.argv[1] != 'make':
+    print >> sys.stderr, '''
+  emmake is a helper for make, setting various environment
+  variables so that emcc etc. are used. Typical usage:
+
+    emmake make [FLAGS]
+
+  (but you can run any command instead of make)
+
+  '''
+
+  try:
+    shared.Building.make(sys.argv[1:])
+  except CalledProcessError, e:
+    sys.exit(e.returncode)
+
+if __name__ == '__main__':
+  run()


### PR DESCRIPTION
Add python2/3 shell execution wrappers for emcmake, emconfigure, emmake and emar, which are called via the shell on OSX.