### PR TITLE
Adds EM_TRUE and EM_FALSE as convenience macros to html5.h

### DIFF
--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -68,6 +68,8 @@ extern "C" {
 #define EMSCRIPTEN_RESULT_NO_DATA             -7
 
 #define EM_BOOL int
+#define EM_TRUE 1
+#define EM_FALSE 0
 #define EM_UTF8 char
 
 #define DOM_KEY_LOCATION int


### PR DESCRIPTION
I was surprised, that the macros EM_TRUE and EM_FALSE are missing, although some parts of the documentation mention them... Did I look at the wrong place, or did they exist in the past and were not removed from the doc.

Anyhow, here is my pull request.

(Supersedes #4242)