### PR TITLE
OpenAL global gain bug fixes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,4 +231,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Noam T.Cohen <noam@ecb.co.il>
 * Nick Shin <nick.shin@gmail.com>
 * Gregg Tavares <github@greggman.com>
+* Tanner Rogalsky <tanner@tannerrogalsky.com>
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -472,7 +472,7 @@ var LibraryOpenAL = {
           // Disconnect from the panner.
           src.gain.disconnect();
 
-          src.gain.connect(AL.currentContext.ctx.destination);
+          src.gain.connect(AL.currentContext.gain);
         }
       } else if (value === 0 /* AL_FALSE */) {
         if (!src.panner) {
@@ -484,7 +484,7 @@ var LibraryOpenAL = {
           panner.rolloffFactor = src.rolloffFactor;
           panner.setPosition(src.position[0], src.position[1], src.position[2]);
           panner.setVelocity(src.velocity[0], src.velocity[1], src.velocity[2]);
-          panner.connect(AL.currentContext.ctx.destination);
+          panner.connect(AL.currentContext.gain);
 
           // Disconnect from the default source.
           src.gain.disconnect();

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1178,7 +1178,7 @@ var LibraryOpenAL = {
     }
     switch (pname) {
     case 0x100A /* AL_GAIN */:
-      {{{ makeSetValue('value', '0', 'AL.currentContext.gain.gain', 'float') }}}
+      {{{ makeSetValue('value', '0', 'AL.currentContext.gain.gain.value', 'float') }}}
       break;
     default:
 #if OPENAL_DEBUG

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1169,7 +1169,7 @@ var LibraryOpenAL = {
     }
   },
 
-  alGetListenerf: function(pname, values) {
+  alGetListenerf: function(pname, value) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alGetListenerf called without a valid context");


### PR DESCRIPTION
`alGetListenerf` had some typos in it.

Using `alSourcei` to toggle `AL_SOURCE_RELATIVE` caused the source to bypass the main `gain` object on it's way to the audio destination. Essentially, setting the global gain did nothing if you had toggled `AL_SOURCE_RELATIVE` on a source.

Tests `interactive.test_openal_playback` and `interactive.test_openal_buffers` were run and both passed.