### PR TITLE
Add functions for running async callbacks on the main thread.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,3 +254,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dustin VanLerberghe <good_ol_dv@hotmail.com>
 * Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)
 * Régis Fénéon <regis.feneon@gmail.com>
+* Oleksandr Chekhovskyi <oleksandr.chekhovskyi@gmail.com>

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -92,16 +92,39 @@ typedef union em_variant_val
   char *cp;
 } em_variant_val;
 
+typedef void (*em_queued_callback_v)(void);
+typedef void (*em_queued_callback_vi)(void*);
+typedef void (*em_queued_callback_vii)(void*, void*);
+typedef void (*em_queued_callback_viii)(void*, void*, void*);
+
+typedef union em_variant_callback
+{
+  em_queued_callback_v v;
+  em_queued_callback_vi vi;
+  em_queued_callback_vii vii;
+  em_queued_callback_viii viii;
+} em_variant_callback;
+
 #define EM_QUEUED_CALL_MAX_ARGS 8
 typedef struct em_queued_call
 {
   int function;
   int operationDone;
+  em_variant_callback callback;
   em_variant_val args[EM_QUEUED_CALL_MAX_ARGS];
   em_variant_val returnValue;
 } em_queued_call;
 
+// Async call struct must be allocated with malloc, and will be freed automatically on the main thread.
+void emscripten_async_run_in_main_thread(em_queued_call *call);
+
 void emscripten_sync_run_in_main_thread(em_queued_call *call);
+
+void emscripten_async_run_in_main_thread_callback_v(em_queued_callback_v callback);
+void emscripten_async_run_in_main_thread_callback_vi(em_queued_callback_vi callback, void *arg1);
+void emscripten_async_run_in_main_thread_callback_vii(em_queued_callback_vii callback, void *arg1, void *arg2);
+void emscripten_async_run_in_main_thread_callback_viii(em_queued_callback_viii callback, void *arg1, void *arg2, void *arg3);
+
 void *emscripten_sync_run_in_main_thread_0(int function);
 void *emscripten_sync_run_in_main_thread_1(int function, void *arg1);
 void *emscripten_sync_run_in_main_thread_2(int function, void *arg1, void *arg2);
@@ -176,6 +199,10 @@ struct thread_profiler_block
 #define EM_PROXIED_TZSET 119
 #define EM_PROXIED_PTHREAD_CREATE 137
 #define EM_PROXIED_SYSCALL 138
+#define EM_PROXIED_ASYNC_CALLBACK_V 139
+#define EM_PROXIED_ASYNC_CALLBACK_VI 140
+#define EM_PROXIED_ASYNC_CALLBACK_VII 141
+#define EM_PROXIED_ASYNC_CALLBACK_VIII 142
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The idea is to be able to post arbitrary calls to the browser thread, to make it possible to use features that require browser event loop and/or DOM access, even if the app primarily runs in a dedicated thread.

Existing synchronous mechanism for specific functions has been extended to support async mode and arbitrary function pointers.

Queued calls structure becomes a ring buffer, and producer blocks on overflow. Consumer now only blocks for the duration of extracting a queued call.

This will need tests and docs, but let's confirm the general direction first.
