### PR TITLE
Update sdl2 net port

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -155,6 +155,8 @@ if operation == 'build':
       build_port('sdl2', 'libsdl2.bc', ['-s', 'USE_SDL=2'])
     elif what == 'sdl2-image':
       build_port('sdl2-image', 'libsdl2_image.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'])
+    elif what == 'sdl2-net':
+      build_port('sdl2-net', 'libsdl2_net.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
     elif what == 'freetype':
       build_port('freetype', 'libfreetype.a', ['-s', 'USE_FREETYPE=1'])
     elif what == 'sdl2-ttf':

--- a/embuilder.py
+++ b/embuilder.py
@@ -41,6 +41,7 @@ Available operations and tasks:
         sdl2
         sdl2-image
         sdl2-ttf
+        sdl2-net
         vorbis
         zlib
 
@@ -79,7 +80,7 @@ operation = sys.argv[1]
 if operation == 'build':
   tasks = sys.argv[2:]
   if 'ALL' in tasks:
-    tasks = ['libc', 'libc-mt', 'dlmalloc', 'dlmalloc_threadsafe', 'pthreads', 'libcxx', 'libcxx_noexcept', 'libcxxabi', 'gl', 'bullet', 'freetype', 'libpng', 'ogg', 'sdl2', 'sdl2-image', 'vorbis', 'zlib']
+    tasks = ['libc', 'libc-mt', 'dlmalloc', 'dlmalloc_threadsafe', 'pthreads', 'libcxx', 'libcxx_noexcept', 'libcxxabi', 'gl', 'bullet', 'freetype', 'libpng', 'ogg', 'sdl2', 'sdl2-image', 'sdl2-ttf', 'sdl2-net', 'vorbis', 'zlib']
     if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER'):
       print 'Skipping building of native-optimizer since environment variable EMSCRIPTEN_NATIVE_OPTIMIZER is present and set to point to a prebuilt native optimizer path.'
     elif hasattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER'):

--- a/site/source/docs/compiling/Building-Projects.rst
+++ b/site/source/docs/compiling/Building-Projects.rst
@@ -176,6 +176,8 @@ You should see some notifications about SDL2 being used, and built if it wasn't 
 
 .. note:: *SDL_image* has also been added to ports, use it with ``-s USE_SDL_IMAGE=2``. To see a list of all available ports, run ``emcc --show-ports``. For SDL2_image to be useful, you generally need to specify the image formats you are planning on using with -s SDL2_IMAGE_FORMATS='["png"]'. This will also ensure that ``IMG_Init`` works properly. Alternatively, you can use specify ``emcc --use-preload-plugins`` (and ``--preload-file`` your images, so the browser codecs decode them), but then your calls to ``IMG_Init`` will fail.
 
+.. note:: *SDL_net* has also been added to ports, use it with ``-s USE_SDL_NET=2``. To see a list of all available ports, run ``emcc --show-ports``.
+
 .. note:: Emscripten also has support for older SDL1, which is built-in. If you do not specify SDL2 as in the command above, then SDL1 is linked in and the SDL1 include paths are used. SDL1 has support for *sdl-config*, which is present in `system/bin <https://github.com/kripken/emscripten/blob/master/system/bin/sdl-config>`_. Using the native *sdl-config* may result in compilation or missing-symbol errors. You will need to modify the build system to look for files in **emscripten/system** or **emscripten/system/bin** in order to use the Emscripten *sdl-config*.
 
 Adding more ports

--- a/src/settings.js
+++ b/src/settings.js
@@ -642,6 +642,7 @@ var USE_SDL = 1; // Specify the SDL version that is being linked against.
                  // 2 is a port of the SDL C code on emscripten-ports
 var USE_SDL_IMAGE = 1; // Specify the SDL_image version that is being linked against. Must match USE_SDL
 var USE_SDL_TTF = 1; // Specify the SDL_ttf version that is being linked against. Must match USE_SDL
+var USE_SDL_NET = 1; // Specify the SDL_net version that is being linked against. Must match USE_SDL
 var USE_ZLIB = 0; // 1 = use zlib from emscripten-ports
 var USE_LIBPNG = 0; // 1 = use libpng from emscripten-ports
 var USE_BULLET = 0; // 1 = use bullet from emscripten-ports

--- a/tests/sdl2_net_client.c
+++ b/tests/sdl2_net_client.c
@@ -7,70 +7,127 @@
  *
  * emcc -Wall sdl2_net_client.c -s USE_SDL_NET=2 -s USE_SDL=2 -o sdl2_net_client.js
  */
- 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
- 
+#include <errno.h>
+#include <assert.h>
+
 #include "SDL_net.h"
- 
+
+typedef enum {
+  MSG_READ,
+  MSG_WRITE
+} msg_state_t;
+
+typedef struct {
+    TCPsocket sd; /* Socket descriptor */
+    msg_state_t msg_state;
+    int msg_i;
+} state_t;
+
+state_t state;
+
+void finish(int result) {
+  if (state.sd) {
+    SDLNet_TCP_Close(state.sd);
+    SDLNet_Quit();
+  }
+#ifdef __EMSCRIPTEN__
+  REPORT_RESULT();
+  emscripten_force_exit(result);
+#else
+  exit(result);
+#endif
+}
+
+char *msgs[] = {
+  "testmsg1",
+  "anothertestmsg",
+  "exit",
+};
+
+void main_loop()
+{
+  char *sendbuf = msgs[state.msg_i];
+  char recvbuf[256] = {0};
+  int actual = 0, len = strlen(sendbuf) + 1;
+  printf("main loop with string %s and len %d\n", sendbuf, len);
+
+  if (state.msg_state == MSG_WRITE) {
+    printf("trying to send %s\n", sendbuf);
+    if ((actual = SDLNet_TCP_Send(state.sd, (void *)sendbuf, len)) != len)
+    {
+      fprintf(stderr, "SDLNet_TCP_Send: count:%d/%d errno:%d msg:%s\n",
+        actual, len, errno, SDLNet_GetError());
+      if (errno == EAGAIN) {
+        if (actual > 0) {
+          assert(0);
+        }
+        return;
+      }
+      finish(EXIT_FAILURE);
+    }
+    printf("send success\n");
+    state.msg_state = MSG_READ;
+  }
+  if (state.msg_state == MSG_READ) {
+    printf("trying to receive %s\n", sendbuf);
+    if ((actual = SDLNet_TCP_Recv(state.sd, (void *)recvbuf, len)) != len)
+    {
+      fprintf(stderr, "SDLNet_TCP_Recv: count:%d/%d errno:%d msg:%s\n",
+        actual, len, errno, SDLNet_GetError());
+      if (errno == EAGAIN) {
+        if (actual > 0) {
+          assert(0);
+        }
+        return;
+      }
+      finish(EXIT_FAILURE);
+    }
+    printf("receive success\n");
+    assert(strcmp(sendbuf, recvbuf) == 0);
+    if (!strcmp(recvbuf, "exit")) {
+      finish(EXIT_SUCCESS);
+    }
+    state.msg_i++;
+    state.msg_state = MSG_WRITE;
+  }
+}
+
 int main(int argc, char **argv)
 {
   IPaddress ip;   /* Server address */
-  TCPsocket sd;   /* Socket descriptor */
-  int quit, len;
-  char buffer[512];
- 
-  /* Simple parameter checking */
-  if (argc < 3)
-  {
-    fprintf(stderr, "Usage: %s host port\n", argv[0]);
-    exit(EXIT_FAILURE);
-  }
- 
+  memset(&state, 0, sizeof(state_t));
+  state.msg_state = MSG_WRITE;
+
   if (SDLNet_Init() < 0)
   {
     fprintf(stderr, "SDLNet_Init: %s\n", SDLNet_GetError());
-    exit(EXIT_FAILURE);
+    finish(EXIT_FAILURE);
   }
- 
+
   /* Resolve the host we are connecting to */
-  if (SDLNet_ResolveHost(&ip, argv[1], atoi(argv[2])) < 0)
+  if (SDLNet_ResolveHost(&ip, "localhost", SOCKK) < 0)
   {
     fprintf(stderr, "SDLNet_ResolveHost: %s\n", SDLNet_GetError());
-    exit(EXIT_FAILURE);
+    finish(EXIT_FAILURE);
   }
- 
-  /* Open a connection with the IP provided (listen on the host's port) */
-  if (!(sd = SDLNet_TCP_Open(&ip)))
+
+  /* Open a connection with the IP provided */
+  if (!(state.sd = SDLNet_TCP_Open(&ip)))
   {
     fprintf(stderr, "SDLNet_TCP_Open: %s\n", SDLNet_GetError());
-    exit(EXIT_FAILURE);
+    finish(EXIT_FAILURE);
   }
- 
+
   /* Send messages */
-  quit = 0;
-  while (!quit)
-  {
-    printf("Write something:\n>");
-    scanf("%s", buffer);
- 
-    len = strlen(buffer) + 1;
-    if (SDLNet_TCP_Send(sd, (void *)buffer, len) < len)
-    {
-      fprintf(stderr, "SDLNet_TCP_Send: %s\n", SDLNet_GetError());
-      exit(EXIT_FAILURE);
-    }
- 
-    if(strcmp(buffer, "exit") == 0)
-      quit = 1;
-    if(strcmp(buffer, "quit") == 0)
-      quit = 1;
-  }
- 
-  SDLNet_TCP_Close(sd);
-  SDLNet_Quit();
- 
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(main_loop, 60, 0);
+#else
+  while (1) main_loop();
+#endif
+
   return EXIT_SUCCESS;
 }
-

--- a/tests/sdl2_net_client.c
+++ b/tests/sdl2_net_client.c
@@ -1,0 +1,76 @@
+/*
+ * Compile with:
+ *
+ * gcc -Wall `sdl-config --cflags` sdl2_net_client.c -o sdl2_net_client `sdl-config --libs` -lSDL_net
+ *
+ * or
+ *
+ * emcc -Wall sdl2_net_client.c -s USE_SDL_NET=2 -s USE_SDL=2 -o sdl2_net_client.js
+ */
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+ 
+#include "SDL_net.h"
+ 
+int main(int argc, char **argv)
+{
+  IPaddress ip;   /* Server address */
+  TCPsocket sd;   /* Socket descriptor */
+  int quit, len;
+  char buffer[512];
+ 
+  /* Simple parameter checking */
+  if (argc < 3)
+  {
+    fprintf(stderr, "Usage: %s host port\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+ 
+  if (SDLNet_Init() < 0)
+  {
+    fprintf(stderr, "SDLNet_Init: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+ 
+  /* Resolve the host we are connecting to */
+  if (SDLNet_ResolveHost(&ip, argv[1], atoi(argv[2])) < 0)
+  {
+    fprintf(stderr, "SDLNet_ResolveHost: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+ 
+  /* Open a connection with the IP provided (listen on the host's port) */
+  if (!(sd = SDLNet_TCP_Open(&ip)))
+  {
+    fprintf(stderr, "SDLNet_TCP_Open: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+ 
+  /* Send messages */
+  quit = 0;
+  while (!quit)
+  {
+    printf("Write something:\n>");
+    scanf("%s", buffer);
+ 
+    len = strlen(buffer) + 1;
+    if (SDLNet_TCP_Send(sd, (void *)buffer, len) < len)
+    {
+      fprintf(stderr, "SDLNet_TCP_Send: %s\n", SDLNet_GetError());
+      exit(EXIT_FAILURE);
+    }
+ 
+    if(strcmp(buffer, "exit") == 0)
+      quit = 1;
+    if(strcmp(buffer, "quit") == 0)
+      quit = 1;
+  }
+ 
+  SDLNet_TCP_Close(sd);
+  SDLNet_Quit();
+ 
+  return EXIT_SUCCESS;
+}
+

--- a/tests/sdl2_net_server.c
+++ b/tests/sdl2_net_server.c
@@ -1,0 +1,144 @@
+/*
+ * Compile with:
+ *
+ * gcc -Wall `sdl-config --cflags` sdl2_net_server.c -o sdl2_net_server `sdl-config --libs` -lSDL_net
+ *
+ * or
+ *
+ * emcc -Wall sdl2_net_server.c -s USE_SDL_NET=2 -s USE_SDL=2 -o sdl2_net_server.js
+ */
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+ 
+#include "SDL_net.h"
+
+#define MAX_SOCKETS 128
+#define MAX_CLIENTS MAX_SOCKETS - 1
+ 
+int main(int argc, char **argv)
+{
+  TCPsocket sd; /* Socket descriptor, Client socket descriptor */
+  IPaddress ip, *remoteIP;
+  int quit;
+  char buffer[512];
+  TCPsocket clientSocket[MAX_CLIENTS];
+ 
+  if (SDLNet_Init() < 0)
+  {
+    fprintf(stderr, "SDLNet_Init: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+ 
+  /* Resolving the host using NULL make network interface to listen */
+  if (SDLNet_ResolveHost(&ip, NULL, 2000) < 0)
+  {
+    fprintf(stderr, "SDLNet_ResolveHost: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+ 
+  SDLNet_SocketSet socketSet = SDLNet_AllocSocketSet(MAX_SOCKETS);
+
+  for (int loop = 0; loop < MAX_CLIENTS; loop++)
+  {
+      clientSocket[loop] = NULL;
+  }
+
+  /* Open a connection with the IP provided (listen on the host's port) */
+  if (!(sd = SDLNet_TCP_Open(&ip)))
+  {
+    fprintf(stderr, "SDLNet_TCP_Open: %s\n", SDLNet_GetError());
+    exit(EXIT_FAILURE);
+  }
+  SDLNet_TCP_AddSocket(socketSet, sd);
+ 
+  /* Wait for a connection, send data and term */
+  quit = 0;
+  while (!quit)
+  {
+    /* Check the sd if there is a pending connection.
+     * If there is one, accept that, and open a new socket for communicating */
+    SDLNet_CheckSockets(socketSet, 20);
+    int serverSocketActivity = SDLNet_SocketReady(sd);
+
+    if (serverSocketActivity)
+    {
+      printf("new server socket activity!\n");
+      TCPsocket csd = SDLNet_TCP_Accept(sd);
+      /* Now we can communicate with the client using csd socket
+       * sd will remain opened waiting other connections */
+ 
+      /* Get the remote address */
+      if ((remoteIP = SDLNet_TCP_GetPeerAddress(csd)))
+      {
+        /* Print the address, converting in the host format */
+        printf("Host connected: %x %d\n", SDLNet_Read32(&remoteIP->host), SDLNet_Read16(&remoteIP->port));
+      } else {
+        fprintf(stderr, "SDLNet_TCP_GetPeerAddress: %s\n", SDLNet_GetError());
+      }
+
+      for (int loop = 0; loop < MAX_CLIENTS; loop++)
+      {
+          if (clientSocket[loop] == NULL)
+          {
+            clientSocket[loop] = csd;
+            SDLNet_TCP_AddSocket(socketSet, clientSocket[loop]);
+            break;
+          }
+      }
+    }
+    for (int clientNumber = 0; clientNumber < MAX_CLIENTS; clientNumber++)
+    {
+      int clientSocketActivity = SDLNet_SocketReady(clientSocket[clientNumber]);
+
+      if (clientSocketActivity != 0)
+      {
+        int recvLen = SDLNet_TCP_Recv(clientSocket[clientNumber], buffer, 512); 
+        if (recvLen > 0)
+        {
+          int trim = 0;
+          for (int i = recvLen; i > 0; i++) {
+            if (buffer[i] == '\r' || buffer[i] == '\n' || buffer[i] == ' ') {
+              trim++;
+            } else {
+              break;
+            }
+          }
+          buffer[recvLen - trim] = 0;
+          printf("Client %d says: %s\n", clientNumber, buffer);
+ 
+          if(strcmp(buffer, "exit") == 0) /* Terminate this connection */
+          {
+            printf("Terminate connection\n");
+            SDLNet_TCP_Close(clientSocket[clientNumber]);
+            clientSocket[clientNumber] = NULL;
+          }
+          if(strcmp(buffer, "quit") == 0) /* Quit the program */
+          {
+            quit = 1;
+            printf("Quit program\n");
+          }
+        } else {
+          SDLNet_TCP_Close(clientSocket[clientNumber]);
+          clientSocket[clientNumber] = NULL;
+        }
+      } 
+    }
+  }
+ 
+  printf("Shutting down...\n");
+  SDLNet_TCP_Close(sd);
+  for (int loop = 0; loop < MAX_CLIENTS; loop++)
+  {
+    if (clientSocket[loop] != NULL) 
+    {
+      SDLNet_TCP_Close(clientSocket[loop]);
+      clientSocket[loop] = NULL;
+    }
+  }
+  SDLNet_Quit();
+ 
+  return EXIT_SUCCESS;
+}
+

--- a/tests/sdl2_net_server.c
+++ b/tests/sdl2_net_server.c
@@ -7,138 +7,159 @@
  *
  * emcc -Wall sdl2_net_server.c -s USE_SDL_NET=2 -s USE_SDL=2 -o sdl2_net_server.js
  */
- 
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <string.h>
- 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #include "SDL_net.h"
 
 #define MAX_SOCKETS 128
 #define MAX_CLIENTS MAX_SOCKETS - 1
- 
+
+typedef struct {
+  TCPsocket clientSocket[MAX_CLIENTS];
+  SDLNet_SocketSet socketSet;
+  TCPsocket sd; /* Socket descriptor, Client socket descriptor */
+} state_t;
+
+state_t state;
+
+void finish() { // untested
+  printf("Shutting down...\n");
+  SDLNet_TCP_Close(state.sd);
+  for (int loop = 0; loop < MAX_CLIENTS; loop++)
+  {
+    if (state.clientSocket[loop] != NULL)
+    {
+      SDLNet_TCP_Close(state.clientSocket[loop]);
+      state.clientSocket[loop] = NULL;
+    }
+  }
+  SDLNet_Quit();
+
+#ifdef __EMSCRIPTEN__
+  emscripten_force_exit(0);
+#else
+  exit(0);
+#endif
+}
+
+void main_loop() {
+  char buffer[512];
+  IPaddress *remoteIP;
+
+  /* Check the sd if there is a pending connection.
+   * If there is one, accept that, and open a new socket for communicating */
+  SDLNet_CheckSockets(state.socketSet, 20);
+  int serverSocketActivity = SDLNet_SocketReady(state.sd);
+
+  if (serverSocketActivity)
+  {
+    printf("new server socket activity!\n");
+    TCPsocket csd = SDLNet_TCP_Accept(state.sd);
+    /* Now we can communicate with the client using csd socket
+     * sd will remain opened waiting other connections */
+
+    /* Get the remote address */
+    if ((remoteIP = SDLNet_TCP_GetPeerAddress(csd)))
+    {
+      /* Print the address, converting in the host format */
+      printf("Host connected: %x %d\n", SDLNet_Read32(&remoteIP->host), SDLNet_Read16(&remoteIP->port));
+    } else {
+      fprintf(stderr, "SDLNet_TCP_GetPeerAddress: %s\n", SDLNet_GetError());
+    }
+
+    for (int loop = 0; loop < MAX_CLIENTS; loop++)
+    {
+        if (state.clientSocket[loop] == NULL)
+        {
+          state.clientSocket[loop] = csd;
+          SDLNet_TCP_AddSocket(state.socketSet, state.clientSocket[loop]);
+          break;
+        }
+    }
+  }
+  for (int clientNumber = 0; clientNumber < MAX_CLIENTS; clientNumber++)
+  {
+    int clientSocketActivity = SDLNet_SocketReady(state.clientSocket[clientNumber]);
+
+    if (clientSocketActivity != 0)
+    {
+      int recvLen = SDLNet_TCP_Recv(state.clientSocket[clientNumber], buffer, 512);
+      if (recvLen > 0)
+      {
+        assert(buffer[recvLen-1] == '\0');
+
+        printf("Client %d says: %s\n", clientNumber, buffer);
+        if (SDLNet_TCP_Send(state.clientSocket[clientNumber], buffer, recvLen) < recvLen) {
+          printf("Failed to echo message %s\n", buffer);
+        } else {
+          printf("Echoed back %d bytes\n", recvLen);
+        }
+
+        if(strcmp(buffer, "exit") == 0) /* Terminate this connection */
+        {
+          printf("Terminate connection\n");
+          SDLNet_TCP_Close(state.clientSocket[clientNumber]);
+          state.clientSocket[clientNumber] = NULL;
+        }
+        if(strcmp(buffer, "quit") == 0) /* Quit the program */
+        {
+          printf("Quit program\n");
+          finish();
+        }
+      } else {
+        printf("Closing client socket\n");
+        SDLNet_TCP_Close(state.clientSocket[clientNumber]);
+        state.clientSocket[clientNumber] = NULL;
+      }
+    }
+  }
+}
+
 int main(int argc, char **argv)
 {
-  TCPsocket sd; /* Socket descriptor, Client socket descriptor */
-  IPaddress ip, *remoteIP;
-  int quit;
-  char buffer[512];
-  TCPsocket clientSocket[MAX_CLIENTS];
- 
+  IPaddress ip;
+
   if (SDLNet_Init() < 0)
   {
     fprintf(stderr, "SDLNet_Init: %s\n", SDLNet_GetError());
     exit(EXIT_FAILURE);
   }
- 
+
   /* Resolving the host using NULL make network interface to listen */
-  if (SDLNet_ResolveHost(&ip, NULL, 2000) < 0)
+  if (SDLNet_ResolveHost(&ip, INADDR_ANY, SOCKK) < 0)
   {
     fprintf(stderr, "SDLNet_ResolveHost: %s\n", SDLNet_GetError());
     exit(EXIT_FAILURE);
   }
- 
-  SDLNet_SocketSet socketSet = SDLNet_AllocSocketSet(MAX_SOCKETS);
+
+  state.socketSet = SDLNet_AllocSocketSet(MAX_SOCKETS);
 
   for (int loop = 0; loop < MAX_CLIENTS; loop++)
   {
-      clientSocket[loop] = NULL;
+      state.clientSocket[loop] = NULL;
   }
-
   /* Open a connection with the IP provided (listen on the host's port) */
-  if (!(sd = SDLNet_TCP_Open(&ip)))
+  if (!(state.sd = SDLNet_TCP_Open(&ip)))
   {
     fprintf(stderr, "SDLNet_TCP_Open: %s\n", SDLNet_GetError());
     exit(EXIT_FAILURE);
   }
-  SDLNet_TCP_AddSocket(socketSet, sd);
- 
+  SDLNet_TCP_AddSocket(state.socketSet, state.sd);
+
   /* Wait for a connection, send data and term */
-  quit = 0;
-  while (!quit)
-  {
-    /* Check the sd if there is a pending connection.
-     * If there is one, accept that, and open a new socket for communicating */
-    SDLNet_CheckSockets(socketSet, 20);
-    int serverSocketActivity = SDLNet_SocketReady(sd);
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(main_loop, 60, 0);
+#else
+  while (1) main_loop();
+#endif
 
-    if (serverSocketActivity)
-    {
-      printf("new server socket activity!\n");
-      TCPsocket csd = SDLNet_TCP_Accept(sd);
-      /* Now we can communicate with the client using csd socket
-       * sd will remain opened waiting other connections */
- 
-      /* Get the remote address */
-      if ((remoteIP = SDLNet_TCP_GetPeerAddress(csd)))
-      {
-        /* Print the address, converting in the host format */
-        printf("Host connected: %x %d\n", SDLNet_Read32(&remoteIP->host), SDLNet_Read16(&remoteIP->port));
-      } else {
-        fprintf(stderr, "SDLNet_TCP_GetPeerAddress: %s\n", SDLNet_GetError());
-      }
-
-      for (int loop = 0; loop < MAX_CLIENTS; loop++)
-      {
-          if (clientSocket[loop] == NULL)
-          {
-            clientSocket[loop] = csd;
-            SDLNet_TCP_AddSocket(socketSet, clientSocket[loop]);
-            break;
-          }
-      }
-    }
-    for (int clientNumber = 0; clientNumber < MAX_CLIENTS; clientNumber++)
-    {
-      int clientSocketActivity = SDLNet_SocketReady(clientSocket[clientNumber]);
-
-      if (clientSocketActivity != 0)
-      {
-        int recvLen = SDLNet_TCP_Recv(clientSocket[clientNumber], buffer, 512); 
-        if (recvLen > 0)
-        {
-          int trim = 0;
-          for (int i = recvLen; i > 0; i++) {
-            if (buffer[i] == '\r' || buffer[i] == '\n' || buffer[i] == ' ') {
-              trim++;
-            } else {
-              break;
-            }
-          }
-          buffer[recvLen - trim] = 0;
-          printf("Client %d says: %s\n", clientNumber, buffer);
- 
-          if(strcmp(buffer, "exit") == 0) /* Terminate this connection */
-          {
-            printf("Terminate connection\n");
-            SDLNet_TCP_Close(clientSocket[clientNumber]);
-            clientSocket[clientNumber] = NULL;
-          }
-          if(strcmp(buffer, "quit") == 0) /* Quit the program */
-          {
-            quit = 1;
-            printf("Quit program\n");
-          }
-        } else {
-          SDLNet_TCP_Close(clientSocket[clientNumber]);
-          clientSocket[clientNumber] = NULL;
-        }
-      } 
-    }
-  }
- 
-  printf("Shutting down...\n");
-  SDLNet_TCP_Close(sd);
-  for (int loop = 0; loop < MAX_CLIENTS; loop++)
-  {
-    if (clientSocket[loop] != NULL) 
-    {
-      SDLNet_TCP_Close(clientSocket[loop]);
-      clientSocket[loop] = NULL;
-    }
-  }
-  SDLNet_Quit();
- 
   return EXIT_SUCCESS;
 }
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -715,7 +715,7 @@ fi
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-image'], ['success'], True, [os.path.join('ports-builds', 'sdl2-image', 'libsdl2_image.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'freetype'], ['building and verifying freetype', 'success'], True, [os.path.join('ports-builds', 'freetype', 'libfreetype.a')]),
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-ttf'], ['building and verifying sdl2-ttf', 'success'], True, [os.path.join('ports-builds', 'sdl2-ttf', 'libsdl2_ttf.bc')]),
-      ([PYTHON, 'embuilder.py', 'build', 'sdl2-net'], ['success'], True, [os.path.join('ports-builds', 'sdl2-net', 'libsdl2_net.bc')]),
+      ([PYTHON, 'embuilder.py', 'build', 'sdl2-net'], ['building and verifying sdl2-net', 'success'], True, [os.path.join('ports-builds', 'sdl2-net', 'libsdl2_net.bc')]),
     ]:
       print command
       Cache.erase()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -546,6 +546,7 @@ fi
     assert 'Available ports:' in out, out
     assert 'SDL2' in out, out
     assert 'SDL2_image' in out, out
+    assert 'SDL2_net' in out, out
 
     # using ports
 
@@ -714,6 +715,7 @@ fi
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-image'], ['success'], True, [os.path.join('ports-builds', 'sdl2-image', 'libsdl2_image.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'freetype'], ['building and verifying freetype', 'success'], True, [os.path.join('ports-builds', 'freetype', 'libfreetype.a')]),
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-ttf'], ['building and verifying sdl2-ttf', 'success'], True, [os.path.join('ports-builds', 'sdl2-ttf', 'libsdl2_ttf.bc')]),
+      ([PYTHON, 'embuilder.py', 'build', 'sdl2-net'], ['success'], True, [os.path.join('ports-builds', 'sdl2-net', 'libsdl2_net.bc')]),
     ]:
       print command
       Cache.erase()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -354,6 +354,11 @@ ok.
       with harness:
         self.btest(os.path.join('sockets', 'test_sockets_echo_client.c'), expected='0', args=['-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram, sockets_include])
 
+  def test_sdl2_sockets_echo(self):
+    harness = CompiledServerHarness('sdl2_net_server.c', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'], 49164)
+    with harness:
+      self.btest('sdl2_net_client.c', expected='0', args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2', '-DSOCKK=%d' % harness.listen_port])
+
   def test_sockets_async_echo(self):
     if WINDOWS: return self.skip('This test is Unix-specific.')
     # Run with ./runner.py sockets.test_sockets_async_echo

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -1,4 +1,4 @@
-import bullet, freetype, libpng, ogg, sdl, sdl_image, sdl_ttf, vorbis, zlib
+import bullet, freetype, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
-ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, sdl_ttf]
+ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, sdl_ttf, sdl_net]

--- a/tools/ports/sdl_net.py
+++ b/tools/ports/sdl_net.py
@@ -1,0 +1,38 @@
+import os, shutil, logging
+
+TAG = 'version_1'
+
+def get(ports, settings, shared):
+  if settings.USE_SDL_NET == 2:
+    sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
+    assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_net'
+    ports.fetch_project('sdl2-net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG)
+    def create():
+      logging.warning('building port: sdl2-net')
+      shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_net.h'))
+      shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_net.h'))
+      srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split(' ')
+      commands = []
+      o_s = []
+      for src in srcs:
+        o = os.path.join(ports.get_build_dir(), 'sdl2-net', src + '.o')
+        commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
+        o_s.append(o)
+      shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
+      ports.run_commands(commands)
+      final = os.path.join(ports.get_build_dir(), 'sdl2-net', 'libsdl2_net.bc')
+      shared.Building.link(o_s, final)
+      return final
+    return [shared.Cache.get('sdl2-net', create)]
+  else:
+    return []
+
+def process_args(ports, args, settings, shared):
+  if settings.USE_SDL_NET == 2:
+    get(ports, settings, shared)
+    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2-net', 'include')]
+  return args
+
+def show():
+  return 'SDL2_net (zlib license)'
+

--- a/tools/ports/sdl_net.py
+++ b/tools/ports/sdl_net.py
@@ -23,14 +23,13 @@ def get(ports, settings, shared):
       final = os.path.join(ports.get_build_dir(), 'sdl2-net', 'libsdl2_net.bc')
       shared.Building.link(o_s, final)
       return final
-    return [shared.Cache.get('sdl2-net', create)]
+    return [shared.Cache.get('sdl2-net', create, what='port')]
   else:
     return []
 
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL_NET == 2:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2-net', 'include')]
   return args
 
 def show():


### PR DESCRIPTION
I've rebased @jbaicoianu's PR (#3241), made some minor tweaks to make sdl2-net consistent with the other sdl2 components and added a test. This uses CompiledServerHarness (i.e. emscriptened server and client) rather than WebsockifyServerHarness (i.e. native server and emscriptened client) because the end user may not have the native sdl2-net installed.

This requires https://github.com/emscripten-ports/SDL2_net/pull/1 to be merged, as sdl2-net apparently doesn't understand EINPROGRESS which emscripten always returns.

I want to note here that sdl2-net behaviour under emscripten doesn't always match up with the documentation (https://www.libsdl.org/projects/SDL_net/docs/SDL_net.html). This test is a pretty important example! E.g. the official docs have the following to say about `SDLNet_TCP_Send`:

> Returns: the number of bytes sent. If the number returned is less than len, then an error occured, such as the client disconnecting.

This is misleading because the error could be EAGAIN, which isn't really an error (hence I've had to handle it in the tests). I also believe that this statement about `SDLNet_TCP_Recv` is not true:

> If you read more than is sent from the other end, then it will wait until the full requested length is sent, or until the connection is closed from the other end.

Again because of EAGAIN handling, but I'm not 100% sure.

Closes #3241.