### PR TITLE
Fixed glfw window and framebuffer size callbacks.

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -39,6 +39,7 @@ var LibraryGLFW = {
       this.id = id;
       this.x = 0;
       this.y = 0;
+      this.fullscreen = false; // Used to determine if app in fullscreen mode
       this.storedX = 0; // Used to store X before fullscreen
       this.storedY = 0; // Used to store Y before fullscreen
       this.width = width;
@@ -480,9 +481,12 @@ var LibraryGLFW = {
       event.preventDefault();
     },
 
-    onFullScreenEventChange: function() {
+    onCanvasResize: function(width, height) {
       if (!GLFW.active) return;
 
+      var resizeNeeded = true;
+
+      // If the client is requestiong fullscreen mode
       if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
         GLFW.active.storedX = GLFW.active.x;
         GLFW.active.storedY = GLFW.active.y;
@@ -491,14 +495,37 @@ var LibraryGLFW = {
         GLFW.active.x = GLFW.active.y = 0;
         GLFW.active.width = screen.width;
         GLFW.active.height = screen.height;
-      } else {
+        GLFW.active.fullscreen = true;
+
+      // If the client is reverting from fullscreen mode
+      } else if (GLFW.active.fullscreen == true) {
         GLFW.active.x = GLFW.active.storedX;
         GLFW.active.y = GLFW.active.storedY;
         GLFW.active.width = GLFW.active.storedWidth;
         GLFW.active.height = GLFW.active.storedHeight;
+        GLFW.active.fullscreen = false;
+
+      // If the width/height values do not match current active window sizes
+      } else if (GLFW.active.width != width || GLFW.active.height != height) {
+          GLFW.active.width = width;
+          GLFW.active.height = height;
+      } else {
+        resizeNeeded = false;
       }
 
-      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height, true); // resets the canvas size to counter the aspect preservation of Browser.updateCanvasDimensions
+      // If any of the above conditions were true, we need to resize the canvas
+      if (resizeNeeded) {
+        // resets the canvas size to counter the aspect preservation of Browser.updateCanvasDimensions
+        Browser.setCanvasSize(GLFW.active.width, GLFW.active.height);
+        // TODO: Client dimensions (clientWidth/clientHeight) vs pixel dimensions (width/height) of
+        // the canvas should drive window and framebuffer size respectfully.
+        GLFW.onWindowSizeChanged();
+        GLFW.onFramebufferSizeChanged();
+      }
+    },
+
+    onWindowSizeChanged: function() {
+      if (!GLFW.active) return;
 
       if (!GLFW.active.windowSizeFunc) return;
 
@@ -508,6 +535,16 @@ var LibraryGLFW = {
 
 #if USE_GLFW == 3
       Runtime.dynCall('viii', GLFW.active.windowSizeFunc, [GLFW.active.id, GLFW.active.width, GLFW.active.height]);
+#endif
+    },
+
+    onFramebufferSizeChanged: function() {
+      if (!GLFW.active) return;
+
+      if (!GLFW.active.framebufferSizeFunc) return;
+
+#if USE_GLFW == 3
+      Runtime.dynCall('viii', GLFW.active.framebufferSizeFunc, [GLFW.active.id, GLFW.active.width, GLFW.active.height]);
 #endif
     },
 
@@ -858,7 +895,7 @@ var LibraryGLFW = {
     Module["canvas"].addEventListener('mousewheel', GLFW.onMouseWheel, true);
 
     Browser.resizeListeners.push(function(width, height) {
-       GLFW.onFullScreenEventChange();
+       GLFW.onCanvasResize(width, height);
     });
     return 1; // GL_TRUE
   },
@@ -1127,7 +1164,7 @@ var LibraryGLFW = {
   glfwSetFramebufferSizeCallback: function(winid, cbfun) {
     var win = GLFW.WindowFromId(winid);
     if (!win) return;
-    win.windowFramebufferSizeFunc = cbfun;
+    win.framebufferSizeFunc = cbfun;
   },
 
   glfwGetInputMode: function(winid, mode) {


### PR DESCRIPTION
* Generalizes onFullScreenEventChange to handle all canvas resize events
* glfwSetWindowSizeCallback now called when glfwSetWindowSize is invoked
* Implements behavior for glfwSetFramebufferSizeCallback
* Fixes misspelled framebufferSizeFunc variable
* Solves #3558 (with the caveat that glfwSetWindowSize() needs to be called. I don't think we can listen for when the canvas element's clientWidth or clientHeight is changed)