### PR TITLE
Duplicate function elimination

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -232,4 +232,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nick Shin <nick.shin@gmail.com>
 * Gregg Tavares <github@greggman.com>
 * Tanner Rogalsky <tanner@tannerrogalsky.com>
-
+* Richard Cook <rcook@tableau.com> (copyright owned by Tableau Software, Inc.)
+* Arnab Choudhury <achoudhury@tableau.com> (copyright owned by Tableau Software, Inc.)
+* Charles Vaughn <cvaughn@tableau.com> (copyright owned by Tableau Software, Inc.)

--- a/emcc.py
+++ b/emcc.py
@@ -1634,6 +1634,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         else:
           JSOptimizer.queue += ['registerize']
 
+      # NOTE: Important that this comes after registerize/registerizeHarder
+      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and opt_level >= 2:
+        JSOptimizer.flush()
+        shared.Building.eliminate_duplicate_funcs(final)
+
       if not shared.Settings.EMTERPRETIFY:
         do_minify()
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -681,4 +681,9 @@ var PTHREADS_PROFILING = 0; // True when building with --threadprofiler
 
 var MAX_GLOBAL_ALIGN = -1; // received from the backend
 
+// Duplicate function elimination
+var ELIMINATE_DUPLICATE_FUNCTIONS = 0; // disabled by default
+var ELIMINATE_DUPLICATE_FUNCTIONS_PASSES = 5;
+var ELIMINATE_DUPLICATE_FUNCTIONS_DUMP_EQUIVALENT_FUNCTIONS = 0;
+
 // Reserved: variables containing POINTER_MASKING.

