### PR TITLE
Implement Runtime.dynCall for wasm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1543,6 +1543,10 @@ var asm = Module['asm'](%s, %s, buffer);
      'Module' + access_quote('asmLibraryArg'),
      receiving)]
 
+  # Store a list of all address-taken functions in the module. This is currently used by the dynCall
+  # mechanism, which looks up a function pointer to get its name, and calls that directly.
+  # TODO: It would be good to find a way to implement this functionality without exporting all
+  # address-taken functions.
   indirect_funcs = '[' + ','.join(['"%s"' % asmjs_mangle(f) for f in metadata['indirect_table']]) + ']'
   funcs_js.append('''
 Module%s = %s;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -196,6 +196,11 @@ var Runtime = {
 #if ASSERTIONS
       assert(args.length == sig.length-1);
 #endif
+      if (Module['usingWasm']) {
+        // look up function by name
+        name = Module['indirectFunctions'][ptr]
+        return Module[name].apply(null, args);
+      }
 #if ASSERTIONS
       assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
 #endif
@@ -502,4 +507,3 @@ if (RETAIN_COMPILER_SETTINGS) {
     } catch(e){}
   }
 }
-

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -197,7 +197,7 @@ var Runtime = {
       assert(args.length == sig.length-1);
 #endif
       if (Module['usingWasm']) {
-        // look up function by name
+        // look up function by name and call it directly
         name = Module['indirectFunctions'][ptr]
         return Module[name].apply(null, args);
       }


### PR DESCRIPTION
The asm.js approach to dynCall of having a bunch of function pointer tables won't work for wasm. Currently the only way to call a wasm function from javascript is by exported name. This change implements Runtime.dynCall (needed for e.g. static destructors) by looking up the function name 
(which has been attached to the Module) and calling it. The wasm engine should check the signature itself.