### PR TITLE
Fix wrong parameter types in documentation

### DIFF
--- a/site/build/text/docs/api_reference/emscripten.h.txt
+++ b/site/build/text/docs/api_reference/emscripten.h.txt
@@ -911,7 +911,7 @@ int emscripten_async_wget2_data(const char* url, const char* requesttype, cons
         callbacks, untouched by the API itself. This may be used by a
         callback to identify the associated call.
 
-      * **int free** (*const*) -- Tells the runtime whether to free
+      * **free** (*int*) -- Tells the runtime whether to free
         the returned buffer after "onload" is complete. If "false"
         freeing the buffer is the receiver's responsibility.
 
@@ -1076,7 +1076,7 @@ void emscripten_idb_async_store(const char *db_name, const char *file_id, void* 
         callbacks, untouched by the API itself. This may be used by a
         callback to identify the associated call.
 
-      * **onload** (*em_async_wget_onload_func*) --
+      * **onload** (*em_arg_callback_func*) --
 
         Callback on successful load of the URL into the buffer. The
         callback function parameter values are:
@@ -1119,7 +1119,7 @@ void emscripten_idb_async_delete(const char *db_name, const char *file_id, voi
 
         * *(void*)* : Equal to "arg" (user defined data).
 
-void emscripten_idb_async_exists(const char *db_name, const char *file_id, void* arg, em_arg_callback_func oncheck, em_arg_callback_func onerror)
+void emscripten_idb_async_exists(const char *db_name, const char *file_id, void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror)
 
    Checks if data with a certain ID exists in the local IndexedDB
    storage asynchronously.
@@ -1136,7 +1136,7 @@ void emscripten_idb_async_exists(const char *db_name, const char *file_id, voi
         callbacks, untouched by the API itself. This may be used by a
         callback to identify the associated call.
 
-      * **oncheck** (*em_arg_callback_func*) --
+      * **oncheck** (*em_idb_exists_func*) --
 
         Callback on successful check, with arguments
 
@@ -1652,7 +1652,7 @@ em_socket_error_callback
 Functions
 ---------
 
-void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback *callback)
+void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback callback)
 
    Triggered by a "WebSocket" error.
 
@@ -1662,7 +1662,7 @@ void emscripten_set_socket_error_callback(void *userData, em_socket_error_callb
       * **userData** (*void**) -- Arbitrary user data to be passed
         to the callback.
 
-      * **callback** (*em_socket_error_callback**) -- Pointer to a
+      * **callback** (*em_socket_error_callback*) -- Pointer to a
         callback function. The callback returns a file descriptor,
         error code and message, and the arbitrary "userData" passed to
         this function.

--- a/site/build/text/docs/api_reference/html5.h.txt
+++ b/site/build/text/docs/api_reference/html5.h.txt
@@ -2717,7 +2717,7 @@ EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *tar
         which to initialize the WebGL context. If 0 is passed, the
         element specified by "Module.canvas" will be used.
 
-      * **attributes** (*EmscriptenWebGLContextAttributes**) -- The
+      * **attributes** (*const EmscriptenWebGLContextAttributes**) -- The
         attributes of the requested context version.
 
    Returns:

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -550,8 +550,8 @@ Functions
 	:param param: Request parameters for POST requests (see ``requesttype``). The parameters are specified in the same way as they would be in the URL for an equivalent GET request: e.g. ``key=value&key2=value2``.
 	:type param: const char*
 	:param void* arg: User-defined data that is passed to the callbacks, untouched by the API itself. This may be used by a callback to identify the associated call.
-	:param const int free: Tells the runtime whether to free the returned buffer after ``onload`` is complete. If ``false`` freeing the buffer is the receiver's responsibility.
-	:type free: const int
+	:param int free: Tells the runtime whether to free the returned buffer after ``onload`` is complete. If ``false`` freeing the buffer is the receiver's responsibility.
+	:type free: int
 	:param em_async_wget2_data_onload_func onload: Callback on successful load of the file. The callback function parameter values are:
 	
 		- *(void*)* : Equal to ``arg`` (user defined data).
@@ -637,7 +637,7 @@ Emscripten Asynchronous IndexedDB API
 	:param ptr: A pointer to the data to store.
 	:param num: How many bytes to store.
 	:param void* arg: User-defined data that is passed to the callbacks, untouched by the API itself. This may be used by a callback to identify the associated call.
-	:param em_async_wget_onload_func onload: Callback on successful load of the URL into the buffer. The callback function parameter values are:	
+	:param em_arg_callback_func onload: Callback on successful load of the URL into the buffer. The callback function parameter values are:
 	
 		- *(void*)* : Equal to ``arg`` (user defined data).
 	
@@ -662,7 +662,7 @@ Emscripten Asynchronous IndexedDB API
 	
 		- *(void*)* : Equal to ``arg`` (user defined data).
 
-.. c:function:: void emscripten_idb_async_exists(const char *db_name, const char *file_id, void* arg, em_arg_callback_func oncheck, em_arg_callback_func onerror)
+.. c:function:: void emscripten_idb_async_exists(const char *db_name, const char *file_id, void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror)
 		 
 	Checks if data with a certain ID exists in the local IndexedDB storage asynchronously.
 	
@@ -671,7 +671,7 @@ Emscripten Asynchronous IndexedDB API
 	:param db_name: The IndexedDB database.
 	:param file_id: The identifier of the data.
 	:param void* arg: User-defined data that is passed to the callbacks, untouched by the API itself. This may be used by a callback to identify the associated call.
-	:param em_arg_callback_func oncheck: Callback on successful check, with arguments
+	:param em_idb_exists_func oncheck: Callback on successful check, with arguments
 
 		- *(void*)* : Equal to ``arg`` (user defined data).
 		- *int* : Whether the file exists or not.
@@ -998,14 +998,14 @@ Callback functions
 Functions
 ---------
 
-.. c:function:: void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback *callback)
+.. c:function:: void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback callback)
 
 	Triggered by a ``WebSocket`` error. 
 	
 	See :ref:`emscripten-api-reference-sockets` for more information.
 	
 	:param void* userData: Arbitrary user data to be passed to the callback.
-	:param em_socket_error_callback* callback: Pointer to a callback function. The callback returns a file descriptor, error code and message, and the arbitrary ``userData`` passed to this function.
+	:param em_socket_error_callback callback: Pointer to a callback function. The callback returns a file descriptor, error code and message, and the arbitrary ``userData`` passed to this function.
 
 
 .. c:function:: void emscripten_set_socket_open_callback(void *userData, em_socket_callback callback)

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -1977,7 +1977,7 @@ Functions
 	:param target: The DOM canvas element in which to initialize the WebGL context. If 0 is passed, the element specified by ``Module.canvas`` will be used.
 	:type target: const char*
 	:param attributes: The attributes of the requested context version.
-	:type attributes: EmscriptenWebGLContextAttributes*
+	:type attributes: const EmscriptenWebGLContextAttributes*
 	:returns: On success, a strictly positive value that represents a handle to the created context. On failure, a negative number that can be cast to an |EMSCRIPTEN_RESULT| field to get the reason why the context creation failed.
 	:rtype: |EMSCRIPTEN_WEBGL_CONTEXT_HANDLE|
 

--- a/site/source/docs/api_reference/trace.h.rst
+++ b/site/source/docs/api_reference/trace.h.rst
@@ -404,7 +404,7 @@ Functions
 .. c:function:: void emscripten_trace_record_allocation(const void *address, int32_t size)
 
    :param address: Memory address which has been allocated.
-   :type address: void*
+   :type address: const void*
    :param size: Size of the memory block allocated.
    :type size: int32_t
    :rtype: void
@@ -417,9 +417,9 @@ Functions
 .. c:function:: void emscripten_trace_record_reallocation(const void *old_address, const void *new_address, int32_t size)
 
    :param old_address: Old address of the memory block which has been reallocated.
-   :type old_address: void*
+   :type old_address: const void*
    :param new_address: New address of the memory block which has been reallocated.
-   :type new_address: void*
+   :type new_address: const void*
    :param size: New size of the memory block reallocated.
    :type size: int32_t
    :rtype: void
@@ -432,7 +432,7 @@ Functions
 .. c:function:: void emscripten_trace_record_free(const void *address)
 
    :param address: Memory address which is being freed.
-   :type address: void*
+   :type address: const void*
    :rtype: void
 
    This must be called for each and every ``free`` operation. The best place
@@ -446,7 +446,7 @@ Functions
 .. c:function:: void emscripten_trace_annotate_address_type(const void *address, const char *type)
 
    :param address: Memory address which should be annotated.
-   :type address: void*
+   :type address: const void*
    :param type: The name of the data type being allocated.
    :type type: const char*
    :rtype: void
@@ -458,7 +458,7 @@ Functions
 .. c:function:: void emscripten_trace_associate_storage_size(const void *address, int32_t size)
 
    :param address: Memory address which should be annotated.
-   :type address: void*
+   :type address: const void*
    :param size: Size of the memory associated with this allocation.
    :type type: int32_t
    :rtype: void


### PR DESCRIPTION
The types did not match the declarations in the header files.

Thanks!