### PR TITLE
A test for the recursive insertvalue fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -243,3 +243,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dave Fletcher <graveyhead@gmail.com>
 * Lars-Magnus Skog <ralphtheninja@riseup.net>
 * Pieter Vantorre <pietervantorre@gmail.com>
+* Maher Sallam <maher@sallam.me>

--- a/tests/cases/insertvalue_recursive.ll
+++ b/tests/cases/insertvalue_recursive.ll
@@ -1,0 +1,26 @@
+; ModuleID = 'insertvalue_recursive.ll'
+target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
+target triple = "asmjs-unknown-emscripten"
+
+%nested_struct = type { [1 x i64] }
+%struct = type { [1 x i64], %nested_struct }
+
+@.str = private unnamed_addr constant [15 x i8] c"hello, world!\0A\00", align 1
+
+declare i32 @printf(i8*, ...)
+
+define i32 @main() {
+entry:
+  %.1 = insertvalue [1 x i64] undef, i64 1, 0
+  %inserted.first = insertvalue %struct undef, [1 x i64] %.1, 0
+
+  %.2 = insertvalue [1 x i64] undef, i64 2, 0
+  %.nested_struct = insertvalue %nested_struct undef, [1 x i64] %.2, 0
+  %inserted.second = insertvalue %struct %inserted.first, %nested_struct %.nested_struct, 1
+  
+  %.3 = alloca %struct, align 8
+  store %struct %inserted.second, %struct* %.3, align 8
+  
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str, i32 0, i32 0)) ; [#uses=0 type=i32]
+  ret i32 0
+}


### PR DESCRIPTION
This adds a test for recursive usage of the insertvalue instruction fixed in kripken/emscripten-fastcomp#134. I ran all the test cases using `python tests/runner.py ALL.test_cases` and they all pass.