### PR TITLE
Misc doc fixes

### DIFF
--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -79,7 +79,7 @@ The following ``Module`` attributes affect code execution.
 
 .. js:attribute:: Module.noExitRuntime
 
-	If ``noExitRuntime`` is set to ``true``, the runtime is not shut down after ``run`` completes. Shutting down the runtime calls shutdown callbacks, for example ``atexit`` calls. If you want to continue using the code after ``run()`` finishes, it is necessary to set this. This is automatically set for you if you use an API command that implies that you want the runtime to not be shut down, for example ``emscripten_set_main_loop``.
+	If ``noExitRuntime`` is set to ``true``, the runtime is not shut down after ``run`` completes. Shutting down the runtime calls shutdown callbacks, for example ``atexit`` calls and closing filesystems (including WebSockets opened by Emscripten). If you want to continue using the code after ``run()`` finishes, it is necessary to set this. This is automatically set for you if you use an API command that implies that you want the runtime to not be shut down, for example ``emscripten_set_main_loop``.
 
 .. js:attribute:: Module.filePackagePrefixURL
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -222,7 +222,7 @@ mergeInto(LibraryManager.library, {
 #if ASSERTIONS
       abortDecorators.push(function(output, what) {
         if (EmterpreterAsync.state !== 0) {
-          return output + '\nThis error happened during an emterpreter-async save or load of the stack. Was there non-emterpreted code on the stack during save (which is unallowed)? You may want to adjust EMTERPRETIFY_BLACKLIST, EMTERPRETIFY_WHITELIST.\nThis is what the stack looked like when we tried to save it: ' + [EmterpreterAsync.state, EmterpreterAsync.saveStack];
+          return output + '\nThis error happened during an emterpreter-async save or load of the stack, or while the emterpreter was paused. Was there non-emterpreted code on the stack during save (which is unallowed), or was some non-emterpreted code called during a pause? You may want to adjust EMTERPRETIFY_BLACKLIST, EMTERPRETIFY_WHITELIST, or use emscripten_sleep_with_yield to permit functions to execute during a pause.\nThis is what the stack looked like when we tried to save it/when it was saved: ' + [EmterpreterAsync.state, EmterpreterAsync.saveStack];
         }
         return output;
       });


### PR DESCRIPTION
- Explicitly note that the exiting the runtime closes sockets
- Correct the emterpreter motivating example description
- Suggest emscripten_sleep_with_yield if calling asm.js functions during emterpreter pause
