### PR TITLE
Fix file_packager's --use-preload-cache on safari. Fixes #2977

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -242,3 +242,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ashley Sommer <flubba86@gmail.com>
 * Dave Fletcher <graveyhead@gmail.com>
 * Lars-Magnus Skog <ralphtheninja@riseup.net>
+* Pieter Vantorre <pietervantorre@gmail.com>

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -634,12 +634,13 @@ if has_preloaded:
       };
 
       function cacheRemotePackage(db, packageName, packageData, packageMeta, callback, errback) {
-        var transaction = db.transaction([PACKAGE_STORE_NAME, METADATA_STORE_NAME], IDB_RW);
-        var packages = transaction.objectStore(PACKAGE_STORE_NAME);
-        var metadata = transaction.objectStore(METADATA_STORE_NAME);
+        var transaction_packages = db.transaction([PACKAGE_STORE_NAME], IDB_RW);
+        var packages = transaction_packages.objectStore(PACKAGE_STORE_NAME);
 
         var putPackageRequest = packages.put(packageData, packageName);
         putPackageRequest.onsuccess = function(event) {
+          var transaction_metadata = db.transaction([METADATA_STORE_NAME], IDB_RW);
+          var metadata = transaction_metadata.objectStore(METADATA_STORE_NAME);
           var putMetadataRequest = metadata.put(packageMeta, packageName);
           putMetadataRequest.onsuccess = function(event) {
             callback(packageData);


### PR DESCRIPTION
bug was caused by the following safari issue:
https://bugs.webkit.org/show_bug.cgi?id=136937

tests ran: tests_browser.

That's the only test that seemed relevant. after doing a grep in the tests folder and looking where --use-preload-cache was being used.