### PR TITLE
Add missing EXT_color_buffer_float extension

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -622,7 +622,7 @@ var LibraryGL = {
                                              "OES_texture_float_linear", "OES_texture_half_float_linear", "WEBGL_compressed_texture_atc",
                                              "WEBGL_compressed_texture_pvrtc", "EXT_color_buffer_half_float", "WEBGL_color_buffer_float",
                                              "EXT_frag_depth", "EXT_sRGB", "WEBGL_draw_buffers", "WEBGL_shared_resources",
-                                             "EXT_shader_texture_lod" ];
+                                             "EXT_shader_texture_lod", "EXT_color_buffer_float"];
 
       function shouldEnableAutomatically(extension) {
         var ret = false;


### PR DESCRIPTION
The extension `EXT_color_buffer_float` allow for many float and half-float render targets to be renderable, which are not in the core GLES3 spec. This is safe to enable by default.

https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/