### PR TITLE
Add a function for requesting canvas transfer to a thread.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -253,3 +253,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Aiden Koss <madd0131@umn.edu>
 * Dustin VanLerberghe <good_ol_dv@hotmail.com>
 * Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)
+* Oleksandr Chekhovskyi <oleksandr.chekhovskyi@gmail.com>

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2000,6 +2000,15 @@ Functions
 	:rtype: |EMSCRIPTEN_RESULT|
 
 	
+.. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_commit_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context)
+
+	Push rendered frame to the original canvas element. This function is only used for ``OffscreenCanvas`` contexts.
+
+	:param EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context: The WebGL context to commit.
+	:returns: :c:data:`EMSCRIPTEN_RESULT_SUCCESS`, or one of the other result values.
+	:rtype: |EMSCRIPTEN_RESULT|
+
+
 .. c:function:: EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context()
 
 	Returns the currently active WebGL rendering context, or 0 if no context is active. Calling any WebGL functions when there is no active rendering context is undefined and may throw a JavaScript exception.

--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -93,6 +93,14 @@ The following ``Module`` attributes affect code execution.
 
 	If set, :js:attr:`Module.printErr` will log when any file is read.
 
+.. js:attribute:: Module.canvas
+
+	Canvas object used for rendering. Can be ``HTMLCanvasElement`` or ``OffscreenCanvas``.
+
+.. js:attribute:: Module.transferCanvas
+
+	When ``transferCanvas`` is set to ``true``, ``Module.canvas`` will be transferred from main browser thread to the next created thread as ``OffscreenCanvas``. This new thread will be able to create a WebGL context and issue rendering commands directly. Function ``emscripten_transfer_canvas`` can be used in native code to set this flag.
+
 	
 Other methods
 =============

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -417,7 +417,9 @@ var LibraryGL = {
         errorInfo = event.statusMessage || errorInfo;
       }
       try {
-        canvas.addEventListener('webglcontextcreationerror', onContextCreationError, false);
+        if (canvas.addEventListener) {
+          canvas.addEventListener('webglcontextcreationerror', onContextCreationError, false);
+        }
         try {
           if (webGLContextAttributes.majorVersion == 1 && webGLContextAttributes.minorVersion == 0) {
             ctx = canvas.getContext("webgl", webGLContextAttributes) || canvas.getContext("experimental-webgl", webGLContextAttributes);
@@ -427,7 +429,9 @@ var LibraryGL = {
             throw 'Unsupported WebGL context version ' + majorVersion + '.' + minorVersion + '!'
           }
         } finally {
-          canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
+          if (canvas.removeEventListener) {
+            canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
+          }
         }
         if (!ctx) throw ':(';
       } catch (e) {
@@ -545,6 +549,13 @@ var LibraryGL = {
       if (!context) return false;
       GLctx = Module.ctx = context.GLctx; // Active WebGL context object.
       GL.currentContext = context; // Active Emscripten GL layer context object.
+      return true;
+    },
+
+    commitContext: function(contextHandle) {
+      var context = GL.contexts[contextHandle];
+      if (!context) return false;
+      context.GLctx.commit();
       return true;
     },
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1757,6 +1757,11 @@ var LibraryJSEvents = {
     return success ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
   },
 
+  emscripten_webgl_commit_context: function(contextHandle) {
+    var success = GL.commitContext(contextHandle);
+    return success ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+  },
+
   emscripten_webgl_get_current_context: function() {
     return GL.currentContext ? GL.currentContext.handle : 0;
   },

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -368,6 +368,15 @@ var LibraryPThread = {
 
     worker.pthread = pthread;
 
+    if (threadParams.transferCanvas) {
+      var offscreen = Module['canvas'].transferControlToOffscreen();
+
+      worker.postMessage({
+        cmd: 'canvas',
+        canvas: offscreen,
+      }, [offscreen]);
+    }
+
     // Ask the worker to start executing its pthread entry point function.
     worker.postMessage({
       cmd: 'run',
@@ -402,6 +411,10 @@ var LibraryPThread = {
 
   emscripten_force_num_logical_cores: function(cores) {
     {{{ makeSetValue('__num_logical_cores', 0, 'cores', 'i32') }}};
+  },
+
+  emscripten_transfer_canvas: function() {
+    Module['transferCanvas'] = true;
   },
 
   pthread_create__deps: ['_spawn_thread', 'pthread_getschedparam', 'pthread_self'],
@@ -470,6 +483,11 @@ var LibraryPThread = {
       pthread_ptr: threadInfoStruct,
       arg: arg,
     };
+
+    if (Module['transferCanvas']) {
+      threadParams.transferCanvas = true;
+      delete Module['transferCanvas'];
+    }
 
     if (ENVIRONMENT_IS_PTHREAD) {
       // The prepopulated pool of web workers that can host pthreads is stored in the main JS thread. Therefore if a

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -15,6 +15,8 @@ var LibraryPThreadStub = {
     // Ignored, no threading available.
   },
 
+  emscripten_transfer_canvas: function() {},
+
   emscripten_is_main_runtime_thread: function() {
     return 1;
   },

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -54,6 +54,8 @@ this.onmessage = function(e) {
     importScripts(e.data.url);
     FS.createStandardStreams();
     postMessage({ cmd: 'loaded' });
+  } else if (e.data.cmd === 'canvas') {
+    Module['canvas'] = e.data.canvas;
   } else if (e.data.cmd === 'run') { // This worker was idle, and now should start executing its pthread entry point.
     threadInfoStruct = e.data.threadInfoStruct;
     __register_pthread_ptr(threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0); // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -412,6 +412,7 @@ extern void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttri
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target, const EmscriptenWebGLContextAttributes *attributes);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+extern EMSCRIPTEN_RESULT emscripten_webgl_commit_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context();
 

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -22,6 +22,9 @@ int emscripten_num_logical_cores();
 // to query the number of cores in the system.
 void emscripten_force_num_logical_cores(int cores);
 
+// Request canvas transfer to the next created thread.
+void emscripten_transfer_canvas(void);
+
 // Atomically stores the given value to the memory location, and returns the value that was there prior to the store.
 uint8_t emscripten_atomic_exchange_u8(void/*uint8_t*/ *addr, uint8_t newVal);
 uint16_t emscripten_atomic_exchange_u16(void/*uint16_t*/ *addr, uint16_t newVal);


### PR DESCRIPTION
At this point, this is an RFC - code might need improvements.

This is to enable use of OffscreenCanvas with pthreads. Calling `emscripten_transfer_canvas()` will make the next created pthread receive the canvas from the main browser thread, and this new thread will be able to issue GL commands directly.

Canvas has to be transferred after the worker is created, but before it started running C++ code (because then it can no longer receive regular JS worker messages), and so the transfer is done in _spawn_thread function.