--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
@@ -1,0 +1,14 @@
+// EMSCRIPTEN_START_ASM
+var asm = (function(global, env, buffer) {
+ "use asm";
+ var e = 0;
+ 
+// EMSCRIPTEN_START_FUNCS
+function a() {
+ var c = 0.0;
+ return 0;
+}
+// EMSCRIPTEN_END_FUNCS
+ var f = 0;
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+// EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
@@ -1,0 +1,22 @@
+// EMSCRIPTEN_START_ASM
+var asm = (function(global, env, buffer) {
+ "use asm";
+ var e = 0;
+ 
+// EMSCRIPTEN_START_FUNCS
+ function a() {
+  var c = +0;
+  return 0;
+ }
+ function b() {
+  var c = +0;
+  return 0;
+ }
+// EMSCRIPTEN_END_FUNCS
+ var f = 0;
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+// EMSCRIPTEN_END_ASM
+// EMSCRIPTEN_GENERATED_FUNCTIONS
+
+
+

--- a/tests/optimizer/test-function-eliminator-replace-array-value-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value-output.js
@@ -1,0 +1,25 @@
+// EMSCRIPTEN_START_ASM
+var asm = (function(global, env, buffer) {
+ "use asm";
+ 
+// EMSCRIPTEN_START_FUNCS
+function d() {
+ a();
+ e();
+ return;
+}
+
+function c() {
+ a();
+ return;
+}
+
+function a() {
+ return 0;
+}
+
+// EMSCRIPTEN_END_FUNCS
+
+ var f = [ a ];
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+// EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-replace-array-value-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value-with-hash-info.js
@@ -1,0 +1,32 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  b();
+  
+  // We expect that b gets replaced by a below
+  var f = [b];
+  e();
+
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-array-value.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value.js
@@ -1,0 +1,23 @@
+// EMSCRIPTEN_START_ASM
+var asm = (function(global, env, buffer) {
+ "use asm";
+// EMSCRIPTEN_START_FUNCS
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  b();
+  e();
+  return;
+ }
+// EMSCRIPTEN_END_FUNCS
+  var f = [ b ];
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+// EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-replace-function-call-output-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-output-with-hash-info.js
@@ -1,0 +1,22 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  a();
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"d":"c"}

--- a/tests/optimizer/test-function-eliminator-replace-function-call-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-output.js
@@ -1,0 +1,14 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  a();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-function-call-two-passes-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-two-passes-output.js
@@ -1,0 +1,10 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-function-call-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-with-hash-info.js
@@ -1,0 +1,27 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  b();
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-function-call.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call.js
@@ -1,0 +1,20 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  b();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+
+

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment-output.js
@@ -1,0 +1,18 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  a();
+  var f = {
+   g: a
+  };
+  e();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment-with-hash-info.js
@@ -1,0 +1,34 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  b();
+  
+  // We expect that b gets replaced by a below
+  var f = {
+    g: b
+  };
+  e();
+
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment.js
@@ -1,0 +1,24 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  b();
+  var f = {
+   g: b
+  };
+  e();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+
+

--- a/tests/optimizer/test-function-eliminator-replace-variable-value-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value-output.js
@@ -1,0 +1,16 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  a();
+  var e = a;
+  e();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-variable-value-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value-with-hash-info.js
@@ -1,0 +1,32 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  b();
+  
+  // We expect that b gets replaced by a below
+  var e = b;  
+  e();
+
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"b" : "a"}

--- a/tests/optimizer/test-function-eliminator-replace-variable-value.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value.js
@@ -1,0 +1,22 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  b();
+  var e = b;
+  e();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+
+

--- a/tests/optimizer/test-function-eliminator-simple-output.js
+++ b/tests/optimizer/test-function-eliminator-simple-output.js
@@ -1,0 +1,6 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-simple-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-simple-with-hash-info.js
@@ -1,0 +1,15 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-simple.js
+++ b/tests/optimizer/test-function-eliminator-simple.js
@@ -1,0 +1,12 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+
+

--- a/tests/optimizer/test-function-eliminator-variable-clash-output.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash-output.js
@@ -1,0 +1,18 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  var a = 0;
+  b();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-variable-clash-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash-with-hash-info.js
@@ -1,0 +1,31 @@
+var asm = (function(global, env, buffer) {
+"use asm";
+function a()
+{
+return 0;
+}
+
+function b()
+{
+return 0;
+}
+
+function c()
+{
+  a();
+  return;
+}
+
+function d()
+{
+  // Because a is used both as a variable and a function, we will
+  // not use a as a candidate for replacement, nor will we replace
+  // calls to b with a.
+  var a = 0;
+  b();
+  return;
+}
+
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+// {}

--- a/tests/optimizer/test-function-eliminator-variable-clash.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash.js
@@ -1,0 +1,21 @@
+var asm = (function(global, env, buffer) {
+ "use asm";
+ function a() {
+  return 0;
+ }
+ function b() {
+  return 0;
+ }
+ function c() {
+  a();
+  return;
+ }
+ function d() {
+  var a = 0;
+  b();
+  return;
+ }
+})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+
+
+

--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -14,7 +14,16 @@ from runner import test_modes, PYTHON, path_from_root
 assert not os.environ.get('EM_SAVE_DIR'), 'Need separate directories to avoid the parallel tests clashing'
 
 # run slower ones first, to optimize total time
-optimal_order = ['asm2i', 'asm2nn', 'asm3', 'asm2', 'asm2g', 'asm2f', 'asm1', 'default']
+optimal_order = [
+  'asm2i',
+  'asm2nn',
+  'asm3',
+  'asm2',
+  'asm2g',
+  'asm2f',
+  'asm1',
+  'default'
+]
 assert set(optimal_order) == set(test_modes), 'need to update the list of slowest modes'
 
 # set up a background thread to report progress

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -96,7 +96,16 @@ further debug the compiler itself, see emcc.
 
 # Core test runner class, shared between normal tests and benchmarks
 checked_sanity = False
-test_modes = ['default', 'asm1', 'asm2', 'asm3', 'asm2f', 'asm2g', 'asm2i', 'asm2nn']
+test_modes = [
+  'default',
+  'asm1',
+  'asm2',
+  'asm3',
+  'asm2f',
+  'asm2g',
+  'asm2i',
+  'asm2nn'
+]
 test_index = 0
 
 use_all_engines = os.environ.get('EM_ALL_ENGINES') # generally js engines are equivalent, testing 1 is enough. set this
@@ -359,6 +368,22 @@ class RunnerCore(unittest.TestCase):
         if n == 0: return src[start:t+1]
       t += 1
       assert t < len(src)
+
+  def count_funcs(self, javascript_file):
+    num_funcs = 0
+    start_tok = "// EMSCRIPTEN_START_FUNCS"
+    end_tok = "// EMSCRIPTEN_END_FUNCS"
+    start_off = 0
+    end_off = 0
+
+    with open (javascript_file, 'rt') as fin:
+      blob = "".join(fin.readlines())
+      start_off = blob.find(start_tok) + len(start_tok)
+      end_off = blob.find(end_tok)
+      asm_chunk = blob[start_off:end_off]
+      num_funcs = asm_chunk.count('function ')
+
+    return num_funcs
 
   def run_generated_code(self, engine, filename, args=[], check_timeout=True, output_nicerizer=None, assert_returncode=0):
     stdout = os.path.join(self.get_dir(), 'stdout') # use files, as PIPE can get too full and hang us

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -1,0 +1,378 @@
+
+import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging, traceback
+import shared
+from js_optimizer import *
+
+DUPLICATE_FUNCTION_ELIMINATOR = path_from_root('tools', 'eliminate-duplicate-functions.js')
+
+def process_shell(js, js_engine, shell, equivalentfn_hash_info=None):
+  suffix = '.eliminatedupes'
+
+  temp_file = temp_files.get(suffix + '.js').name
+  f = open(temp_file, 'w')
+  f.write(shell)
+  f.write('\n')
+
+  f.write(equivalentfn_hash_info)
+  f.close()
+
+  (output,error) = subprocess.Popen(js_engine +
+      [DUPLICATE_FUNCTION_ELIMINATOR, temp_file, '--use-hash-info', '--no-minimize-whitespace'],
+      stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+  assert len(output) > 0
+  assert len(error) == 0
+
+  return output
+
+def run_on_chunk(command):
+  try:
+    file_suffix = '.js'
+    index = command.index(DUPLICATE_FUNCTION_ELIMINATOR)
+    filename = command[index + 1]
+
+    if '--gen-hash-info' in command:
+      file_suffix = '.json'
+
+    if os.environ.get('EMCC_SAVE_OPT_TEMP') and os.environ.get('EMCC_SAVE_OPT_TEMP') != '0':
+      saved = 'save_' + os.path.basename(filename)
+      while os.path.exists(saved): saved = 'input' + str(int(saved.replace('input', '').replace('.txt', ''))+1) + '.txt'
+      print >> sys.stderr, 'running DFE command', ' '.join(map(lambda c: c if c != filename else saved, command))
+      shutil.copyfile(filename, os.path.join(shared.get_emscripten_temp_dir(), saved))
+
+    if shared.EM_BUILD_VERBOSE_LEVEL >= 3: print >> sys.stderr, 'run_on_chunk: ' + str(command)
+
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    output = proc.communicate()[0]
+    assert proc.returncode == 0, 'Error in optimizer (return code ' + str(proc.returncode) + '): ' + output
+    assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output
+    filename = temp_files.get(os.path.basename(filename) + '.jo' + file_suffix).name
+
+    # Important to write out in binary mode, because the data we are writing contains Windows line endings '\r\n' because it was PIPED from console.
+    # Otherwise writing \r\n to ascii mode file will result in Windows amplifying \n to \r\n, generating bad \r\r\n line endings.
+    f = open(filename, 'wb')
+    f.write(output)
+    f.close()
+    if DEBUG and not shared.WINDOWS: print >> sys.stderr, '.' # Skip debug progress indicator on Windows, since it doesn't buffer well with multiple threads printing to console.
+    return filename
+  except KeyboardInterrupt:
+    # avoid throwing keyboard interrupts from a child process
+    raise Exception()
+  except (TypeError, ValueError) as e:
+    formatted_lines = traceback.format_exc().splitlines()
+
+    print >> sys.stderr, ">>>>>>>>>>>>>>>>>"
+    for formatted_line in formatted_lines:
+        print >> sys.stderr, formatted_line
+    print >> sys.stderr, "<<<<<<<<<<<<<<<<<"
+
+    raise
+
+def dump_equivalent_functions(passed_in_filename, global_data):
+  # Represents the sets of equivalent functions for the passed in filename
+  equivalent_fn_info = {}
+  equivalent_fn_json_file = passed_in_filename + ".equivalent_functions.json"
+
+  # If we are running more than one pass, then we want to merge
+  # all the hash infos into one
+  if os.path.isfile(equivalent_fn_json_file):
+    print >> sys.stderr, "Merging data from current pass for {} into {}".format(passed_in_filename, equivalent_fn_json_file)
+    with open(equivalent_fn_json_file) as data_file:
+      equivalent_fn_info = json.load(data_file)
+  else:
+    print >> sys.stderr, "Writing equivalent functions for {} to {}".format(passed_in_filename, equivalent_fn_json_file)
+
+  # Merge the global data's fn_hash_to_fn_name structure into
+  # the equivalent function info hash.
+  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].iteritems():
+    if fn_hash not in equivalent_fn_info:
+      # Exclude single item arrays as they are of no use to us.
+      if len(fn_names) > 1:
+        equivalent_fn_info[fn_hash] = fn_names[:]
+    else:
+      for fn_name in fn_names:
+        if fn_name not in equivalent_fn_info[fn_hash]:
+          equivalent_fn_info[fn_hash].append(fn_name)
+
+  with open(equivalent_fn_json_file, 'w') as fout:
+    fout.write(json.dumps(equivalent_fn_info))
+
+def write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename):
+  # Represents the aggregated info for all the json files passed in
+  # Each json file contains info for one of the processed chunks
+  global_data = {}
+  global_data['fn_hash_to_fn_name'] = {}
+  global_data['fn_hash_to_fn_body'] = {}
+  global_data['variable_names'] = {}
+
+  for json_file in json_files:
+    with open(json_file) as data_file:
+      data = json.load(data_file)
+
+      # Merge the data's fn_hash_to_fn_name structure into
+      # the global data hash.
+      for fn_hash, fn_names in data['fn_hash_to_fn_name'].iteritems():
+        if fn_hash not in global_data['fn_hash_to_fn_name']:
+            global_data['fn_hash_to_fn_name'][fn_hash] = fn_names[:]
+            global_data['fn_hash_to_fn_body'][fn_hash] = data['fn_hash_to_fn_body'][fn_hash]
+        else:
+          assert(data['fn_hash_to_fn_body'][fn_hash] == global_data['fn_hash_to_fn_body'][fn_hash])
+
+          for fn_name in fn_names:
+            if fn_name not in global_data['fn_hash_to_fn_name'][fn_hash]:
+              global_data['fn_hash_to_fn_name'][fn_hash].append(fn_name)
+
+      # Merge the data's variable_names structure into
+      # the global data hash.
+      for variable, value in data['variable_names'].iteritems():
+        if variable not in global_data['variable_names']:
+            global_data['variable_names'][variable] = value
+
+  variable_names = global_data['variable_names']
+
+  # Lets generate the equivalent function hash from the global data set
+  equivalent_fn_hash = {}
+  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].iteritems():
+    shortest_fn = None
+    for fn_name in fn_names:
+      if (fn_name not in variable_names) and (shortest_fn is None or (len(fn_name) < len(shortest_fn))):
+        shortest_fn = fn_name
+
+    if shortest_fn is not None:
+      for fn_name in fn_names:
+        if fn_name not in variable_names and fn_name != shortest_fn:
+          equivalent_fn_hash[fn_name] = shortest_fn
+
+  # Dump the sets of equivalent functions if the user desires it
+  # This comes in handy for debugging
+  if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS_DUMP_EQUIVALENT_FUNCTIONS:
+    dump_equivalent_functions(passed_in_filename, global_data)
+
+  # Now write the equivalent function hash to the last line of the file
+  f.write('// ' + json.dumps(equivalent_fn_hash, separators=(',',':')))
+
+# gen_hash_info is used to determine whether we are generating
+# the global set of function implementation hashes. If set to
+# False, we assume that we have to use the global hash info to
+# reduce the set of duplicate functions
+def run_on_js(filename, gen_hash_info=False):
+  js_engine=shared.NODE_JS
+
+  js = open(filename).read()
+  if os.linesep != '\n':
+    js = js.replace(os.linesep, '\n') # we assume \n in the splitting code
+
+  equivalentfn_hash_info = None
+  passed_in_filename = filename
+
+  # Find markers
+  start_funcs = js.find(start_funcs_marker)
+  end_funcs = js.rfind(end_funcs_marker)
+
+  if start_funcs < 0 or end_funcs < start_funcs:
+    logging.critical('Invalid input file. Did not contain appropriate markers. (start_funcs: %s, end_funcs: %s)' % (start_funcs, end_funcs))
+    sys.exit(1)
+
+  if not gen_hash_info:
+    equivalentfn_hash_info = js[js.rfind('//'):]
+
+    start_asm = js.find(start_asm_marker)
+    end_asm = js.rfind(end_asm_marker)
+    assert (start_asm >= 0) == (end_asm >= 0)
+
+    # We need to split out the asm shell as well, for minification
+    pre = js[:start_asm + len(start_asm_marker)]
+    post = js[end_asm:]
+    asm_shell = js[start_asm + len(start_asm_marker):start_funcs + len(start_funcs_marker)] + '''
+EMSCRIPTEN_FUNCS();
+''' + js[end_funcs + len(end_funcs_marker):end_asm + len(end_asm_marker)]
+    js = js[start_funcs + len(start_funcs_marker):end_funcs]
+
+    # we assume there is a maximum of one new name per line
+    asm_shell_pre, asm_shell_post = process_shell(js, js_engine, asm_shell, equivalentfn_hash_info).split('EMSCRIPTEN_FUNCS();');
+    asm_shell_post = asm_shell_post.replace('});', '})');
+    pre += asm_shell_pre + '\n' + start_funcs_marker
+    post = end_funcs_marker + asm_shell_post + post
+
+    if not gen_hash_info:
+      # We don't need the extra info at the end
+      post = post[:post.rfind('//')].strip()
+  else:
+    pre = js[:start_funcs + len(start_funcs_marker)]
+    post = js[end_funcs + len(end_funcs_marker):]
+    js = js[start_funcs + len(start_funcs_marker):end_funcs]
+    post = end_funcs_marker + post
+
+  total_size = len(js)
+  funcs = split_funcs(js, False)
+
+  js = None
+
+  # if we are making source maps, we want our debug numbering to start from the
+  # top of the file, so avoid breaking the JS into chunks
+  cores = int(os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
+
+  intended_num_chunks = int(round(cores * NUM_CHUNKS_PER_CORE))
+  chunk_size = min(MAX_CHUNK_SIZE, max(MIN_CHUNK_SIZE, total_size / intended_num_chunks))
+  chunks = shared.chunkify(funcs, chunk_size)
+
+  chunks = filter(lambda chunk: len(chunk) > 0, chunks)
+  if DEBUG and len(chunks) > 0: print >> sys.stderr, 'chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(map(len, chunks)), '-', min(map(len, chunks))
+  funcs = None
+
+  if len(chunks) > 0:
+    def write_chunk(chunk, i):
+      temp_file = temp_files.get('.jsfunc_%d.js' % i).name
+      f = open(temp_file, 'w')
+      f.write(chunk)
+
+      if not gen_hash_info:
+        f.write('\n')
+        f.write(equivalentfn_hash_info)
+      f.close()
+      return temp_file
+    filenames = [write_chunk(chunks[i], i) for i in range(len(chunks))]
+  else:
+    filenames = []
+
+  old_filenames = filenames[:]
+  if len(filenames) > 0:
+    commands = map(lambda filename: js_engine + [DUPLICATE_FUNCTION_ELIMINATOR, filename, '--gen-hash-info' if gen_hash_info else '--use-hash-info', '--no-minimize-whitespace'], filenames)
+
+    if DEBUG and commands is not None:
+      print >> sys.stderr, [' '.join(command if command is not None else '(null)') for command in commands]
+
+    cores = min(cores, len(filenames))
+    if len(chunks) > 1 and cores >= 2:
+      # We can parallelize
+      if DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks, using %d cores  (total: %.2f MB)' % (len(chunks), cores, total_size/(1024*1024.))
+      pool = multiprocessing.Pool(processes=cores)
+      filenames = pool.map(run_on_chunk, commands, chunksize=1)
+    else:
+      # We can't parallize, but still break into chunks to avoid uglify/node memory issues
+      if len(chunks) > 1 and DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks' % (len(chunks))
+      filenames = [run_on_chunk(command) for command in commands]
+  else:
+    filenames = []
+
+  json_files = []
+
+  # We're going to be coalescing the files back at the end
+  # Just replace the file list with the ones provided in
+  # the command list - and save off the generated Json
+  if gen_hash_info:
+    json_files = filenames[:]
+    filenames = old_filenames[:]
+
+  for filename in filenames: temp_files.note(filename)
+
+  filename += '.jo.js'
+  f = open(filename, 'w')
+  f.write(pre);
+  pre = None
+
+  # sort functions by size, to make diffing easier and to improve aot times
+  funcses = []
+  for out_file in filenames:
+    funcses.append(split_funcs(open(out_file).read(), False))
+  funcs = [item for sublist in funcses for item in sublist]
+  funcses = None
+  def sorter(x, y):
+    diff = len(y[1]) - len(x[1])
+    if diff != 0: return diff
+    if x[0] < y[0]: return 1
+    elif x[0] > y[0]: return -1
+    return 0
+  if not os.environ.get('EMCC_NO_OPT_SORT'):
+    funcs.sort(sorter)
+
+  for func in funcs:
+    f.write(func[1])
+  funcs = None
+
+  f.write('\n')
+  f.write(post);
+  # No need to write suffix: if there was one, it is inside post which exists when suffix is there
+  f.write('\n')
+
+  if gen_hash_info and len(json_files) > 0:
+    write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename)
+  f.close()
+
+  return filename
+
+def save_temp_file(file_to_process):
+  if os.environ.get('EMSCRIPTEN_SAVE_TEMP_FILES') and os.environ.get('EMSCRIPTEN_TEMP_FILES_DIR'):
+    destinationFile = file_to_process
+
+    temp_dir_name = os.environ.get('TEMP_DIR')
+    destinationFile = destinationFile.replace(temp_dir_name, os.environ.get('EMSCRIPTEN_TEMP_FILES_DIR'))
+
+    if not os.path.exists(os.path.dirname(destinationFile)):
+      os.makedirs(os.path.dirname(destinationFile))
+
+    print >> sys.stderr, "Copying {} to {}".format(file_to_process, destinationFile)
+    shutil.copyfile(file_to_process, destinationFile)
+
+def get_func_names(javascript_file):
+  func_names = []
+  start_tok = "// EMSCRIPTEN_START_FUNCS"
+  end_tok = "// EMSCRIPTEN_END_FUNCS"
+  start_off = 0
+  end_off = 0
+
+  with open (javascript_file, 'rt') as fin:
+    blob = "".join(fin.readlines())
+    start_off = blob.find(start_tok) + len(start_tok)
+    end_off = blob.find(end_tok)
+    asm_chunk = blob[start_off:end_off]
+
+    for match in re.finditer('function (\S+?)\s*\(', asm_chunk):
+      func_names.append(match.groups(1)[0])
+
+  return func_names
+
+def eliminate_duplicate_funcs(file_name):
+  if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS_DUMP_EQUIVALENT_FUNCTIONS != 0:
+    # Remove previous log file if it exists
+    equivalent_fn_json_file = file_name + ".equivalent_functions.json"
+    if os.path.isfile(equivalent_fn_json_file):
+      print >> sys.stderr, "Deleting old json: " + equivalent_fn_json_file
+      os.remove(equivalent_fn_json_file)
+
+    old_funcs = get_func_names(file_name)
+
+  for pass_num in range(shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS_PASSES):
+    if DEBUG: print >> sys.stderr, "[PASS {}]: eliminating duplicate functions in: {}.".format(pass_num, file_name)
+
+    # Generate the JSON for the equivalent hash first
+    processed_file = run_on_js(filename=file_name, gen_hash_info=True)
+
+    save_temp_file(processed_file)
+
+    # Use the hash to reduce the JS file
+    final_file = run_on_js(filename=processed_file, gen_hash_info=False)
+
+    save_temp_file(final_file)
+
+    shared.safe_move(final_file, file_name)
+
+  if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS_DUMP_EQUIVALENT_FUNCTIONS != 0:
+    new_funcs = get_func_names(file_name)
+
+    eliminated_funcs_file = file_name + ".eliminated_functions.json"
+    print >> sys.stderr, "Writing eliminated functions to file: {}".format(eliminated_funcs_file)
+
+    with open(eliminated_funcs_file, 'w') as fout:
+      eliminated_functions = list(set(old_funcs)-set(new_funcs))
+      eliminated_functions.sort()
+      for eliminated_function in eliminated_functions:
+        fout.write('{}\n'.format(eliminated_function))
+
+def run(filename, js_engine=shared.NODE_JS):
+  js_engine = shared.listify(js_engine)
+
+  return temp_files.run_and_clean(lambda: eliminate_duplicate_funcs(filename))
+
+if __name__ == '__main__':
+  out = run(sys.argv[1], sys.argv[2:])
+

--- a/tools/eliminate-duplicate-functions.js
+++ b/tools/eliminate-duplicate-functions.js
@@ -1,0 +1,541 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// Eliminate-Duplicate-Functions.js
+//
+// This is a Javascript file that is used to post-process an Emscripten transpiled JS file.
+// It will remove all the duplicate functions from the generated ASM. In its current form,
+// the input JS file is expected to be a 'chunk' from an Emscripten generated ASM.JS file.
+//
+// An ASM JS chunk consists of a number of ASM.JS function definitions. It can also represent
+// the ASM JS 'shell' which consists of the global variable declarations for the generated ASM JS.
+//
+// The file will remove all the generated functions that are deemed to be identical. Currently,
+// the file will only run one pass of the algorithm. The caller of this JS file can run multiple
+// passes to ensure that higher level functions which will become identical after a pass can
+// be further eliminated.
+//
+// Usually, 4 or at most 5 passes will result in an optimal reduction - i.e., in a file that
+// cannot be reduced any further.
+///////////////////////////////////////////////////////////////////////////////////////////////
+var crypto = require('crypto');
+var uglify = require('../tools/eliminator/node_modules/uglify-js');
+
+var nodeFS = require('fs');
+var nodePath = require('path');
+var debug = false;
+var debugFile = undefined;
+var debugFileName = 'function_eliminator.log';
+var genHashInfo = false;
+var useHashInfo = false;
+var useAsmAst = false;
+
+// Variables that helps control verbosity of debug spew
+// Set appropriate zones here (to 0 or 1) for debugging various
+// parts of the algorithm.
+var ZONE_IDENTIFY_DUPLICATE_FUNCS = 1;
+var ZONE_REPLACE_FUNCTION_REFERENCES = 1;
+var ZONE_REPLACE_DUPLICATE_FUNCS = 1;
+var ZONE_EQUIVALENT_FUNCTION_HASH = 1;
+var ZONE_TOP_LEVEL = 1;
+var ZONE_DUMP_AST = 0;
+
+if (!nodeFS.existsSync) {
+  nodeFS.existsSync = function(path) {
+    try {
+      return !!nodeFS.readFileSync(path);
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+function srcToAst(src) {
+  return uglify.parser.parse(src, false, false);
+}
+
+function astToSrc(ast, minifyWhitespace) {
+  return uglify.uglify.gen_code(ast, {
+    debug: debug,
+    ascii_only: true,
+    beautify: !minifyWhitespace,
+    indent_level: 1
+  });
+}
+
+// Traverses the children of a node. If the traverse function returns an object,
+// replaces the child. If it returns true, stop the traversal and return true.
+function traverseChildren(node, traverse, pre, post) {
+  for (var i = 0; i < node.length; i++) {
+    var subnode = node[i];
+    if (Array.isArray(subnode)) {
+      var subresult = traverse(subnode, pre, post);
+      if (subresult === true) return true;
+      if (subresult !== null && typeof subresult === 'object') node[i] = subresult;
+    }
+  }
+}
+
+print = function(x) {
+  process['stdout'].write(x + '\n');
+};
+
+printErr = function(x) {
+  process['stderr'].write(x + '\n');
+};
+
+function debugLog(zone, str) {
+  if (debug && (zone !== 0)) {
+    nodeFS.writeSync(debugFile, str + '\n');
+  }
+}
+
+// Traverses a JavaScript syntax tree rooted at the given node calling the given
+// callback for each node.
+//   @arg node: The root of the AST.
+//   @arg pre: The pre to call for each node. This will be called with
+//     the node as the first argument and its type as the second. If true is
+//     returned, the traversal is stopped. If an object is returned,
+//     it replaces the passed node in the tree. If null is returned, we stop
+//     traversing the subelements (but continue otherwise).
+//   @arg post: A callback to call after traversing all children.
+//   @returns: If the root node was replaced, the new root node. If the traversal
+//     was stopped, true. Otherwise undefined.
+function traverse(node, pre, post) {
+  var type = node[0],
+    result, len;
+  var relevant = typeof type === 'string';
+  if (relevant) {
+    var result = pre(node, type);
+    if (result === true) return true;
+    if (result && result !== null) node = result; // Continue processing on this node
+  }
+  if (result !== null) {
+    if (traverseChildren(node, traverse, pre, post) === true) return true;
+  }
+  if (relevant) {
+    if (post) {
+      var postResult = post(node, type);
+      result = result || postResult;
+    }
+  }
+  return result;
+}
+
+function dumpAst(ast) {
+  debugLog(ZONE_DUMP_AST, JSON.stringify(ast, null, '  '));
+}
+
+function getFunctionBody(node) {
+  // Remove the function <name> part of the source for the function
+  var functionSrc = astToSrc(node, true);
+  var functionNameRegex = /(function .*?)\(/;
+  return functionSrc.replace(functionNameRegex, "(");
+}
+
+function traverseFunctions(ast, callback) {
+  var topLevelList = useAsmAst ? ast : ast[1];
+
+  for (var listIndex = 0; listIndex < topLevelList.length; ++listIndex) {
+    var node = topLevelList[listIndex];
+
+    if (node[0] === 'defun') {
+      callback(node);
+    }
+  }
+}
+
+function identifyDuplicateFunctions(ast) {
+  debugLog(ZONE_TOP_LEVEL, "identifyDuplicateFunctions");
+
+  var functionHashToFunctionName = {};
+
+  traverseFunctions(ast, function(node) {
+    debugLog(ZONE_IDENTIFY_DUPLICATE_FUNCS, "Node: " + node);
+    var functionBody = getFunctionBody(node);
+
+    debugLog(ZONE_IDENTIFY_DUPLICATE_FUNCS, "Function Body: " + functionBody + "\n");
+    var functionHash = crypto.createHash('sha256').update(functionBody).digest('hex');
+
+    if (functionHashToFunctionName[functionHash] === undefined) {
+      functionHashToFunctionName[functionHash] = [];
+    }
+
+    debugLog(ZONE_IDENTIFY_DUPLICATE_FUNCS, typeof node[1]);
+    functionHashToFunctionName[functionHash].push(node[1]);
+    debugLog(ZONE_IDENTIFY_DUPLICATE_FUNCS, functionHash + '->' + node[1]);
+  });
+
+  if (debug) {
+    for (var key in functionHashToFunctionName) {
+      debugLog(ZONE_IDENTIFY_DUPLICATE_FUNCS, key + "->" + functionHashToFunctionName[key]);
+    }
+  }
+
+  return functionHashToFunctionName;
+}
+
+function getVariableNames(ast) {
+  var variableNames = {};
+  traverse(ast, function(node, type) {
+    if (type === 'var') {
+
+      var vars = node[1];
+
+      if (Array.isArray(vars)) {
+        for (var i = 0; i < vars.length; i++) {
+          var ident = vars[i][0];
+
+          variableNames[ident] = 1;
+        }
+      }
+    }
+  });
+
+  return variableNames;
+}
+
+function replaceFunctionDefinitions(ast, equivalentFunctionHash) {
+  debugLog(ZONE_TOP_LEVEL, 'replaceFunctionDefinitions');
+
+  var topLevelList = useAsmAst ? ast : ast[1];
+  var indicesToRemove = [];
+  for (var listIndex = 0; listIndex < topLevelList.length; ++listIndex) {
+    var node = topLevelList[listIndex];
+
+    if (node[0] === 'defun' && equivalentFunctionHash[node[1]] !== undefined) {
+      indicesToRemove.push(listIndex);
+    }
+  }
+
+  if (indicesToRemove.length > 0) {
+    for (var i = indicesToRemove.length - 1; i >= 0; --i) {
+      debugLog(ZONE_REPLACE_DUPLICATE_FUNCS, "Removing " + topLevelList[indicesToRemove[i]][1]);
+      topLevelList.splice(indicesToRemove[i], 1);
+    }
+  }
+}
+
+function replaceFunctionReferences(ast, equivalentFunctionHash) {
+  debugLog(ZONE_TOP_LEVEL, 'replaceFunctionReferences');
+  traverse(ast, function(node, type) {
+    if (type === 'call') {
+      var functionName = node[1][1];
+
+      // Replace the call with a call to the equivalent function if there is one
+      if (equivalentFunctionHash[functionName] !== undefined) {
+        node[1][1] = equivalentFunctionHash[functionName];
+      }
+    } else if (type === 'var') {
+      var vars = node[1];
+      for (var i = 0; i < vars.length; i++) {
+        debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, 'Variable: ' + vars[i]);
+        var value = vars[i][1][1];
+        debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, 'Variable value: ' + value);
+
+        if (equivalentFunctionHash[value] !== undefined) {
+          debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, 'Variable value replacement: ' + equivalentFunctionHash[value]);
+          vars[i][1][1] = equivalentFunctionHash[value];
+        }
+      }
+    } else if (type === 'assign') {
+      if (node[3][0] === 'name' && equivalentFunctionHash[node[3][1]] !== undefined) {
+        node[3][1] = equivalentFunctionHash[node[3][1]];
+      }
+    } else if (type === 'object') {
+      var assignments = node[1];
+
+      for (var i = 0; i < assignments.length; i++) {
+        debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, 'Object Value Assignment: ' + assignments[i][1][1]);
+
+        if (equivalentFunctionHash[assignments[i][1][1]] !== undefined) {
+          assignments[i][1][1] = equivalentFunctionHash[assignments[i][1][1]];
+        }
+      }
+    } else if (type === 'array') {
+      var arrayVars = node[1];
+
+      if (Array.isArray(arrayVars)) {
+        for (var i = 0; i < arrayVars.length; i++) {
+          debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, "Array: " + arrayVars[i][0] + ", " + arrayVars[i][1]);
+          // First element contains type, 2nd contains value
+          if (arrayVars[i][0] == 'name' && equivalentFunctionHash[arrayVars[i][1]] !== undefined) {
+            debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, "Replacing array value " + arrayVars[i][1]);
+            arrayVars[i][1] = equivalentFunctionHash[arrayVars[i][1]];
+          }
+        }
+      } else {
+        debugLog(ZONE_REPLACE_FUNCTION_REFERENCES, "ArrayVars (not an array): " + arrayVars + ", node: " + node);
+      }
+    }
+  });
+}
+
+function replaceDuplicateFuncs(ast, equivalentFunctionHash) {
+  debugLog(ZONE_TOP_LEVEL, "replaceDuplicateFuncs");
+
+  // Replace references to all functions with their equivalent function
+  replaceFunctionReferences(ast, equivalentFunctionHash);
+
+  // Now lets replace the function definitions
+  replaceFunctionDefinitions(ast, equivalentFunctionHash);
+}
+
+function logEquivalentFunctionHash(equivalentFunctionHash) {
+  if (debug && ZONE_EQUIVALENT_FUNCTION_HASH != 0) {
+    debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, "Equivalent Function Hash:");
+    for (var fn in equivalentFunctionHash) {
+      debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, fn + "->" + equivalentFunctionHash[fn]);
+    }
+  }
+}
+
+function generateEquivalentFunctionHash(functionHashToFunctionName, variableNames) {
+  var equivalentFunctionHash = {};
+
+  debugLog(ZONE_TOP_LEVEL, "generateEquivalentFunctionHash");
+
+  if (debug && ZONE_EQUIVALENT_FUNCTION_HASH != 0) {
+    debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, "Equivalent Functions:");
+
+    for (var fnHash in functionHashToFunctionName) {
+      if (functionHashToFunctionName[fnHash].length > 1) {
+        debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, JSON.stringify(functionHashToFunctionName[fnHash], null, '  '));
+      }
+    }
+  }
+
+  for (var fnHash in functionHashToFunctionName) {
+    var equivalentFunctions = functionHashToFunctionName[fnHash];
+    var shortestFunction = undefined;
+    var equivalentFn = undefined;
+
+    // From each list of equivalent functions, pick the
+    // shortest one that is not also a variable name
+    for (var index in equivalentFunctions) {
+      equivalentFn = equivalentFunctions[index];
+
+      // If one of the variables is not the same name as the equivalent function,
+      // and the equivalent function is shorter than the shortest function.
+      if ((variableNames[equivalentFn] === undefined) &&
+        (shortestFunction === undefined || equivalentFn.length < shortestFunction.length)) {
+        shortestFunction = equivalentFn;
+      }
+
+      if (debug && variableNames[equivalentFn] !== undefined) {
+        debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, equivalentFn + " is a variable");
+      }
+    }
+
+    if (shortestFunction !== undefined) {
+      // Populate the equivalent function hash with this info
+      for (var index in equivalentFunctions) {
+        equivalentFn = equivalentFunctions[index];
+
+        // If we're not the shortest function, and
+        // we are not a variable name
+        if ((equivalentFn !== shortestFunction) && variableNames[equivalentFn] === undefined) {
+          equivalentFunctionHash[equivalentFn] = shortestFunction;
+          debugLog(ZONE_EQUIVALENT_FUNCTION_HASH, equivalentFn + "->" + shortestFunction);
+        }
+      }
+    }
+  }
+
+  return equivalentFunctionHash;
+}
+
+function getBodyForFunction(ast, functionName) {
+  var functionBody = undefined;
+  var topLevelList = ast[1];
+
+  for (var listIndex = 0; listIndex < topLevelList.length; ++listIndex) {
+    var node = topLevelList[listIndex];
+
+    if (node[0] === 'defun' && node[1] === functionName) {
+      functionBody = getFunctionBody(node);
+      break;
+    }
+  }
+
+  return functionBody;
+}
+
+function checkForHashCollisions(ast, functionHashToFunctionName) {
+  var functionHashToFunctionBody = {};
+
+  for (var functionHash in functionHashToFunctionName) {
+    var equivalentFunctions = functionHashToFunctionName[functionHash];
+    var functionBody = getBodyForFunction(ast, equivalentFunctions[0]);
+
+    functionHashToFunctionBody[functionHash] = functionBody;
+
+    // If we have more than one equivalent function, make sure
+    // that the bodies are the same from the hash values
+    if (equivalentFunctions.length > 1) {
+      for (var functionIndex = 1; functionIndex < equivalentFunctions.length; ++functionIndex) {
+        var curFunctionBody = getBodyForFunction(ast, equivalentFunctions[functionIndex]);
+
+        if (curFunctionBody !== functionBody) {
+          printErr("ERROR!!! Function bodies for two hash-equivalent functions differ!!! Candidates: "
+                  + equivalentFunctions[0] + ", " + equivalentFunctions[functionIndex]);
+          process.exit(1);
+        }
+      }
+    }
+  }
+
+  return functionHashToFunctionBody;
+}
+
+function eliminateDuplicateFuncs(ast) {
+  debugLog(ZONE_TOP_LEVEL, "eliminateDuplicateFuncs");
+
+  // Phase 1 - identify duplicate functions
+  var functionHashToFunctionName = identifyDuplicateFunctions(ast);
+
+  // Phase 1.1 - Check for hash collisions
+  checkForHashCollisions(ast, functionHashToFunctionName);
+
+  // Phase 2 - identify variables that conflict with function names
+  var variableNames = getVariableNames(ast);
+
+  // Phase 3 - generate the equivalent function hash
+  var equivalentFunctionHash = generateEquivalentFunctionHash(functionHashToFunctionName, variableNames);
+
+  // Phase 4 - for each set of equivalent functions, pick one and
+  // use it to replace the other equivalent functions.
+  replaceDuplicateFuncs(ast, equivalentFunctionHash);
+
+  return;
+}
+
+function find(filename) {
+  var prefixes = [nodePath.join(__dirname, '..', 'src'), process.cwd()];
+  for (var i = 0; i < prefixes.length; ++i) {
+    var combined = nodePath.join(prefixes[i], filename);
+    if (nodeFS.existsSync(combined)) {
+      return combined;
+    }
+  }
+  return filename;
+}
+
+function findAsmAst(ast) {
+  var asmNode = undefined;
+  traverse(ast, function(node, type) {
+    if (type === 'var') {
+
+      var vars = node[1];
+      for (var i = 0; i < vars.length; i++) {
+        var ident = vars[i][0];
+
+        if (ident === 'asm') {
+          asmNode = vars[i][1][1][3]; // asm->call->toplevel-ast
+        }
+      }
+    }
+  });
+
+  return asmNode;
+}
+
+function printHashInfo(ast) {
+  debugLog(ZONE_TOP_LEVEL, "printHashInfo");
+
+  var infoHash = {};
+  infoHash['variable_names'] = getVariableNames(ast);
+  infoHash['fn_hash_to_fn_name'] = identifyDuplicateFunctions(ast);
+  infoHash['fn_hash_to_fn_body'] = checkForHashCollisions(ast, infoHash['fn_hash_to_fn_name']);
+
+  print(JSON.stringify(infoHash));
+}
+
+read = function(filename) {
+  var absolute = find(filename);
+  return nodeFS['readFileSync'](absolute).toString();
+};
+
+// Main
+var arguments_ = process['argv'].slice(2);
+var noMinimizeWhitespace = false; // Eliminate whitespace by default
+var functionName = undefined;
+var src = undefined; 
+
+for (var argIndex = 0; argIndex < arguments_.length; ++argIndex) {
+  var arg = arguments_[argIndex];
+  if (arg === '--debug') {
+    debug = true;
+    debugFile = nodeFS.openSync(debugFileName, 'w');
+  } else if (arg === '--no-minimize-whitespace') {
+    noMinimizeWhitespace = true;
+  } else if (arg === '--gen-hash-info') {
+    genHashInfo = true;
+  } else if (arg === '--use-hash-info') {
+    useHashInfo = true;
+  } else if (arg === '--use-asm-ast') {
+    useAsmAst = true;
+  } else if (arg === '--get-function-body') {
+    if (argIndex === arguments_.length_ - 1) {
+      throw new Error('Please specify valid arguments!');
+    }
+
+    functionName = arguments_[argIndex+1];
+    argIndex += 1;
+  } else if (/^--/.test(arg)) {
+    throw new Error('Please specify valid arguments!');
+  } else if (src === undefined) {
+    src = read(arg);
+  } else {
+    throw new Error('Please specify valid arguments!');
+  }
+}
+
+var ast = srcToAst(src);
+var asmAst = ast;
+
+if (useAsmAst) {
+  asmAst = findAsmAst(ast);
+}
+
+if (debug) {
+  dumpAst(ast);
+}
+
+if (functionName !== undefined) {
+  var functionBody = getBodyForFunction(ast, functionName);
+
+  if (functionBody === undefined) {
+    throw new Error('Could not find body for function ' + functionName + '!!!');
+  }
+
+  print(functionBody);
+} else if (genHashInfo) {
+  printHashInfo(asmAst);
+} else {
+  equivalentFunctionHash = {};
+
+  if (useHashInfo) {
+    // The last line has the required info
+    infoHashJsonStart = src.lastIndexOf("//") + 2 // 2 for going past the //
+
+    if (infoHashJsonStart == -1) {
+      throw new Error('--use-hash-info specified but no JSON found at the end of the file!');
+    }
+
+    equivalentFunctionHash = JSON.parse(src.substring(infoHashJsonStart));
+
+    logEquivalentFunctionHash(equivalentFunctionHash);
+    replaceDuplicateFuncs(asmAst, equivalentFunctionHash);
+  } else {
+    eliminateDuplicateFuncs(asmAst);
+  }
+
+  var minimizeWhitespace = (debug || noMinimizeWhitespace) ? false : true;
+  var js = astToSrc(ast, minimizeWhitespace);
+
+  print(js);
+}
+
+if (debug && debugFile !== undefined) {
+  printErr('Wrote debug log to ' + debugFileName);
+  nodeFS.close(debugFile);
+}

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1655,6 +1655,11 @@ class Building:
     return ret
 
   @staticmethod
