### PR TITLE
Add ref to FAQ's 'when safe to call code' from 'how to call code'

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -38,6 +38,11 @@ to more detailed information.
    environment, see :ref:`emscripten-runtime-environment`. For file system
    related manners, see the :ref:`file-system-overview`.
 
+.. note:: Before you can call your code, the runtime environment may need
+   to load a memory initialization file asynchronously depending on optimization
+   and build settings.
+   See :ref:`faq-when-safe-to-call-compiled-functions` in the FAQ.
+
 
 .. _interacting-with-code-ccall-cwrap:
 


### PR DESCRIPTION
A lot of people on the list are asking questions about calling into
C/C++ code which fails because they're calling before initialization.
Add a link to the FAQ section explaining how to wait for initialization
to the page about how to call into compiled C/C++ code.

[I haven't been able to successfully build a local HTML copy of the docs, so I'm not 100% sure this is correct linking syntax. Please test!]