### PR TITLE
Add llvm cos and sin intrinsic functions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1403,7 +1403,11 @@ LibraryManager.library = {
   llvm_trunc_f64: 'Math_trunc',
   llvm_floor_f32: 'Math_floor',
   llvm_floor_f64: 'Math_floor',
-
+  llvm_cos_f32: 'Math_cos',
+  llvm_cos_f64: 'Math_cos',
+  llvm_sin_f32: 'Math_sin',
+  llvm_sin_f64: 'Math_sin',
+  
   round__asm: true,
   round__sig: 'dd',
   round: function(d) {


### PR DESCRIPTION
Was getting errors stating that llvm_cos_f32 and llvm_sin_f32 are unimplemented.
This commit fixes that.
Added llvm cos and sin intrinsic functions to library.js
