### PR TITLE
Make BINARYEN_ROOT a config file setting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -238,3 +238,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Pierre Krieger <pierre.krieger1708@gmail.com>
 * Jakob Stoklund Olesen <stoklund@2pi.dk>
 * Jérémy Anger <angerj.dev@gmail.com>
+* Derek Schuff <dschuff@chromium.org> (copyright owned by Google, Inc.)

--- a/emcc.py
+++ b/emcc.py
@@ -1774,7 +1774,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.BINARYEN:
       # Emit wasm.js at the top of the js. TODO: for html, it could be a separate script tag
-      binaryen_bin = os.path.join(shared.Settings.BINARYEN, 'bin')
+      binaryen_bin = shared.BINARYEN_ROOT
       wasm_js = open(os.path.join(binaryen_bin, 'wasm.js')).read()
       wasm_js = wasm_js.replace("Module['asmjsCodeFile']", '"' + os.path.basename(asm_target) + '"') # " or '? who knows :)
       wasm_js = wasm_js.replace('Module["asmjsCodeFile"]', '"' + os.path.basename(asm_target) + '"')
@@ -1938,4 +1938,3 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
 if __name__ == '__main__':
   run()
-

--- a/emscripten.py
+++ b/emscripten.py
@@ -1262,9 +1262,9 @@ def emscript_wasm_backend(infile, settings, outfile, outfile_name, libraries=[],
     import shutil
     shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
 
-  assert settings['BINARYEN'], 'need BINARYEN option set so we can use Binaryen s2wasm on the backend output'
+  assert shared.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
   wasm = outfile_name[:-3] + '.wast'
-  s2wasm_args = [os.path.join(settings['BINARYEN'], 'bin', 's2wasm'), temp_s]
+  s2wasm_args = [os.path.join(shared.BINARYEN_ROOT, 's2wasm'), temp_s]
   s2wasm_args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]
   if DEBUG:
     logging.debug('emscript: binaryen s2wasm: ' + ' '.join(s2wasm_args))
@@ -1665,4 +1665,3 @@ WARNING: You should normally never use this! Use emcc instead.
 
 if __name__ == '__main__':
   _main()
-

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -9,6 +9,7 @@ import os
 # this helps projects using emscripten find it
 EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '{{{ EMSCRIPTEN_ROOT }}}') # directory
 LLVM_ROOT = os.path.expanduser(os.getenv('LLVM') or '{{{ LLVM_ROOT }}}') # directory
+BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '{{{ BINARYEN_ROOT }}}') # directory
 
 # If not specified, defaults to sys.executable.
 #PYTHON = 'python'
@@ -54,4 +55,3 @@ COMPILER_ENGINE = NODE_JS
 #                 here because of v8 issue 1822.
 
 JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
-

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -224,6 +224,9 @@ else:
     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
     llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
+    binaryen_root = os.path.dirname(find_executable('asm2wasm') or '/usr/bin/asm2wasm')
+    config_file = config_file.replace('\'{{{ BINARYEN_ROOT }}}\'', repr(binaryen_root))
+
     node = find_executable('nodejs') or find_executable('node') or 'node'
     config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))
     if WINDOWS:


### PR DESCRIPTION
Currently the BINARYEN -s setting is used both as a flag to enable wasm
creation with binaryen, and to specify the path. This change keeps -s
BINARYEN=1 to enable binaryen, but moves the path to a setting called
BINARYEN_ROOT in the config file, alongside LLVM_ROOT and
EMSCRIPTEN_ROOT. It also makes the path include the 'bin' directory for
consistency with those directories.