### PR TITLE
Add atomicrmw i64 test

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -261,6 +261,17 @@ var LibraryPThreadStub = {
     {{{ makeSetValue('ptr', 4, 'h^valh', 'i32') }}};
     {{{ makeStructuralReturn(['l', 'h']) }}};
   },
+
+  emscripten_atomic_add_u32: 'llvm_atomic_load_add_i32_p0i32',
+  emscripten_atomic_load_u64: '__atomic_load_8',
+  emscripten_atomic_store_u64: '__atomic_store_8',
+  emscripten_atomic_cas_u64: '__atomic_compare_exchange_8',
+  emscripten_atomic_exchange_u64: '__atomic_exchange_8',
+  _emscripten_atomic_fetch_and_add_u64: '__atomic_fetch_add_8',
+  _emscripten_atomic_fetch_and_sub_u64: '__atomic_fetch_sub_8',
+  _emscripten_atomic_fetch_and_and_u64: '__atomic_fetch_and_8',
+  _emscripten_atomic_fetch_and_or_u64: '__atomic_fetch_or_8',
+  _emscripten_atomic_fetch_and_xor_u64: '__atomic_fetch_xor_8',
 };
 
 mergeInto(LibraryManager.library, LibraryPThreadStub);

--- a/tests/atomicrmw_i64.ll
+++ b/tests/atomicrmw_i64.ll
@@ -1,0 +1,22 @@
+; ModuleID = 'tests/hello_world.bc'
+target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
+target triple = "asmjs-unknown-emscripten"
+
+@.str = private unnamed_addr constant [18 x i8] c"hello, world %d!\0A\00", align 1
+@.str.1 = private unnamed_addr constant [164 x i8] c"{ var xhr = new XMLHttpRequest(); xhr.open('GET', 'http://localhost:8888/report_result?' + $0, !$1); xhr.send(); setTimeout(function() { window.close() }, 1000); }\00", align 1
+
+declare i32 @printf(i8*, ...)
+
+define i32 @main() {
+entry:
+  %s4 = alloca i64, align 8
+  %ar = atomicrmw add i64* %s4, i64 1 monotonic
+  ; %ar = load i64, i64* %s4, align 8
+  %value = trunc i64 %ar to i32
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i32 %value)
+  call i32 (i8*, ...) @emscripten_asm_const_int(i8* getelementptr inbounds ([164 x i8], [164 x i8]* @.str.1, i32 0, i32 0), i32 %value, i32 0)
+  ret i32 0
+}
+
+declare i32 @emscripten_asm_const_int(i8*, ...) #1
+

--- a/tests/cases/atomicrmw_i64.ll
+++ b/tests/cases/atomicrmw_i64.ll
@@ -1,0 +1,20 @@
+; ModuleID = 'tests/hello_world.bc'
+target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
+target triple = "asmjs-unknown-emscripten"
+
+@.str = private unnamed_addr constant [18 x i8] c"hello, world %d!\0A\00", align 1
+
+declare i32 @printf(i8*, ...)
+
+define i32 @main() {
+entry:
+  %s4 = alloca i64, align 8
+  %ar = atomicrmw add i64* %s4, i64 1 monotonic
+  ; %ar = load i64, i64* %s4, align 8
+  %value = trunc i64 %ar to i32
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i32 %value)
+  ret i32 0
+}
+
+declare i32 @emscripten_asm_const_int(i8*, ...) #1
+

--- a/tests/cases/atomicrmw_i64.txt
+++ b/tests/cases/atomicrmw_i64.txt
@@ -1,0 +1,1 @@
+hello, world 0!

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2936,6 +2936,11 @@ window.close = function() {
     try_delete('pthread-main.js')
     self.run_browser('test2.html', '', '/report_result?1')
 
+  # test atomicrmw i64
+  def test_atomicrmw_i64(self):
+    Popen([PYTHON, EMCC, path_from_root('tests', 'atomicrmw_i64.ll'), '-s', 'USE_PTHREADS=1', '-o', 'test.html']).communicate()
+    self.run_browser('test.html', None, '/report_result?0')
+
   # Test that it is possible to send a signal via calling alarm(timeout), which in turn calls to the signal handler set by signal(SIGALRM, func);
   def test_sigalrm(self):
     self.btest(path_from_root('tests', 'sigalrm.cpp'), expected='0', args=['-O3'], timeout=30)


### PR DESCRIPTION
A test for #4025. This requires https://github.com/kripken/emscripten-fastcomp/pull/130 to land.

This only works if pthreads is enabled, because the atomic method is in libpthreads. Should we perhaps make it work single-threaded if no pthreads?