### PR TITLE
Fix sanity check that would sometimes fail on some machines

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -515,7 +515,7 @@ def check_sanity(force=False):
           if sanity_mtime <= settings_mtime:
             reason = 'settings file has changed'
           else:
-            sanity_data = open(sanity_file).read()
+            sanity_data = open(sanity_file).read().rstrip('\n\r') # workaround weird bug with read() that appends new line char in some old python version
             if sanity_data != generate_sanity():
               reason = 'system change: %s vs %s' % (generate_sanity(), sanity_data)
             else:


### PR DESCRIPTION
I'm not sure how this ends up happening, but sometimes on some machines the `.emscripten_cache` file contains a `\n` character at the end, which makes the `if sanity_data != generate_sanity()` test fail.

I think this is safe to remove all occurrence of `\n` and `\r` if they get appended somehow after calling `read` on the file.