### PR TITLE
Update file_packager.py

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -71,7 +71,7 @@ See the source for more details.'''
 
 DEBUG = os.environ.get('EMCC_DEBUG')
 
-data_target = sys.argv[1]
+data_target = sys.argv[1].replace('\\','/')
 
 IMAGE_SUFFIXES = ('.jpg', '.png', '.bmp')
 AUDIO_SUFFIXES = ('.ogg', '.wav', '.mp3')


### PR DESCRIPTION
change windows path backslash to unix path forwardslash

tests have shown when something like the following is done
> file_packager.py ...\u_test\assets.data" --preload . --js-output="...\u_test\assets.data.js"

the "\u..." in the path -- when assigned to (for example) "var PACKAGE_NAME" will error with "ILLEGAL TOKEN" as and unknown unicode character escape character...  stopping further javascript processing...

[emscripten_u_test.zip](https://github.com/kripken/emscripten/files/107480/emscripten_u_test.zip)