### PR TITLE
Fixes glfwSetWindowSizeCallback conformance with glfw2 standard API.

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -579,6 +579,11 @@ var LibraryGLFW = {
       var win = GLFW.WindowFromId(winid);
       if (!win) return;
       win.windowSizeFunc = cbfun;
+     
+#if USE_GLFW == 2
+      if (!win.windowSizeFunc) return;
+      Runtime.dynCall('vii', win.windowSizeFunc, [win.width, win.height]);
+#endif
     },
 
     setWindowCloseCallback: function(winid, cbfun) {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -581,6 +581,10 @@ var LibraryGLFW = {
       win.windowSizeFunc = cbfun;
      
 #if USE_GLFW == 2
+      // As documented in GLFW2 API (http://www.glfw.org/GLFWReference27.pdf#page=22), when size
+      // callback function is set, it will be called with the current window size before this
+      // function returns.
+      // GLFW3 on the over hand doesn't have this behavior (https://github.com/glfw/glfw/issues/62).
       if (!win.windowSizeFunc) return;
       Runtime.dynCall('vii', win.windowSizeFunc, [win.width, win.height]);
 #endif

--- a/tests/glfw.c
+++ b/tests/glfw.c
@@ -27,6 +27,9 @@ unsigned int nb_params = sizeof(params) / sizeof(int);
 int features[] = {GLFW_MOUSE_CURSOR, GLFW_STICKY_KEYS, GLFW_STICKY_MOUSE_BUTTONS, GLFW_SYSTEM_KEYS, GLFW_KEY_REPEAT, GLFW_AUTO_POLL_EVENTS};
 unsigned int nb_features = sizeof(features) / sizeof(int);
 
+// Will be set to 1 as soon as OnResize callback is called
+int on_resize_called = 0;
+
 float rotate_y = 0,
       rotate_z = 0;
 const float rotations_per_tick = .2;
@@ -62,10 +65,15 @@ void Init()
     Shut_Down(1);
   glfwSetWindowTitle("The GLFW Window");
  
-  glfwSetKeyCallback( OnKeyPressed );
-  glfwSetCharCallback( OnCharPressed );
+  glfwSetKeyCallback(OnKeyPressed);
+  glfwSetCharCallback(OnCharPressed);
   glfwSetWindowCloseCallback(OnClose);
   glfwSetWindowSizeCallback(OnResize);
+  if (!on_resize_called)
+  {
+    Shut_Down(1);
+  }
+
   glfwSetWindowRefreshCallback(OnRefresh);
   glfwSetMouseWheelCallback(OnMouseWheel);
   glfwSetMousePosCallback(OnMouseMove);
@@ -319,6 +327,7 @@ void OnRefresh(){
 }
 
 void OnResize( int width, int height ){
+  on_resize_called = 1;
   printf("Resizing to %i %i\n", width, height);
 }
 


### PR DESCRIPTION
On calls to glfwSetWindowSizeCallback, calls the provided callback function, as described by glfw2 documentation: When a callback function is set, it will be called with the current window size before this function returns.
Note that glfw3 API doesn't behaves this way according to its documentation.
