### PR TITLE
removed "extern C" to make it compile under Win32

### DIFF
--- a/tests/hello_world_sdl.cpp
+++ b/tests/hello_world_sdl.cpp
@@ -5,7 +5,7 @@
 #include <emscripten.h>
 #endif
 
-extern "C" int main(int argc, char** argv) {
+int main(int argc, char** argv) {
   printf("hello, world!\n");
 
   SDL_Init(SDL_INIT_VIDEO);


### PR DESCRIPTION
Under Win32 I get this compiler error (I'm following the Emscripten Tutorial from http://kripken.github.io/emscripten-site/docs/getting_started/Tutorial.html)


```msdos
 C:\bin\Emscripten\emscripten\1.35.0\system\include\SDL
End of search list.
hello_sdl.c:8:8: error: expected identifier or '('
extern "C" int main(int argc, char** argv) {
       ^
1 error generated.
ERROR:root:compiler frontend failed to generate LLVM bitcode, halting
```

I'm not an expert in C/C++ but I do not think that a C-file needs an "extern C" linkage.

After having removed it the compilation succeeded.