### PR TITLE
`alListenerf` bug fix and tests.

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1254,7 +1254,7 @@ var LibraryOpenAL = {
     }
     switch (param) {
     case 0x100A /* AL_GAIN */:
-      AL.currentContext.gain.value = value;
+      AL.currentContext.gain.gain.value = value;
       break;
     default:
 #if OPENAL_DEBUG

--- a/tests/openal_playback.cpp
+++ b/tests/openal_playback.cpp
@@ -59,6 +59,16 @@ int main() {
   alListenerfv(AL_VELOCITY, listenerVel);
   alListenerfv(AL_ORIENTATION, listenerOri);
 
+  // check getting and setting global gain
+  ALfloat volume;
+  alGetListenerf(AL_GAIN, &volume);
+  assert(volume == 1.0);
+  alListenerf(AL_GAIN, 0.0);
+  alGetListenerf(AL_GAIN, &volume);
+  assert(volume == 0.0);
+
+  alListenerf(AL_GAIN, 1.0); // reset gain to default
+
   ALuint buffers[1];
 
   alGenBuffers(1, buffers);


### PR DESCRIPTION
This is a follow up to #4091. 

It fixes a bug with setting the global gain using `alListenerf`. 

It also adds tests for `alListenerf` and `alGetListenerf`.

Tests `interactive.test_openal_playback` and `interactive.test_openal_buffers` were run without regressions.