### PR TITLE
missing_zlib_include

### DIFF
--- a/tests/zlib/gzguts.h
+++ b/tests/zlib/gzguts.h
@@ -27,6 +27,10 @@
 #endif
 #include <fcntl.h>
 
+#ifdef __unix__
+#include <unistd.h>
+#endif
+
 #ifdef NO_DEFLATE       /* for compatibility with old definition */
 #  define NO_GZCOMPRESS
 #endif


### PR DESCRIPTION
The tests test_zlib, test_freetype, test_lua and test_popper fail on zlib build failure which comes from the following build error:

	gzlib.c:184:24: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
	        state->start = LSEEK(state->fd, 0, SEEK_CUR);
	                       ^
	gzlib.c:11:17: note: expanded from macro 'LSEEK'
	#  define LSEEK lseek
	                ^
	gzlib.c:184:24: note: did you mean 'fseek'?
	gzlib.c:11:17: note: expanded from macro 'LSEEK'
	#  define LSEEK lseek
	                ^
	/Users/clb/emslave/buildslave/osx-incoming/emsdk/emscripten/incoming/system/include/libc/stdio.h:75:5: note: 'fseek' declared here
	int fseek(FILE *, long, int);
	    ^
	1 error generated.
	ERROR:root:compiler frontend failed to generate LLVM bitcode, halting
	make: *** [gzlib.o] Error 1
	ERROR

I don't understand why this failure can only occur on the OS X bot but not on Linux or Windows. Perhaps there is some platform specific ./configure stuff leaking and we are building in C99 only on OS X? In any case, adding this header looks like the correct thing to do.