### PR TITLE
fix_bits_symlink

### DIFF
--- a/system/include/libc/bits
+++ b/system/include/libc/bits
@@ -1,1 +1,1 @@
-../arch/emscripten/bits
+../../lib/libc/musl/arch/emscripten/bits


### PR DESCRIPTION
Fix broken symlink system/include/libc/bits to point to /system/lib/libc/musl/arch/emscripten/bits