### PR TITLE
Update OpenAL source only when visible

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -31,17 +31,16 @@ var LibraryOpenAL = {
 #endif
 
     updateSources: function updateSources(context) {
-      // If we are animating using the requestAnimationFrame method, then the main loop does not run when in the background.
-      // To give a perfect glitch-free audio stop when switching from foreground to background, we need to avoid updating
-      // audio altogether when in the background, so detect that case and kill audio buffer streaming if so.
-      if (Browser.mainLoop.timingMode == 1/*EM_TIMING_RAF*/ && document['visibilityState'] != 'visible') return;
-
       for (var srcId in context.src) {
         AL.updateSource(context.src[srcId]);
       }
     },
 
     updateSource: function updateSource(src) {
+      // If we are animating using the requestAnimationFrame method, then the main loop does not run when in the background.
+      // To give a perfect glitch-free audio stop when switching from foreground to background, we need to avoid updating
+      // audio altogether when in the background, so detect that case and kill audio buffer streaming if so.
+      if (Browser.mainLoop.timingMode == 1/*EM_TIMING_RAF*/ && document['visibilityState'] != 'visible') return;
 #if OPENAL_DEBUG
       var idx = AL.srcIdBySrc(src);
 #endif


### PR DESCRIPTION
Problem what we hit is that if application is not focused then app runs with ~2FPS. 
At run-time we call indirectly `updateSource` (Because we do a call for `alSourcePlay`) 
As a side effect of that we can hear a chopping sound from time to time when application is hidden. 