### PR TITLE
path is not defined -> use nodePath

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -240,3 +240,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jérémy Anger <angerj.dev@gmail.com>
 * Derek Schuff <dschuff@chromium.org> (copyright owned by Google, Inc.)
 * Ashley Sommer <flubba86@gmail.com>
+* Lars-Magnus Skog <ralphtheninja@riseup.net>

--- a/src/shell.js
+++ b/src/shell.js
@@ -88,7 +88,7 @@ if (ENVIRONMENT_IS_NODE) {
     var ret = nodeFS['readFileSync'](filename);
     // The path is absolute if the normalized version is the same as the resolved.
     if (!ret && filename != nodePath['resolve'](filename)) {
-      filename = path.join(__dirname, '..', 'src', filename);
+      filename = nodePath['join'](__dirname, '..', 'src', filename);
       ret = nodeFS['readFileSync'](filename);
     }
     if (ret && !binary) ret = ret.toString();


### PR DESCRIPTION
`path` is undefined so `path.join()` will crash, use `nodePath['join']` instead.

I'm not sure how to test this, feel free to give feedback so I can correct that if needed.