+  def eliminate_duplicate_funcs(filename):
+    import duplicate_function_eliminator
+    duplicate_function_eliminator.eliminate_duplicate_funcs(filename)
+
+  @staticmethod
   def closure_compiler(filename, pretty=True):
     if not check_closure_compiler():
       logging.error('Cannot run closure compiler')


### PR DESCRIPTION
This is a pull request containing duplicate function elimination work by Arnab Choudhury and other collaborators at Tableau.

* Ran main test suite using `python tests/runner.py`.
* No regressions were introduced

Commit message follows:

-----

This change adds support for duplicate function elimination to the
JavaScript optimizer.  A new JS file has been added -
eliminate-duplicate-functions.js - which is used to postprocess the
output generated by Emscripten. We add a new file, rather than
augmenting the existing JS optimizer file, for a variety of reasons -
pass independence, reduced coupling between Python scripts and the JS
optimizer, etc.

We introduce a multipass algorithm in which each pass consists of the
following four phases:

Phase 1 - identify duplicate functions using a hash of the function body
Phase 2 - identify variable names that would conflict after renaming
function calls
Phase 3 - generate mapping from equivalent functions to their
replacement function - use the information from Phase 2 to ensure that
the replacement function is not a variable name
Phase 4 - use the mapping generated in Phase 3 to perform the reduction

