### PR TITLE
Fix GL_SHADING_LANGUAGE_VERSION

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -730,9 +730,9 @@ var LibraryGL = {
       case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
         var glslVersion = GLctx.getParameter(GLctx.SHADING_LANGUAGE_VERSION);
         // Map WebGL GL_SHADING_LANGUAGE_VERSION string format to GLES format.
-        if (glslVersion.indexOf('WebGL GLSL ES 1.0') != -1) glslVersion = 'OpenGL ES GLSL 1.00 (WebGL)';
+        if (glslVersion.indexOf('WebGL GLSL ES 1.0') != -1) glslVersion = 'OpenGL ES GLSL ES 1.00 (WebGL)';
 #if USE_WEBGL2
-        else if (glslVersion.indexOf('WebGL GLSL ES 3.00') != -1) glslVersion = 'OpenGL ES GLSL 3.00 (WebGL 2)';
+        else if (glslVersion.indexOf('WebGL GLSL ES 3.00') != -1) glslVersion = 'OpenGL ES GLSL ES 3.00 (WebGL 2)';
 #endif
         ret = allocate(intArrayFromString(glslVersion), 'i8', ALLOC_NORMAL);
         break;


### PR DESCRIPTION
OpenGL ES 2 specification section 6.1.5 and OpenGL ES 3 specification section 6.1.6 state:

> The SHADING_LANGUAGE_VERSION string is laid out as follows:
> `"OpenGL ES GLSL ES N.M vendor-specific information"`

Emscripten misses the second "ES" in there.  This tripped up our engine, which expects a conforming string.  This patch fixes that.