### PR TITLE
Simd js intrinsics update

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -484,14 +484,14 @@ function _emscripten_asm_const_%s(%s) {
                          'load', 'store', 'load1', 'store1', 'load2', 'store2', 'load3', 'store3']
     simdintboolfuncs = ['and', 'xor', 'or', 'not']
     if metadata['simdInt8x16']:
-      simdinttypes += ['Int8x16']
-      simdintfloatfuncs += ['fromInt8x16Bits']
+      simdinttypes += ['Int8x16', 'Uint8x16']
+      simdintfloatfuncs += ['fromInt8x16Bits', 'fromUint8x16Bits']
     if metadata['simdInt16x8']:
-      simdinttypes += ['Int16x8']
-      simdintfloatfuncs += ['fromInt16x8Bits']
+      simdinttypes += ['Int16x8', 'Uint16x8']
+      simdintfloatfuncs += ['fromInt16x8Bits', 'fromUint16x8Bits']
     if metadata['simdInt32x4']:
-      simdinttypes += ['Int32x4']
-      simdintfloatfuncs += ['fromInt32x4', 'fromInt32x4Bits']
+      simdinttypes += ['Int32x4', 'Uint32x4']
+      simdintfloatfuncs += ['fromInt32x4', 'fromInt32x4Bits', 'fromUint32x4Bits']
     if metadata['simdFloat32x4']:
       simdfloattypes += ['Float32x4']
       simdintfloatfuncs += ['fromFloat32x4', 'fromFloat32x4Bits']
