### PR TITLE
fix unresolved symbol in embind

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1487,7 +1487,7 @@ var LibraryEmbind = {
     }
   },
 
-  $makeClassHandle__deps: ['throwInternalError'],
+  $makeClassHandle__deps: ['$throwInternalError'],
   $makeClassHandle: function(prototype, record) {
     if (!record.ptrType || !record.ptr) {
         throwInternalError('makeClassHandle requires ptr and ptrType');


### PR DESCRIPTION
I encountered the error `error: unresolved symbol: throwInternalError` when building a project that uses embind. This PR resolves it.