### PR TITLE
Fix missing functions in documentation

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -317,7 +317,7 @@ Functions
 	:rtype: double
 	:return: The pixel ratio or 1.0 if not supported.
 
-.. c:function::void emscripten_hide_mouse(void)
+.. c:function:: void emscripten_hide_mouse(void)
 
 	Hide the OS mouse cursor over the canvas.
 
@@ -1170,21 +1170,21 @@ Typedefs
 Functions
 ---------
 
-.. c::function:: void emscripten_sleep(unsigned int ms)
+.. c:function:: void emscripten_sleep(unsigned int ms)
 
     Sleep for `ms` milliseconds.
 
-.. c::function:: emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size)
+.. c:function:: emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size)
 
     Create a coroutine which will be run as `func(arg)`.
 
     :param int stack_size: the stack size that should be allocated for the coroutine, use 0 for the default value.
 
-.. c::function:: int emscripten_coroutine_next(emscripten_coroutine coroutine)
+.. c:function:: int emscripten_coroutine_next(emscripten_coroutine coroutine)
 
     Run `coroutine` until it returns, or `emscripten_yield` is called. A non-zero value is returned if `emscripten_yield` is called, otherwise 0 is returned, and future calls of `emscripten_coroutine_next` on this coroutine is undefined behaviour.
 
-.. c::function:: void emscripten_yield(void)
+.. c:function:: void emscripten_yield(void)
 
     This function should only be called in a coroutine created by `emscripten_coroutine_create`, when it called, the coroutine is paused and the caller will continue.
     


### PR DESCRIPTION
Five functions were missing in output because of wrong sphinx syntax.

Thanks!