### PR TITLE
Missed pthread_rwlock_unlock stub in pthreads_stub

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -239,3 +239,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jakob Stoklund Olesen <stoklund@2pi.dk>
 * Jérémy Anger <angerj.dev@gmail.com>
 * Derek Schuff <dschuff@chromium.org> (copyright owned by Google, Inc.)
+* Ashley Sommer <flubba86@gmail.com>

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -171,6 +171,7 @@ var LibraryPThreadStub = {
   pthread_rwlock_wrlock: function() { return 0; },
   pthread_rwlock_trywrlock: function() { return 0; },
   pthread_rwlock_timedwrlock: function() { return 0; },
+  pthread_rwlock_unlock: function() { return 0; },
 
   pthread_rwlockattr_init: function() { return 0; },
   pthread_rwlockattr_destroy: function() { return 0; },


### PR DESCRIPTION
I have some code which is failing with " `pthread_rwlock_unlock` is unimplemented. "
Looks like `pthread_rwlock_unlock` was missed when adding the extra pthread stubs in this commit: https://github.com/kripken/emscripten/commit/aa8a1ac54a70173b99101fcff3847e4e12c70698