### PR TITLE
atomics_futexwait_integers_to_strings

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -784,9 +784,9 @@ var LibraryPThread = {
 #if PTHREADS_PROFILING
       PThread.setThreadStatusConditional(_pthread_self(), {{{ cDefine('EM_THREAD_STATUS_WAITFUTEX') }}}, {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
 #endif
-      if (ret == Atomics.TIMEDOUT) return -{{{ cDefine('ETIMEDOUT') }}};
-      if (ret == Atomics.NOTEQUAL) return -{{{ cDefine('EWOULDBLOCK') }}};
-      if (ret == 0) return 0;
+      if (ret === Atomics.TIMEDOUT) return -{{{ cDefine('ETIMEDOUT') }}};
+      if (ret === Atomics.NOTEQUAL) return -{{{ cDefine('EWOULDBLOCK') }}};
+      if (ret === Atomics.OK) return 0;
       throw 'Atomics.futexWait returned an unexpected value ' + ret;
     } else {
       // Atomics.futexWait is not available in the main browser thread, so simulate it via busy spinning.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1118,6 +1118,15 @@ if (typeof Atomics === 'undefined') {
   Atomics['xor'] = function(t, i, v) { var w = t[i]; t[i] ^= v; return w; }
 }
 
+// In old Atomics spec, Atomics.OK/.TIMEDOUT/.NOTEQUAL were integers. In new spec, Atomics functions return strings, so if we are in the new spec,
+// assign the strings to the place where the integers would have been to keep implementation of emscripten_futex_wait straightforward without dynamic checks for both.
+// See https://github.com/tc39/ecmascript_sharedmem/issues/69 for details.
+if (typeof Atomics['OK'] === 'undefined') {
+  Atomics['OK'] = 'ok';
+  Atomics['TIMEDOUT'] = 'timed-out';
+  Atomics['NOTEQUAL'] = 'not-equal';
+}
+
 #else // USE_PTHREADS
 
 #if SPLIT_MEMORY == 0


### PR DESCRIPTION
 Account for upcoming Atomics spec change "integers to strings" in backwards and forwards compatible way, see https://github.com/tc39/ecmascript_sharedmem/issues/69.

CC @lars-t-hansen.