### PR TITLE
Windows r r n fix

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -87,7 +87,10 @@ function JSify(data, functionsOnly) {
   }
 
   function processLibraryFunction(snippet, ident, finalName) {
-    snippet = snippet.toString();
+    // It is possible that when printing the function as a string on Windows, the js interpreter we are in returns the string with Windows
+    // line endings \r\n. This is undesirable, since line endings are managed in the form \n in the output for binary file writes, so
+    // make sure the endings are uniform.
+    snippet = snippet.toString().replace(/\r\n/gm,"\n");
     assert(snippet.indexOf('XXX missing C define') == -1,
            'Trying to include a library function with missing C defines: ' + finalName + ' | ' + snippet);
 

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -13,8 +13,13 @@ def check_line_endings(filename, print_errors=True):
     if print_errors: print >> sys.stderr, "Unable to read file '" + filename + "', or file was empty!"
     return 1
 
-  if "\r\r\n" in data:
-    if print_errors: print >> sys.stderr, "File '" + filename + "' contains BAD line endings of form \\r\\r\\n!"
+  bad_line_ending_index = data.find("\r\r\n")
+  if bad_line_ending_index != -1:
+    if print_errors:
+      print >> sys.stderr, "File '" + filename + "' contains BAD line endings of form \\r\\r\\n!"
+      bad_line = data[max(0,bad_line_ending_index-50):min(len(data), bad_line_ending_index+50)]
+      bad_line = bad_line.replace('\r', '\\r').replace('\n', '\\n')
+      print >> sys.stderr, "Content around the location: '" + bad_line + "'"
     return 1 # Bad line endings in file, return a non-zero process exit code.
 
   has_dos_line_endings = False


### PR DESCRIPTION
Fixes those current Windows bot run failures with

	======================================================================
	FAIL: test_bad_typeid (test_core.default)
	----------------------------------------------------------------------
	Traceback (most recent call last):
	  File "G:\slaves\emcc\win-incoming\build\emscripten\tests\test_core.py", line 1571, in test_bad_typeid
	    ''', 'exception caught: std::bad_typeid')
	  File "G:\slaves\emcc\win-incoming\build\emscripten\tests\runner.py", line 573, in do_run
	    js_output = self.run_generated_code(engine, filename + '.o.js', args, output_nicerizer=output_nicerizer, assert_returncode=assert_returncode)
	  File "G:\slaves\emcc\win-incoming\build\emscripten\tests\runner.py", line 362, in run_generated_code
	    assert(check_line_endings(filename) == 0) # Make sure that we produced proper line endings to the .js file we are about to run.
	AssertionError

as seen at http://clb.demon.fi:8112/builders/win-incoming/builds/1136/steps/Tests-default/logs/stdio