### PR TITLE
gamepad_only_once_per_frame

### DIFF
--- a/tests/test_html5.c
+++ b/tests/test_html5.c
@@ -264,8 +264,8 @@ void mainloop()
   for(int i = 0; i < numGamepads && i < 32; ++i)
   {
     EmscriptenGamepadEvent ge;
-    int failed = emscripten_get_gamepad_status(i, &ge);
-    if (!failed)
+    int ret = emscripten_get_gamepad_status(i, &ge);
+    if (ret == EMSCRIPTEN_RESULT_SUCCESS)
     {
       int g = ge.index;
       for(int j = 0; j < ge.numAxes; ++j)


### PR DESCRIPTION
Only poll gamepad api once per application frame in order to be safe if subsequent polls might change the data under the hood, which might lead to missing button events if they are buffered. See https://github.com/w3c/gamepad/issues/22. Also reduces the amount of garbage that is generated, and the number of times we jump to a call inside the browser if application iterates through multiple gamepads per frame.