NOTE: In some rare cases, we may actually not be able to move on from
Phase 3 if we find that we cannot generate a mapping because of
conflicts with variable names.

One pass can reveal new sets of identical functions which in turn can be
reduced by further passes. Empirically, four or five passes are
sufficient to eliminate all duplicate functions. Internally, therefore,
the elimination will perform 5 passes by default. This can be overridden
by setting the EMCC_ELIMINATE_DUPE_FUNC_PASSES environment variable.

Generated asm.js is broken into several batches (at function boundaries)
to enable parallelization of the elimination. This saves on memory and
makes use of more CPU cores to save on build time. A number of tests
have been introduced to test this functionality as well.

The change also introduces various tweaks to the amount of diagnostic
information that is dumped out by the JavaScript optimizer. Verbose
logging is now only enabled in debug mode (via the EMCC_LOG_DEBUG
environment variable). We also dump backtraces on encountering unhandled
exceptions: this is useful when Emscripten runs as part of a large build
process. In order to view detailed information about which functions
were merged, the EMCC_DUMP_EQUIVALENT_FUNCTIONS environment variable can
be set. This generates a log file in the same directory as the generated
JavaScript listing the sets of merged functions. This can be decoded
using the symbol map generated by Emscripten. It is, therefore,
recommended that developers enable symbol map generation when attempting
to modify or debug this feature.

The duplicate function removal is currently enabled if an optimization
level greater than or equal to -O2 is specified. The function
elimination process can be entirely bypassed by setting the
EMCC_NO_DUPLICATE_FUNCTION_ELIMINATION environment variable.

Improvements/future work

It has been observed that on average we experience a code size reduction
of 25% when transpiling large C++ code bases.  Typically, C++ code that
makes heavy use of templates will experience the greatest reduction in
code size. There are several directions that future work might take:

* Deduplication of code across templates: e.g. reduction of
std::vector<long> and std::vector<int> to single instantiations of
template code when appropriate

* Histogram-based selection of candidates for replacement: improved code
size should be attainable by assigning the shortest identifiers to the
most frequently referenced functions (in the style of Huffman coding)

* Convergence: the five-pass default chosen in this implementation is
based on empirical observations on a 150,000LOC C++ code base

* Candidate selection: this will, most likely, influence both the
convergence time (i.e. number of passes) and the code size reduction;
currently, when selecting candidates, we choose the shortest identifier
from the list that is not also a variable name