@@ -509,9 +509,7 @@ function _emscripten_asm_const_%s(%s) {
 
     simdfloatfuncs = simdfuncs + simdintfloatfuncs + ['div', 'min', 'max', 'minNum', 'maxNum', 'sqrt',
                                   'abs', 'reciprocalApproximation', 'reciprocalSqrtApproximation'];
-    simdintfuncs = simdfuncs + simdintfloatfuncs + simdintboolfuncs + ['shiftRightArithmeticByScalar',
-                                'shiftRightLogicalByScalar',
-                                'shiftLeftByScalar'];
+    simdintfuncs = simdfuncs + simdintfloatfuncs + simdintboolfuncs + ['shiftLeftByScalar', 'shiftRightByScalar'];
     simdboolfuncs = simdfuncs + simdintboolfuncs + ['anyTrue', 'allTrue']
     simdtypes = simdfloattypes + simdinttypes + simdbooltypes
 

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -117,15 +117,7 @@ function simdCheckLaneIndex(index, lanes) {
 var lanes = [];
 
 function simdCreate(type) {
-  // XXX Emscripten:
-  // Work around v8 NaN canonicalization issue: if lanes contains floats with non-canonical NaN bit patterns,
-  // type.fn.apply() will canonicalize the NaNs and the bits are lost (most likely as part of float->double expansion).
-  // Directly passing the arguments into the function preserves them.
-  if (type.name == "Float32x4") {
-    return SIMD.Float32x4(lanes[0], lanes[1], lanes[2], lanes[3]);
-  } else {
-    return type.fn.apply(type.fn, lanes);
-  }
+  return type.fn.apply(type.fn, lanes);
 }
 
 function simdToString(type, a) {
@@ -178,11 +170,9 @@ function simdFrom(toType, fromType, a) {
 
 function simdFromBits(toType, fromType, a) {
   a = fromType.fn.check(a);
-  for (var i = 0; i < fromType.lanes; i++)
-    fromType.buffer[i] = fromType.fn.extractLane(a, i);
-  for (var i = 0; i < toType.lanes; i++)
-    lanes[i] = toType.buffer[i];
-  return simdCreate(toType);
+  var newValue = new toType.fn();
+  newValue.s_ = new toType.view(a.s_.buffer);
+  return newValue;
 }
 
 function simdSelect(type, selector, a, b) {
@@ -235,7 +225,6 @@ function binaryAdd(a, b) { return a + b; }
 function binarySub(a, b) { return a - b; }
 function binaryMul(a, b) { return a * b; }
 function binaryDiv(a, b) { return a / b; }
-function binaryAbsDiff(a, b) { return Math.abs(a - b); }
 
 var binaryImul;
 if (typeof Math.imul !== 'undefined') {
@@ -258,15 +247,6 @@ function simdBinaryOp(type, op, a, b) {
   for (var i = 0; i < type.lanes; i++)
     lanes[i] = op(type.fn.extractLane(a, i), type.fn.extractLane(b, i));
   return simdCreate(type);
-}
-
-function simdWideningBinaryOp(type, op, a, b) {
-  a = type.fn.check(a);
-  b = type.fn.check(b);
-  for (var i = 0; i < type.wideType.lanes; i++)
-    lanes[i] = op(type.fn.extractLane(a, i),
-                  type.fn.extractLane(b, i));
-  return simdCreate(type.wideType);
 }
 
 function binaryEqual(a, b) { return a == b; }
@@ -300,20 +280,13 @@ function simdAllTrue(type, a) {
 
 function binaryShiftLeft(a, bits) { return a << bits; }
 function binaryShiftRightArithmetic(a, bits) { return a >> bits; }
+function binaryShiftRightLogical(a, bits) { return a >>> bits; }
 
 function simdShiftOp(type, op, a, bits) {
   a = type.fn.check(a);
   for (var i = 0; i < type.lanes; i++)
     lanes[i] = op(type.fn.extractLane(a, i), bits);
   return simdCreate(type);
-}
-
-function simdHorizontalSum(type, a) {
-  a = type.fn.check(a);
-  var result = 0;
-  for (var i = 0; i < type.lanes; i++)
-    result += type.fn.extractLane(a, i);
-  return result;
 }
 
 function simdLoad(type, tarray, index, count) {
@@ -326,17 +299,14 @@ function simdLoad(type, tarray, index, count) {
   if (index < 0 || (index * bpe + bytes) > tarray.byteLength)
     throw new RangeError("The value of index is invalid.");
 
-  var buf = type.buffer;
-  var array = bpe == 1 ? _i8x16 :
-              bpe == 2 ? _i16x8 :
-              bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
-              _f64x2;
-  var n = bytes / bpe;
-  for (var i = 0; i < n; i++)
-    array[i] = tarray[index + i];
-  for (i = 0; i < count; i++) lanes[i] = buf[i];
-  for (; i < type.lanes; i++) lanes[i] = 0;
-  return simdCreate(type);
+  var newValue = type.fn();
+  var dst = new Uint8Array(newValue.s_.buffer);
+  var src = new Uint8Array(tarray.buffer, tarray.byteOffset + index * bpe, bytes);
+
+  for (var i = 0; i < bytes; i++) {
+    dst[i] = src[i];
+  }
+  return newValue;
 }
 
 function simdStore(type, tarray, index, a, count) {
@@ -350,23 +320,13 @@ function simdStore(type, tarray, index, a, count) {
     throw new RangeError("The value of index is invalid.");
 
   a = type.fn.check(a);
-  // If count is odd and tarray's elements are 8 bytes wide, we have to create
-  // a new view.
-  if ((count % 2 != 0) && bpe == 8) {
-    var view = new type.view(tarray.buffer,
-                             tarray.byteOffset + index * 8, count);
-    for (var i = 0; i < count; i++)
-      view[i] = type.fn.extractLane(a, i);
-  } else {
-    for (var i = 0; i < count; i++)
-      type.buffer[i] = type.fn.extractLane(a, i);
-    var array = bpe == 1 ? _i8x16 :
-                bpe == 2 ? _i16x8 :
-                bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
-                _f64x2;
-    var n = bytes / bpe;
-    for (var i = 0; i < n; i++)
-      tarray[index + i] = array[i];
+
+  // The underlying buffers are copied byte by byte, to avoid float
+  // canonicalization.
+  var src = new Uint8Array(a.s_.buffer);
+  var dst = new Uint8Array(tarray.buffer, tarray.byteOffset + index * bpe, bytes);
+  for (var i = 0; i < bytes; i++) {
+    dst[i] = src[i];
   }
   return a;
 }
@@ -374,20 +334,222 @@ function simdStore(type, tarray, index, a, count) {
 // Constructors and extractLane functions are closely related and must be
 // polyfilled together.
 
-// Bool64x2
-if (typeof SIMD.Bool64x2 === "undefined" ||
-    typeof SIMD.Bool64x2.extractLane === "undefined") {
-  SIMD.Bool64x2 = function(s0, s1) {
-    if (!(this instanceof SIMD.Bool64x2)) {
-      return new SIMD.Bool64x2(s0, s1);
+// Float32x4
+if (typeof SIMD.Float32x4 === "undefined" ||
+    typeof SIMD.Float32x4.extractLane === "undefined") {
+  SIMD.Float32x4 = function(s0, s1, s2, s3) {
+    if (!(this instanceof SIMD.Float32x4)) {
+      return new SIMD.Float32x4(s0, s1, s2, s3);
     }
-    this.s_ = [!!s0, !!s1];
+    this.s_ = convertArray(_f32x4, new Float32Array([s0, s1, s2, s3]));
   }
 
-  SIMD.Bool64x2.extractLane = function(v, i) {
-    v = SIMD.Bool64x2.check(v);
-    simdCheckLaneIndex(i, 2);
+  SIMD.Float32x4.extractLane = function(v, i) {
+    v = SIMD.Float32x4.check(v);
+    simdCheckLaneIndex(i, 4);
     return v.s_[i];
+  }
+}
+
+// Miscellaneous functions that aren't easily parameterized on type.
+
+if (typeof SIMD.Float32x4.swizzle === "undefined") {
+  SIMD.Float32x4.swizzle = function(a, s0, s1, s2, s3) {
+    return simdSwizzle(float32x4, a, [s0, s1, s2, s3]);
+  }
+}
+
+if (typeof SIMD.Float32x4.shuffle === "undefined") {
+  SIMD.Float32x4.shuffle = function(a, b, s0, s1, s2, s3) {
+    return simdShuffle(float32x4, a, b, [s0, s1, s2, s3]);
+  }
+}
+
+// Int32x4
+if (typeof SIMD.Int32x4 === "undefined" ||
+    typeof SIMD.Int32x4.extractLane === "undefined") {
+  SIMD.Int32x4 = function(s0, s1, s2, s3) {
+    if (!(this instanceof SIMD.Int32x4)) {
+      return new SIMD.Int32x4(s0, s1, s2, s3);
+    }
+    this.s_ = convertArray(_i32x4, new Int32Array([s0, s1, s2, s3]));
+  }
+
+  SIMD.Int32x4.extractLane = function(v, i) {
+    v = SIMD.Int32x4.check(v);
+    simdCheckLaneIndex(i, 4);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Int32x4.swizzle === "undefined") {
+  SIMD.Int32x4.swizzle = function(a, s0, s1, s2, s3) {
+    return simdSwizzle(int32x4, a, [s0, s1, s2, s3]);
+  }
+}
+
+if (typeof SIMD.Int32x4.shuffle === "undefined") {
+  SIMD.Int32x4.shuffle = function(a, b, s0, s1, s2, s3) {
+    return simdShuffle(int32x4, a, b, [s0, s1, s2, s3]);
+  }
+}
+
+// Int16x8
+if (typeof SIMD.Int16x8 === "undefined" ||
+    typeof SIMD.Int16x8.extractLane === "undefined") {
+  SIMD.Int16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+    if (!(this instanceof SIMD.Int16x8)) {
+      return new SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+    }
+    this.s_ = convertArray(_i16x8, new Int16Array([s0, s1, s2, s3, s4, s5, s6, s7]));
+  }
+
+  SIMD.Int16x8.extractLane = function(v, i) {
+    v = SIMD.Int16x8.check(v);
+    simdCheckLaneIndex(i, 8);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Int16x8.swizzle === "undefined") {
+  SIMD.Int16x8.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7) {
+    return simdSwizzle(int16x8, a, [s0, s1, s2, s3, s4, s5, s6, s7]);
+  }
+}
+
+if (typeof SIMD.Int16x8.shuffle === "undefined") {
+  SIMD.Int16x8.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7) {
+    return simdShuffle(int16x8, a, b, [s0, s1, s2, s3, s4, s5, s6, s7]);
+  }
+}
+
+// Int8x16
+if (typeof SIMD.Int8x16 === "undefined" ||
+    typeof SIMD.Int8x16.extractLane === "undefined") {
+  SIMD.Int8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
+                          s8, s9, s10, s11, s12, s13, s14, s15) {
+    if (!(this instanceof SIMD.Int8x16)) {
+      return new SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                              s8, s9, s10, s11, s12, s13, s14, s15);
+    }
+    this.s_ = convertArray(_i8x16, new Int8Array([s0, s1, s2, s3, s4, s5, s6, s7,
+                                    s8, s9, s10, s11, s12, s13, s14, s15]));
+  }
+
+  SIMD.Int8x16.extractLane = function(v, i) {
+    v = SIMD.Int8x16.check(v);
+    simdCheckLaneIndex(i, 16);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Int8x16.swizzle === "undefined") {
+  SIMD.Int8x16.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7,
+                                     s8, s9, s10, s11, s12, s13, s14, s15) {
+    return simdSwizzle(int8x16, a, [s0, s1, s2, s3, s4, s5, s6, s7,
+                                    s8, s9, s10, s11, s12, s13, s14, s15]);
+  }
+}
+
+if (typeof SIMD.Int8x16.shuffle === "undefined") {
+  SIMD.Int8x16.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7,
+                                        s8, s9, s10, s11, s12, s13, s14, s15) {
+    return simdShuffle(int8x16, a, b, [s0, s1, s2, s3, s4, s5, s6, s7,
+                                       s8, s9, s10, s11, s12, s13, s14, s15]);
+  }
+}
+
+// Uint32x4
+if (typeof SIMD.Uint32x4 === "undefined" ||
+    typeof SIMD.Uint32x4.extractLane === "undefined") {
+  SIMD.Uint32x4 = function(s0, s1, s2, s3) {
+    if (!(this instanceof SIMD.Uint32x4)) {
+      return new SIMD.Uint32x4(s0, s1, s2, s3);
+    }
+    this.s_ = convertArray(_ui32x4, new Uint32Array([s0, s1, s2, s3]));
+  }
+
+  SIMD.Uint32x4.extractLane = function(v, i) {
+    v = SIMD.Uint32x4.check(v);
+    simdCheckLaneIndex(i, 4);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Uint32x4.swizzle === "undefined") {
+  SIMD.Uint32x4.swizzle = function(a, s0, s1, s2, s3) {
+    return simdSwizzle(uint32x4, a, [s0, s1, s2, s3]);
+  }
+}
+
+if (typeof SIMD.Uint32x4.shuffle === "undefined") {
+  SIMD.Uint32x4.shuffle = function(a, b, s0, s1, s2, s3) {
+    return simdShuffle(uint32x4, a, b, [s0, s1, s2, s3]);
+  }
+}
+
+// Uint16x8
+if (typeof SIMD.Uint16x8 === "undefined" ||
+    typeof SIMD.Uint16x8.extractLane === "undefined") {
+  SIMD.Uint16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+    if (!(this instanceof SIMD.Uint16x8)) {
+      return new SIMD.Uint16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+    }
+    this.s_ = convertArray(_ui16x8, new Uint16Array([s0, s1, s2, s3, s4, s5, s6, s7]));
+  }
+
+  SIMD.Uint16x8.extractLane = function(v, i) {
+    v = SIMD.Uint16x8.check(v);
+    simdCheckLaneIndex(i, 8);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Uint16x8.swizzle === "undefined") {
+  SIMD.Uint16x8.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7) {
+    return simdSwizzle(uint16x8, a, [s0, s1, s2, s3, s4, s5, s6, s7]);
+  }
+}
+
+if (typeof SIMD.Uint16x8.shuffle === "undefined") {
+  SIMD.Uint16x8.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7) {
+    return simdShuffle(uint16x8, a, b, [s0, s1, s2, s3, s4, s5, s6, s7]);
+  }
+}
+
+// Uint8x16
+if (typeof SIMD.Uint8x16 === "undefined" ||
+    typeof SIMD.Uint8x16.extractLane === "undefined") {
+  SIMD.Uint8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
+                           s8, s9, s10, s11, s12, s13, s14, s15) {
+    if (!(this instanceof SIMD.Uint8x16)) {
+      return new SIMD.Uint8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+                               s8, s9, s10, s11, s12, s13, s14, s15);
+    }
+    this.s_ = convertArray(_ui8x16, new Uint8Array([s0, s1, s2, s3, s4, s5, s6, s7,
+                                     s8, s9, s10, s11, s12, s13, s14, s15]));
+  }
+
+  SIMD.Uint8x16.extractLane = function(v, i) {
+    v = SIMD.Uint8x16.check(v);
+    simdCheckLaneIndex(i, 16);
+    return v.s_[i];
+  }
+}
+
+if (typeof SIMD.Uint8x16.swizzle === "undefined") {
+  SIMD.Uint8x16.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7,
+                                      s8, s9, s10, s11, s12, s13, s14, s15) {
+    return simdSwizzle(uint8x16, a, [s0, s1, s2, s3, s4, s5, s6, s7,
+                                     s8, s9, s10, s11, s12, s13, s14, s15]);
+  }
+}
+
+if (typeof SIMD.Uint8x16.shuffle === "undefined") {
+  SIMD.Uint8x16.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7,
+                                         s8, s9, s10, s11, s12, s13, s14, s15) {
+    return simdShuffle(uint8x16, a, b, [s0, s1, s2, s3, s4, s5, s6, s7,
+                                        s8, s9, s10, s11, s12, s13, s14, s15]);
   }
 }
 
@@ -445,154 +607,7 @@ if (typeof SIMD.Bool8x16 === "undefined" ||
   }
 }
 
-// Float64x2
-if (typeof SIMD.Float64x2 === "undefined" ||
-    typeof SIMD.Float64x2.extractLane === "undefined") {
-  SIMD.Float64x2 = function(s0, s1) {
-    if (!(this instanceof SIMD.Float64x2)) {
-      return new SIMD.Float64x2(s0, s1);
-    }
-    this.s_ = convertArray(_f64x2, [s0, s1]);
-  }
-
-  SIMD.Float64x2.extractLane = function(v, i) {
-    v = SIMD.Float64x2.check(v);
-    simdCheckLaneIndex(i, 2);
-    return v.s_[i];
-  }
-}
-
-// Float32x4
-if (typeof SIMD.Float32x4 === "undefined" ||
-    typeof SIMD.Float32x4.extractLane === "undefined") {
-  SIMD.Float32x4 = function(s0, s1, s2, s3) {
-    if (!(this instanceof SIMD.Float32x4)) {
-      return new SIMD.Float32x4(s0, s1, s2, s3);
-    }
-    // XXX Emscripten:
-    // Don't use convertArray() here to construct the Float32x4, since v8 most likely due to float->double
-    // expansion will lose noncanonical NaN bits if present, producing an incorrect bit pattern as a result.
-    this.s_ = new Float32Array(new ArrayBuffer(16));
-    this.s_[0] = s0;
-    this.s_[1] = s1;
-    this.s_[2] = s2;
-    this.s_[3] = s3;
-  }
-
-  SIMD.Float32x4.extractLane = function(v, i) {
-    v = SIMD.Float32x4.check(v);
-    simdCheckLaneIndex(i, 4);
-    return v.s_[i];
-  }
-}
-
-// Int32x4
-if (typeof SIMD.Int32x4 === "undefined" ||
-    typeof SIMD.Int32x4.extractLane === "undefined") {
-  SIMD.Int32x4 = function(s0, s1, s2, s3) {
-    if (!(this instanceof SIMD.Int32x4)) {
-      return new SIMD.Int32x4(s0, s1, s2, s3);
-    }
-    this.s_ = convertArray(_i32x4, [s0, s1, s2, s3]);
-  }
-
-  SIMD.Int32x4.extractLane = function(v, i) {
-    v = SIMD.Int32x4.check(v);
-    simdCheckLaneIndex(i, 4);
-    return v.s_[i];
-  }
-}
-
-// Int16x8
-if (typeof SIMD.Int16x8 === "undefined" ||
-    typeof SIMD.Int16x8.extractLane === "undefined") {
-  SIMD.Int16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
-    if (!(this instanceof SIMD.Int16x8)) {
-      return new SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
-    }
-    this.s_ = convertArray(_i16x8, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-
-  SIMD.Int16x8.extractLane = function(v, i) {
-    v = SIMD.Int16x8.check(v);
-    simdCheckLaneIndex(i, 8);
-    return v.s_[i];
-  }
-}
-
-// Int8x16
-if (typeof SIMD.Int8x16 === "undefined" ||
-    typeof SIMD.Int8x16.extractLane === "undefined") {
-  SIMD.Int8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
-                          s8, s9, s10, s11, s12, s13, s14, s15) {
-    if (!(this instanceof SIMD.Int8x16)) {
-      return new SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
-                              s8, s9, s10, s11, s12, s13, s14, s15);
-    }
-    this.s_ = convertArray(_i8x16, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                    s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-
-  SIMD.Int8x16.extractLane = function(v, i) {
-    v = SIMD.Int8x16.check(v);
-    simdCheckLaneIndex(i, 16);
-    return v.s_[i];
-  }
-}
-
-// Uint32x4
-if (typeof SIMD.Uint32x4 === "undefined" ||
-    typeof SIMD.Uint32x4.extractLane === "undefined") {
-  SIMD.Uint32x4 = function(s0, s1, s2, s3) {
-    if (!(this instanceof SIMD.Uint32x4)) {
-      return new SIMD.Uint32x4(s0, s1, s2, s3);
-    }
-    this.s_ = convertArray(_ui32x4, [s0, s1, s2, s3]);
-  }
-
-  SIMD.Uint32x4.extractLane = function(v, i) {
-    v = SIMD.Uint32x4.check(v);
-    simdCheckLaneIndex(i, 4);
-    return v.s_[i];
-  }
-}
-
-// Uint16x8
-if (typeof SIMD.Uint16x8 === "undefined" ||
-    typeof SIMD.Uint16x8.extractLane === "undefined") {
-  SIMD.Uint16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
-    if (!(this instanceof SIMD.Uint16x8)) {
-      return new SIMD.Uint16x8(s0, s1, s2, s3, s4, s5, s6, s7);
-    }
-    this.s_ = convertArray(_ui16x8, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-
-  SIMD.Uint16x8.extractLane = function(v, i) {
-    v = SIMD.Uint16x8.check(v);
-    simdCheckLaneIndex(i, 8);
-    return v.s_[i];
-  }
-}
-
-// Uint8x16
-if (typeof SIMD.Uint8x16 === "undefined" ||
-    typeof SIMD.Uint8x16.extractLane === "undefined") {
-  SIMD.Uint8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
-                           s8, s9, s10, s11, s12, s13, s14, s15) {
-    if (!(this instanceof SIMD.Uint8x16)) {
-      return new SIMD.Uint8x16(s0, s1, s2, s3, s4, s5, s6, s7,
-                               s8, s9, s10, s11, s12, s13, s14, s15);
-    }
-    this.s_ = convertArray(_ui8x16, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                     s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-
-  SIMD.Uint8x16.extractLane = function(v, i) {
-    v = SIMD.Uint8x16.check(v);
-    simdCheckLaneIndex(i, 16);
-    return v.s_[i];
-  }
-}
+// Type data to generate the remaining functions.
 
 var float32x4 = {
   name: "Float32x4",
@@ -601,21 +616,6 @@ var float32x4 = {
   laneSize: 4,
   buffer: _f32x4,
   view: Float32Array,
-  mulFn: binaryMul,
-  fns: ["check", "splat", "replaceLane", "select",
-        "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
-        "add", "sub", "mul", "div", "neg", "abs", "min", "max", "minNum", "maxNum",
-        "reciprocalApproximation", "reciprocalSqrtApproximation", "sqrt",
-        "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
-}
-
-var float64x2 = {
-  name: "Float64x2",
-  fn: SIMD.Float64x2,
-  lanes: 2,
-  laneSize: 8,
-  buffer: _f64x2,
-  view: Float64Array,
   mulFn: binaryMul,
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
@@ -638,8 +638,8 @@ var int32x4 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "neg", "min", "max",
-        "shiftLeftByScalar", "shiftRightArithmeticByScalar",
+        "add", "sub", "mul", "neg",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
 }
 
@@ -657,8 +657,8 @@ var int16x8 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "neg", "min", "max",
-        "shiftLeftByScalar", "shiftRightArithmeticByScalar",
+        "add", "sub", "mul", "neg",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "addSaturate", "subSaturate",
         "load", "store"],
 }
@@ -677,8 +677,8 @@ var int8x16 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "neg", "min", "max",
-        "shiftLeftByScalar", "shiftRightArithmeticByScalar",
+        "add", "sub", "mul", "neg",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "addSaturate", "subSaturate",
         "load", "store"],
 }
@@ -698,9 +698,8 @@ var uint32x4 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "min", "max",
-        "shiftLeftByScalar", "shiftRightLogicalByScalar",
-        "horizontalSum",
+        "add", "sub", "mul",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "load", "load1", "load2", "load3", "store", "store1", "store2", "store3"],
 }
 
@@ -719,9 +718,8 @@ var uint16x8 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "min", "max",
-        "shiftLeftByScalar", "shiftRightLogicalByScalar",
-        "horizontalSum", "absoluteDifference", "widenedAbsoluteDifference",
+        "add", "sub", "mul",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "addSaturate", "subSaturate",
         "load", "store"],
 }
@@ -741,21 +739,10 @@ var uint8x16 = {
   fns: ["check", "splat", "replaceLane", "select",
         "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
         "and", "or", "xor", "not",
-        "add", "sub", "mul", "min", "max",
-        "shiftLeftByScalar", "shiftRightLogicalByScalar",
-        "horizontalSum", "absoluteDifference", "widenedAbsoluteDifference",
+        "add", "sub", "mul",
+        "shiftLeftByScalar", "shiftRightByScalar",
         "addSaturate", "subSaturate",
         "load", "store"],
-}
-
-var bool64x2 = {
-  name: "Bool64x2",
-  fn: SIMD.Bool64x2,
-  lanes: 2,
-  laneSize: 8,
-  notFn: unaryLogicalNot,
-  fns: ["check", "splat", "replaceLane",
-        "allTrue", "anyTrue", "and", "or", "xor", "not"],
 }
 
 var bool32x4 = {
@@ -790,13 +777,11 @@ var bool8x16 = {
 
 // Each SIMD type has a corresponding Boolean SIMD type, which is returned by
 // relational ops.
-float64x2.boolType = bool64x2.boolType = bool64x2;
-float32x4.boolType = int32x4.boolType = uint32x4.boolType = bool32x4.boolType = bool32x4;
-int16x8.boolType = uint16x8.boolType = bool16x8.boolType = bool16x8;
-int8x16.boolType = uint8x16.boolType = bool8x16.boolType = bool8x16;
+float32x4.boolType = int32x4.boolType = uint32x4.boolType = bool32x4;
+int16x8.boolType = uint16x8.boolType = bool16x8;
+int8x16.boolType = uint8x16.boolType = bool8x16;
 
-// SIMD fromTIMD types.
-float64x2.from = [];
+// SIMD from<type> types.
 float32x4.from = [int32x4, uint32x4];
 int32x4.from = [float32x4, uint32x4];
 int16x8.from = [uint16x8];
@@ -805,29 +790,117 @@ uint32x4.from = [float32x4, int32x4];
 uint16x8.from = [int16x8];
 uint8x16.from = [int8x16];
 
-// SIMD fromTIMDBits types.
-float64x2.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
-float32x4.fromBits = [float64x2, int32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
-int32x4.fromBits = [float64x2, float32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
-int16x8.fromBits = [float64x2, float32x4, int32x4, int8x16, uint32x4, uint16x8, uint8x16];
-int8x16.fromBits = [float64x2, float32x4, int32x4, int16x8, uint32x4, uint16x8, uint8x16];
-uint32x4.fromBits = [float64x2, float32x4, int32x4, int16x8, int8x16, uint16x8, uint8x16];
-uint16x8.fromBits = [float64x2, float32x4, int32x4, int16x8, int8x16, uint32x4, uint8x16];
-uint8x16.fromBits = [float64x2, float32x4, int32x4, int16x8, int8x16, uint32x4, uint16x8];
+// SIMD from<type>Bits types.
+float32x4.fromBits = [int32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
+int32x4.fromBits = [float32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
+int16x8.fromBits = [float32x4, int32x4, int8x16, uint32x4, uint16x8, uint8x16];
+int8x16.fromBits = [float32x4, int32x4, int16x8, uint32x4, uint16x8, uint8x16];
+uint32x4.fromBits = [float32x4, int32x4, int16x8, int8x16, uint16x8, uint8x16];
+uint16x8.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint8x16];
+uint8x16.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint16x8];
 
-// SIMD widening types.
-uint16x8.wideType = uint32x4;
-uint8x16.wideType = uint16x8;
+var simdTypes = [float32x4,
+                 int32x4, int16x8, int8x16,
+                 uint32x4, uint16x8, uint8x16,
+                 bool32x4, bool16x8, bool8x16];
 
-var allTypes = [float64x2, float32x4,
-                int32x4, int16x8, int8x16,
-                uint32x4, uint16x8, uint8x16,
-                bool32x4, bool16x8, bool8x16];
+// SIMD Phase2 types.
 
-// XXX Emscripten: Add member functions to Bool64x2 as well.
-allTypes.push(bool64x2);
-// XXX Emscripten: Float64x2 value conversion to other types (In two lowest channels. Two highest channels zero).
-float64x2.from = [int32x4, uint32x4, float32x4];
+if (typeof simdPhase2 !== 'undefined') {
+  // Float64x2
+  if (typeof SIMD.Float64x2 === "undefined" ||
+      typeof SIMD.Float64x2.extractLane === "undefined") {
+    SIMD.Float64x2 = function(s0, s1) {
+      if (!(this instanceof SIMD.Float64x2)) {
+        return new SIMD.Float64x2(s0, s1);
+      }
+      this.s_ = convertArray(_f64x2, new Float64Array([s0, s1]));
+    }
+
+    SIMD.Float64x2.extractLane = function(v, i) {
+      v = SIMD.Float64x2.check(v);
+      simdCheckLaneIndex(i, 2);
+      return v.s_[i];
+    }
+  }
+
+  if (typeof SIMD.Float64x2.swizzle === "undefined") {
+    SIMD.Float64x2.swizzle = function(a, s0, s1) {
+      return simdSwizzle(float64x2, a, [s0, s1]);
+    }
+  }
+
+  if (typeof SIMD.Float64x2.shuffle === "undefined") {
+    SIMD.Float64x2.shuffle = function(a, b, s0, s1) {
+      return simdShuffle(float64x2, a, b, [s0, s1]);
+    }
+  }
+
+  // Bool64x2
+  if (typeof SIMD.Bool64x2 === "undefined" ||
+      typeof SIMD.Bool64x2.extractLane === "undefined") {
+    SIMD.Bool64x2 = function(s0, s1) {
+      if (!(this instanceof SIMD.Bool64x2)) {
+        return new SIMD.Bool64x2(s0, s1);
+      }
+      this.s_ = [!!s0, !!s1];
+    }
+
+    SIMD.Bool64x2.extractLane = function(v, i) {
+      v = SIMD.Bool64x2.check(v);
+      simdCheckLaneIndex(i, 2);
+      return v.s_[i];
+    }
+  }
+
+  var float64x2 = {
+    name: "Float64x2",
+    fn: SIMD.Float64x2,
+    lanes: 2,
+    laneSize: 8,
+    buffer: _f64x2,
+    view: Float64Array,
+    mulFn: binaryMul,
+    fns: ["check", "splat", "replaceLane", "select",
+          "equal", "notEqual", "lessThan", "lessThanOrEqual", "greaterThan", "greaterThanOrEqual",
+          "add", "sub", "mul", "div", "neg", "abs", "min", "max", "minNum", "maxNum",
+          "reciprocalApproximation", "reciprocalSqrtApproximation", "sqrt",
+          "load", "store"],
+  }
+
+  var bool64x2 = {
+    name: "Bool64x2",
+    fn: SIMD.Bool64x2,
+    lanes: 2,
+    laneSize: 8,
+    notFn: unaryLogicalNot,
+    fns: ["check", "splat", "replaceLane",
+          "allTrue", "anyTrue", "and", "or", "xor", "not"],
+  }
+
+  float64x2.boolType = bool64x2;
+
+  float32x4.fromBits.push(float64x2);
+  int32x4.fromBits.push(float64x2);
+  int16x8.fromBits.push(float64x2);
+  int8x16.fromBits.push(float64x2);
+  uint32x4.fromBits.push(float64x2);
+  uint16x8.fromBits.push(float64x2);
+  uint8x16.fromBits.push(float64x2);
+
+  float64x2.fromBits = [float32x4, int32x4, int16x8, int8x16,
+                        uint32x4, uint16x8, uint8x16];
+
+  int32x4.fromBits = [float32x4, int16x8, int8x16, uint32x4, uint16x8, uint8x16];
+  int16x8.fromBits = [float32x4, int32x4, int8x16, uint32x4, uint16x8, uint8x16];
+  int8x16.fromBits = [float32x4, int32x4, int16x8, uint32x4, uint16x8, uint8x16];
+  uint32x4.fromBits = [float32x4, int32x4, int16x8, int8x16, uint16x8, uint8x16];
+  uint16x8.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint8x16];
+  uint8x16.fromBits = [float32x4, int32x4, int16x8, int8x16, uint32x4, uint16x8];
+
+  simdTypes.push(float64x2);
+  simdTypes.push(bool64x2);
+}
 
 // SIMD prototype functions.
 var prototypeFns = {
@@ -1109,11 +1182,7 @@ var simdFns = {
   sqrt:
     function(type) {
       return function(a) {
-        a = type.fn.check(a);
-        return type.fn(Math.sqrt(type.fn.extractLane(a, 0)),
-                       Math.sqrt(type.fn.extractLane(a, 1)),
-                       Math.sqrt(type.fn.extractLane(a, 2)),
-                       Math.sqrt(type.fn.extractLane(a, 3)));
+        return simdUnaryOp(type, Math.sqrt, a);
       }
     },
 
@@ -1126,45 +1195,20 @@ var simdFns = {
       }
     },
 
-  shiftRightArithmeticByScalar:
+  shiftRightByScalar:
     function(type) {
-      return function(a, bits) {
-        if (bits>>>0 >= type.laneSize * 8)
-          bits = type.laneSize * 8 - 1;
-        return simdShiftOp(type, binaryShiftRightArithmetic, a, bits);
-      }
-    },
-
-  shiftRightLogicalByScalar:
-    function(type) {
-      return function(a, bits) {
-        if (bits>>>0 >= type.laneSize * 8)
-          return type.fn.splat(0);
-        function shift(val, amount) {
-          return val >>> amount;
+      if (type.unsigned) {
+        return function(a, bits) {
+          if (bits>>>0 >= type.laneSize * 8)
+            return type.fn.splat(0);
+          return simdShiftOp(type, binaryShiftRightLogical, a, bits);
         }
-        return simdShiftOp(type, shift, a, bits);
-      }
-    },
-
-  absoluteDifference:
-    function(type) {
-      return function(a, b) {
-        return simdBinaryOp(type, binaryAbsDiff, a, b);
-      }
-    },
-
-  horizontalSum:
-    function(type) {
-      return function(a) {
-        return simdHorizontalSum(type, a);
-      }
-    },
-
-  widenedAbsoluteDifference:
-    function(type) {
-      return function(a, b) {
-        return simdWideningBinaryOp(type, binaryAbsDiff, a, b);
+      } else {
+        return function(a, bits) {
+          if (bits>>>0 >= type.laneSize * 8)
+            bits = type.laneSize * 8 - 1;
+          return simdShiftOp(type, binaryShiftRightArithmetic, a, bits);
+        }
       }
     },
 
@@ -1187,7 +1231,7 @@ var simdFns = {
 
 // Install functions.
 
-allTypes.forEach(function(type) {
+simdTypes.forEach(function(type) {
   // Install each prototype function on each SIMD prototype.
   var simdFn = type.fn;
   var proto = simdFn.prototype;
@@ -1224,115 +1268,9 @@ allTypes.forEach(function(type) {
   }
 });
 
-// Miscellaneous functions that aren't easily parameterized on type.
-
-if (typeof SIMD.Float64x2.swizzle === "undefined") {
-  SIMD.Float64x2.swizzle = function(a, s0, s1) {
-    return simdSwizzle(float64x2, a, [s0, s1]);
-  }
-}
-
-if (typeof SIMD.Float64x2.shuffle === "undefined") {
-  SIMD.Float64x2.shuffle = function(a, b, s0, s1) {
-    return simdShuffle(float64x2, a, b, [s0, s1]);
-  }
-}
-
-if (typeof SIMD.Float32x4.swizzle === "undefined") {
-  SIMD.Float32x4.swizzle = function(a, s0, s1, s2, s3) {
-    return simdSwizzle(float32x4, a, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Float32x4.shuffle === "undefined") {
-  SIMD.Float32x4.shuffle = function(a, b, s0, s1, s2, s3) {
-    return simdShuffle(float32x4, a, b, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Int32x4.swizzle === "undefined") {
-  SIMD.Int32x4.swizzle = function(a, s0, s1, s2, s3) {
-    return simdSwizzle(int32x4, a, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Int32x4.shuffle === "undefined") {
-  SIMD.Int32x4.shuffle = function(a, b, s0, s1, s2, s3) {
-    return simdShuffle(int32x4, a, b, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Uint32x4.swizzle === "undefined") {
-  SIMD.Uint32x4.swizzle = function(a, s0, s1, s2, s3) {
-    return simdSwizzle(uint32x4, a, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Uint32x4.shuffle === "undefined") {
-  SIMD.Uint32x4.shuffle = function(a, b, s0, s1, s2, s3) {
-    return simdShuffle(uint32x4, a, b, [s0, s1, s2, s3]);
-  }
-}
-
-if (typeof SIMD.Int16x8.swizzle === "undefined") {
-  SIMD.Int16x8.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7) {
-    return simdSwizzle(int16x8, a, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-}
-
-if (typeof SIMD.Int16x8.shuffle === "undefined") {
-  SIMD.Int16x8.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7) {
-    return simdShuffle(int16x8, a, b, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-}
-
-if (typeof SIMD.Uint16x8.swizzle === "undefined") {
-  SIMD.Uint16x8.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7) {
-    return simdSwizzle(uint16x8, a, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-}
-
-if (typeof SIMD.Uint16x8.shuffle === "undefined") {
-  SIMD.Uint16x8.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7) {
-    return simdShuffle(uint16x8, a, b, [s0, s1, s2, s3, s4, s5, s6, s7]);
-  }
-}
-
-if (typeof SIMD.Int8x16.swizzle === "undefined") {
-  SIMD.Int8x16.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7,
-                                     s8, s9, s10, s11, s12, s13, s14, s15) {
-    return simdSwizzle(int8x16, a, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                    s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-}
-
-if (typeof SIMD.Int8x16.shuffle === "undefined") {
-  SIMD.Int8x16.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7,
-                                        s8, s9, s10, s11, s12, s13, s14, s15) {
-    return simdShuffle(int8x16, a, b, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                       s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-}
-
-if (typeof SIMD.Uint8x16.swizzle === "undefined") {
-  SIMD.Uint8x16.swizzle = function(a, s0, s1, s2, s3, s4, s5, s6, s7,
-                                      s8, s9, s10, s11, s12, s13, s14, s15) {
-    return simdSwizzle(uint8x16, a, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                     s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-}
-
-if (typeof SIMD.Uint8x16.shuffle === "undefined") {
-  SIMD.Uint8x16.shuffle = function(a, b, s0, s1, s2, s3, s4, s5, s6, s7,
-                                         s8, s9, s10, s11, s12, s13, s14, s15) {
-    return simdShuffle(uint8x16, a, b, [s0, s1, s2, s3, s4, s5, s6, s7,
-                                        s8, s9, s10, s11, s12, s13, s14, s15]);
-  }
-}
-
-
 // If we're in a browser, the global namespace is named 'window'. If we're
-// in node, it's named 'global'. If we're in a shell, 'this' might work.
+// in node, it's named 'global'. If we're in a web worker, it's named
+// 'self'. If we're in a shell, 'this' might work.
 })(typeof window !== "undefined"
    ? window
    : (typeof process === 'object' &&
@@ -1342,93 +1280,3 @@ if (typeof SIMD.Uint8x16.shuffle === "undefined") {
      : typeof self === 'object'
        ? self
        : this);
-
-// XXX Emscripten-specific below XXX
-
-// Work around Firefox Nightly bug that Float64x2 comparison return a Int32x4 instead of a Bool64x2.
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.equal(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevEqual = SIMD.Float64x2.equal;
-    SIMD.Float64x2.equal = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevEqual(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    }
-    console.error('Warning: Patching up SIMD.Float64x2.equal to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.notEqual(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevNotEqual = SIMD.Float64x2.notEqual;
-    SIMD.Float64x2.notEqual = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevNotEqual(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    } 
-    console.error('Warning: Patching up SIMD.Float64x2.notEqual to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.greaterThan(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevGreaterThan = SIMD.Float64x2.greaterThan;
-    SIMD.Float64x2.greaterThan = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevGreaterThan(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    } 
-    console.error('Warning: Patching up SIMD.Float64x2.greaterThan to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.greaterThanOrEqual(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevGreaterThanOrEqual = SIMD.Float64x2.greaterThanOrEqual;
-    SIMD.Float64x2.greaterThanOrEqual = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevGreaterThanOrEqual(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    } 
-    console.error('Warning: Patching up SIMD.Float64x2.greaterThanOrEqual to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.lessThan(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevLessThan = SIMD.Float64x2.lessThan;
-    SIMD.Float64x2.lessThan = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevLessThan(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    } 
-    console.error('Warning: Patching up SIMD.Float64x2.lessThan to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-try {
-  if (SIMD.Int32x4.check(SIMD.Float64x2.lessThanOrEqual(SIMD.Float64x2.splat(5.0), SIMD.Float64x2.splat(5.0)))) {
-    SIMD.Float64x2.prevLessThanOrEqual = SIMD.Float64x2.lessThanOrEqual;
-    SIMD.Float64x2.lessThanOrEqual = function(a, b) {
-      var int32x4 = SIMD.Float64x2.prevLessThanOrEqual(a, b);
-      return SIMD.Bool64x2(SIMD.Int32x4.extractLane(int32x4, 1) != 0, SIMD.Int32x4.extractLane(int32x4, 3) != 0);
-    } 
-    console.error('Warning: Patching up SIMD.Float64x2.lessThanOrEqual to return a Bool64x2 instead of Int32x4!');
-  }
-} catch(e) {}
-
-
-if (!SIMD.Int32x4.fromBool64x2Bits) {
-  SIMD.Int32x4.fromBool64x2Bits = function(bool64x2) {
-    var lane0 = SIMD.Bool64x2.extractLane(bool64x2, 0)?-1:0;
-    var lane1 = SIMD.Bool64x2.extractLane(bool64x2, 1)?-1:0;
-    return SIMD.Int32x4(lane0, lane0, lane1, lane1);
-  }
-}
-
-// TODO: Remove and replace with shiftRightScalar once https://bugzilla.mozilla.org/show_bug.cgi?id=1201934 lands.
-if (!SIMD.Int8x16.shiftRightLogicalByScalar) {
-  SIMD.Int8x16.shiftRightLogicalByScalar = function(s, v) {
-    return SIMD.Int8x16.fromUint8x16Bits(SIMD.Uint8x16.shiftRightLogicalByScalar(SIMD.Uint8x16.fromInt8x16Bits(s), v));
-  }
-}
-if (!SIMD.Int16x8.shiftRightLogicalByScalar) {
-  SIMD.Int16x8.shiftRightLogicalByScalar = function(s, v) {
-    return SIMD.Int16x8.fromUint16x8Bits(SIMD.Uint16x8.shiftRightLogicalByScalar(SIMD.Uint16x8.fromInt16x8Bits(s), v));
-  }
-}
-if (!SIMD.Int32x4.shiftRightLogicalByScalar) {
-  SIMD.Int32x4.shiftRightLogicalByScalar = function(s, v) {
-    return SIMD.Int32x4.fromUint32x4Bits(SIMD.Uint32x4.shiftRightLogicalByScalar(SIMD.Uint32x4.fromInt32x4Bits(s), v));
-  }
-}

--- a/system/include/emscripten/emmintrin.h
+++ b/system/include/emscripten/emmintrin.h
@@ -614,7 +614,7 @@ static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
 _mm_cvtps_pd(__m128 __a)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_float64x2_fromFloat32x4(__a);
+  return (__m128d) { (double)__a[0], (double)__a[1] };
 #else
   return __builtin_ia32_cvtps2pd(__a);
 #endif
@@ -624,7 +624,7 @@ static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi32_pd(__m128i __a)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_float64x2_fromInt32x4(__a);
+  return (__m128d) { (double)__a[0], (double)__a[1] };
 #else
   return __builtin_ia32_cvtdq2pd((__v4si)__a);
 #endif
@@ -1494,7 +1494,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srai_epi16(__m128i __a, int __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int16x8_shiftRightArithmeticByScalar(__a, __count);
+  return emscripten_int16x8_shiftRightByScalar(__a, __count);
 #else
   return (__m128i)__builtin_ia32_psrawi128((__v8hi)__a, __count);
 #endif
@@ -1504,7 +1504,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_sra_epi16(__m128i __a, __m128i __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int16x8_shiftRightArithmeticByScalar(__a, __count[1] == 0 ? __count[0] : 16);
+  return emscripten_int16x8_shiftRightByScalar(__a, __count[1] == 0 ? __count[0] : 16);
 #else
   return (__m128i)__builtin_ia32_psraw128((__v8hi)__a, (__v8hi)__count);
 #endif
@@ -1514,7 +1514,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srai_epi32(__m128i __a, int __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int32x4_shiftRightArithmeticByScalar(__a, __count);
+  return emscripten_int32x4_shiftRightByScalar(__a, __count);
 #else
   return (__m128i)__builtin_ia32_psradi128((__v4si)__a, __count);
 #endif
@@ -1524,7 +1524,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_sra_epi32(__m128i __a, __m128i __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int32x4_shiftRightArithmeticByScalar(__a, __count[1] == 0 ? __count[0] : 32);
+  return emscripten_int32x4_shiftRightByScalar(__a, __count[1] == 0 ? __count[0] : 32);
 #else
   return (__m128i)__builtin_ia32_psrad128((__v4si)__a, (__v4si)__count);
 #endif
@@ -1557,7 +1557,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srli_epi16(__m128i __a, int __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int16x8_shiftRightLogicalByScalar(__a, __count);
+  return (int16x8)emscripten_uint16x8_shiftRightByScalar((uint16x8)__a, __count);
 #else
   return (__m128i)__builtin_ia32_psrlwi128((__v8hi)__a, __count);
 #endif
@@ -1567,7 +1567,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srl_epi16(__m128i __a, __m128i __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int16x8_shiftRightLogicalByScalar(__a, __count[1] == 0 ? __count[0] : 16);
+  return (int16x8)emscripten_uint16x8_shiftRightByScalar((uint16x8)__a, __count[1] == 0 ? __count[0] : 16);
 #else
   return (__m128i)__builtin_ia32_psrlw128((__v8hi)__a, (__v8hi)__count);
 #endif
@@ -1577,7 +1577,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srli_epi32(__m128i __a, int __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int32x4_shiftRightLogicalByScalar(__a, __count);
+  return (int32x4)emscripten_uint32x4_shiftRightByScalar((uint32x4)__a, __count);
 #else
   return (__m128i)__builtin_ia32_psrldi128((__v4si)__a, __count);
 #endif
@@ -1587,7 +1587,7 @@ static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_srl_epi32(__m128i __a, __m128i __count)
 {
 #ifdef __EMSCRIPTEN__
-  return emscripten_int16x8_shiftRightLogicalByScalar(__a, __count[1] == 0 ? __count[0] : 16);
+  return (int32x4)emscripten_uint32x4_shiftRightByScalar((uint32x4)__a, __count[1] == 0 ? __count[0] : 32);
 #else
   return (__m128i)__builtin_ia32_psrld128((__v4si)__a, (__v4si)__count);
 #endif

--- a/system/include/emscripten/vector.h
+++ b/system/include/emscripten/vector.h
@@ -8,6 +8,13 @@ extern "C" {
 // Direct mappings to the SIMD.js API specification as intrinsic functions: http://tc39.github.io/ecmascript_simd/
 // These can be used as an alternative to using SSEx intrinsics and LLVM/GCC built-in intrinsics support.
 
+// Note: Since there are a lot of types and functions, when modifying this file, please keep a canonical sorted ordering of types
+// float64x2->float32x4->int64x2->uint64x2->int32x4->uint32x4->int16x8->uint16x8->int8x16->uint8x16->bool64x2->bool32x4->bool16x8->bool8x16
+// and all functions in the list order specified in the EcmaScript SIMD.js specification
+// so that cross-referencing changes against the implementation and the specification is much easier.
+
+// Also, if changing this file, remember to do the matching changes in LLVM side at https://github.com/kripken/emscripten-fastcomp/blob/incoming/lib/Target/JSBackend/CallHandlers.h
+
 typedef double float64x2 __attribute__((__vector_size__(16), __may_alias__));
 typedef float float32x4 __attribute__((__vector_size__(16), __may_alias__));
 typedef long long int64x2 __attribute__((__vector_size__(16), __may_alias__));
@@ -21,8 +28,7 @@ typedef unsigned char uint8x16 __attribute__((__vector_size__(16), __may_alias__
 
 // C/C++ side code does not actually have the boolean types, these are marked for documentation purposes. Feel free
 // to use the int SIMD types in user code as well.
-//typedef int64x2 bool64x2;
-typedef int32x4 bool64x2;
+typedef int32x4 bool64x2; // int64x2 would give trouble, since that type doesn't exist and we aren't prepared to handle it in LLVM side.
 typedef int32x4 bool32x4;
 typedef int16x8 bool16x8;
 typedef int8x16 bool8x16;

--- a/system/include/emscripten/vector.h
+++ b/system/include/emscripten/vector.h
@@ -5,116 +5,459 @@
 extern "C" {
 #endif
 
-// Support for the JS SIMD API proposal, https://github.com/johnmccutchan/ecmascript_simd
+// Direct mappings to the SIMD.js API specification as intrinsic functions: http://tc39.github.io/ecmascript_simd/
+// These can be used as an alternative to using SSEx intrinsics and LLVM/GCC built-in intrinsics support.
 
-typedef float float32x4 __attribute__((__vector_size__(16), __may_alias__));
 typedef double float64x2 __attribute__((__vector_size__(16), __may_alias__));
+typedef float float32x4 __attribute__((__vector_size__(16), __may_alias__));
 typedef long long int64x2 __attribute__((__vector_size__(16), __may_alias__));
+typedef unsigned long long uint64x2 __attribute__((__vector_size__(16), __may_alias__));
 typedef int int32x4 __attribute__((__vector_size__(16), __may_alias__));
+typedef unsigned int uint32x4 __attribute__((__vector_size__(16), __may_alias__));
 typedef short int16x8 __attribute__((__vector_size__(16), __may_alias__));
+typedef unsigned short uint16x8 __attribute__((__vector_size__(16), __may_alias__));
 typedef char int8x16 __attribute__((__vector_size__(16), __may_alias__));
+typedef unsigned char uint8x16 __attribute__((__vector_size__(16), __may_alias__));
 
-unsigned int emscripten_float32x4_signmask(float32x4 __x) __attribute__((__nothrow__, __const__));
+// C/C++ side code does not actually have the boolean types, these are marked for documentation purposes. Feel free
+// to use the int SIMD types in user code as well.
+//typedef int64x2 bool64x2;
+typedef int32x4 bool64x2;
+typedef int32x4 bool32x4;
+typedef int16x8 bool16x8;
+typedef int8x16 bool8x16;
 
-float32x4 emscripten_float32x4_min(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_minNum(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_max(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_maxNum(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_abs(float32x4 __a) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_sqrt(float32x4 __a) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_reciprocalApproximation(float32x4 __a) __attribute__((__nothrow__, __const__));
-float32x4 emscripten_float32x4_reciprocalSqrtApproximation(float32x4 __a) __attribute__((__nothrow__, __const__));
-inline int32x4 emscripten_float32x4_lessThan(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
-inline int32x4 emscripten_float32x4_lessThanOrEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
-inline int32x4 emscripten_float32x4_equal(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
-inline int32x4 emscripten_float32x4_notEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
-inline int32x4 emscripten_float32x4_greaterThanOrEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
-inline int32x4 emscripten_float32x4_greaterThan(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
-#define emscripten_float32x4_not(x) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_not(emscripten_int32x4_fromFloat32x4Bits((x))))
-#define emscripten_float32x4_and(a, b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_and(emscripten_int32x4_fromFloat32x4Bits((a)), emscripten_int32x4_fromFloat32x4Bits((b))))
-#define emscripten_float32x4_or(a, b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_or(emscripten_int32x4_fromFloat32x4Bits((a)), emscripten_int32x4_fromFloat32x4Bits((b))))
-#define emscripten_float32x4_xor(a, b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_xor(emscripten_int32x4_fromFloat32x4Bits((a)), emscripten_int32x4_fromFloat32x4Bits((b))))
-float32x4 emscripten_float32x4_select(int32x4 __a, float32x4 __b, float32x4 __c) __attribute__((__nothrow__, __const__));
-
-inline int32x4 emscripten_int32x4_and(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
-inline int32x4 emscripten_int32x4_or(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
-inline int32x4 emscripten_int32x4_xor(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
-inline int32x4 emscripten_int32x4_not(int32x4 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
-inline int32x4 emscripten_int32x4_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
-inline int32x4 emscripten_int32x4_fromFloat32x4(float32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, int32x4); }
-
-inline int32x4 emscripten_int32x4_lessThan(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
-inline int32x4 emscripten_int32x4_lessThanOrEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
-inline int32x4 emscripten_int32x4_equal(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
-inline int32x4 emscripten_int32x4_notEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
-inline int32x4 emscripten_int32x4_greaterThanOrEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
-inline int32x4 emscripten_int32x4_greaterThan(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
-
-float64x2 emscripten_float64x2_min(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_minNum(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+// Float64x2
+float64x2 emscripten_float64x2_set(double __s0, double __s1) __attribute__((__nothrow__, __const__));
+float64x2 emscripten_float64x2_splat(double __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_float64x2_check, not relevant for C/C++.
+inline float64x2 emscripten_float64x2_add(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline float64x2 emscripten_float64x2_sub(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline float64x2 emscripten_float64x2_mul(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+inline float64x2 emscripten_float64x2_div(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__)) { return __a / __b; }
 float64x2 emscripten_float64x2_max(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+float64x2 emscripten_float64x2_min(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
 float64x2 emscripten_float64x2_maxNum(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_abs(float64x2 __a) __attribute__((__nothrow__, __const__));
+float64x2 emscripten_float64x2_minNum(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+inline float64x2 emscripten_float64x2_neg(float64x2 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
 float64x2 emscripten_float64x2_sqrt(float64x2 __a) __attribute__((__nothrow__, __const__));
 float64x2 emscripten_float64x2_reciprocalApproximation(float64x2 __a) __attribute__((__nothrow__, __const__));
 float64x2 emscripten_float64x2_reciprocalSqrtApproximation(float64x2 __a) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_fromInt32x4Bits(int32x4 __a) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_fromInt32x4(int32x4 __a) __attribute__((__nothrow__, __const__));
-float64x2 emscripten_float64x2_fromFloat32x4(float32x4 __a) __attribute__((__nothrow__, __const__));
+float64x2 emscripten_float64x2_abs(float64x2 __a) __attribute__((__nothrow__, __const__));
+#define emscripten_float64x2_and(__a, __b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_and(emscripten_int32x4_fromFloat64x2Bits((__a)), emscripten_int32x4_fromFloat64x2Bits((__b))))
+#define emscripten_float64x2_xor(__a, __b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_xor(emscripten_int32x4_fromFloat64x2Bits((__a)), emscripten_int32x4_fromFloat64x2Bits((__b))))
+#define emscripten_float64x2_or(__a, __b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_or(emscripten_int32x4_fromFloat64x2Bits((__a)), emscripten_int32x4_fromFloat64x2Bits((__b))))
+#define emscripten_float64x2_not(__a) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_not(emscripten_int32x4_fromFloat64x2Bits((__a))))
+bool64x2 emscripten_float64x2_lessThan(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+bool64x2 emscripten_float64x2_lessThanOrEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+bool64x2 emscripten_float64x2_greaterThan(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+bool64x2 emscripten_float64x2_greaterThanOrEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+bool64x2 emscripten_float64x2_equal(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+bool64x2 emscripten_float64x2_notEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_float64x2_anyTrue, only defined on boolean SIMD types.
+// n.b. No emscripten_float64x2_allTrue, only defined on boolean SIMD types.
+float64x2 emscripten_float64x2_select(bool64x2 __a, float64x2 __b, float64x2 __c) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_float64x2_addSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_float64x2_subSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_float64x2_shiftLeftByScalar, only defined on integer SIMD types.
+// n.b. No emscripten_float64x2_shiftRightByScalar, only defined on integer SIMD types.
+inline float emscripten_float64x2_extractLane(float64x2 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline float64x2 emscripten_float64x2_replaceLane(float64x2 __a, int __lane, float __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_float64x2_store(const void *__p, float64x2 __a) __attribute__((__nothrow__));
+void emscripten_float64x2_store1(const void *__p, float64x2 __a) __attribute__((__nothrow__));
+float64x2 emscripten_float64x2_load(const void *__p) __attribute__((__nothrow__, __pure__));
+float64x2 emscripten_float64x2_load1(const void *__p) __attribute__((__nothrow__, __pure__));
 float64x2 emscripten_float64x2_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_lessThan(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_lessThanOrEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_equal(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_notEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_greaterThanOrEqual(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_float64x2_greaterThan(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-//float64x2 emscripten_float64x2_and(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-//float64x2 emscripten_float64x2_or(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-//float64x2 emscripten_float64x2_xor(float64x2 __a, float64x2 __b) __attribute__((__nothrow__, __const__));
-//float64x2 emscripten_float64x2_not(float64x2 __a) __attribute__((__nothrow__, __const__));
-// Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1176425
-#define emscripten_float64x2_not(x) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_not(emscripten_int32x4_fromFloat64x2Bits((x))))
-#define emscripten_float64x2_and(a, b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_and(emscripten_int32x4_fromFloat64x2Bits((a)), emscripten_int32x4_fromFloat64x2Bits((b))))
-#define emscripten_float64x2_or(a, b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_or(emscripten_int32x4_fromFloat64x2Bits((a)), emscripten_int32x4_fromFloat64x2Bits((b))))
-#define emscripten_float64x2_xor(a, b) emscripten_float64x2_fromInt32x4Bits(emscripten_int32x4_xor(emscripten_int32x4_fromFloat64x2Bits((a)), emscripten_int32x4_fromFloat64x2Bits((b))))
-float64x2 emscripten_float64x2_select(int32x4 __a, float64x2 __b, float64x2 __c) __attribute__((__nothrow__, __const__));
+inline float64x2 emscripten_float64x2_fromInt32x4Bits(int32x4 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+inline float64x2 emscripten_float64x2_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+inline float64x2 emscripten_float64x2_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+inline float64x2 emscripten_float64x2_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+inline float64x2 emscripten_float64x2_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+inline float64x2 emscripten_float64x2_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (float64x2)__a; }
+float64x2 emscripten_float64x2_swizzle(float64x2 __a, int __lane0, int __lane1) __attribute__((__nothrow__, __const__));
+float64x2 emscripten_float64x2_shuffle(float64x2 __a, float64x2 __b, int __lane0, int __lane1) __attribute__((__nothrow__, __const__));
 
-int32x4 emscripten_int32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_int32x4_fromFloat64x2(float64x2 __a) __attribute__((__nothrow__, __const__));
-
-int32x4 emscripten_int32x4_select(int32x4 __a, int32x4 __b, int32x4 __c) __attribute__((__nothrow__, __const__));
-
-inline float32x4 emscripten_float32x4_fromInt32x4Bits(int32x4 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
-inline float32x4 emscripten_float32x4_fromInt32x4(int32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, float32x4); }
-
-int8x16 emscripten_int8x16_shiftLeftByScalar(int8x16 __a, int __count) __attribute__((__nothrow__, __const__));
-int8x16 emscripten_int8x16_shiftRightLogicalByScalar(int8x16 __a, int __count) __attribute__((__nothrow__, __const__));
-int8x16 emscripten_int8x16_shiftRightArithmeticByScalar(int8x16 __a, int __count) __attribute__((__nothrow__, __const__));
-
-int16x8 emscripten_int16x8_shiftLeftByScalar(int16x8 __a, int __count) __attribute__((__nothrow__, __const__));
-int16x8 emscripten_int16x8_shiftRightLogicalByScalar(int16x8 __a, int __count) __attribute__((__nothrow__, __const__));
-int16x8 emscripten_int16x8_shiftRightArithmeticByScalar(int16x8 __a, int __count) __attribute__((__nothrow__, __const__));
-
-int32x4 emscripten_int32x4_shiftLeftByScalar(int32x4 __a, int __count) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_int32x4_shiftRightLogicalByScalar(int32x4 __a, int __count) __attribute__((__nothrow__, __const__));
-int32x4 emscripten_int32x4_shiftRightArithmeticByScalar(int32x4 __a, int __count) __attribute__((__nothrow__, __const__));
-
-int8x16 emscripten_int8x16_not(int8x16 __a) __attribute__((__nothrow__, __const__));
-int8x16 emscripten_int8x16_and(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__));
-int8x16 emscripten_int8x16_or(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__));
-int8x16 emscripten_int8x16_xor(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__));
-
-int16x8 emscripten_int16x8_not(int16x8 __a) __attribute__((__nothrow__, __const__));
-int16x8 emscripten_int16x8_and(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__));
-int16x8 emscripten_int16x8_or(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__));
-int16x8 emscripten_int16x8_xor(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__));
-
-float32x4 emscripten_float32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
-float32x4 emscripten_float32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
+// Float32x4
+float32x4 emscripten_float32x4_set(float __s0, float __s1, float __s2, float __s3) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_splat(float __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_float32x4_check, not relevant for C/C++.
+inline float32x4 emscripten_float32x4_add(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline float32x4 emscripten_float32x4_sub(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline float32x4 emscripten_float32x4_mul(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+inline float32x4 emscripten_float32x4_div(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a / __b; }
+float32x4 emscripten_float32x4_max(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_min(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_maxNum(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_minNum(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__));
+inline float32x4 emscripten_float32x4_neg(float32x4 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+float32x4 emscripten_float32x4_sqrt(float32x4 __a) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_reciprocalApproximation(float32x4 __a) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_reciprocalSqrtApproximation(float32x4 __a) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_abs(float32x4 __a) __attribute__((__nothrow__, __const__));
+#define emscripten_float32x4_and(__a, __b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_and(emscripten_int32x4_fromFloat32x4Bits((__a)), emscripten_int32x4_fromFloat32x4Bits((__b))))
+#define emscripten_float32x4_xor(__a, __b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_xor(emscripten_int32x4_fromFloat32x4Bits((__a)), emscripten_int32x4_fromFloat32x4Bits((__b))))
+#define emscripten_float32x4_or(__a, __b) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_or(emscripten_int32x4_fromFloat32x4Bits((__a)), emscripten_int32x4_fromFloat32x4Bits((__b))))
+#define emscripten_float32x4_not(__a) emscripten_float32x4_fromInt32x4Bits(emscripten_int32x4_not(emscripten_int32x4_fromFloat32x4Bits(__a)))
+inline bool32x4 emscripten_float32x4_lessThan(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool32x4 emscripten_float32x4_lessThanOrEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool32x4 emscripten_float32x4_greaterThan(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool32x4 emscripten_float32x4_greaterThanOrEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool32x4 emscripten_float32x4_equal(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool32x4 emscripten_float32x4_notEqual(float32x4 __a, float32x4 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+// n.b. No emscripten_float32x4_anyTrue, only defined on boolean SIMD types.
+// n.b. No emscripten_float32x4_allTrue, only defined on boolean SIMD types.
+float32x4 emscripten_float32x4_select(bool32x4 __a, float32x4 __b, float32x4 __c) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_float32x4_addSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_float32x4_subSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_float32x4_shiftLeftByScalar, only defined on integer SIMD types.
+// n.b. No emscripten_float32x4_shiftRightByScalar, only defined on integer SIMD types.
+inline float emscripten_float32x4_extractLane(float32x4 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline float32x4 emscripten_float32x4_replaceLane(float32x4 __a, int __lane, float __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_float32x4_store(const void *__p, float32x4 __a) __attribute__((__nothrow__));
 void emscripten_float32x4_store1(const void *__p, float32x4 __a) __attribute__((__nothrow__));
 void emscripten_float32x4_store2(const void *__p, float32x4 __a) __attribute__((__nothrow__));
+void emscripten_float32x4_store3(const void *__p, float32x4 __a) __attribute__((__nothrow__));
+float32x4 emscripten_float32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
+float32x4 emscripten_float32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
+float32x4 emscripten_float32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
+float32x4 emscripten_float32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
+inline float32x4 emscripten_float32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromInt32x4Bits(int32x4 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
+inline float32x4 emscripten_float32x4_fromInt32x4(int32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, float32x4); }
+inline float32x4 emscripten_float32x4_fromUint32x4(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, float32x4); }
+float32x4 emscripten_float32x4_swizzle(float32x4 __a, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+float32x4 emscripten_float32x4_shuffle(float32x4 __a, float32x4 __b, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+
+// Int32x4
+int32x4 emscripten_int32x4_set(int __s0, int __s1, int __s2, int __s3) __attribute__((__nothrow__, __const__));
+int32x4 emscripten_int32x4_splat(int __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_int32x4_check, not relevant for C/C++.
+inline int32x4 emscripten_int32x4_add(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline int32x4 emscripten_int32x4_sub(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline int32x4 emscripten_int32x4_mul(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_int32x4_div, division is only defined on floating point types.
+// n.b. No emscripten_int32x4_max, only defined on floating point types.
+// n.b. No emscripten_int32x4_min, only defined on floating point types.
+// n.b. No emscripten_int32x4_maxNum, only defined on floating point types.
+// n.b. No emscripten_int32x4_minNum, only defined on floating point types.
+inline int32x4 emscripten_int32x4_neg(int32x4 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_int32x4_sqrt, only defined on floating point types.
+// n.b. No emscripten_int32x4_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_int32x4_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_int32x4_abs, only defined on floating point types.
+inline int32x4 emscripten_int32x4_and(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline int32x4 emscripten_int32x4_xor(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline int32x4 emscripten_int32x4_or(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline int32x4 emscripten_int32x4_not(int32x4 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool32x4 emscripten_int32x4_lessThan(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool32x4 emscripten_int32x4_lessThanOrEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool32x4 emscripten_int32x4_greaterThan(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool32x4 emscripten_int32x4_greaterThanOrEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool32x4 emscripten_int32x4_equal(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool32x4 emscripten_int32x4_notEqual(int32x4 __a, int32x4 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_int32x4_anyTrue emscripten_bool32x4_anyTrue
+#define emscripten_int32x4_allTrue emscripten_bool32x4_allTrue
+int32x4 emscripten_int32x4_select(int32x4 __a, int32x4 __b, int32x4 __c) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_int32x4_addSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_int32x4_subSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+int32x4 emscripten_int32x4_shiftLeftByScalar(int32x4 __a, int __count) __attribute__((__nothrow__, __const__));
+int32x4 emscripten_int32x4_shiftRightByScalar(int32x4 __a, int __count) __attribute__((__nothrow__, __const__)); // Arithmetic right shift, i.e. sign-extending, or integer division
+inline int emscripten_int32x4_extractLane(int32x4 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline int32x4 emscripten_int32x4_replaceLane(int32x4 __a, int __lane, int __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_int32x4_store(const void *__p, int32x4 __a) __attribute__((__nothrow__));
+void emscripten_int32x4_store1(const void *__p, int32x4 __a) __attribute__((__nothrow__));
+void emscripten_int32x4_store2(const void *__p, int32x4 __a) __attribute__((__nothrow__));
+void emscripten_int32x4_store3(const void *__p, int32x4 __a) __attribute__((__nothrow__));
+int32x4 emscripten_int32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
+int32x4 emscripten_int32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
+int32x4 emscripten_int32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
+int32x4 emscripten_int32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
+inline int32x4 emscripten_int32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
+inline int32x4 emscripten_int32x4_fromFloat32x4(float32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, int32x4); }
+inline int32x4 emscripten_int32x4_fromUint32x4(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, int32x4); }
+int32x4 emscripten_int32x4_fromFloat64x2(float64x2 __a) __attribute__((__nothrow__, __const__)); // Unofficial, converts the two Float64x2 to two lowest lanes of an Int32x4, and sets the higher two lanes to zero.
+int32x4 emscripten_int32x4_swizzle(int32x4 __a, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+int32x4 emscripten_int32x4_shuffle(int32x4 __a, int32x4 __b, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+
+// Uint32x4
+uint32x4 emscripten_uint32x4_set(unsigned int __s0, unsigned int __s1, unsigned int __s2, unsigned int __s3) __attribute__((__nothrow__, __const__));
+uint32x4 emscripten_uint32x4_splat(unsigned int __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_uint32x4_check, not relevant for C/C++.
+inline uint32x4 emscripten_uint32x4_add(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline uint32x4 emscripten_uint32x4_sub(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline uint32x4 emscripten_uint32x4_mul(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_uint32x4_div, division is only defined on floating point types.
+// n.b. No emscripten_uint32x4_max, only defined on floating point types.
+// n.b. No emscripten_uint32x4_min, only defined on floating point types.
+// n.b. No emscripten_uint32x4_maxNum, only defined on floating point types.
+// n.b. No emscripten_uint32x4_minNum, only defined on floating point types.
+inline uint32x4 emscripten_uint32x4_neg(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_uint32x4_sqrt, only defined on floating point types.
+// n.b. No emscripten_uint32x4_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_uint32x4_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_uint32x4_abs, only defined on floating point types.
+inline uint32x4 emscripten_uint32x4_and(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline uint32x4 emscripten_uint32x4_xor(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline uint32x4 emscripten_uint32x4_or(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline uint32x4 emscripten_uint32x4_not(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool32x4 emscripten_uint32x4_lessThan(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool32x4 emscripten_uint32x4_lessThanOrEqual(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool32x4 emscripten_uint32x4_greaterThan(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool32x4 emscripten_uint32x4_greaterThanOrEqual(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool32x4 emscripten_uint32x4_equal(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool32x4 emscripten_uint32x4_notEqual(uint32x4 __a, uint32x4 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_uint32x4_anyTrue emscripten_bool32x4_anyTrue
+#define emscripten_uint32x4_allTrue emscripten_bool32x4_allTrue
+uint32x4 emscripten_uint32x4_select(uint32x4 __a, uint32x4 __b, uint32x4 __c) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_uint32x4_addSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+// n.b. No emscripten_uint32x4_subSaturate, only defined on 8-bit and 16-bit integer SIMD types.
+uint32x4 emscripten_uint32x4_shiftLeftByScalar(uint32x4 __a, int __count) __attribute__((__nothrow__, __const__));
+uint32x4 emscripten_uint32x4_shiftRightByScalar(uint32x4 __a, int __count) __attribute__((__nothrow__, __const__));
+inline int emscripten_uint32x4_extractLane(uint32x4 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline uint32x4 emscripten_uint32x4_replaceLane(uint32x4 __a, int __lane, int __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_uint32x4_store(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
+void emscripten_uint32x4_store1(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
+void emscripten_uint32x4_store2(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
+void emscripten_uint32x4_store3(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
+uint32x4 emscripten_uint32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
+uint32x4 emscripten_uint32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
+uint32x4 emscripten_uint32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
+uint32x4 emscripten_uint32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
+inline uint32x4 emscripten_uint32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromInt32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
+inline uint32x4 emscripten_uint32x4_fromFloat32x4(float32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, uint32x4); }
+inline uint32x4 emscripten_uint32x4_fromInt32x4(int32x4 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, uint32x4); }
+uint32x4 emscripten_uint32x4_fromFloat64x2(float64x2 __a) __attribute__((__nothrow__, __const__)); // Unofficial, converts the two Float64x2 to two lowest lanes of an Uint32x4, and sets the higher two lanes to zero.
+uint32x4 emscripten_uint32x4_swizzle(uint32x4 __a, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+uint32x4 emscripten_uint32x4_shuffle(uint32x4 __a, uint32x4 __b, int __lane0, int __lane1, int __lane2, int __lane3) __attribute__((__nothrow__, __const__));
+
+// Int16x8
+int16x8 emscripten_int16x8_set(short __s0, short __s1, short __s2, short __s3, short __s4, short __s5, short __s6, short __s7) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_splat(short __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_int16x8_check, not relevant for C/C++.
+inline int16x8 emscripten_int16x8_add(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline int16x8 emscripten_int16x8_sub(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline int16x8 emscripten_int16x8_mul(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_int16x8_div, division is only defined on floating point types.
+// n.b. No emscripten_int16x8_max, only defined on floating point types.
+// n.b. No emscripten_int16x8_min, only defined on floating point types.
+// n.b. No emscripten_int16x8_maxNum, only defined on floating point types.
+// n.b. No emscripten_int16x8_minNum, only defined on floating point types.
+inline int16x8 emscripten_int16x8_neg(int16x8 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_int16x8_sqrt, only defined on floating point types.
+// n.b. No emscripten_int16x8_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_int16x8_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_int16x8_abs, only defined on floating point types.
+inline int16x8 emscripten_int16x8_and(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline int16x8 emscripten_int16x8_xor(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline int16x8 emscripten_int16x8_or(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline int16x8 emscripten_int16x8_not(int16x8 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool16x8 emscripten_int16x8_lessThan(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool16x8 emscripten_int16x8_lessThanOrEqual(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool16x8 emscripten_int16x8_greaterThan(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool16x8 emscripten_int16x8_greaterThanOrEqual(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool16x8 emscripten_int16x8_equal(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool16x8 emscripten_int16x8_notEqual(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_int16x8_anyTrue emscripten_bool16x8_anyTrue
+#define emscripten_int16x8_allTrue emscripten_bool16x8_allTrue
+int16x8 emscripten_int16x8_select(bool16x8 __a, int16x8 __b, int16x8 __c) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_addSaturate(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_subSaturate(int16x8 __a, int16x8 __b) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_shiftLeftByScalar(int16x8 __a, int __count) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_shiftRightByScalar(int16x8 __a, int __count) __attribute__((__nothrow__, __const__));
+inline short emscripten_int16x8_extractLane(int16x8 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline int16x8 emscripten_int16x8_replaceLane(int16x8 __a, int __lane, short __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_int16x8_store(const void *__p, int16x8 __a) __attribute__((__nothrow__));
+int16x8 emscripten_int16x8_load(const void *__p) __attribute__((__nothrow__, __pure__));
+inline int16x8 emscripten_int16x8_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromInt32x4Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (int16x8)__a; }
+inline int16x8 emscripten_int16x8_fromUint16x8(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, int16x8); }
+int16x8 emscripten_int16x8_swizzle(int16x8 __a, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7) __attribute__((__nothrow__, __const__));
+int16x8 emscripten_int16x8_shuffle(int16x8 __a, int16x8 __b, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7) __attribute__((__nothrow__, __const__));
+
+// Uint16x8
+uint16x8 emscripten_uint16x8_set(unsigned short __s0, unsigned short __s1, unsigned short __s2, unsigned short __s3, unsigned short __s4, unsigned short __s5, unsigned short __s6, unsigned short __s7) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_splat(unsigned short __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_uint16x8_check, not relevant for C/C++.
+inline uint16x8 emscripten_uint16x8_add(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline uint16x8 emscripten_uint16x8_sub(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline uint16x8 emscripten_uint16x8_mul(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_uint16x8_div, division is only defined on floating point types.
+// n.b. No emscripten_uint16x8_max, only defined on floating point types.
+// n.b. No emscripten_uint16x8_min, only defined on floating point types.
+// n.b. No emscripten_uint16x8_maxNum, only defined on floating point types.
+// n.b. No emscripten_uint16x8_minNum, only defined on floating point types.
+inline uint16x8 emscripten_uint16x8_neg(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_uint16x8_sqrt, only defined on floating point types.
+// n.b. No emscripten_uint16x8_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_uint16x8_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_uint16x8_abs, only defined on floating point types.
+inline uint16x8 emscripten_uint16x8_and(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline uint16x8 emscripten_uint16x8_xor(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline uint16x8 emscripten_uint16x8_or(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline uint16x8 emscripten_uint16x8_not(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool16x8 emscripten_uint16x8_lessThan(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool16x8 emscripten_uint16x8_lessThanOrEqual(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool16x8 emscripten_uint16x8_greaterThan(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool16x8 emscripten_uint16x8_greaterThanOrEqual(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool16x8 emscripten_uint16x8_equal(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool16x8 emscripten_uint16x8_notEqual(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_uint16x8_anyTrue emscripten_bool16x8_anyTrue
+#define emscripten_uint16x8_allTrue emscripten_bool16x8_allTrue
+uint16x8 emscripten_uint16x8_select(bool16x8 __a, uint16x8 __b, uint16x8 __c) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_addSaturate(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_subSaturate(uint16x8 __a, uint16x8 __b) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_shiftLeftByScalar(uint16x8 __a, int __count) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_shiftRightByScalar(uint16x8 __a, int __count) __attribute__((__nothrow__, __const__));
+inline unsigned short emscripten_uint16x8_extractLane(uint16x8 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline uint16x8 emscripten_uint16x8_replaceLane(uint16x8 __a, int __lane, unsigned short __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_uint16x8_store(const void *__p, uint16x8 __a) __attribute__((__nothrow__));
+uint16x8 emscripten_uint16x8_load(const void *__p) __attribute__((__nothrow__, __pure__));
+inline uint16x8 emscripten_uint16x8_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromInt32x4Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint16x8)__a; }
+inline uint16x8 emscripten_uint16x8_fromInt16x8(int16x8 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, uint16x8); }
+uint16x8 emscripten_uint16x8_swizzle(uint16x8 __a, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7) __attribute__((__nothrow__, __const__));
+uint16x8 emscripten_uint16x8_shuffle(uint16x8 __a, uint16x8 __b, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7) __attribute__((__nothrow__, __const__));
+
+// Int8x16
+int8x16 emscripten_int8x16_set(char __s0, char __s1, char __s2, char __s3, char __s4, char __s5, char __s6, char __s7, char __s8, char __s9, char __s10, char __s11, char __s12, char __s13, char __s14, char __s15) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_splat(char __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_int8x16_check, not relevant for C/C++.
+inline int8x16 emscripten_int8x16_add(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline int8x16 emscripten_int8x16_sub(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline int8x16 emscripten_int8x16_mul(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_int8x16_div, division is only defined on floating point types.
+// n.b. No emscripten_int8x16_max, only defined on floating point types.
+// n.b. No emscripten_int8x16_min, only defined on floating point types.
+// n.b. No emscripten_int8x16_maxNum, only defined on floating point types.
+// n.b. No emscripten_int8x16_minNum, only defined on floating point types.
+inline int8x16 emscripten_int8x16_neg(int8x16 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_int8x16_sqrt, only defined on floating point types.
+// n.b. No emscripten_int8x16_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_int8x16_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_int8x16_abs, only defined on floating point types.
+inline int8x16 emscripten_int8x16_and(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline int8x16 emscripten_int8x16_xor(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline int8x16 emscripten_int8x16_or(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline int8x16 emscripten_int8x16_not(int8x16 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool8x16 emscripten_int8x16_lessThan(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool8x16 emscripten_int8x16_lessThanOrEqual(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool8x16 emscripten_int8x16_greaterThan(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool8x16 emscripten_int8x16_greaterThanOrEqual(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool8x16 emscripten_int8x16_equal(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool8x16 emscripten_int8x16_notEqual(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_int8x16_anyTrue emscripten_bool8x16_anyTrue
+#define emscripten_int8x16_allTrue emscripten_bool8x16_allTrue
+int8x16 emscripten_int8x16_select(bool8x16 __a, int8x16 __b, int8x16 __c) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_addSaturate(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_subSaturate(int8x16 __a, int8x16 __b) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_shiftLeftByScalar(int8x16 __a, int __count) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_shiftRightByScalar(int8x16 __a, int __count) __attribute__((__nothrow__, __const__));
+inline char emscripten_int8x16_extractLane(int8x16 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline int8x16 emscripten_int8x16_replaceLane(int8x16 __a, int __lane, char __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_int8x16_store(const void *__p, int8x16 __a) __attribute__((__nothrow__));
+int8x16 emscripten_int8x16_load(const void *__p) __attribute__((__nothrow__, __pure__));
+inline int8x16 emscripten_int8x16_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromInt32x4Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromUint8x16Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (int8x16)__a; }
+inline int8x16 emscripten_int8x16_fromUint8x16(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, int8x16); }
+int8x16 emscripten_int8x16_swizzle(int8x16 __a, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7, int __lane8, int __lane9, int __lane10, int __lane11, int __lane12, int __lane13, int __lane14, int __lane15) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_int8x16_shuffle(int8x16 __a, int8x16 __b, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7, int __lane8, int __lane9, int __lane10, int __lane11, int __lane12, int __lane13, int __lane14, int __lane15) __attribute__((__nothrow__, __const__));
+
+// Uint8x16
+int8x16 emscripten_uint8x16_set(unsigned char __s0, unsigned char __s1, unsigned char __s2, unsigned char __s3, unsigned char __s4, unsigned char __s5, unsigned char __s6, unsigned char __s7, unsigned char __s8, unsigned char __s9, unsigned char __s10, unsigned char __s11, unsigned char __s12, unsigned char __s13, unsigned char __s14, unsigned char __s15) __attribute__((__nothrow__, __const__));
+int8x16 emscripten_uint8x16_splat(unsigned char __s) __attribute__((__nothrow__, __const__));
+// n.b. No emscripten_uint8x16_check, not relevant for C/C++.
+inline uint8x16 emscripten_uint8x16_add(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a + __b; }
+inline uint8x16 emscripten_uint8x16_sub(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a - __b; }
+inline uint8x16 emscripten_uint8x16_mul(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a * __b; }
+// n.b. No emscripten_uint8x16_div, division is only defined on floating point types.
+// n.b. No emscripten_uint8x16_max, only defined on floating point types.
+// n.b. No emscripten_uint8x16_min, only defined on floating point types.
+// n.b. No emscripten_uint8x16_maxNum, only defined on floating point types.
+// n.b. No emscripten_uint8x16_minNum, only defined on floating point types.
+inline uint8x16 emscripten_uint8x16_neg(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return -__a; }
+// n.b. No emscripten_uint8x16_sqrt, only defined on floating point types.
+// n.b. No emscripten_uint8x16_reciprocalApproximation, only defined on floating point types.
+// n.b. No emscripten_uint8x16_reciprocalSqrtApproximation, only defined on floating point types.
+// n.b. No emscripten_uint8x16_abs, only defined on floating point types.
+inline uint8x16 emscripten_uint8x16_and(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a & __b; }
+inline uint8x16 emscripten_uint8x16_xor(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a ^ __b; }
+inline uint8x16 emscripten_uint8x16_or(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a | __b; }
+inline uint8x16 emscripten_uint8x16_not(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return ~__a; }
+inline bool8x16 emscripten_uint8x16_lessThan(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a < __b; }
+inline bool8x16 emscripten_uint8x16_lessThanOrEqual(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a <= __b; }
+inline bool8x16 emscripten_uint8x16_greaterThan(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a > __b; }
+inline bool8x16 emscripten_uint8x16_greaterThanOrEqual(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a >= __b; }
+inline bool8x16 emscripten_uint8x16_equal(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a == __b; }
+inline bool8x16 emscripten_uint8x16_notEqual(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__)) { return __a != __b; }
+#define emscripten_uint8x16_anyTrue emscripten_bool8x16_anyTrue
+#define emscripten_uint8x16_allTrue emscripten_bool8x16_allTrue
+uint8x16 emscripten_uint8x16_select(bool8x16 __a, uint8x16 __b, uint8x16 __c) __attribute__((__nothrow__, __const__));
+uint8x16 emscripten_uint8x16_addSaturate(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__));
+uint8x16 emscripten_uint8x16_subSaturate(uint8x16 __a, uint8x16 __b) __attribute__((__nothrow__, __const__));
+uint8x16 emscripten_uint8x16_shiftLeftByScalar(uint8x16 __a, int __count) __attribute__((__nothrow__, __const__));
+uint8x16 emscripten_uint8x16_shiftRightByScalar(uint8x16 __a, int __count) __attribute__((__nothrow__, __const__));
+inline unsigned char emscripten_uint8x16_extractLane(uint8x16 __a, int __lane) __attribute__((__nothrow__, __const__)) { return __a[__lane]; }
+inline uint8x16 emscripten_uint8x16_replaceLane(uint8x16 __a, int __lane, unsigned char __s) __attribute__((__nothrow__, __const__)) { __a[__lane] = __s; return __a; }
+void emscripten_uint8x16_store(const void *__p, uint8x16 __a) __attribute__((__nothrow__));
+uint8x16 emscripten_uint8x16_load(const void *__p) __attribute__((__nothrow__, __pure__));
+inline uint8x16 emscripten_uint8x16_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromInt32x4Bits(uint8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromInt16x8Bits(int16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromUint16x8Bits(uint16x8 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromInt8x16Bits(int8x16 __a) __attribute__((__nothrow__, __const__)) { return (uint8x16)__a; }
+inline uint8x16 emscripten_uint8x16_fromInt8x16(int8x16 __a) __attribute__((__nothrow__, __const__)) { return __builtin_convertvector(__a, uint8x16); }
+uint8x16 emscripten_uint8x16_swizzle(uint8x16 __a, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7, int __lane8, int __lane9, int __lane10, int __lane11, int __lane12, int __lane13, int __lane14, int __lane15) __attribute__((__nothrow__, __const__));
+uint8x16 emscripten_uint8x16_shuffle(uint8x16 __a, uint8x16 __b, int __lane0, int __lane1, int __lane2, int __lane3, int __lane4, int __lane5, int __lane6, int __lane7, int __lane8, int __lane9, int __lane10, int __lane11, int __lane12, int __lane13, int __lane14, int __lane15) __attribute__((__nothrow__, __const__));
+
+// Bool64x2
+bool emscripten_bool64x2_anyTrue(bool64x2 __a, bool64x2 __b) __attribute__((__nothrow__, __const__));
+bool emscripten_bool64x2_allTrue(bool64x2 __a, bool64x2 __b) __attribute__((__nothrow__, __const__));
+
+// Bool32x4
+bool emscripten_bool32x4_anyTrue(bool32x4 __a, bool32x4 __b) __attribute__((__nothrow__, __const__));
+bool emscripten_bool32x4_allTrue(bool32x4 __a, bool32x4 __b) __attribute__((__nothrow__, __const__));
+
+// Bool16x8
+bool emscripten_bool16x8_anyTrue(bool16x8 __a, bool16x8 __b) __attribute__((__nothrow__, __const__));
+bool emscripten_bool16x8_allTrue(bool16x8 __a, bool16x8 __b) __attribute__((__nothrow__, __const__));
+
+// Bool8x16
+bool emscripten_bool8x16_anyTrue(bool8x16 __a, bool8x16 __b) __attribute__((__nothrow__, __const__));
+bool emscripten_bool8x16_allTrue(bool8x16 __a, bool8x16 __b) __attribute__((__nothrow__, __const__));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/xmmintrin.h
+++ b/system/include/emscripten/xmmintrin.h
@@ -181,7 +181,15 @@ _mm_storeu_ps(float *__p, __m128 __a)
 static __inline__ int __attribute__((__always_inline__))
 _mm_movemask_ps(__m128 __a)
 {
-  return emscripten_float32x4_signmask(__a);
+  union {
+    __m128 __v;
+    int __x[4];
+  } __attribute__((__packed__, __may_alias__)) __p;
+  __p.__v = __a;
+  return (__p.__x[0] < 0 ? 1 : 0)
+       | (__p.__x[1] < 0 ? 2 : 0)
+       | (__p.__x[2] < 0 ? 4 : 0)
+       | (__p.__x[3] < 0 ? 8 : 0);
 }
 
 static __inline__ __m128 __attribute__((__always_inline__))

--- a/tests/core/test_simd.in
+++ b/tests/core/test_simd.in
@@ -60,9 +60,6 @@ int main(int argc, char **argv) {
     d = _mm_set_ps(10.0, 14.0, -12, -2.0);
     printf("6floats! %d, %d, %d, %d   %d, %d, %d, %d\n", (int)c[0], (int)c[1],
            (int)c[2], (int)c[3], (int)d[0], (int)d[1], (int)d[2], (int)d[3]);
-    printf("7calcs: %d\n",
-           emscripten_float32x4_signmask(c));  // TODO: just not just
-                                               // compilation but output as well
   }
 
   return 0;

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -325,13 +325,22 @@ class RunnerCore(unittest.TestCase):
   def validate_asmjs(self, err):
     if "asm.js type error: 'Int8x16' is not a standard SIMD type" in err:
       err = err.replace("asm.js type error: 'Int8x16' is not a standard SIMD type", "")
-      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Int8x16 due to implementation not yet available in SpiderMonkey\n"
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Int8x16 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1136226\n"
     if "asm.js type error: 'Int16x8' is not a standard SIMD type" in err:
       err = err.replace("asm.js type error: 'Int16x8' is not a standard SIMD type", "")
-      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Int16x8 due to implementation not yet available in SpiderMonkey\n"
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Int16x8 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1136226\n"
+    if "asm.js type error: 'Uint8x16' is not a standard SIMD type" in err:
+      err = err.replace("asm.js type error: 'Uint8x16' is not a standard SIMD type", "")
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Uint8x16 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1244117\n"
+    if "asm.js type error: 'Uint16x8' is not a standard SIMD type" in err:
+      err = err.replace("asm.js type error: 'Uint16x8' is not a standard SIMD type", "")
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Uint16x8 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1244117\n"
+    if "asm.js type error: 'Uint32x4' is not a standard SIMD type" in err:
+      err = err.replace("asm.js type error: 'Uint32x4' is not a standard SIMD type", "")
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Uint32x4 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1240796\n"
     if "asm.js type error: 'Float64x2' is not a standard SIMD type" in err:
       err = err.replace("asm.js type error: 'Float64x2' is not a standard SIMD type", "")
-      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Float64x2 due to implementation not yet available in SpiderMonkey\n"
+      print >> sys.stderr, "\nWARNING: ignoring asm.js type error from Float64x2 due to implementation not yet available in SpiderMonkey. See https://bugzilla.mozilla.org/show_bug.cgi?id=1124205\n"
     if 'uccessfully compiled asm.js code' in err and 'asm.js link error' not in err:
       print >> sys.stderr, "[was asm.js'ified]"
     elif 'asm.js' in err: # if no asm.js error, then not an odin build

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1780,10 +1780,7 @@ var ASM_BOOL8X16 = 8;
 var ASM_BOOL16X8 = 9;
 var ASM_BOOL32X4 = 10;
 var ASM_BOOL64X2 = 11;
-var ASM_UINT32X4 = 12;
-var ASM_UINT16X8 = 13;
-var ASM_UINT8X16 = 14;
-var ASM_NONE = 15;
+var ASM_NONE = 12;
 
 var ASM_SIG = {
   0: 'i',
@@ -1798,10 +1795,7 @@ var ASM_SIG = {
   9: 'X',
   10: 'C',
   11: 'V',
-  12: 'N', // Unsigned integer SIMD.js types have letters NML.
-  13: 'M',
-  14: 'L',
-  15: 'v'
+  12: 'v'
 };
 
 var ASM_FLOAT_ZERO = null; // TODO: share the entire node?
@@ -1835,12 +1829,6 @@ function detectType(node, asmInfo, inVarDef) {
           case 'SIMD_Int16x8_check':   return ASM_INT16X8;
           case 'SIMD_Int32x4':
           case 'SIMD_Int32x4_check':   return ASM_INT32X4;
-          case 'SIMD_Uint8x16':
-          case 'SIMD_Uint8x16_check':  return ASM_UINT8X16;
-          case 'SIMD_Uint16x8':
-          case 'SIMD_Uint16x8_check':  return ASM_UINT16X8;
-          case 'SIMD_Uint32x4':
-          case 'SIMD_Uint32x4_check':  return ASM_UINT32X4;
           case 'SIMD_Bool8x16':
           case 'SIMD_Bool8x16_check':  return ASM_BOOL8X16;
           case 'SIMD_Bool16x8':
@@ -1915,9 +1903,6 @@ function makeAsmCoercion(node, type) {
     case ASM_INT8X16:   return ['call', ['name', 'SIMD_Int8x16_check'],   [node]];
     case ASM_INT16X8:   return ['call', ['name', 'SIMD_Int16x8_check'],   [node]];
     case ASM_INT32X4:   return ['call', ['name', 'SIMD_Int32x4_check'],   [node]];
-    case ASM_UINT8X16:  return ['call', ['name', 'SIMD_Uint8x16_check'],  [node]];
-    case ASM_UINT16X8:  return ['call', ['name', 'SIMD_Uint16x8_check'],  [node]];
-    case ASM_UINT32X4:  return ['call', ['name', 'SIMD_Uint32x4_check'],  [node]];
     case ASM_BOOL8X16:  return ['call', ['name', 'SIMD_Bool8x16_check'],  [node]];
     case ASM_BOOL16X8:  return ['call', ['name', 'SIMD_Bool16x8_check'],  [node]];
     case ASM_BOOL32X4:  return ['call', ['name', 'SIMD_Bool32x4_check'],  [node]];
@@ -1958,15 +1943,6 @@ function makeAsmCoercedZero(type) {
     }
     case ASM_INT32X4: {
       return ['call', ['name', 'SIMD_Int32x4'], [['num', 0], ['num', 0], ['num', 0], ['num', 0]]];
-    }
-    case ASM_UINT8X16: {
-      return ['call', ['name', 'SIMD_Uint8x16'], [['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0]]];
-    }
-    case ASM_UINT16X8: {
-      return ['call', ['name', 'SIMD_Uint16x8'], [['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0]]];
-    }
-    case ASM_UINT32X4: {
-      return ['call', ['name', 'SIMD_Uint32x4'], [['num', 0], ['num', 0], ['num', 0], ['num', 0]]];
     }
     case ASM_BOOL8X16: {
       return ['call', ['name', 'SIMD_Bool8x16'], [['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0], ['num', 0]]];
@@ -2356,9 +2332,6 @@ function registerize(ast) {
           case ASM_INT8X16:   ret = 'I16'; break;
           case ASM_INT16X8:   ret = 'I8'; break;
           case ASM_INT32X4:   ret = 'I4'; break;
-          case ASM_UINT8X16:  ret = 'U16'; break;
-          case ASM_UINT16X8:  ret = 'U8'; break;
-          case ASM_UINT32X4:  ret = 'U4'; break;
           case ASM_BOOL8X16:  ret = 'B16'; break;
           case ASM_BOOL16X8:  ret = 'B8'; break;
           case ASM_BOOL32X4:  ret = 'B4'; break;
@@ -2479,7 +2452,7 @@ function registerize(ast) {
     // we just use a fresh register to make sure we avoid this, but it could be
     // optimized to check for safe registers (free, and not used in this loop level).
     var varRegs = {}; // maps variables to the register they will use all their life
-    var freeRegsClasses = asm ? [[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []] : []; // two classes for asm, one otherwise XXX - hardcoded length
+    var freeRegsClasses = asm ? [[], [], [], [], [], [], [], [], [], [], [], [], []] : []; // two classes for asm, one otherwise XXX - hardcoded length
     var nextReg = 1;
     var fullNames = {};
     var loopRegs = {}; // for each loop nesting level, the list of bound variables
@@ -2642,8 +2615,8 @@ function registerizeHarder(ast) {
     // Utilities for allocating register variables.
     // We need distinct register pools for each type of variable.
 
-    var allRegsByType = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}]; // XXX - hardcoded length
-    var regPrefixByType = ['i', 'd', 'f', 'F4', 'F2', 'I16', 'I8', 'I4', 'B16', 'B8', 'B4', 'B2', 'U16', 'U8', 'U4', 'n'];
+    var allRegsByType = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}]; // XXX - hardcoded length
+    var regPrefixByType = ['i', 'd', 'f', 'F4', 'F2', 'I16', 'I8', 'I4', 'B16', 'B8', 'B4', 'B2', 'n'];
     var nextReg = 1;
 
     function createReg(forName) {


### PR DESCRIPTION
SIMD.js updates:
  - Update SIMD.js polyfill to latest version as of today (2016/29/01)
  - Work around SIMD.js polyfill bug https://github.com/tc39/ecmascript_simd/issues/313
  - Work around SIMD.js polyfill bug https://github.com/tc39/ecmascript_simd/issues/314
  - Add support for unsigned SIMD types Uint32x4, Uint16x8 and Uint8x16.
  - Remove remains of old shiftRightArithmeticByScalar() and shiftRightLogicalByScalar() that no longer exist.
  - Remove use of old Float32x4.signmask() function which no longer exists.
  - Complete Emscripten vector.h intrinsics file to include all the functions exposed in the SIMD.js API so far.
  - Closes https://github.com/kripken/emscripten/issues/3982.
  - Related to https://github.com/kripken/emscripten/issues/4011 and https://github.com/kripken/emscripten/issues/4051.