### PR TITLE
delete_stacktop

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1203,6 +1203,12 @@ Runtime.setDynamicTop = asm['setDynamicTop'];
 Runtime.setTempRet0 = asm['setTempRet0'];
 Runtime.getTempRet0 = asm['getTempRet0'];
 ''')
+    funcs_js.append('''delete STACKTOP;
+''')
+    if settings['ASSERTIONS']:
+      # Some older browsers have had bugs with deleting variables from the global object, so test that it succeeds.
+      funcs_js.append('''assert(typeof STACKTOP === 'undefined');
+''')
 
     # Set function table masks
     masks = {}

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -885,7 +885,8 @@ function updateGlobalBufferViews() {
 }
 
 var STATIC_BASE = 0, STATICTOP = 0, staticSealed = false; // static area
-var STACK_BASE = 0, STACKTOP = 0, STACK_MAX = 0; // stack area
+var STACK_BASE = 0, STACK_MAX = 0; // stack area
+STACKTOP = 0; // Create without 'var' keyword to make this a deletable property. After the asm.js module has been created, STACKTOP is managed inside asm.js module and this variable is deleted.
 var DYNAMIC_BASE = 0, DYNAMICTOP = 0; // dynamic area handled by sbrk
 
 #if USE_PTHREADS


### PR DESCRIPTION
Explicitly delete the STACKTOP variable in global scope after ownership of maintaining that variable has been passed to the asm.js module. This is to avoid the footgun that code outside the asm.js module might accidentally refer to the old STACKTOP variable that had stale contents.
