### PR TITLE
Move cxa_guard methods into compiled code

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -942,16 +942,6 @@ LibraryManager.library = {
     throw 'Assertion failed: ' + (condition ? Pointer_stringify(condition) : 'unknown condition') + ', at: ' + [filename ? Pointer_stringify(filename) : 'unknown filename', line, func ? Pointer_stringify(func) : 'unknown function'] + ' at ' + stackTrace();
   },
 
-  __cxa_guard_acquire: function(variable) {
-    if (!{{{ makeGetValue(0, 'variable', 'i8', null, null, 1) }}}) { // ignore SAFE_HEAP stuff because llvm mixes i64 and i8 here
-      {{{ makeSetValue(0, 'variable', '1', 'i8') }}};
-      return 1;
-    }
-    return 0;
-  },
-  __cxa_guard_release: function() {},
-  __cxa_guard_abort: function() {},
-
   $EXCEPTIONS: {
     last: 0,
     caught: [],

--- a/system/lib/libcxxabi/src/cxa_guard.cpp
+++ b/system/lib/libcxxabi/src/cxa_guard.cpp
@@ -9,6 +9,29 @@
 
 #include "abort_message.h"
 
+#if __EMSCRIPTEN__
+
+// XXX EMSCRIPTEN making guard operations simple and LTO-optimizable opens up
+//                a lot of code saving opportunities
+
+#include <stdint.h>
+
+extern "C"
+{
+
+int __cxa_guard_acquire(uint64_t* p) {
+  char* q = (char*)p;
+  if (*q == 1) return 0;
+  *q = 1;
+  return 1;
+}
+void __cxa_guard_release(uint64_t*) {}
+void __cxa_guard_abort(uint64_t*) {}
+
+}
+
+#else
+
 #include <pthread.h>
 #include <stdint.h>
 
@@ -229,3 +252,5 @@ void __cxa_guard_abort(guard_type* guard_object)
 }  // extern "C"
 
 }  // __cxxabiv1
+
+#endif // EMSCRIPTEN

--- a/system/lib/libcxxabi/symbols
+++ b/system/lib/libcxxabi/symbols
@@ -2,6 +2,9 @@
          C _ZNKSt3__120__vector_base_commonILb1EE20__throw_length_errorEv
          C _ZNKSt3__121__basic_string_commonILb1EE20__throw_length_errorEv
          C _ZNKSt3__121__basic_string_commonILb1EE20__throw_out_of_rangeEv
+         T __cxa_guard_acquire
+         T __cxa_guard_release
+         T __cxa_guard_abort
          D __cxa_new_handler
          D __cxa_terminate_handler
          D __cxa_unexpected_handler

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -163,6 +163,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       'cxa_default_handlers.cpp',
       'cxa_demangle.cpp',
       'cxa_exception_storage.cpp',
+      'cxa_guard.cpp',
       'cxa_new_delete.cpp',
       'cxa_handlers.cpp',
       'exception.cpp',


### PR DESCRIPTION
This moves cxa_guard stuff where LLVM LTO can optimize it, which is useful as it's generally in global initializers that is on the startup path. Right now we have a lot of calls out of asm.js for this.

Note that this doesn't use locks, just like we have been doing all along in JS. So this doesn't change anything, it just makes things more optimizable. However, perhaps as a followup we could consider enabling locks in pthreads builds (it would be nice not to, though, as knowing global initializers are single-threaded makes things more optimizable).

(Needs a version bump too, of course.)
