### PR TITLE
Custom messaging when proxied to worker

### DIFF
--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -102,7 +102,11 @@ Other methods
 	This method should be called to destroy C++ objects created in JavaScript using :ref:`WebIDL bindings <WebIDL-Binder>`. If this method is not called, an object may be garbage collected, but its destructor will not be called.
 
 	:param obj: The JavaScript-wrapped C++ object to be destroyed.
-	
+
+.. js:function:: Module.onCustomMessage
+
+	When compiled with ``PROXY_TO_WORKER = 1`` (see `settings.js <https://github.com/kripken/emscripten/blob/master/src/settings.js>`_), this callback (which should be implemented on both the client and worker's ``Module`` object) allows sending custom messages and data between the web worker and the main thread (using the ``postCustomMessage`` function defined in `proxyClient.js <https://github.com/kripken/emscripten/blob/master/src/proxyClient.js>`_ and `proxyWorker.js <https://github.com/kripken/emscripten/blob/master/src/proxyWorker.js>`_).
+
 Overriding execution environment
 ================================
 

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -223,9 +223,22 @@ worker.onmessage = function worker_onmessage(event) {
       }
       break;
     }
+    case 'custom': {
+      if (Module['onCustomMessage']) {
+        Module['onCustomMessage'](event);
+      } else {
+        throw 'Custom message received but client Module.onCustomMessage not implemented.';
+      }
+      break;
+    }
     default: throw 'what?';
   }
 };
+
+function postCustomMessage(data, options) {
+  options = options || {};
+  worker.postMessage({ target: 'custom', userData: data, preMain: options.preMain });
+}
 
 function cloneObject(event) {
   var ret = {};

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -458,7 +458,18 @@ onmessage = function onmessage(message) {
       removeRunDependency('worker-init');
       break;
     }
+    case 'custom': {
+      if (Module['onCustomMessage']) {
+        Module['onCustomMessage'](message);
+      } else {
+        throw 'Custom message received but worker Module.onCustomMessage not implemented.';
+      }
+      break;
+    }
     default: throw 'wha? ' + message.data.target;
   }
 };
 
+function postCustomMessage(data) {
+  postMessage({ target: 'custom', userData: data });
+}

--- a/tests/custom_messages_proxy.c
+++ b/tests/custom_messages_proxy.c
@@ -1,0 +1,12 @@
+#include <emscripten.h>
+
+int main()
+{
+    EM_ASM({
+        customMessageData += '[main]';
+        postCustomMessage({ op: 'fromMain' });
+    });
+
+    emscripten_exit_with_live_runtime();
+    return 0;
+}

--- a/tests/custom_messages_proxy_postjs.js
+++ b/tests/custom_messages_proxy_postjs.js
@@ -1,0 +1,30 @@
+var customMessageData = '';
+
+Module.onCustomMessage = function (message) {
+  var data = message.data.userData;
+  switch (data.op) {
+    case 'preMainCustomMessage': {
+      customMessageData += data.data;
+      break;
+    }
+    case 'runMain': {
+      postCustomMessage({ op: 'runningMain', data: customMessageData });
+      removeRunDependency('Custom Message Init');
+      break;
+    }
+    case 'postMainCustomMessage': {
+      customMessageData += data.data;
+      break;
+    }
+    case 'finish': {
+      postCustomMessage({ op: 'finishing', data: customMessageData + '[finish]' });
+      break;
+    }
+    default: {
+        throw 'unknown custom message';
+    }
+  }
+
+}
+
+addRunDependency('Custom Message Init');

--- a/tests/custom_messages_proxy_shell.html
+++ b/tests/custom_messages_proxy_shell.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Custom messaging proxy test</title>
+  </head>
+  <body>
+     <div>
+      <canvas id="canvas"></canvas>
+    </div>
+    <textarea id="output" rows="8"></textarea>
+    <script type="text/javascript">
+      var WebGLCLient;
+
+      function sendResult(success) {
+        if (window.sentTestResult) return;
+        window.sentTestResult = true;
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8888/report_result?' + (success ? 1 : 0));
+        xhr.send();
+        setTimeout(function() { window.close() }, 1000);
+      }
+
+      var Module = {
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          if (0) { // XXX disabled for safety typeof dump == 'function') {
+            dump(text + '\n'); // fast, straight to the real console
+          } else {
+            console.error(text);
+          }
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+
+        onCustomMessage: function(message) {
+          var data = message.data.userData;
+          switch (data.op) {
+            case 'runningMain': {
+              Module.print('runningMain with data: ' + data.data);
+              if (data.data !== '[preMain]') {
+                sendResult(false);
+              }
+              break;
+            }
+            case 'fromMain': {
+              postCustomMessage({ op: 'finish' });
+              break;
+            }
+            case 'finishing': {
+              Module.print('terminating with data: ' + data.data);
+              sendResult(data.data === '[preMain][main][postMain][finish]');
+              break;
+            }
+            default: {
+              Module.print('unknown custom message');
+              sendResult(false);
+            }
+          }
+        }
+      };
+    </script>
+    {{{ SCRIPT }}}
+    <script type="text/javascript">
+      postCustomMessage({ op: 'postMainCustomMessage', data: '[postMain]' });
+      postCustomMessage({ op: 'preMainCustomMessage', data: '[preMain]' }, { preMain: true });
+      postCustomMessage({ op: 'runMain' }, { preMain: true });
+    </script>
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3053,6 +3053,9 @@ window.close = function() {
   def test_canvas_size_proxy(self):
     self.btest(path_from_root('tests', 'canvas_size_proxy.c'), expected='0', args=['--proxy-to-worker'])
 
+  def test_custom_messages_proxy(self):
+    self.btest(path_from_root('tests', 'custom_messages_proxy.c'), expected='1', args=['--proxy-to-worker', '--shell-file', path_from_root('tests', 'custom_messages_proxy_shell.html'), '--post-js', path_from_root('tests', 'custom_messages_proxy_postjs.js')])
+
   def test_separate_asm(self):
     for opts in [['-O0'], ['-O1'], ['-O2'], ['-O2', '--closure', '1']]:
       print opts


### PR DESCRIPTION
* Adds the ability to send/receive user-specified messages asynchronously between the main thread and the web worker
* Custom messages can be specified to be handled before or after `main` is called
* Fixes a bug where a post-`main` message sent before `main` is called may be processed after other post-`main` messages are sent after `main` was already called, or not processed at all.
* Adds a test