### PR TITLE
Add support for pretty printing Emscripten heap objects

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1522,8 +1522,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if DEBUG:
           # Copy into temp dir as well, so can be run there too
           shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-
-          return 'memoryInitializer = "%s";' % os.path.basename(memfile)
+        return 'memoryInitializer = "%s";' % os.path.basename(memfile)
       src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
       open(final + '.mem.js', 'w').write(src)
       final += '.mem.js'

--- a/emcc.py
+++ b/emcc.py
@@ -1118,6 +1118,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.CYBERDWARF:
       newargs.append('-g')
+      shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
       js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
       js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
 
@@ -1521,9 +1522,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if DEBUG:
           # Copy into temp dir as well, so can be run there too
           shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-        if shared.Settings.CYBERDWARF:
-          return 'memoryInitializer = "%s"; emDebugCDFile = "%s";' % (os.path.basename(memfile), os.path.basename(memfile)[:-3] + "cd")
-        else:
+
           return 'memoryInitializer = "%s";' % os.path.basename(memfile)
       src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
       open(final + '.mem.js', 'w').write(src)
@@ -1585,7 +1584,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             passes = ['asm'] + passes
             if shared.Settings.PRECISE_F32:
               passes = ['asmPreciseF32'] + passes
-            if emit_symbol_map or shared.Settings.CYBERDWARF and 'minifyNames' in passes:
+            if (emit_symbol_map or shared.Settings.CYBERDWARF) and 'minifyNames' in passes:
               passes += ['symbolMap='+target+'.symbols']
             if profiling_funcs and 'minifyNames' in passes:
               passes += ['profilingFuncs']

--- a/emcc.py
+++ b/emcc.py
@@ -128,9 +128,9 @@ def run():
         break
 
   if len(sys.argv) == 1 or '--help' in sys.argv:
-    # Documentation for emcc and its options must be updated in: 
+    # Documentation for emcc and its options must be updated in:
     #    site/source/docs/tools_reference/emcc.rst
-    # A prebuilt local version of the documentation is available at: 
+    # A prebuilt local version of the documentation is available at:
     #    site/build/text/docs/tools_reference/emcc.txt
     #    (it is read from there and printed out when --help is invoked)
     # You can also build docs locally as HTML or other formats in site/
@@ -241,7 +241,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         idx += 1
 
     if compiler == shared.EMCC: compiler = [shared.PYTHON, shared.EMCC]
-    else: compiler = [compiler] 
+    else: compiler = [compiler]
     cmd = compiler + list(filter_emscripten_options(sys.argv[1:]))
     if not use_js: cmd += shared.EMSDK_OPTS + ['-D__EMSCRIPTEN__', '-DEMSCRIPTEN']
     if use_js: cmd += ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1'] # configure tests should fail when an undefined symbol exists
@@ -1116,6 +1116,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
       assert not shared.Settings.SPLIT_MEMORY, 'WebAssembly does not support split memory'
 
+    if shared.Settings.CYBERDWARF:
+      newargs.append('-g')
+      js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
+      js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
+
     if tracing:
       if shared.Settings.ALLOW_MEMORY_GROWTH:
         shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
@@ -1302,7 +1307,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     log_time('calculate system libraries')
 
-    # final will be an array if linking is deferred, otherwise a normal string. 
+    # final will be an array if linking is deferred, otherwise a normal string.
     DEFAULT_FINAL = in_temp(target_basename + '.bc')
     def get_final():
       global final
@@ -1357,7 +1362,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     # Optimize, if asked to
     if not LEAVE_INPUTS_RAW:
-      link_opts = [] if debug_level >= 4 else ['-strip-debug'] # remove LLVM debug if we are not asked for it
+      link_opts = [] if debug_level >= 4 or shared.Settings.CYBERDWARF else ['-strip-debug'] # remove LLVM debug if we are not asked for it
       if not shared.Settings.ASSERTIONS:
         link_opts += ['-disable-verify']
 
@@ -1422,6 +1427,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       wasm_temp = final[:-3] + '.wast'
       shutil.move(wasm_temp, wasm_text_target)
       open(wasm_text_target + '.mappedGlobals', 'w').write('{}') # no need for mapped globals for now, but perhaps some day
+
+    if shared.Settings.CYBERDWARF:
+      cd_target = final + '.cd'
+      shutil.move(cd_target, target + '.cd')
 
     log_time('emscript (llvm => executable code)')
 
@@ -1512,7 +1521,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if DEBUG:
           # Copy into temp dir as well, so can be run there too
           shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-        return 'memoryInitializer = "%s";' % os.path.basename(memfile)
+        if shared.Settings.CYBERDWARF:
+          return 'memoryInitializer = "%s"; emDebugCDFile = "%s";' % (os.path.basename(memfile), os.path.basename(memfile)[:-3] + "cd")
+        else:
+          return 'memoryInitializer = "%s";' % os.path.basename(memfile)
       src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
       open(final + '.mem.js', 'w').write(src)
       final += '.mem.js'
@@ -1573,7 +1585,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             passes = ['asm'] + passes
             if shared.Settings.PRECISE_F32:
               passes = ['asmPreciseF32'] + passes
-            if emit_symbol_map and 'minifyNames' in passes:
+            if emit_symbol_map or shared.Settings.CYBERDWARF and 'minifyNames' in passes:
               passes += ['symbolMap='+target+'.symbols']
             if profiling_funcs and 'minifyNames' in passes:
               passes += ['profilingFuncs']
@@ -1795,6 +1807,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     #src = open(final).read()
     #src = re.sub(r'\n+[ \n]*\n+', '\n', src)
     #open(final, 'w').write(src)
