### PR TITLE
accurate_em_timing_settimeout

### DIFF
--- a/tests/emscripten_main_loop_settimeout.cpp
+++ b/tests/emscripten_main_loop_settimeout.cpp
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+
+int numFrames = 0;
+
+void looper() {
+  static double frame0 = emscripten_get_now();
+
+  double start = emscripten_get_now();
+
+  ++numFrames;
+  printf("Frame %d\n", numFrames);
+  if (numFrames == 10) {
+    double now = emscripten_get_now();
+    double msecsPerFrame = (now - frame0) / (numFrames-1); // Sub one to account for intervals vs endpoints
+    printf("Avg. msecs/frame: %f\n", msecsPerFrame);
+#ifdef REPORT_RESULT
+    int result = (msecsPerFrame > 350 && msecsPerFrame < 650); // Expecting 500msecs/frame, but allow a lot of leeway. Bad value would be 900msecs/frame (400msecs of processing below and 500msecs of delay)
+    REPORT_RESULT();
+#endif
+    emscripten_cancel_main_loop();
+  }
+
+  // Busy wait 400 msecs.
+  double now = start;
+  while (now - start < 400) {
+    now = emscripten_get_now();
+  }
+}
+
+int main() {
+  // Want to run at 2 fps, or 500msecs/frame.
+  emscripten_set_main_loop(looper, 2, 0);
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1478,6 +1478,9 @@ keydown(100);keyup(100); // trigger the end
   def test_emscripten_main_loop(self):
     self.btest('emscripten_main_loop.cpp', '0')
 
+  def test_emscripten_main_loop_settimeout(self):
+    self.btest('emscripten_main_loop_settimeout.cpp', '1')
+
   def test_emscripten_main_loop_and_blocker(self):
     self.btest('emscripten_main_loop_and_blocker.cpp', '0')
 


### PR DESCRIPTION
Fix emscripten_set_main_loop() with EM_TIMING_SETTIMEOUT timing mode to properly account for the time spent inside the main loop function when counting the delay for the next frame. Fixes #4200.