### PR TITLE
provide $NM via emconfigure

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4842,6 +4842,12 @@ print os.environ.get('CROSS_COMPILE')
     check('emconfigure', [PYTHON, 'test.py'], expect=path_from_root('em'))
     check('emmake', [PYTHON, 'test.py'], expect=path_from_root('em'))
 
+    open('test.py', 'w').write('''
+import os
+print os.environ.get('NM')
+''')
+    check('emconfigure', [PYTHON, 'test.py'], expect=tools.shared.LLVM_NM)
+
   def test_sdl2_config(self):
     for args, expected in [
       [['--version'], '2.0.0'],

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1063,6 +1063,7 @@ class Building:
     env['CXX'] = EMXX if not WINDOWS else 'python %r' % EMXX
     env['AR'] = EMAR if not WINDOWS else 'python %r' % EMAR
     env['LD'] = EMCC if not WINDOWS else 'python %r' % EMCC
+    env['NM'] = LLVM_NM
     env['LDSHARED'] = EMCC if not WINDOWS else 'python %r' % EMCC
     env['RANLIB'] = EMRANLIB if not WINDOWS else 'python %r' % EMRANLIB
     env['EMMAKEN_COMPILER'] = Building.COMPILER


### PR DESCRIPTION
this seems to get libjansson building, which uses autoconf and libtool.
if $NM is not defined when its ./configure runs, it defaults to the
    system nm, which of course does not work on emscripten .o files