### PR TITLE
raf_garbage

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1097,6 +1097,14 @@ var LibraryBrowser = {
 
     Browser.mainLoop.func = func;
     Browser.mainLoop.arg = arg;
+    var argArray = [arg];
+    var browserIterationFunc = function() {
+      if (typeof arg !== 'undefined') {
+        Runtime.dynCall('vi', func, argArray);
+      } else {
+        Runtime.dynCall('v', func);
+      }
+    };
 
     var thisMainLoopId = Browser.mainLoop.currentlyRunningMainloop;
 
@@ -1149,13 +1157,7 @@ var LibraryBrowser = {
         Browser.mainLoop.method = ''; // just warn once per call to set main loop
       }
 
-      Browser.mainLoop.runIter(function() {
-        if (typeof arg !== 'undefined') {
-          Runtime.dynCall('vi', func, [arg]);
-        } else {
-          Runtime.dynCall('v', func);
-        }
-      });
+      Browser.mainLoop.runIter(browserIterationFunc);
 
 #if STACK_OVERFLOW_CHECK
       checkStackCookie();


### PR DESCRIPTION
Optimize away two units of garbage that were generated each frame by main loop tick iteration: an on-demand generated function and an argument wrapped inside an array.

After this, Firefox profiler shows only one source of garbage being generated in my 10kCubes sample: glBufferSubData() when uploading vertex data on demand for text rendering. Test case up at https://dl.dropboxusercontent.com/u/40949268/emcc/10kCubes_no_vsync_little_garbage/10kCubes.html