### PR TITLE
lowercase_s_in_fullscreen

### DIFF
--- a/src/headless.js
+++ b/src/headless.js
@@ -145,8 +145,8 @@ var document = {
       case 'div': {
         return {
           appendChild: function() {},
-          requestFullScreen: function() {
-            return document.getElementById('canvas').requestFullScreen();
+          requestFullscreen: function() {
+            return document.getElementById('canvas').requestFullscreen();
           },
         };
       }
@@ -177,7 +177,7 @@ var document = {
     appendChild: function(){},
   },
   exitPointerLock: function(){},
-  cancelFullScreen: function(){},
+  exitFullscreen: function(){},
 };
 var alert = function(x) {
   print(x);

--- a/src/headlessCanvas.js
+++ b/src/headlessCanvas.js
@@ -607,7 +607,7 @@ function headlessCanvas() {
     eventListeners: {},
     addEventListener: function(){},
     removeEventListener: function(){},
-    requestFullScreen: function() {
+    requestFullscreen: function() {
       document.fullscreenElement = document.getElementById('canvas');
       window.setTimeout(function() {
         document.callEventListeners('fullscreenchange');

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -3,7 +3,8 @@
 // Utilities for browser environments
 var LibraryBrowser = {
   $Browser__deps: ['emscripten_set_main_loop', 'emscripten_set_main_loop_timing'],
-  $Browser__postset: 'Module["requestFullScreen"] = function Module_requestFullScreen(lockPointer, resizeCanvas, vrDevice) { Browser.requestFullScreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
+  $Browser__postset: 'Module["requestFullScreen"] = function Module_requestFullScreen(lockPointer, resizeCanvas, vrDevice) { Module.printErr("Module.requestFullScreen is deprecated. Please call Module.requestFullscreen instead."); Module["requestFullScreen"] = Module["requestFullscreen"]; Browser.requestFullScreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
+                     'Module["requestFullscreen"] = function Module_requestFullscreen(lockPointer, resizeCanvas, vrDevice) { Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
                      'Module["requestAnimationFrame"] = function Module_requestAnimationFrame(func) { Browser.requestAnimationFrame(func) };\n' +
                      'Module["setCanvasSize"] = function Module_setCanvasSize(width, height, noUpdates) { Browser.setCanvasSize(width, height, noUpdates) };\n' +
                      'Module["pauseMainLoop"] = function Module_pauseMainLoop() { Browser.mainLoop.pause() };\n' +
@@ -74,7 +75,7 @@ var LibraryBrowser = {
         if (Module['postMainLoop']) Module['postMainLoop']();
       }
     },
-    isFullScreen: false,
+    isFullscreen: false,
     pointerLock: false,
     moduleContextCreatedCallbacks: [],
     workers: [],
@@ -313,10 +314,10 @@ var LibraryBrowser = {
 
     destroyContext: function(canvas, useWebGL, setInModule) {},
 
-    fullScreenHandlersInstalled: false,
+    fullscreenHandlersInstalled: false,
     lockPointer: undefined,
     resizeCanvas: undefined,
-    requestFullScreen: function(lockPointer, resizeCanvas, vrDevice) {
+    requestFullscreen: function(lockPointer, resizeCanvas, vrDevice) {
       Browser.lockPointer = lockPointer;
       Browser.resizeCanvas = resizeCanvas;
       Browser.vrDevice = vrDevice;
@@ -325,24 +326,22 @@ var LibraryBrowser = {
       if (typeof Browser.vrDevice === 'undefined') Browser.vrDevice = null;
 
       var canvas = Module['canvas'];
-      function fullScreenChange() {
-        Browser.isFullScreen = false;
+      function fullscreenChange() {
+        Browser.isFullscreen = false;
         var canvasContainer = canvas.parentNode;
-        if ((document['webkitFullScreenElement'] || document['webkitFullscreenElement'] ||
-             document['mozFullScreenElement'] || document['mozFullscreenElement'] ||
-             document['fullScreenElement'] || document['fullscreenElement'] ||
-             document['msFullScreenElement'] || document['msFullscreenElement'] ||
+        if ((document['fullscreenElement'] || document['mozFullScreenElement'] ||
+             document['msFullscreenElement'] || document['webkitFullscreenElement'] ||
              document['webkitCurrentFullScreenElement']) === canvasContainer) {
-          canvas.cancelFullScreen = document['cancelFullScreen'] ||
-                                    document['mozCancelFullScreen'] ||
-                                    document['webkitCancelFullScreen'] ||
-                                    document['msExitFullscreen'] ||
-                                    document['exitFullscreen'] ||
-                                    function() {};
-          canvas.cancelFullScreen = canvas.cancelFullScreen.bind(document);
+          canvas.exitFullscreen = document['exitFullscreen'] ||
+                                  document['cancelFullScreen'] ||
+                                  document['mozCancelFullScreen'] ||
+                                  document['msExitFullscreen'] ||
+                                  document['webkitCancelFullScreen'] ||
+                                  function() {};
+          canvas.exitFullscreen = canvas.exitFullscreen.bind(document);
           if (Browser.lockPointer) canvas.requestPointerLock();
-          Browser.isFullScreen = true;
-          if (Browser.resizeCanvas) Browser.setFullScreenCanvasSize();
+          Browser.isFullscreen = true;
+          if (Browser.resizeCanvas) Browser.setFullscreenCanvasSize();
         } else {
           
           // remove the full screen specific parent of the canvas again to restore the HTML structure from before going full screen
@@ -351,16 +350,17 @@ var LibraryBrowser = {
           
           if (Browser.resizeCanvas) Browser.setWindowedCanvasSize();
         }
-        if (Module['onFullScreen']) Module['onFullScreen'](Browser.isFullScreen);
+        if (Module['onFullScreen']) Module['onFullScreen'](Browser.isFullscreen);
+        if (Module['onFullscreen']) Module['onFullscreen'](Browser.isFullscreen);
         Browser.updateCanvasDimensions(canvas);
       }
 
-      if (!Browser.fullScreenHandlersInstalled) {
-        Browser.fullScreenHandlersInstalled = true;
-        document.addEventListener('fullscreenchange', fullScreenChange, false);
-        document.addEventListener('mozfullscreenchange', fullScreenChange, false);
-        document.addEventListener('webkitfullscreenchange', fullScreenChange, false);
-        document.addEventListener('MSFullscreenChange', fullScreenChange, false);
+      if (!Browser.fullscreenHandlersInstalled) {
+        Browser.fullscreenHandlersInstalled = true;
+        document.addEventListener('fullscreenchange', fullscreenChange, false);
+        document.addEventListener('mozfullscreenchange', fullscreenChange, false);
+        document.addEventListener('webkitfullscreenchange', fullscreenChange, false);
+        document.addEventListener('MSFullscreenChange', fullscreenChange, false);
       }
 
       // create a new parent to ensure the canvas has no siblings. this allows browsers to optimize full screen performance when its parent is the full screen root
@@ -369,17 +369,25 @@ var LibraryBrowser = {
       canvasContainer.appendChild(canvas);
 
       // use parent of canvas as full screen root to allow aspect ratio correction (Firefox stretches the root to screen size)
-      canvasContainer.requestFullScreen = canvasContainer['requestFullScreen'] ||
+      canvasContainer.requestFullscreen = canvasContainer['requestFullscreen'] ||
                                           canvasContainer['mozRequestFullScreen'] ||
                                           canvasContainer['msRequestFullscreen'] ||
-                                         (canvasContainer['webkitRequestFullScreen'] ? function() { canvasContainer['webkitRequestFullScreen'](Element['ALLOW_KEYBOARD_INPUT']) } : null) ||
-                                         (canvasContainer['webkitRequestFullscreen'] ? function() { canvasContainer['webkitRequestFullscreen'](Element['ALLOW_KEYBOARD_INPUT']) } : null);
+                                         (canvasContainer['webkitRequestFullscreen'] ? function() { canvasContainer['webkitRequestFullscreen'](Element['ALLOW_KEYBOARD_INPUT']) } : null) ||
+                                         (canvasContainer['webkitRequestFullScreen'] ? function() { canvasContainer['webkitRequestFullScreen'](Element['ALLOW_KEYBOARD_INPUT']) } : null);
 
       if (vrDevice) {
-        canvasContainer.requestFullScreen({ vrDisplay: vrDevice });
+        canvasContainer.requestFullscreen({ vrDisplay: vrDevice });
       } else {
-        canvasContainer.requestFullScreen();
+        canvasContainer.requestFullscreen();
       }
+    },
+
+    requestFullScreen: function(lockPointer, resizeCanvas, vrDevice) {
+        Module.printErr('Browser.requestFullScreen() is deprecated. Please call Browser.requestFullscreen instead.');
+        Browser.requestFullScreen = function(lockPointer, resizeCanvas, vrDevice) {
+          return Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice);
+        }
+        return Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice);
     },
 
     nextRAF: 0,
@@ -653,7 +661,7 @@ var LibraryBrowser = {
 
     windowedWidth: 0,
     windowedHeight: 0,
-    setFullScreenCanvasSize: function() {
+    setFullscreenCanvasSize: function() {
       // check if SDL is available   
       if (typeof SDL != "undefined") {
       	var flags = {{{ makeGetValue('SDL.screen+Runtime.QUANTUM_SIZE*0', '0', 'i32', 0, 1) }}};
@@ -690,10 +698,8 @@ var LibraryBrowser = {
           h = Math.round(w / Module['forcedAspectRatio']);
         }
       }
-      if (((document['webkitFullScreenElement'] || document['webkitFullscreenElement'] ||
-           document['mozFullScreenElement'] || document['mozFullscreenElement'] ||
-           document['fullScreenElement'] || document['fullscreenElement'] ||
-           document['msFullScreenElement'] || document['msFullscreenElement'] ||
+      if ((document['fullscreenElement'] || document['mozFullScreenElement'] ||
+           document['msFullscreenElement'] || document['webkitFullscreenElement'] ||
            document['webkitCurrentFullScreenElement']) === canvas.parentNode) && (typeof screen != 'undefined')) {
          var factor = Math.min(screen.width / w, screen.height / h);
          w = Math.round(w * factor);
@@ -1281,7 +1287,7 @@ var LibraryBrowser = {
     var canvas = Module['canvas'];
     {{{ makeSetValue('width', '0', 'canvas.width', 'i32') }}};
     {{{ makeSetValue('height', '0', 'canvas.height', 'i32') }}};
-    {{{ makeSetValue('isFullscreen', '0', 'Browser.isFullScreen ? 1 : 0', 'i32') }}};
+    {{{ makeSetValue('isFullscreen', '0', 'Browser.isFullscreen ? 1 : 0', 'i32') }}};
   },
 
   emscripten_create_worker: function(url) {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -507,7 +507,7 @@ var LibraryGLFW = {
       var resizeNeeded = true;
 
       // If the client is requestiong fullscreen mode
-      if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
+      if (document["fullscreen"] || document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
         GLFW.active.storedX = GLFW.active.x;
         GLFW.active.storedY = GLFW.active.y;
         GLFW.active.storedWidth = GLFW.active.width;
@@ -568,22 +568,37 @@ var LibraryGLFW = {
 #endif
     },
 
-    requestFullScreen: function() {
+    requestFullscreen: function() {
       var RFS = Module["canvas"]['requestFullscreen'] ||
-                Module["canvas"]['requestFullScreen'] ||
                 Module["canvas"]['mozRequestFullScreen'] ||
                 Module["canvas"]['webkitRequestFullScreen'] ||
                 (function() {});
       RFS.apply(Module["canvas"], []);
     },
 
-    cancelFullScreen: function() {
+    requestFullScreen: function() {
+      Module.printErr('GLFW.requestFullScreen() is deprecated. Please call GLFW.requestFullscreen instead.');
+      GLFW.requestFullScreen = function() {
+        return GLFW.requestFullscreen();
+      }
+      return GLFW.requestFullscreen();
+    },
+
+    exitFullscreen: function() {
       var CFS = document['exitFullscreen'] ||
                 document['cancelFullScreen'] ||
                 document['mozCancelFullScreen'] ||
                 document['webkitCancelFullScreen'] ||
           (function() {});
       CFS.apply(document, []);
+    },
+
+    cancelFullScreen: function() {
+      Module.printErr('GLFW.cancelFullScreen() is deprecated. Please call GLFW.exitFullscreen instead.');
+      GLFW.cancelFullScreen = function() {
+        return GLFW.exitFullscreen();
+      }
+      return GLFW.exitFullscreen();
     },
 
     getTime: function() {
@@ -777,9 +792,9 @@ var LibraryGLFW = {
 
       if (GLFW.active.id == win.id) {
         if (width == screen.width && height == screen.height) {
-          GLFW.requestFullScreen();
+          GLFW.requestFullscreen();
         } else {
-          GLFW.cancelFullScreen();
+          GLFW.cancelFullscreen();
           Browser.setCanvasSize(width, height);
           win.width = width;
           win.height = height;
@@ -809,7 +824,7 @@ var LibraryGLFW = {
       if (width <= 0 || height <= 0) return 0;
 
       if (monitor) {
-        GLFW.requestFullScreen();
+        GLFW.requestFullscreen();
       } else {
         Browser.setCanvasSize(width, height);
       }

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -249,19 +249,19 @@ var LibraryGLUT = {
 
     // TODO add fullscreen API ala:
     // http://johndyer.name/native-fullscreen-javascript-api-plus-jquery-plugin/
-    onFullScreenEventChange: function(event) {
+    onFullscreenEventChange: function(event) {
       var width;
       var height;
-      if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
+      if (document["fullscreen"] || document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
         width = screen["width"];
         height = screen["height"];
       } else {
         width = GLUT.windowWidth;
         height = GLUT.windowHeight;
         // TODO set position
-        document.removeEventListener('fullscreenchange', GLUT.onFullScreenEventChange, true);
-        document.removeEventListener('mozfullscreenchange', GLUT.onFullScreenEventChange, true);
-        document.removeEventListener('webkitfullscreenchange', GLUT.onFullScreenEventChange, true);
+        document.removeEventListener('fullscreenchange', GLUT.onFullscreenEventChange, true);
+        document.removeEventListener('mozfullscreenchange', GLUT.onFullscreenEventChange, true);
+        document.removeEventListener('webkitfullscreenchange', GLUT.onFullscreenEventChange, true);
       }
       Browser.setCanvasSize(width, height);
       /* Can't call _glutReshapeWindow as that requests cancelling fullscreen. */
@@ -272,22 +272,33 @@ var LibraryGLUT = {
       _glutPostRedisplay();
     },
 
-    requestFullScreen: function() {
-      var RFS = Module["canvas"]['requestFullscreen'] ||
-                Module["canvas"]['requestFullScreen'] ||
-                Module["canvas"]['mozRequestFullScreen'] ||
-                Module["canvas"]['webkitRequestFullScreen'] ||
-                (function() {});
-      RFS.apply(Module["canvas"], []);
+    requestFullscreen: function() {
+      Browser.requestFullscreen(/*lockPointer=*/false, /*resieCanvas=*/false);
     },
 
-    cancelFullScreen: function() {
+    requestFullScreen: function() {
+      Module.printErr('GLUT.requestFullScreen() is deprecated. Please call GLUT.requestFullscreen instead.');
+      GLUT.requestFullScreen = function() {
+        return GLUT.requestFullscreen();
+      }
+      return GLUT.requestFullscreen();
+    },
+
+    exitFullscreen: function() {
       var CFS = document['exitFullscreen'] ||
                 document['cancelFullScreen'] ||
                 document['mozCancelFullScreen'] ||
                 document['webkitCancelFullScreen'] ||
-                (function() {});
+          (function() {});
       CFS.apply(document, []);
+    },
+
+    cancelFullScreen: function() {
+      Module.printErr('GLUT.cancelFullScreen() is deprecated. Please call GLUT.exitFullscreen instead.');
+      GLUT.cancelFullScreen = function() {
+        return GLUT.exitFullscreen();
+      }
+      return GLUT.exitFullscreen();
     }
   },
 
@@ -530,7 +541,7 @@ var LibraryGLUT = {
 
   glutReshapeWindow__deps: ['$GLUT', 'glutPostRedisplay'],
   glutReshapeWindow: function(width, height) {
-    GLUT.cancelFullScreen();
+    GLUT.exitFullscreen();
     Browser.setCanvasSize(width, height);
     if (GLUT.reshapeFunc) {
       Runtime.dynCall('vii', GLUT.reshapeFunc, [width, height]);
@@ -540,7 +551,7 @@ var LibraryGLUT = {
 
   glutPositionWindow__deps: ['$GLUT', 'glutPostRedisplay'],
   glutPositionWindow: function(x, y) {
-    GLUT.cancelFullScreen();
+    GLUT.exitFullscreen();
     /* TODO */
     _glutPostRedisplay();
   },
@@ -551,10 +562,10 @@ var LibraryGLUT = {
     GLUT.windowY = 0; // TODO
     GLUT.windowWidth  = Module['canvas'].width;
     GLUT.windowHeight = Module['canvas'].height;
-    document.addEventListener('fullscreenchange', GLUT.onFullScreenEventChange, true);
-    document.addEventListener('mozfullscreenchange', GLUT.onFullScreenEventChange, true);
-    document.addEventListener('webkitfullscreenchange', GLUT.onFullScreenEventChange, true);
-    GLUT.requestFullScreen();
+    document.addEventListener('fullscreenchange', GLUT.onFullscreenEventChange, true);
+    document.addEventListener('mozfullscreenchange', GLUT.onFullscreenEventChange, true);
+    document.addEventListener('webkitfullscreenchange', GLUT.onFullscreenEventChange, true);
+    GLUT.requestFullscreen();
   },
 
   glutInitDisplayMode: function(mode) {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -546,7 +546,7 @@ var LibraryJSEvents = {
     },
 
     fullscreenEnabled: function() {
-      return document.fullscreenEnabled || document.mozFullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled;
+      return document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled;
     },
     
     fillFullscreenChangeEventData: function(eventStruct, e) {

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -706,7 +706,7 @@ var LibrarySDL = {
             SDL.canRequestFullscreen = true;
           } else if (event.type === 'keyup' || event.type === 'mouseup') {
             if (SDL.isRequestingFullscreen) {
-              Module['requestFullScreen'](true, true);
+              Module['requestFullscreen'](/*lockPointer=*/true, /*resizeCanvas=*/true);
               SDL.isRequestingFullscreen = false;
             }
             SDL.canRequestFullscreen = false;
@@ -1739,7 +1739,7 @@ var LibrarySDL = {
   SDL_ShowCursor: function(toggle) {
     switch (toggle) {
       case 0: // SDL_DISABLE
-        if (Browser.isFullScreen) { // only try to lock the pointer when in full screen mode
+        if (Browser.isFullscreen) { // only try to lock the pointer when in full screen mode
           Module['canvas'].requestPointerLock();
           return 0;
         } else { // else return SDL_ENABLE to indicate the failure
@@ -2094,8 +2094,8 @@ var LibrarySDL = {
   SDL_WM_GrabInput: function() {},
   
   SDL_WM_ToggleFullScreen: function(surf) {
-    if (Browser.isFullScreen) {
-      Module['canvas'].cancelFullScreen();
+    if (Browser.isFullscreen) {
+      Module['canvas'].exitFullscreen();
       return 1;
     } else {
       if (!SDL.canRequestFullscreen) {
@@ -3207,7 +3207,7 @@ var LibrarySDL = {
   SDL_DestroyRenderer: function(renderer) {},
 
   SDL_GetWindowFlags: function(x, y) {
-    if (Browser.isFullScreen) {
+    if (Browser.isFullscreen) {
        return 1;
     }
 
@@ -3244,8 +3244,8 @@ var LibrarySDL = {
   SDL_LogSetOutputFunction: function(callback, userdata) {},
 
   SDL_SetWindowFullscreen: function(window, fullscreen) {
-    if (Browser.isFullScreen) {
-      Module['canvas'].cancelFullScreen();
+    if (Browser.isFullscreen) {
+      Module['canvas'].exitFullscreen();
       return 1;
     } else {
       return 0;

--- a/src/shell.html
+++ b/src/shell.html
@@ -1201,7 +1201,7 @@
 <span id='controls'>
   <span><input type="checkbox" id="resize">Resize canvas</span>
   <span><input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer &nbsp;&nbsp;&nbsp;</span>
-  <span><input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+  <span><input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                             document.getElementById('resize').checked)">
   </span>
 </span>

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -61,7 +61,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/canvas_style_proxy_shell.html
+++ b/tests/canvas_style_proxy_shell.html
@@ -61,7 +61,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/embind/shell.html
+++ b/tests/embind/shell.html
@@ -25,7 +25,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/pthread/test_pthread_mandelbrot_shell.html
+++ b/tests/pthread/test_pthread_mandelbrot_shell.html
@@ -1197,7 +1197,7 @@
 <span id='controls' style="display:none">
   <span><input type="checkbox" id="resize">Resize canvas</span>
   <span><input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer &nbsp;&nbsp;&nbsp;</span>
-  <span><input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+  <span><input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                             document.getElementById('resize').checked)">
   </span>
 </span>

--- a/tests/sdl_canvas_size.html
+++ b/tests/sdl_canvas_size.html
@@ -28,7 +28,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/test_fflush.html
+++ b/tests/test_fflush.html
@@ -61,7 +61,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/test_html5_fullscreen.html
+++ b/tests/test_html5_fullscreen.html
@@ -61,7 +61,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     

--- a/tests/webgl_destroy_context_shell.html
+++ b/tests/webgl_destroy_context_shell.html
@@ -61,7 +61,7 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
                                                                                 document.getElementById('resize').checked)">
     </div>
     


### PR DESCRIPTION
Rename "requestFullScreen" to "requestFullscreen" and "cancelFullScreen" to "exitFullscreen" to strictly adhere to the same function naming as the Fullscreen API spec. Rename internal APIs to use lower case 's' as well for 'fullscreen' where applicable. Remove a bunch of capitalizations for symbol names that no browser ever implemented, e.g. afaik 'mozFullscreenElement' never existed, but was always 'mozFullScreenElement'. Relates to #4310.