### PR TITLE
fix_dollars_in_codemod_symbols

### DIFF
--- a/tools/client_mods.py
+++ b/tools/client_mods.py
@@ -23,6 +23,10 @@ try {
   var m = /var ([^=]+)=global\.Math\.fround;/.exec(code);
   var minified = m[1];
   if (!minified) throw 'fail';
+
+  // The minified JS variable for Math.fround might contain the '$' sign, so this must be escaped to \$ to be used as a search pattern.
+  minified = minified.replace(/\$/g, "\\\\$$");
+
   do {
     var moar = false; // we need to re-do, as x(x( will not be fixed
     code = code.replace(new RegExp('[^a-zA-Z0-9\\\\$\\\\_]' + minified + '\\\\(', 'g'), function(s) { moar = true; return s[0] + '(' });
@@ -71,59 +75,92 @@ try {
   var atomics_or = /var\s+([^=]+?)\s*=\s*global\.Atomics\.or;/.exec(code)[1];
   var atomics_xor = /var\s+([^=]+?)\s*=\s*global\.Atomics\.xor;/.exec(code)[1];
 
+  // JS variables may contain the '$' sign, so these must be escaped. However,
+  // the '$' sign needs to be escaped differently depending on whether it's on the
+  // string to search for side (espace by '\\'), or the value to replace
+  // with side (escape by '$').
+  function escapeDollarForRegexSearch(str) { return str.replace(/\$/g, "\\\\$$"); }
+  function escapeDollarForRegexValue(str) { return str.replace(/\$/g, "$$$$"); }
+
+  var wb = '([^\\\\w\\\\$])'; // word break (one character, which is backinserted)
+
+  var s_heap8 = escapeDollarForRegexSearch(heap8);
+  var s_heap16 = escapeDollarForRegexSearch(heap16);
+  var s_heap32 = escapeDollarForRegexSearch(heap32);
+  var s_heapf32 = escapeDollarForRegexSearch(heapf32);
+  var s_heapf64 = escapeDollarForRegexSearch(heapf64);
+
   // The Atomics built-ins take as first parameter the heap object, however when replacing those with
   // polyfill versions, it is not possible to pass a heap object as the first parameter. Therefore
   // route each call to Atomics to a polyfill function for each type, e.g. "Atomics_add(HEAP32, index, val)" -> "Atomics_add_32(index, val)"
-  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\('+heap8+',', 'g'), atomics_load + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\('+heap16+',', 'g'), atomics_load + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\('+heap32+',', 'g'), atomics_load + "_32(");
-  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\('+heapf32+',', 'g'), atomics_load + "_f32(");
-  code = code.replace(new RegExp('\\\\b' + atomics_load + '\\\\('+heapf64+',', 'g'), atomics_load + "_f64(");
+  var s_atomics_load = escapeDollarForRegexSearch(atomics_load);
+  var v_atomics_load = escapeDollarForRegexValue(atomics_load);
+  code = code.replace(new RegExp(wb + s_atomics_load + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_load + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_load + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_load + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_load + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_load + "_32(");
+  code = code.replace(new RegExp(wb + s_atomics_load + '\\\\('+s_heapf32+',', 'g'), '$1' + v_atomics_load + "_f32(");
+  code = code.replace(new RegExp(wb + s_atomics_load + '\\\\('+s_heapf64+',', 'g'), '$1' + v_atomics_load + "_f64(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\('+heap8+',', 'g'), atomics_store + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\('+heap16+',', 'g'), atomics_store + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\('+heap32+',', 'g'), atomics_store + "_32(");
-  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\('+heapf32+',', 'g'), atomics_store + "_f32(");
-  code = code.replace(new RegExp('\\\\b' + atomics_store + '\\\\('+heapf64+',', 'g'), atomics_store + "_f64(");
+  var s_atomics_store = escapeDollarForRegexSearch(atomics_store);
+  var v_atomics_store = escapeDollarForRegexValue(atomics_store);
+  code = code.replace(new RegExp(wb + s_atomics_store + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_store + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_store + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_store + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_store + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_store + "_32(");
+  code = code.replace(new RegExp(wb + s_atomics_store + '\\\\('+s_heapf32+',', 'g'), '$1' + v_atomics_store + "_f32(");
+  code = code.replace(new RegExp(wb + s_atomics_store + '\\\\('+s_heapf64+',', 'g'), '$1' + v_atomics_store + "_f64(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap8+',', 'g'), atomics_add + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap16+',', 'g'), atomics_add + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_add + '\\\\('+heap32+',', 'g'), atomics_add + "_32(");
+  var s_atomics_add = escapeDollarForRegexSearch(atomics_add);
+  var v_atomics_add = escapeDollarForRegexValue(atomics_add);
+  code = code.replace(new RegExp(wb + s_atomics_add + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_add + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_add + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_add + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_add + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_add + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap8+',', 'g'), atomics_sub + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap16+',', 'g'), atomics_sub + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_sub + '\\\\('+heap32+',', 'g'), atomics_sub + "_32(");
+  var s_atomics_sub = escapeDollarForRegexSearch(atomics_sub);
+  var v_atomics_sub = escapeDollarForRegexValue(atomics_sub);
+  code = code.replace(new RegExp(wb + s_atomics_sub + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_sub + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_sub + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_sub + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_sub + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_sub + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap8+',', 'g'), atomics_and + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap16+',', 'g'), atomics_and + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_and + '\\\\('+heap32+',', 'g'), atomics_and + "_32(");
+  var s_atomics_and = escapeDollarForRegexSearch(atomics_and);
+  var v_atomics_and = escapeDollarForRegexValue(atomics_and);
+  code = code.replace(new RegExp(wb + s_atomics_and + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_and + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_and + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_and + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_and + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_and + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap8+',', 'g'), atomics_or + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap16+',', 'g'), atomics_or + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_or + '\\\\('+heap32+',', 'g'), atomics_or + "_32(");
+  var s_atomics_or = escapeDollarForRegexSearch(atomics_or);
+  var v_atomics_or = escapeDollarForRegexValue(atomics_or);
+  code = code.replace(new RegExp(wb + s_atomics_or + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_or + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_or + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_or + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_or + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_or + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap8+',', 'g'), atomics_xor + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap16+',', 'g'), atomics_xor + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_xor + '\\\\('+heap32+',', 'g'), atomics_xor + "_32(");
+  var s_atomics_xor = escapeDollarForRegexSearch(atomics_xor);
+  var v_atomics_xor = escapeDollarForRegexValue(atomics_xor);
+  code = code.replace(new RegExp(wb + s_atomics_xor + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_xor + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_xor + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_xor + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_xor + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_xor + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_exchange + '\\\\('+heap8+',', 'g'), atomics_exchange + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_exchange + '\\\\('+heap16+',', 'g'), atomics_exchange + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_exchange + '\\\\('+heap32+',', 'g'), atomics_exchange + "_32(");
+  var s_atomics_exchange = escapeDollarForRegexSearch(atomics_exchange);
+  var v_atomics_exchange = escapeDollarForRegexValue(atomics_exchange);
+  code = code.replace(new RegExp(wb + s_atomics_exchange + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_exchange + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_exchange + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_exchange + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_exchange + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_exchange + "_32(");
 
-  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap8+',', 'g'), atomics_compareExchange + "_8(");
-  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap16+',', 'g'), atomics_compareExchange + "_16(");
-  code = code.replace(new RegExp('\\\\b' + atomics_compareExchange + '\\\\('+heap32+',', 'g'), atomics_compareExchange + "_32(");
+  var s_atomics_compareExchange = escapeDollarForRegexSearch(atomics_compareExchange);
+  var v_atomics_compareExchange = escapeDollarForRegexValue(atomics_compareExchange);
+  code = code.replace(new RegExp(wb + s_atomics_compareExchange + '\\\\('+s_heap8+',', 'g'), '$1' + v_atomics_compareExchange + "_8(");
+  code = code.replace(new RegExp(wb + s_atomics_compareExchange + '\\\\('+s_heap16+',', 'g'), '$1' + v_atomics_compareExchange + "_16(");
+  code = code.replace(new RegExp(wb + s_atomics_compareExchange + '\\\\('+s_heap32+',', 'g'), '$1' + v_atomics_compareExchange + "_32(");
 
   // Remove the import statements of Atomics built-ins.
