### PR TITLE
Prevent the name minifier choosing 'void' as a variable name

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -2234,7 +2234,7 @@ function getStackBumpSize(ast) {
 
 // Name minification
 
-var RESERVED = set('do', 'if', 'in', 'for', 'new', 'try', 'var', 'env', 'let');
+var RESERVED = set('do', 'if', 'in', 'for', 'new', 'try', 'var', 'env', 'let', 'case', 'else', 'enum', 'void', 'this', 'void', 'with');
 var VALID_MIN_INITS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$';
 var VALID_MIN_LATERS = VALID_MIN_INITS + '0123456789';
 

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3572,7 +3572,7 @@ void registerizeHarder(Ref ast) {
 // end registerizeHarder
 
 // minified names generation
-StringSet RESERVED("do if in for new try var env let");
+StringSet RESERVED("do if in for new try var env let case else enum this void with");
 const char *VALID_MIN_INITS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$";
 const char *VALID_MIN_LATERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$0123456789";
 


### PR DESCRIPTION
Yes, I really did have enough functions to get all the way up to `void` in the naming!