### PR TITLE
ntohs is implemented in C, list it in deps.json

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -22,6 +22,8 @@
   "gethostbyname": ["malloc"],
   "gethostbyname_r": ["free"],
   "getaddrinfo": ["malloc", "htonl", "htons", "ntohs"],
+  "_inet_ntop6_raw": ["ntohs"],
+  "_read_sockaddr": ["ntohs"],
   "freeaddrinfo": ["free"],
   "gai_strerror": ["malloc"],
   "setprotoent": ["malloc"],

--- a/src/library.js
+++ b/src/library.js
@@ -3033,7 +3033,7 @@ LibraryManager.library = {
     }
     return 1;
   },
-  _inet_ntop6_raw__deps: ['ntohs', '_inet_ntop4_raw'],
+  _inet_ntop6_raw__deps: ['_inet_ntop4_raw'],
   _inet_ntop6_raw: function(ints) {
     //  ref:  http://www.ietf.org/rfc/rfc2373.txt - section 2.5.4
     //  Format for IPv4 compatible and mapped  128-bit IPv6 Addresses


### PR DESCRIPTION
...instead of library.js.

Additionally list it for _read_sockaddr which uses it on the third line of the function - https://github.com/kripken/emscripten/blob/master/src/library.js#L3129