-  code = code.replace(new RegExp("var " + atomics_load + "\\\\s*=\\\\s*global\\.Atomics\\.load;"), "");
-  code = code.replace(new RegExp("var " + atomics_store + "\\\\s*=\\\\s*global\\.Atomics\\.store;"), "");
-  code = code.replace(new RegExp("var " + atomics_exchange + "\\\\s*=\\\\s*global\\.Atomics\\.exchange;"), "");
-  code = code.replace(new RegExp("var " + atomics_compareExchange + "\\\\s*=\\\\s*global\\.Atomics\\.compareExchange;"), "");
-  code = code.replace(new RegExp("var " + atomics_add + "\\\\s*=\\\\s*global\\.Atomics\\.add;"), "");
-  code = code.replace(new RegExp("var " + atomics_sub + "\\\\s*=\\\\s*global\\.Atomics\\.sub;"), "");
-  code = code.replace(new RegExp("var " + atomics_and + "\\\\s*=\\\\s*global\\.Atomics\\.and;"), "");
-  code = code.replace(new RegExp("var " + atomics_or + "\\\\s*=\\\\s*global\\.Atomics\\.or;"), "");
-  code = code.replace(new RegExp("var " + atomics_xor + "\\\\s*=\\\\s*global\\.Atomics\\.xor;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_load + "\\\\s*=\\\\s*global\\.Atomics\\.load;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_store + "\\\\s*=\\\\s*global\\.Atomics\\.store;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_exchange + "\\\\s*=\\\\s*global\\.Atomics\\.exchange;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_compareExchange + "\\\\s*=\\\\s*global\\.Atomics\\.compareExchange;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_add + "\\\\s*=\\\\s*global\\.Atomics\\.add;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_sub + "\\\\s*=\\\\s*global\\.Atomics\\.sub;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_and + "\\\\s*=\\\\s*global\\.Atomics\\.and;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_or + "\\\\s*=\\\\s*global\\.Atomics\\.or;"), "");
+  code = code.replace(new RegExp("var " + s_atomics_xor + "\\\\s*=\\\\s*global\\.Atomics\\.xor;"), "");
 
   // Implement polyfill versions of Atomics intrinsics inside the asm.js scope.
   code = code.replace("// EMSCRIPTEN_START_FUNCS", "// EMSCRIPTEN_START_FUNCS\\n"


### PR DESCRIPTION
Fix codemods replacement for -s USE_PTHREADS=2 and -s PRECISE_F32=2 for the case when symbol name minification happens to generate a symbol that has a dollar sign in it. Fixes tests `browser.test_pthread_setspecific_mainthread` and `browser.test_pthread_num_logical_cores`.

Ran `browser.test_codemods` and `browser.test_pthread*` against non-SAB-supporting Firefox to check all of these pass.

Also used the following local hack to stress the behavior with '$' signs:

	C:\code\emsdk\emscripten\incoming>git diff tools/js-optimizer.js
	diff --git a/tools/js-optimizer.js b/tools/js-optimizer.js
	index 960112f..d0c9ebe 100644
	--- a/tools/js-optimizer.js
	+++ b/tools/js-optimizer.js
	@@ -2248,7 +2248,7 @@ function ensureMinifiedNames(n) { // make sure the nth index in minifiedNames ex
	     for (var i = 1; i < minifiedState.length; i++) {
	       name += VALID_MIN_LATERS[minifiedState[i]];
	     }
	-    if (!(name in RESERVED)) minifiedNames.push(name);
	+    if (!(name in RESERVED)) minifiedNames.push('$1' +name);
	     // increment the state
	     var i = 0;
	     while (1) {

The tests `browser.test_pthread_setspecific_mainthread` and `browser.test_pthread_num_logical_cores` already found failures with this, though the above hack found a few more. Not sure how to permanently test that, so documenting the above local hack here instead.