### PR TITLE
Openal relative audio fixes

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1298,7 +1298,7 @@ var LibraryOpenAL = {
   alListener3f: function(param, v1, v2, v3) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
-      console.error("alListenerfv called without a valid context");
+      console.error("alListener3f called without a valid context");
 #endif
       return;
     }

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1207,7 +1207,7 @@ var LibraryOpenAL = {
       {{{ makeSetValue('values', '8', 'velocity[2]', 'float') }}}
       break;
     case 0x100F /* AL_ORIENTATION */:
-      var orientation = AL.currentContext.ctx.listener._orientation || [0,0,0,0,0,0];
+      var orientation = AL.currentContext.ctx.listener._orientation || [0,0,-1,0,1,0];
       {{{ makeSetValue('values', '0', 'orientation[0]', 'float') }}}
       {{{ makeSetValue('values', '4', 'orientation[1]', 'float') }}}
       {{{ makeSetValue('values', '8', 'orientation[2]', 'float') }}}

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -465,7 +465,7 @@ var LibraryOpenAL = {
       AL.updateSource(src);
       break;
     case 0x202 /* AL_SOURCE_RELATIVE */:
-      if (value === 1 /* AL_TRUE */) {
+      if (value === 0 /* AL_FALSE */) {
         if (src.panner) {
           src.panner = null;
 
@@ -474,7 +474,7 @@ var LibraryOpenAL = {
 
           src.gain.connect(AL.currentContext.gain);
         }
-      } else if (value === 0 /* AL_FALSE */) {
+      } else if (value === 1 /* AL_TRUE */) {
         if (!src.panner) {
           var panner = src.panner = AL.currentContext.ctx.createPanner();
           panner.panningModel = "equalpower";

--- a/tests/openal_playback.cpp
+++ b/tests/openal_playback.cpp
@@ -147,6 +147,19 @@ int main() {
 
   alSourcei(sources[0], AL_BUFFER, buffers[0]);
 
+  // check basic AL_SOURCE_RELATIVE functionality
+  alGetSourcei(sources[0], AL_SOURCE_RELATIVE, &val);
+  assert(val == AL_FALSE);
+
+  alSourcei(sources[0], AL_SOURCE_RELATIVE, AL_TRUE);
+  alGetSourcei(sources[0], AL_SOURCE_RELATIVE, &val);
+  assert(val == AL_TRUE);
+
+  alSourcei(sources[0], AL_SOURCE_RELATIVE, AL_FALSE);
+  alGetSourcei(sources[0], AL_SOURCE_RELATIVE, &val);
+  assert(val == AL_FALSE);
+  // end AL_SOURCE_RELATIVE checks
+
   ALint state;
   alGetSourcei(sources[0], AL_SOURCE_STATE, &state);
   assert(state == AL_INITIAL);


### PR DESCRIPTION
2 minor changes: 
- Fix function name typo in the openal debug info (`alListenerfv` -> `alListener3f`)
- Make the cached copy of global audio listener's orientation match the actual default (as per [this document](https://developer.mozilla.org/en-US/docs/Web/API/AudioListener/setOrientation))

1 major:
- The logic for if a source was relative was reversed. A test has been added for this.

Tests `interactive.test_openal_playback` and `interactive.test_openal_buffers` were run without regressions.