+
+    # Bundle symbold data in with the cyberdwarf file
+    if shared.Settings.CYBERDWARF:
+        execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
 
     # Emit source maps, if needed
     if debug_level >= 4:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1159,7 +1159,7 @@ var asm = (function(global, env, buffer) {
        access_quote('asmGlobalArg'), the_global,
        shared_array_buffer,
        access_quote('asmLibraryArg'), sending,
-       "'use asm';" if not metadata.get('hasInlineJS') and settings['ASM_JS'] == 1 and not settings['CYBERDWARF'] else "'almost asm';",
+       "'use asm';" if not metadata.get('hasInlineJS') and settings['ASM_JS'] == 1 else "'almost asm';",
        first_in_asm,
        '''
   var HEAP8 = new global%s(buffer);

--- a/emscripten.py
+++ b/emscripten.py
@@ -130,6 +130,8 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
       backend_args += ['-emscripten-asyncify-whitelist=' + ','.join(settings['ASYNCIFY_WHITELIST'])]
     if settings['NO_EXIT_RUNTIME']:
       backend_args += ['-emscripten-no-exit-runtime']
+    if settings['CYBERDWARF']:
+      backend_args += ['-enable-cyberdwarf']
 
     if DEBUG:
       logging.debug('emscript: llvm backend: ' + ' '.join(backend_args))
@@ -237,6 +239,10 @@ def compiler_glue(metadata, settings, libraries, compiler_engine, temp_files, DE
       if set(syscalls).issubset(set([6, 54, 140, 146])): # close, ioctl, llseek, writev
         if DEBUG: logging.debug('very limited syscalls (%s) so disabling full filesystem support' % ', '.join(map(str, syscalls)))
         settings['NO_FILESYSTEM'] = 1
+
+    if settings['CYBERDWARF']:
+      settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'].append("emdebug_Debugger")
+      settings['EXPORTED_FUNCTIONS'].append("emdebug_Debugger")
 
     # Integrate info from backend
     if settings['SIDE_MODULE']:
@@ -1153,7 +1159,7 @@ var asm = (function(global, env, buffer) {
        access_quote('asmGlobalArg'), the_global,
        shared_array_buffer,
        access_quote('asmLibraryArg'), sending,
-       "'use asm';" if not metadata.get('hasInlineJS') and settings['ASM_JS'] == 1 else "'almost asm';", 
+       "'use asm';" if not metadata.get('hasInlineJS') and settings['ASM_JS'] == 1 and not settings['CYBERDWARF'] else "'almost asm';",
        first_in_asm,
        '''
   var HEAP8 = new global%s(buffer);
@@ -1274,7 +1280,7 @@ Runtime.getTempRet0 = asm['getTempRet0'];
     if settings['SIDE_MODULE']:
       funcs_js.append('''
 Runtime.registerFunctions(%(sigs)s, Module);
-''' % { 'sigs': str(map(str, last_forwarded_json['Functions']['tables'].keys())) }) 
+''' % { 'sigs': str(map(str, last_forwarded_json['Functions']['tables'].keys())) })
 
     for i in range(len(funcs_js)): # do this loop carefully to save memory
       if WINDOWS: funcs_js[i] = funcs_js[i].replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
@@ -1286,6 +1292,12 @@ Runtime.registerFunctions(%(sigs)s, Module);
 
     if DEBUG:
       logging.debug('  emscript: python processing: finalize took %s seconds' % (time.time() - t))
+
+    if settings['CYBERDWARF']:
+      assert('cyberdwarf_data' in metadata)
+      cd_file_name = outfile.name + ".cd"
+      with open(cd_file_name, "w") as cd_file:
+        json.dump({'cyberdwarf': metadata['cyberdwarf_data']}, cd_file)
 
 def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_engine=None,
                           temp_files=None, DEBUG=None):

--- a/src/library_cyberdwarf.js
+++ b/src/library_cyberdwarf.js
@@ -1,0 +1,9 @@
+var LibraryCyberdwarf = {
+  // These are empty, designed to be replaced when a debugger is invoked
+  metadata_llvm_dbg_value_constant: function(a,b,c,d) {
+  },
+  metadata_llvm_dbg_value_local: function(a,b,c,d) {
+  }
+};
+
+mergeInto(LibraryManager.library, LibraryCyberdwarf);

--- a/src/library_debugger_toolkit.js
+++ b/src/library_debugger_toolkit.js
@@ -473,4 +473,4 @@ var EMDebugHeapPrinter = function(cdFileLocation) {
   };
 };
 
-mergeInto(LibraryManager.library, {"emdebug_Debugger": EMDebugHeapPrinter});
+mergeInto(LibraryManager.library, { "emdebug_Debugger": EMDebugHeapPrinter });

--- a/src/library_debugger_toolkit.js
+++ b/src/library_debugger_toolkit.js
@@ -1,0 +1,449 @@
+var EMDebugHeapPrinter = function() {
+  var BASIC_TYPE = 0,
+      DERIVED_TYPE = 1,
+      COMPOSITE_TYPE = 2,
+      SUBROUTINE_TYPE = 3,
+      SUBRANGE_INFO = 4,
+      SUBPROGRAM_TYPE = 5,
+      ENUMERATOR_TYPE = 6,
+      STRING_REFERENCE = 10;
+
+  var DW_TAG_array_type = 0x01,
+      DW_TAG_class_type = 0x02,
+      DW_TAG_entry_point = 0x03,
+      DW_TAG_enumeration_type = 0x04,
+      DW_TAG_formal_parameter = 0x05,
+      DW_TAG_imported_declaration = 0x08,
+      DW_TAG_label = 0x0a,
+      DW_TAG_lexical_block = 0x0b,
+      DW_TAG_member = 0x0d,
+      DW_TAG_pointer_type = 0x0f,
+      DW_TAG_reference_type = 0x10,
+      DW_TAG_compile_unit = 0x11,
+      DW_TAG_string_type = 0x12,
+      DW_TAG_structure_type = 0x13,
+      DW_TAG_subroutine_type = 0x15,
+      DW_TAG_typedef = 0x16,
+      DW_TAG_union_type = 0x17,
+      DW_TAG_unspecified_parameters = 0x18,
+      DW_TAG_variant = 0x19,
+      DW_TAG_common_block = 0x1a,
+      DW_TAG_common_inclusion = 0x1b,
+      DW_TAG_inheritance = 0x1c,
+      DW_TAG_inlined_subroutine = 0x1d,
+      DW_TAG_module = 0x1e,
+      DW_TAG_ptr_to_member_type = 0x1f,
+      DW_TAG_set_type = 0x20,
+      DW_TAG_subrange_type = 0x21,
+      DW_TAG_with_stmt = 0x22,
+      DW_TAG_access_declaration = 0x23,
+      DW_TAG_base_type = 0x24,
+      DW_TAG_catch_block = 0x25,
+      DW_TAG_const_type = 0x26,
+      DW_TAG_constant = 0x27,
+      DW_TAG_enumerator = 0x28,
+      DW_TAG_file_type = 0x29,
+      DW_TAG_friend = 0x2a,
+      DW_TAG_namelist = 0x2b,
+      DW_TAG_namelist_item = 0x2c,
+      DW_TAG_packed_type = 0x2d,
+      DW_TAG_subprogram = 0x2e,
+      DW_TAG_template_type_parameter = 0x2f,
+      DW_TAG_template_value_parameter = 0x30,
+      DW_TAG_thrown_type = 0x31,
+      DW_TAG_try_block = 0x32,
+      DW_TAG_variant_part = 0x33,
+      DW_TAG_variable = 0x34,
+      DW_TAG_volatile_type = 0x35,
+      DW_TAG_dwarf_procedure = 0x36,
+      DW_TAG_restrict_type = 0x37,
+      DW_TAG_interface_type = 0x38,
+      DW_TAG_namespace = 0x39,
+      DW_TAG_imported_module = 0x3a,
+      DW_TAG_unspecified_type = 0x3b,
+      DW_TAG_partial_unit = 0x3c,
+      DW_TAG_imported_unit = 0x3d,
+      DW_TAG_condition = 0x3f,
+      DW_TAG_shared_type = 0x40,
+      DW_TAG_lo_user = 0x4080,
+      DW_TAG_hi_user = 0xffff;
+
+  var DW_ATE_address = 0x01,
+      DW_ATE_boolean = 0x02,
+      DW_ATE_complex_float = 0x03,
+      DW_ATE_float = 0x04,
+      DW_ATE_signed = 0x05,
+      DW_ATE_signed_char = 0x06,
+      DW_ATE_unsigned = 0x07,
+      DW_ATE_unsigned_char = 0x08,
+      DW_ATE_imaginary_float = 0x09,
+      DW_ATE_packed_decimal = 0x0a,
+      DW_ATE_numeric_string = 0x0b,
+      DW_ATE_edited = 0x0c,
+      DW_ATE_signed_fixed = 0x0d,
+      DW_ATE_unsigned_fixed = 0x0e,
+      DW_ATE_decimal_float = 0x0f,
+      DW_ATE_lo_user = 0x80,
+      DW_ATE_hi_user = 0xff;
+
+  var TYPE_ID_IDX = 0,
+      NAME_IDX = 1,
+      TAG_IDX = 2,
+      BASE_TYPE_IDX = 3,
+      OFFSET_IDX = 4,
+      SIZE_IDX = 5,
+      C_ELEMS_IDX = 7;
+
+  function TypedVariable(base_ptr, type_id) {
+    this.derives = [];
+    this.primary = null;
+    this.primary_type_id = "";
+    this.base_ptr = base_ptr;
+
+    this.type_id = type_id;
+    this.built = false;
+    this.resolved = false;
+    this.name = "";
+    this.value = "";
+    this.pointerCount = 0;
+    this.offset = 0;
+    this.size = 0;
+    this.standalone_id = 0;
+    this.dereference = true;
+    this.isMember = false;
+    this.isInherited = false
+  }
+
+  TypedVariable.prototype.toString = function() {
+    return "[TypedVariable < " + JSON.stringify(this.derives) + " > " + JSON.stringify(this.primary) + " (&" + this._getMyAddress() + ")]";
+  }
+
+  TypedVariable.prototype._initialBuild = function() {
+    if (this.built) {
+      return;
+    }
+
+    this.built = true;
+    this._buildDeriveChain();
+    this._processTypes();
+  }
+
+  TypedVariable.prototype._buildDeriveChain = function() {
+    var cur_td = type_id_to_type_descriptor(this.type_id, this.base_ptr);
+
+    var ptr = this.base_ptr;
+
+    while (cur_td[TYPE_ID_IDX] == 1 || cur_td[TYPE_ID_IDX] == 10) {
+      if (cur_td[TYPE_ID_IDX] == 1) {
+        this.derives.push(cur_td);
+        this.primary_type_id = cur_td[BASE_TYPE_IDX];
+        if (cur_td[TAG_IDX] == DW_TAG_member) {
+          ptr += cur_td[OFFSET_IDX];
+        }
+        cur_td = type_id_to_type_descriptor(cur_td[BASE_TYPE_IDX], ptr);
+      } else {
+        this.primary_type_id = cur_td[1];
+        cur_td = type_id_to_type_descriptor(cur_td[1], ptr);
+      }
+    }
+
+    this.primary = cur_td;
+  }
+
+  TypedVariable.prototype._processTypes = function() {
+    var name_vec = [];
+
+    for (var i in this.derives) {
+      switch (this.derives[i][TAG_IDX]) {
+        case DW_TAG_reference_type: {
+          name_vec.unshift("&");
+          this.pointerCount++;
+        } break;
+        case DW_TAG_pointer_type: {
+          name_vec.unshift("*");
+          this.pointerCount++;
+        } break;
+        case DW_TAG_const_type: {
+          name_vec.unshift("const");
+        } break;
+        case DW_TAG_inheritance: {
+          this.isInherited = true;
+          name_vec.unshift(">");
+          this.offset = this.derives[i][OFFSET_IDX] / 8;
+        } break;
+        case DW_TAG_member: {
+          this.isMember = true;
+          name_vec.push(":");
+          name_vec.push(this.derives[i][NAME_IDX])
+          this.offset = this.derives[i][OFFSET_IDX] / 8;
+        } break;
+        case DW_TAG_typedef: {
+          // Ignoring typedefs for the time being
+        } break;
+        case DW_TAG_volatile_type: {
+          name_vec.unshift("volatile");
+        }
+        default:
+          console.error("Unimplemented " + type_descriptor);
+      }
+    }
+
+    if (this.primary[TYPE_ID_IDX] == BASIC_TYPE) {
+      this.size = this.primary[4];
+      name_vec.unshift(this.primary[NAME_IDX]);
+    } else if (this.primary[TYPE_ID_IDX] == COMPOSITE_TYPE) {
+      this.size = this.primary[SIZE_IDX];
+      name_vec.unshift(this.primary[NAME_IDX]);
+
+      switch (this.primary[TAG_IDX]) {
+        case DW_TAG_structure_type: {
+          name_vec.unshift("struct");
+        } break;
+        case DW_TAG_class_type: {
+          name_vec.unshift("class");
+        } break;
+        case DW_TAG_enumeration_type: {
+          name_vec.unshift("class");
+        } break;
+        case DW_TAG_union_type: {
+          name_vec.unshift("union");
+        } break;
+        case DW_TAG_array_type: {
+          name_vec.unshift("array");
+        } break;
+        default:
+          console.error("Unimplemented for composite " + this.primary);
+      }
+    }
+
+    this.name = name_vec.join(" ");
+  }
+
+  TypedVariable.prototype._getMyAddress = function() {
+    var base_addr = this.base_ptr + this.offset;
+    for (var i = 0; i < this.pointerCount; i++) {
+      if (base_addr == 0) {
+        return 0;
+      }
+      base_addr = heap["u32"][base_addr >> 2];
+    }
+    return base_addr;
+  }
+
+  TypedVariable.prototype._resolveBaseTypeValue = function() {
+    this.resolved = true;
+    if (this.primary[TYPE_ID_IDX] == BASIC_TYPE) {
+      if (!this.dereference) {
+        switch (this.primary[TAG_IDX]) {
+          case DW_ATE_unsigned:
+          case DW_ATE_float:
+          case DW_ATE_signed: {
+            this.value = this.base_ptr;
+          }; break;
+        }
+      } else {
+        if (this.base_ptr == 0) {
+          this.value = null;
+        } else {
+          var heap_id = type_descriptor_to_heap_id(this.primary);
+          var ptr = this._getMyAddress();
+          this.value = heap[heap_id][ptr >> heap_shift[heap_id]];
+        }
+      }
+    } else {
+      this.value = {};
+
+      for (var i in this.primary[C_ELEMS_IDX]) {
+        var cur_elem = new TypedVariable(this._getMyAddress(), this.primary[C_ELEMS_IDX][i]);
+
+        cur_elem._initialBuild();
+
+        if (cur_elem.size > 0 && (cur_elem.isInherited || cur_elem.isMember)) {
+          var pointed_elem = new TypedVariable(cur_elem._getMyAddress(), cur_elem.primary_type_id);
+          pointed_elem._initialBuild();
+          this.value[cur_elem.name] = pointed_elem;
+        }
+      }
+    }
+  }
+
+  TypedVariable.prototype._buildForPrettyPrint = function(depth) {
+    if (typeof(depth) === "undefined") {
+      depth = 1;
+    }
+
+    if (depth < 1) {
+      return;
+    }
+
+    this._initialBuild();
+    this._resolveBaseTypeValue();
+
+    if (this.primary[TYPE_ID_IDX] != 2 || this._getMyAddress() == 0) {
+      return;
+    }
+
+    for (var i in this.value) {
+      this.value[i]._buildForPrettyPrint(depth - 1);
+    }
+  }
+
+  TypedVariable.prototype._prettyPrintToObjectHelper = function() {
+
+    if (typeof(this.value) !== "object") {
+      return this.value;
+    }
+
+    if (this.value == null) {
+      return "null";
+    }
+
+    var childNames = Object.keys(this.value);
+
+    var retval = {};
+
+    for (var i in childNames) {
+      if (this.value[childNames[i]].resolved) {
+        retval[childNames[i]] = this.value[childNames[i]]._prettyPrintToObjectHelper();
+      } else {
+        retval[childNames[i]] = "cd_tvptr(0x" + this.value[childNames[i]]._getMyAddress().toString(16) + ",'" + this.value[childNames[i]].type_id + "')";
+      }
+    }
+
+    return retval;
+  }
+
+  TypedVariable.prototype.prettyPrintToObject = function(depth) {
+    this._buildForPrettyPrint(depth);
+    var retval = {};
+    retval[this.name] = this._prettyPrintToObjectHelper();
+    return retval;
+  }
+
+  var heap = {};
+  var cyberdwarf = undefined;
+  var heap_shift = {
+    "u8" : 0,
+    "u16": 1,
+    "u32": 2,
+    "i8" : 0,
+    "i16": 1,
+    "i32": 2,
+    "f32": 2,
+    "f64": 3
+  }
+  function install_heap($heap) {
+    heap = {
+      "u8" : new Uint8Array($heap),
+      "u16": new Uint16Array($heap),
+      "u32": new Uint32Array($heap),
+      "i8" : new Int8Array($heap),
+      "i16": new Int16Array($heap),
+      "i32": new Int32Array($heap),
+      "f32": new Float32Array($heap),
+      "f64": new Float64Array($heap)
+    };
+  }
+
+  var symbols = {};
+  function stackTrace() {
+      var err = new Error();
+      return err.stack;
+  }
+
+  function install_cyberdwarf(data_cd) {
+    cyberdwarf = JSON.parse(data_cd)["cyberdwarf"];
+    invert_vtables();
+  }
+
+  function type_descriptor_to_heap_id(type_descriptor) {
+    var id = "";
+    switch (type_descriptor[TAG_IDX]) {
+      case DW_ATE_unsigned: case DW_ATE_unsigned_char: id = "u"; break;
+      case DW_ATE_signed: case DW_ATE_signed_char: id = "i"; break;
+      case DW_ATE_float: id = "f"; break;
+    }
+    id += type_descriptor[4];
+    return id;
+  }
+
+  function type_id_to_type_descriptor(type_id, ptr, dit) {
+    if (!isNaN(+type_id)) {
+      return cyberdwarf["types"][type_id];
+    }
+    if (typeof(type_id) === "string") {
+      if (dit) {
+        type_id = resolve_from_vtable(ptr, type_id);
+      }
+      type_id = cyberdwarf["type_name_map"][type_id];
+    }
+    return cyberdwarf["types"][type_id];
+  }
+
+  function invert_vtables() {
+    cyberdwarf["has_vtable"] = {};
+    for (var i in cyberdwarf["vtable_offsets"]) {
+      cyberdwarf["has_vtable"][cyberdwarf["vtable_offsets"][i]] = true;
+    }
+  }
+
+  function resolve_from_vtable(val, type_name) {
+    var lookup_name = "_ZTV" + type_name.substr(4);
+    if (cyberdwarf["has_vtable"][lookup_name]) {
+      var potential_vtable = "" + (heap["u32"][val >> 2] - 8);
+      if (cyberdwarf["vtable_offsets"][potential_vtable]) {
+        var ans = type_name.substr(0,4) + cyberdwarf["vtable_offsets"][potential_vtable].substr(4);
+        return ans;
+      }
+    }
+    return type_name;
+  }
+
+  var current_function = "";
+  function set_current_function(func_name) {
+    if (typeof(cyberdwarf["function_name_map"][func_name]) !== "undefined") {
+      func_name = cyberdwarf["function_name_map"][func_name];
+    }
+    if (func_name.substring(0,1) == "_") {
+      func_name = func_name.substring(1);
+    }
+    current_function = cyberdwarf["functions"][func_name];
+  }
+
+  function pretty_print_to_object(val, type_id, depth) {
+    install_heap(Module.HEAPU8.buffer);
+    var base_type = new TypedVariable(val, current_function[type_id]);
+    return base_type.prettyPrintToObject(depth);
+  }
+
+  function pretty_print_from_typename(val, type_name, depth) {
+    install_heap(Module.HEAPU8.buffer);
+    var base_type = new TypedVariable(val, type_name);
+    return base_type.prettyPrintToObject(depth);
+  }
+
+  function stack_decoder(val, name, depth, on_heap) {
+    var err = new Error();
+    var stack_frames = err.stack.split("\n");
+    var func_finder = new RegExp("at Object.([^\\s]+)", "g");
+    if (func_finder.exec(stack_frames[4])) {
+      set_current_function(func_finder.exec(stack_frames[4])[1]);
+    } else {
+      var func_finder = new RegExp("at ([^\\s]+)", "g");
+      set_current_function(func_finder.exec(stack_frames[4])[1]);
+    }
+    var decoded = pretty_print_to_object(val, name, depth);
+
+    return decoded;
+  }
+  return {
+    "decode_from_stack": stack_decoder,
+    "install_cd_file": install_cyberdwarf,
+    "set_current_function": set_current_function,
+    "decode_var_by_var_name": pretty_print_to_object,
+    "decode_var_by_type_name": pretty_print_from_typename
+
+  };
+};
+
+mergeInto(LibraryManager.library, {"emdebug_Debugger": EMDebugHeapPrinter});

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -94,6 +94,39 @@ if (memoryInitializer) {
 #endif
 #endif
 
+#if CYBERDWARF
+#if USE_PTHREADS
+if (emDebugCDFile && !ENVIRONMENT_IS_PTHREAD) {
+#else
+if (emDebugCDFile) {
+#endif
+  Module['emdebugger_heap_printer'] = _emdebug_Debugger();
+  if (typeof Module['locateFile'] === 'function') {
+    emDebugCDFile = Module['locateFile'](emDebugCDFile);
+  } else if (Module['cdInitializerPrefixURL']) {
+    emDebugCDFile = Module['cdInitializerPrefixURL'] + memoryInitializer;
+  }
+  if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
+    var data = Module['readBinary'](emDebugCDFile);
+    Module['emdebugger_heap_printer'].install_cd_file(data);
+  } else {
+    addRunDependency('debug cd file');
+    var applyEmDebugCDFile = function(data) {
+      Module['emdebugger_heap_printer'].install_cd_file(data);
+      removeRunDependency('debug cd file');
+    }
+    function doBrowserLoad() {
+      Module['readAsync'](emDebugCDFile, applyEmDebugCDFile, function() {
+        throw 'could not load debug data ' + emDebugCDFile;
+      });
+    }
+    // fetch it from the network ourselves
+    doBrowserLoad();
+  }
+}
+#endif
+
+
 function ExitStatus(status) {
   this.name = "ExitStatus";
   this.message = "Program terminated with exit(" + status + ")";
@@ -204,7 +237,7 @@ function run(args) {
     if (Module['calledRun']) return; // run may have just been called while the async setStatus time below was happening
     Module['calledRun'] = true;
 
-    if (ABORT) return; 
+    if (ABORT) return;
 
     ensureInitRuntime();
 
@@ -401,4 +434,3 @@ var workerResponded = false, workerCallbackId = -1;
 })();
 
 #endif
-

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -95,37 +95,8 @@ if (memoryInitializer) {
 #endif
 
 #if CYBERDWARF
-#if USE_PTHREADS
-if (emDebugCDFile && !ENVIRONMENT_IS_PTHREAD) {
-#else
-if (emDebugCDFile) {
+  Module['emdebugger_heap_printer'] = _emdebug_Debugger(emDebugCDFile);
 #endif
-  Module['emdebugger_heap_printer'] = _emdebug_Debugger();
-  if (typeof Module['locateFile'] === 'function') {
-    emDebugCDFile = Module['locateFile'](emDebugCDFile);
-  } else if (Module['cdInitializerPrefixURL']) {
-    emDebugCDFile = Module['cdInitializerPrefixURL'] + memoryInitializer;
-  }
-  if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
-    var data = Module['readBinary'](emDebugCDFile);
-    Module['emdebugger_heap_printer'].install_cd_file(data);
-  } else {
-    addRunDependency('debug cd file');
-    var applyEmDebugCDFile = function(data) {
-      Module['emdebugger_heap_printer'].install_cd_file(data);
-      removeRunDependency('debug cd file');
-    }
-    function doBrowserLoad() {
-      Module['readAsync'](emDebugCDFile, applyEmDebugCDFile, function() {
-        throw 'could not load debug data ' + emDebugCDFile;
-      });
-    }
-    // fetch it from the network ourselves
-    doBrowserLoad();
-  }
-}
-#endif
-
 
 function ExitStatus(status) {
   this.name = "ExitStatus";

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2,9 +2,9 @@
 
 // === Preamble library stuff ===
 
-// Documentation for the public APIs defined in this file must be updated in: 
+// Documentation for the public APIs defined in this file must be updated in:
 //    site/source/docs/api_reference/preamble.js.rst
-// A prebuilt local version of the documentation is available at: 
+// A prebuilt local version of the documentation is available at:
 //    site/build/text/docs/api_reference/preamble.js.txt
 // You can also build docs locally as HTML or other formats in site/
 // An online HTML version (which may be of a different version of Emscripten)
@@ -152,7 +152,7 @@ var cwrap, ccall;
   // For fast lookup of conversion functions
   var toC = {'string' : JSfuncs['stringToC'], 'array' : JSfuncs['arrayToC']};
 
-  // C calling interface. 
+  // C calling interface.
   ccall = function ccallFunc(ident, returnType, argTypes, args, opts) {
     var func = getCFunc(ident);
     var cArgs = [];
@@ -213,7 +213,7 @@ var cwrap, ccall;
       }
     }
   }
-  
+
   cwrap = function cwrap(ident, returnType, argTypes) {
     argTypes = argTypes || [];
     var cfunc = getCFunc(ident);
@@ -568,7 +568,7 @@ function UTF8ToString(ptr) {
 //   str: the Javascript string to copy.
 //   outU8Array: the array to copy to. Each index in this array is assumed to be one 8-byte element.
 //   outIdx: The starting offset in the array to begin the copying.
-//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null 
+//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null
 //                    terminator, i.e. if maxBytesToWrite=1, only the null terminator will be written and nothing else.
 //                    maxBytesToWrite=0 does not write any bytes to the output, not even the null terminator.
 // Returns the number of bytes written, EXCLUDING the null terminator.
@@ -690,7 +690,7 @@ function UTF16ToString(ptr) {
 // Parameters:
 //   str: the Javascript string to copy.
 //   outPtr: Byte address in Emscripten HEAP where to write the string to.
-//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null 
+//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null
 //                    terminator, i.e. if maxBytesToWrite=2, only the null terminator will be written and nothing else.
 //                    maxBytesToWrite<2 does not write any bytes to the output, not even the null terminator.
 // Returns the number of bytes written, EXCLUDING the null terminator.
@@ -753,7 +753,7 @@ function UTF32ToString(ptr) {
 // Parameters:
 //   str: the Javascript string to copy.
 //   outPtr: Byte address in Emscripten HEAP where to write the string to.
-//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null 
+//   maxBytesToWrite: The maximum number of bytes this function can write to the array. This count should include the null
 //                    terminator, i.e. if maxBytesToWrite=4, only the null terminator will be written and nothing else.
 //                    maxBytesToWrite<4 does not write any bytes to the output, not even the null terminator.
 // Returns the number of bytes written, EXCLUDING the null terminator.
@@ -1273,7 +1273,7 @@ function freeSplitChunk(i) {
 function checkPtr(ptr, shifts) {
   if (ptr <= 0) abort('segmentation fault storing to address ' + ptr);
   if (ptr !== ((ptr >> shifts) << shifts)) abort('alignment error storing to address ' + ptr + ', which was expected to be aligned to a shift of ' + shifts);
-  if ((ptr >> SPLIT_MEMORY_BITS) !== (ptr + Math.pow(2, shifts) - 1 >> SPLIT_MEMORY_BITS)) abort('segmentation fault, write spans split chunks ' + [ptr, shifts]); 
+  if ((ptr >> SPLIT_MEMORY_BITS) !== (ptr + Math.pow(2, shifts) - 1 >> SPLIT_MEMORY_BITS)) abort('segmentation fault, write spans split chunks ' + [ptr, shifts]);
 }
 #endif
 
@@ -1884,6 +1884,10 @@ var /* show errors on likely calls to FS when it was not included */ FS = {
 Module['FS_createDataFile'] = FS.createDataFile;
 Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
 #endif
+#endif
+
+#if CYBERDWARF
+var emDebugCDFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
 #endif
 
 // === Body ===

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1888,6 +1888,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
 
 #if CYBERDWARF
 var emDebugCDFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
+var STWD = '{{{ EXPORTED_RUNTIME_METHODS }}}';
 #endif
 
 // === Body ===

--- a/src/settings.js
+++ b/src/settings.js
@@ -253,7 +253,7 @@ var LEGACY_GL_EMULATION = 0; // Includes code to emulate various desktop GL feat
                              // in some cases, see http://kripken.github.io/emscripten-site/docs/porting/multimedia_and_graphics/OpenGL-support.html
 var GL_FFP_ONLY = 0; // If you specified LEGACY_GL_EMULATION = 1 and only use fixed function pipeline in your code,
                      // you can also set this to 1 to signal the GL emulation layer that it can perform extra
-                     // optimizations by knowing that the user code does not use shaders at all. If 
+                     // optimizations by knowing that the user code does not use shaders at all. If
                      // LEGACY_GL_EMULATION = 0, this setting has no effect.
 
 var STB_IMAGE = 0; // Enables building of stb-image, a tiny public-domain library for decoding images, allowing
@@ -299,11 +299,11 @@ var ASYNCIFY_FUNCTIONS = ['emscripten_sleep', // Functions that call any functio
                           'emscripten_wget',  // will be transformed
                           'emscripten_yield'];
 var ASYNCIFY_WHITELIST = ['qsort',   // Functions in this list are never considered async, even if they appear in ASYNCIFY_FUNCTIONS
-                          'trinkle', // In the asyncify transformation, any function that calls a function pointer is considered async 
+                          'trinkle', // In the asyncify transformation, any function that calls a function pointer is considered async
                           '__toread', // This whitelist is useful when a function is known to be sync
                           '__uflow',  // currently this link contains some functions in libc
-                          '__fwritex', 
-                          'MUSL_vfprintf']; 
+                          '__fwritex',
+                          'MUSL_vfprintf'];
 
 var EXPORTED_RUNTIME_METHODS = [ // Methods that are exported on Module. By default we export quite a bit, you can reduce this list to lower your code size,
                                  // especially when closure is run (exporting prevents closure from eliminating code)
@@ -361,7 +361,7 @@ var FS_LOG = 0; // Log all FS operations.  This is especially helpful when you'r
                 // so that you can create a virtual file system with all of the required files.
 var CASE_INSENSITIVE_FS = 0; // If set to nonzero, the provided virtual filesystem if treated case-insensitive, like
                              // Windows and OSX do. If set to 0, the VFS is case-sensitive, like on Linux.
-var MEMFS_APPEND_TO_TYPED_ARRAYS = 0; // If set to nonzero, MEMFS will always utilize typed arrays as the backing store 
+var MEMFS_APPEND_TO_TYPED_ARRAYS = 0; // If set to nonzero, MEMFS will always utilize typed arrays as the backing store
                                       // for appending data to files. The default behavior is to use typed arrays for files
                                       // when the file size doesn't change after initial creation, and for files that do
                                       // change size, use normal JS arrays instead.
@@ -736,5 +736,7 @@ var EVAL_CTORS = 0; // This tries to evaluate global ctors at compile-time, appl
                     // issue for LLVM is that it doesn't know that we will not link in
                     // further code, so it only tries to optimize ctors with lowest
                     // priority. We do know that, and can optimize all the ctors.
+
+var CYBERDWARF = 0; // disabled by default
 
 // Reserved: variables containing POINTER_MASKING.

--- a/src/settings.js
+++ b/src/settings.js
@@ -739,4 +739,6 @@ var EVAL_CTORS = 0; // This tries to evaluate global ctors at compile-time, appl
 
 var CYBERDWARF = 0; // disabled by default
 
+var BUNDLED_CD_DEBUG_FILE = ""; // Path to the CyberDWARF debug file passed to the compiler
+
 // Reserved: variables containing POINTER_MASKING.

--- a/tests/debugger/test_pointers.cpp
+++ b/tests/debugger/test_pointers.cpp
@@ -1,0 +1,97 @@
+#include <vector>
+#include <set>
+#include <map>
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <emscripten.h>
+
+struct TestBase {
+  float a;
+  char b;
+  char *c;
+  char *d;
+  char **e;
+  char ***f;
+  short **g;
+
+  // Test a reference
+  int &h;
+  TestBase(int& rt) : h(rt) {}
+};
+
+struct TinyStruct {
+  short len;
+  char * chars;
+};
+
+struct StructOfStructs {
+  TestBase *tb;
+  TinyStruct *ts;
+};
+
+void test_1() {
+  int z = 42;
+  TestBase tb(z);
+  tb.a = 42.1f;
+  tb.b = 'b';
+  tb.c = nullptr;
+
+  tb.d = static_cast<char *>(malloc(10));
+  tb.d[0] = 'd';
+
+  tb.e = static_cast<char**>(malloc(sizeof(char*)));
+  tb.e[0] = static_cast<char*>(malloc(sizeof(char)));
+  tb.e[0][0] = 'e';
+
+  tb.f = static_cast<char***>(malloc(sizeof(char**)));
+  tb.f[0] = static_cast<char**>(malloc(sizeof(char*)));
+  tb.f[0][0] = static_cast<char*>(malloc(sizeof(char)));
+  tb.f[0][0][0] = 'f';
+
+  tb.g = static_cast<short**>(malloc(sizeof(short*)));
+  tb.g[0] = static_cast<short*>(malloc(sizeof(short)));
+  tb.g[0][0] = 12345;
+
+  EM_ASM_INT({
+    var decoded = Module['emdebugger_heap_printer'].decode_from_stack($0, "tb", 100)["struct TestBase"];
+    test_assert("Found the answer", decoded["float : a"] - 42 < 1.0);
+    test_assert("Found 'b'", decoded["char : b"] == 98);
+    test_assert("Found null", decoded["char * : c"] == "null");
+    test_assert("Found 'd'", decoded["char * : d"] == 100);
+    test_assert("Found 'e'", decoded["char * * : e"] == 101);
+    test_assert("Found 'f'", decoded["char * * * : f"] == 102);
+    test_assert("Found simple short", decoded["short * * : g"] == 12345);
+    test_assert("Found the answer by reference", decoded["int & : h"] == 42);
+
+  }, &tb);
+
+}
+
+void test_2() {
+  StructOfStructs sos;
+  int z = 50;
+  sos.tb = new TestBase(z);
+  sos.tb->a = 1337;
+
+  sos.ts = static_cast<TinyStruct *>(malloc(sizeof(TinyStruct)));
+  sos.ts->chars = "Hello in there";
+  sos.ts->len = strlen(sos.ts->chars);
+
+  EM_ASM_INT({
+    var decoded = Module['emdebugger_heap_printer'].decode_from_stack($0, "sos", 100)["struct StructOfStructs"];
+    test_assert("Found the answer", decoded["struct TestBase * : tb"]["float : a"] == 1337);
+  }, &sos);
+
+}
+
+
+int main(int argc, char *argv[]) {
+  EM_ASM(init_cd_test("test_pointers"));
+
+  test_1();
+  test_2();
+}

--- a/tests/debugger/test_preamble.js
+++ b/tests/debugger/test_preamble.js
@@ -1,5 +1,6 @@
 function init_cd_test(name) {
   console.log("-------------- Starting test " + name + " --------------");
+  Module['emdebugger_heap_printer'].initialize_debugger();
 }
 
 function TestException(message) {

--- a/tests/debugger/test_preamble.js
+++ b/tests/debugger/test_preamble.js
@@ -1,0 +1,14 @@
+function init_cd_test(name) {
+  console.log("-------------- Starting test " + name + " --------------");
+}
+
+function TestException(message) {
+   this.message = message;
+   this.name = "TestException";
+}
+
+function test_assert(desc, value) {
+  if (!value) {
+    throw new TestException("Test case " + desc + " failed!");
+  }
+}

--- a/tests/debugger/test_union.cpp
+++ b/tests/debugger/test_union.cpp
@@ -1,0 +1,40 @@
+#include <vector>
+#include <set>
+#include <map>
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <emscripten.h>
+
+union TestBase {
+    char c;
+    int i;
+    float f;
+};
+
+void test_1() {
+  TestBase tb;
+  tb.f = 13.37;
+
+  EM_ASM_INT({
+    var decoded = Module['emdebugger_heap_printer'].decode_from_stack($0, "tb", 100)["union TestBase"];
+    console.log(JSON.stringify(decoded, null, "\t"));
+  }, &tb);
+
+  tb.i = 1337;
+
+  EM_ASM_INT({
+    var decoded = Module['emdebugger_heap_printer'].decode_from_stack($0, "tb", 1)["union TestBase"];
+    console.log(JSON.stringify(decoded, null, "\t"));
+  }, &tb);
+
+}
+
+int main(int argc, char *argv[]) {
+  EM_ASM(init_cd_test("test_union"));
+
+  test_1();
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -752,7 +752,7 @@ This pointer might make sense in another type signature:''', '''Invalid function
       }),
     ]:
       Building.COMPILER_TEST_OPTS = test_opts
-      test('zlib', path_from_root('tests', 'zlib', 'example.c'), 
+      test('zlib', path_from_root('tests', 'zlib', 'example.c'),
                    get_zlib_library(self),
                    open(path_from_root('tests', 'zlib', 'ref.txt'), 'r').read(),
                    expected_ranges,
@@ -1532,7 +1532,7 @@ int f() {
   def test_bullet(self):
     Building.emcc(path_from_root('tests','bullet_hello_world.cpp'), ['-s', 'USE_BULLET=1'], output_filename='a.out.js')
     self.assertContained('BULLET RUNNING', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
-  
+
   def test_vorbis(self):
     #This will also test if ogg compiles, because vorbis depends on ogg
     Building.emcc(path_from_root('tests','vorbis_test.c'), ['-s', 'USE_VORBIS=1'], output_filename='a.out.js')
@@ -2013,7 +2013,7 @@ int f() {
       print args, fail
       self.clear()
       try_delete(self.in_dir('a.out.js'))
-      
+
       testFiles = [
         path_from_root('tests', 'embind', 'underscore-1.4.2.js'),
         path_from_root('tests', 'embind', 'imvu_test_adapter.js'),
@@ -2059,7 +2059,7 @@ int f() {
     output = Popen([os.path.join(self.get_dir(), 'files.o.run')], stdin=open(os.path.join(self.get_dir(), 'stdin')), stdout=PIPE, stderr=PIPE).communicate()
     self.assertContained('''size: 37
 data: 119,97,107,97,32,119,97,107,97,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35
-loop: 119 97 107 97 32 119 97 107 97 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 
+loop: 119 97 107 97 32 119 97 107 97 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35
 input:inter-active
 texto
 $
@@ -3335,7 +3335,7 @@ int main(int argc, char **argv) {
     self.assertContained(r'''Failed to rename paths: abc, ; errno=2''', run_js('a.out.js', args=['abc', '']))
 
   def test_readdir_r_silly(self):
-    open('src.cpp', 'w').write(r'''  
+    open('src.cpp', 'w').write(r'''
 #include <iostream>
 #include <cstring>
 #include <cerrno>
@@ -5437,9 +5437,9 @@ mergeInto(LibraryManager.library, {
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
- 
+
 #define TEST_PATH "/boot/README.txt"
- 
+
 int
 main(int argc, char **argv)
 {
@@ -6333,3 +6333,13 @@ int main() {}
     self.function_eliminator_test_helper('test-function-eliminator-replace-variable-value-with-hash-info.js',
                                          'test-function-eliminator-replace-variable-value-output.js',
                                          use_hash_info=True)
+
+  def test_cyberdwarf_pointers(self):
+    check_execute([PYTHON, EMCC, path_from_root('tests', 'debugger', 'test_pointers.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
+    '-std=c++11', '--pre-js', path_from_root('tests', 'debugger', 'test_preamble.js'), '-o', 'test_pointers.js' ], stderr=PIPE)
+    run_js('test_pointers.js', engine=NODE_JS)
+
+  def test_cyberdwarf_union(self):
+    check_execute([PYTHON, EMCC, path_from_root('tests', 'debugger', 'test_union.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
+    '-std=c++11', '--pre-js', path_from_root('tests', 'debugger', 'test_preamble.js'), '-o', 'test_union.js' ], stderr=PIPE)
+    run_js('test_union.js', engine=NODE_JS)

--- a/tools/emdebug_cd_merger.py
+++ b/tools/emdebug_cd_merger.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python2
+# -*- Mode: python -*-
+
+import logging, sys, json
+
+def run():
+    args = sys.argv[1:]
+    assert len(args) == 2
+
+    with open(args[0]) as cd_f:
+        cd_data = json.load(cd_f)
+
+    with open(args[1]) as symbol_f:
+        symbol_list = {x[0]:x[2] for x in [z.strip().partition(":") for z in symbol_f.readlines() if len(z) > 0]}
+
+    cd_data['cyberdwarf']['function_name_map'] = symbol_list
+
+    with open(args[0],"w") as cd_f:
+        json.dump(cd_data, cd_f, separators=(',',':'))
+
+
+if __name__ == '__main__':
+  run()


### PR DESCRIPTION
This uses the DI information extracted by the LLVM changes in the emscripten-fastcomp pull request.

By enabling CYBERDWARF, a user can dump a JSON formatted view of a variable.

test_pointers.cpp should give a good idea of how to use the initial debugger.