### PR TITLE
free_memoryinitializer_after_apply

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -55,6 +55,7 @@ if (memoryInitializer) {
       }
 #endif
       HEAPU8.set(data, Runtime.GLOBAL_BASE);
+      delete Module['memoryInitializerRequest'];
       removeRunDependency('memory initializer');
     }
     function doBrowserLoad() {
@@ -62,10 +63,10 @@ if (memoryInitializer) {
         throw 'could not load memory initializer ' + memoryInitializer;
       });
     }
-    var request = Module['memoryInitializerRequest'];
-    if (request) {
+    if (Module['memoryInitializerRequest']) {
       // a network request has already been created, just use that
       function useRequest() {
+        var request = Module['memoryInitializerRequest'];
         if (request.status !== 200 && request.status !== 0) {
           // If you see this warning, the issue may be that you are using locateFile or memoryInitializerPrefixURL, and defining them in JS. That
           // means that the HTML file doesn't know about them, and when it tries to create the mem init request early, does it to the wrong place.
@@ -76,10 +77,10 @@ if (memoryInitializer) {
         }
         applyMemoryInitializer(request.response);
       }
-      if (request.response) {
+      if (Module['memoryInitializerRequest'].response) {
         setTimeout(useRequest, 0); // it's already here; but, apply it asynchronously
       } else {
-        request.addEventListener('load', useRequest); // wait for it
+        Module['memoryInitializerRequest'].addEventListener('load', useRequest); // wait for it
       }
     } else {
       // fetch it from the network ourselves

--- a/src/shell.js
+++ b/src/shell.js
@@ -219,6 +219,9 @@ for (var key in moduleOverrides) {
     Module[key] = moduleOverrides[key];
   }
 }
+// Free the object hierarchy contained in the overrides, this lets the GC
+// reclaim data used e.g. in memoryInitializerRequest, which is a large typed array.
+moduleOverrides = undefined;
 
 {{BODY}}
 


### PR DESCRIPTION
Once the memory initializer file .mem.js has been applied, make sure that all references to it are released so that the GC can reclaim the memory used by the memory initializer typed array.