### PR TITLE
Worker alert support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Charles Vaughn <cvaughn@tableau.com> (copyright owned by Tableau Software, Inc.)
 * Pierre Krieger <pierre.krieger1708@gmail.com>
 * Jakob Stoklund Olesen <stoklund@2pi.dk>
+* Kerby Geffrard <kerby.geffrard@gmail.com>

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -242,6 +242,8 @@ var LibraryPThread = {
             Module['print']('Thread ' + e.data.threadId + ': ' + e.data.text);
           } else if (e.data.cmd === 'printErr') {
             Module['printErr']('Thread ' + e.data.threadId + ': ' + e.data.text);
+          } else if (e.data.cmd == 'alert') {
+            alert('Thread ' + e.data.threadId + ': ' + e.data.text);
           } else if (e.data.cmd === 'exit') {
             // todo 
           } else if (e.data.cmd === 'cancelDone') {

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -31,7 +31,10 @@ function threadPrintErr() {
   var text = Array.prototype.slice.call(arguments).join(' ');
   postMessage({cmd: 'printErr', text: text, threadId: selfThreadId});
 }
-
+function threadAlert() {
+  var text = Array.prototype.slice.call(arguments).join(' ');
+  postMessage({cmd: 'alert', text: text, threadId: selfThreadId});
+}
 Module['print'] = threadPrint;
 Module['printErr'] = threadPrintErr;
 
@@ -40,6 +43,8 @@ console = {
   log: threadPrint,
   error: threadPrintErr
 };
+
+this.alert = threadAlert;
 
 this.onmessage = function(e) {
   if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.


### PR DESCRIPTION
This allow users to call `alert()` from a thread in a pthread. I used the same procedure than with console.* 

This is because sometimes, we want as a user to call an alert when we get a critical error and we need to notify the user and exit. 

Now this work when called from main thread AND from a thread (or a worker).
```
	EM_ASM_ARGS({
		var alert = Pointer_stringify($0);
		alert(alert);
	}, error_message);
```

I talked about my issue here: 
https://groups.google.com/forum/#!topic/emscripten-discuss/gLYTQS2K3XY