### PR TITLE
Trivial object support for embind

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1540,25 +1540,23 @@ namespace emscripten {
             return *this;
         }
 
-/*
-        template<typename ReturnType, typename ThisType, typename... Args, typename... Policies>
-        EMSCRIPTEN_ALWAYS_INLINE const class_& function(const char* methodName, ReturnType (*function)(ThisType, Args...), Policies...) const {
+        template<typename ReturnType, typename ThisType, typename... Args>
+        EMSCRIPTEN_ALWAYS_INLINE const trivial_class& function(const char* methodName, ReturnType (*function)(ThisType, Args...)) const {
             using namespace internal;
 
-            typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, ThisType, Args...> args;
+            typename WithPolicies<>::template ArgTypeList<ReturnType, ThisType, Args...> args;
             auto invoke = &FunctionInvoker<decltype(function), ReturnType, ThisType, Args...>::invoke;
-            _embind_register_class_function(
+            _embind_register_trivial_class_function(
                 TypeID<ClassType>::get(),
                 methodName,
                 args.getCount(),
                 args.getTypes(),
                 getSignature(invoke),
                 reinterpret_cast<GenericFunction>(invoke),
-                getContext(function),
-                false);
+                getContext(function));
             return *this;
         }
-
+/*
         template<typename FieldType, typename = typename std::enable_if<!std::is_function<FieldType>::value>::type>
         EMSCRIPTEN_ALWAYS_INLINE const class_& property(const char* fieldName, const FieldType ClassType::*field) const {
             using namespace internal;

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -2553,6 +2553,14 @@ module({
             assert.equal(1.5, e.getFloat());
             e.setFloat(1.0);
             assert.equal(1.0, e.getFloat());
+
+            e.reset();
+            assert.equal( true, e.trivialRead());
+            assert.equal( true, cm.trivialRead(e));
+
+            cm.trivialWrite(e);
+            assert.equal(1.5, e.getFloat());
+            assert.equal(5, e.getInt());
         });
     });
 });

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -2545,6 +2545,15 @@ module({
             assert.equal(30, cm.HasStaticMember.v);
         });
     });
+
+    BaseFixture.extend("trivia class", function() {
+        test("can construct trivial objects", function() {
+            var e = new cm.TrivialClass(1.5);
+            console.log( JSON.stringify( e, null, 4));
+            assert.instanceof(e, cm.TrivialClass);
+            assert.equal(1.5, e.getFloat());
+        });
+    });
 });
 
 /* global run_all_tests */

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -2549,9 +2549,10 @@ module({
     BaseFixture.extend("trivia class", function() {
         test("can construct trivial objects", function() {
             var e = new cm.TrivialClass(1.5);
-            console.log( JSON.stringify( e, null, 4));
             assert.instanceof(e, cm.TrivialClass);
             assert.equal(1.5, e.getFloat());
+            e.setFloat(1.0);
+            assert.equal(1.0, e.getFloat());
         });
     });
 });

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -2806,3 +2806,57 @@ EMSCRIPTEN_BINDINGS(static_member) {
         .class_property("v", &HasStaticMember::v)
         ;
 }
+
+class TrivialClass{
+
+public:
+
+    float FloatValue;
+    int IntValue;
+    bool BooleanValue;
+
+    TrivialClass() = default;
+
+    TrivialClass( float value )
+        : FloatValue( value ), IntValue( 0 ), BooleanValue( true ){
+        printf(" Constructed %f", value );
+    }
+
+    TrivialClass( float value, int int_value )
+        : FloatValue( value ), IntValue( int_value ), BooleanValue( false ){
+            printf(" Constructed %f", value );
+    }
+
+    float getFloat() const { return FloatValue; }
+    int getInt() const { return IntValue; }
+    bool getBool() const { return BooleanValue; }
+
+    void Reset(){
+        FloatValue = 0.0f;
+        IntValue = 0;
+        BooleanValue = false;
+    }
+
+};
+
+TrivialClass trivialWrite(){
+    return TrivialClass( 1.234f, 5 );
+}
+
+bool trivialRead( const TrivialClass & value ){
+    return value.FloatValue == 1.0f
+        && value.IntValue == 2
+        && value.BooleanValue == false;
+}
+
+EMSCRIPTEN_BINDINGS(trivial_objects){
+
+    function( "trivialRead", trivialRead );
+    function( "trivialWrite", trivialWrite );
+
+    trivial_class<TrivialClass>("TrivialClass")
+        .constructor<float>()
+        .constructor<float, int>()
+        .function("getFloat", &TrivialClass::getFloat)
+        ;
+}

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -2834,7 +2834,7 @@ public:
 
     void setFloat(float v) { FloatValue = v; }
 
-    void Reset(){
+    void reset(){
         FloatValue = 0.0f;
         IntValue = 0;
         BooleanValue = false;
@@ -2842,13 +2842,14 @@ public:
 
 };
 
-TrivialClass trivialWrite(){
-    return TrivialClass( 1.234f, 5 );
+void trivialWrite(TrivialClass & c){
+    c.FloatValue = 1.5f;
+    c.IntValue = 5;
 }
 
 bool trivialRead( const TrivialClass & value ){
-    return value.FloatValue == 1.0f
-        && value.IntValue == 2
+    return value.FloatValue == 0.0f
+        && value.IntValue == 0
         && value.BooleanValue == false;
 }
 
@@ -2861,6 +2862,9 @@ EMSCRIPTEN_BINDINGS(trivial_objects){
         .constructor<float>()
         .constructor<float, int>()
         .function("getFloat", &TrivialClass::getFloat)
+        .function("getInt", &TrivialClass::getInt)
         .function("setFloat", &TrivialClass::setFloat)
+        .function("reset", &TrivialClass::reset)
+        .function("trivialRead", trivialRead);
         ;
 }

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -2831,6 +2831,9 @@ public:
     int getInt() const { return IntValue; }
     bool getBool() const { return BooleanValue; }
 
+
+    void setFloat(float v) { FloatValue = v; }
+
     void Reset(){
         FloatValue = 0.0f;
         IntValue = 0;
@@ -2858,5 +2861,6 @@ EMSCRIPTEN_BINDINGS(trivial_objects){
         .constructor<float>()
         .constructor<float, int>()
         .function("getFloat", &TrivialClass::getFloat)
+        .function("setFloat", &TrivialClass::setFloat)
         ;
 }


### PR DESCRIPTION
Embind currently supports 2 mode for object exposure : value object and referenced object. The system is great for most types, but there a category of types that does not fit those 2 categories, mostly math types ( vector, matrix ).

The value object mode is too expensive as instance needs to be converted recursively every time it pass the c++/js boundary. On the other end, the referenced object needs to be deleted explicitly though delete. This is not convenient for such types.

This PR is introducing the support of trivial object. By C++ definition, a trivial object is one that does not have non-trivial constructor, copy-constructor and destructor. It can be though as POD object, or raw object. Those C++ classes can be managed as a memory buffer.

The idea is to copy the data of an instance into a separate ArrayBuffer.  So the object is kept byte-wise by the JS object. Every time the object needs to be modified, it is copied back in the heap before calling the C++ function. As the ArrayBuffer is separated from the heap one, the object can be garbage collected.

The work is not completely finished yet, but I would like to have early comments and advices.

The next major feature is to use property to access the buffer directly, e.g. vector.X would not need to go back to the heap.

Any interests, advices, comments?
