### PR TITLE
Added support for alpha attribute in GL context init

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -754,7 +754,8 @@ var LibraryGLFW = {
         var contextAttributes = {
           antialias: (GLFW.hints[0x0002100D] > 1), // GLFW_SAMPLES
           depth: (GLFW.hints[0x00021005] > 0),     // GLFW_DEPTH_BITS
-          stencil: (GLFW.hints[0x00021006] > 0)    // GLFW_STENCIL_BITS
+          stencil: (GLFW.hints[0x00021006] > 0),   // GLFW_STENCIL_BITS
+          alpha: (GLFW.hints[0x00021004] > 0)      // GLFW_ALPHA_BITS 
         }
         Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
       }

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -515,7 +515,8 @@ var LibraryGLUT = {
     var contextAttributes = {
       antialias: ((GLUT.initDisplayMode & 0x0080 /*GLUT_MULTISAMPLE*/) != 0),
       depth: ((GLUT.initDisplayMode & 0x0010 /*GLUT_DEPTH*/) != 0),
-      stencil: ((GLUT.initDisplayMode & 0x0020 /*GLUT_STENCIL*/) != 0)
+      stencil: ((GLUT.initDisplayMode & 0x0020 /*GLUT_STENCIL*/) != 0),
+      alpha: ((GLUT.initDisplayMode & 0x0008 /*GLUT_ALPHA*/) != 0)
     };
     Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
     return Module.ctx ? 1 /* a new GLUT window ID for the created context */ : 0 /* failure */;

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -390,7 +390,8 @@ var LibrarySDL = {
       var webGLContextAttributes = {
         antialias: ((SDL.glAttributes[13 /*SDL_GL_MULTISAMPLEBUFFERS*/] != 0) && (SDL.glAttributes[14 /*SDL_GL_MULTISAMPLESAMPLES*/] > 1)),
         depth: (SDL.glAttributes[6 /*SDL_GL_DEPTH_SIZE*/] > 0),
-        stencil: (SDL.glAttributes[7 /*SDL_GL_STENCIL_SIZE*/] > 0)
+        stencil: (SDL.glAttributes[7 /*SDL_GL_STENCIL_SIZE*/] > 0),
+        alpha: (SDL.glAttributes[3 /*SDL_GL_ALPHA_SIZE*/] > 0)
       };
       
       var ctx = Browser.createContext(canvas, is_SDL_OPENGL, usePageCanvas, webGLContextAttributes);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -999,9 +999,9 @@ keydown(100);keyup(100); // trigger the end
     shutil.copyfile(filepath, temp_filepath)
     
     # perform tests with attributes activated 
-    self.btest('test_webgl_context_attributes_glut.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED'])
+    self.btest('test_webgl_context_attributes_glut.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
     self.btest('test_webgl_context_attributes_sdl.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
-    self.btest('test_webgl_context_attributes_glfw.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED'])
+    self.btest('test_webgl_context_attributes_glfw.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
     
     # perform tests with attributes desactivated
     self.btest('test_webgl_context_attributes_glut.c', '1', args=['--js-library', 'check_webgl_attributes_support.js'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -983,7 +983,13 @@ keydown(100);keyup(100); // trigger the end
           context = canvas.getContext('experimental-webgl', {stencil: true});
           attributes = context.getContextAttributes();
           return attributes.stencil;
-       }
+        },
+        webglAlphaSupported: function() {
+          canvas = document.createElement('canvas');
+          context = canvas.getContext('experimental-webgl', {alpha: true});
+          attributes = context.getContextAttributes();
+          return attributes.alpha;
+        }
       });
     ''')
     
@@ -994,7 +1000,7 @@ keydown(100);keyup(100); // trigger the end
     
     # perform tests with attributes activated 
     self.btest('test_webgl_context_attributes_glut.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED'])
-    self.btest('test_webgl_context_attributes_sdl.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED'])
+    self.btest('test_webgl_context_attributes_sdl.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
     self.btest('test_webgl_context_attributes_glfw.c', '1', args=['--js-library', 'check_webgl_attributes_support.js', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED'])
     
     # perform tests with attributes desactivated

--- a/tests/test_webgl_context_attributes_glfw.c
+++ b/tests/test_webgl_context_attributes_glfw.c
@@ -7,6 +7,7 @@
 int nbSamples = 0;
 int nbDepthBits = 0;
 int nbStencilBits = 0;
+int nbAlphaBits = 0;
 
 int main() {
   
@@ -28,9 +29,14 @@ int main() {
     stencilActivated = true;  
     nbStencilBits = 8;
 #endif
+  
+#ifdef ALPHA_ACTIVATED
+    alphaActivated = true;  
+    nbAlphaBits = 8;
+#endif
 
     glfwOpenWindowHint(GLFW_FSAA_SAMPLES, nbSamples);
-    glfwOpenWindow(WINDOWS_SIZE, WINDOWS_SIZE, 8, 8, 8, 8, nbDepthBits, nbStencilBits, GLFW_WINDOW);
+    glfwOpenWindow(WINDOWS_SIZE, WINDOWS_SIZE, 8, 8, 8, nbAlphaBits, nbDepthBits, nbStencilBits, GLFW_WINDOW);
   
     glewInit();
     initGlObjects();

--- a/tests/test_webgl_context_attributes_glut.c
+++ b/tests/test_webgl_context_attributes_glut.c
@@ -8,7 +8,7 @@ int main(int argc, char *argv[]) {
     
     checkContextAttributesSupport(); 
     
-    unsigned int glutDisplayMode = GLUT_RGBA | GLUT_DOUBLE | GLUT_ALPHA;
+    unsigned int glutDisplayMode = GLUT_RGBA | GLUT_DOUBLE;
         
 #ifdef AA_ACTIVATED
     antiAliasingActivated = true;
@@ -23,6 +23,11 @@ int main(int argc, char *argv[]) {
 #ifdef STENCIL_ACTIVATED
     stencilActivated = true;
     glutDisplayMode |= GLUT_STENCIL;
+#endif
+    
+#ifdef ALPHA_ACTIVATED
+    alphaActivated = true;
+    glutDisplayMode |= GLUT_ALPHA;
 #endif
     
     glutInit(&argc, argv);

--- a/tests/test_webgl_context_attributes_sdl.c
+++ b/tests/test_webgl_context_attributes_sdl.c
@@ -36,6 +36,13 @@ int main(int argc, char *argv[]) {
 #else
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
 #endif
+
+#ifdef ALPHA_ACTIVATED
+    alphaActivated = true;
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+#else
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+#endif
     
     SDL_Surface *screen = SDL_SetVideoMode(WINDOWS_SIZE, WINDOWS_SIZE, 32, SDL_OPENGL);
        


### PR DESCRIPTION
Same pull request as https://github.com/kripken/emscripten/pull/3967 but on incoming.
In order to support alpha, which was not the case since alpha was set to false in Browser.createContext