### PR TITLE
Remove trailing commas

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -442,7 +442,7 @@ if has_preloaded:
         var that = this;
 %s
         this.requests[this.name] = null;
-      },
+      }
     };
 %s
   ''' % ('' if not crunch else '''


### PR DESCRIPTION
Google closure-compler does not like trailing commas.
> Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.

Works only if set --language_in ES5
