### PR TITLE
Support multiple arguments in EMCC_CFLAGS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Charles Vaughn <cvaughn@tableau.com> (copyright owned by Tableau Software, Inc.)
 * Pierre Krieger <pierre.krieger1708@gmail.com>
 * Jakob Stoklund Olesen <stoklund@2pi.dk>
+* Dave Fletcher <graveyhead@gmail.com>

--- a/emcc.py
+++ b/emcc.py
@@ -95,7 +95,7 @@ def run():
   global final, target, script_src, script_inline
 
   if DEBUG: logging.warning('invocation: ' + ' '.join(sys.argv) + (' + ' + EMCC_CFLAGS if EMCC_CFLAGS else '') + '  (in ' + os.getcwd() + ')')
-  if EMCC_CFLAGS: sys.argv.append(EMCC_CFLAGS)
+  if EMCC_CFLAGS: sys.argv.extend(shlex.split(EMCC_CFLAGS))
 
   if DEBUG and LEAVE_INPUTS_RAW: logging.warning('leaving inputs raw')
 


### PR DESCRIPTION
Currently the way the support for EMCC_CFLAGS is written it passes the entire string wholesale into sys.argv.append() which treats it as one single argument. This change splits the string using the shlex module (which handles quoting etc) and appends the items to sys.argv piecewise using extend().