### PR TITLE
compiler-rt: add 128-bit integer shifts

### DIFF
--- a/system/lib/compiler-rt/lib/builtins/ashlti3.c
+++ b/system/lib/compiler-rt/lib/builtins/ashlti3.c
@@ -1,0 +1,45 @@
+/* ===-- ashlti3.c - Implement __ashlti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashlti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: a << b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int
+__ashlti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    twords input;
+    twords result;
+    input.all = a;
+    if (b & bits_in_dword)  /* bits_in_dword <= b < bits_in_tword */
+    {
+        result.s.low = 0;
+        result.s.high = input.s.low << (b - bits_in_dword);
+    }
+    else  /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.low  = input.s.low << b;
+        result.s.high = (input.s.high << b) | (input.s.low >> (bits_in_dword - b));
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/system/lib/compiler-rt/lib/builtins/ashrti3.c
+++ b/system/lib/compiler-rt/lib/builtins/ashrti3.c
@@ -1,0 +1,46 @@
+/* ===-- ashrti3.c - Implement __ashrti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __ashrti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: arithmetic a >> b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int
+__ashrti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    twords input;
+    twords result;
+    input.all = a;
+    if (b & bits_in_dword)  /* bits_in_dword <= b < bits_in_tword */
+    {
+        /* result.s.high = input.s.high < 0 ? -1 : 0 */
+        result.s.high = input.s.high >> (bits_in_dword - 1);
+        result.s.low = input.s.high >> (b - bits_in_dword);
+    }
+    else  /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.high  = input.s.high >> b;
+        result.s.low = (input.s.high << (bits_in_dword - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/system/lib/compiler-rt/lib/builtins/lshrti3.c
+++ b/system/lib/compiler-rt/lib/builtins/lshrti3.c
@@ -1,0 +1,45 @@
+/* ===-- lshrti3.c - Implement __lshrti3 -----------------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __lshrti3 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+/* Returns: logical a >> b */
+
+/* Precondition:  0 <= b < bits_in_tword */
+
+COMPILER_RT_ABI ti_int
+__lshrti3(ti_int a, si_int b)
+{
+    const int bits_in_dword = (int)(sizeof(di_int) * CHAR_BIT);
+    utwords input;
+    utwords result;
+    input.all = a;
+    if (b & bits_in_dword)  /* bits_in_dword <= b < bits_in_tword */
+    {
+        result.s.high = 0;
+        result.s.low = input.s.high >> (b - bits_in_dword);
+    }
+    else  /* 0 <= b < bits_in_dword */
+    {
+        if (b == 0)
+            return a;
+        result.s.high  = input.s.high >> b;
+        result.s.low = (input.s.high << (bits_in_dword - b)) | (input.s.low >> b);
+    }
+    return result.all;
+}
+
+#endif /* CRT_HAS_128BIT */

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -238,15 +238,17 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   def create_wasm_compiler_rt(libname):
     srcdir = shared.path_from_root('system', 'lib', 'compiler-rt', 'lib', 'builtins')
-    filenames = ['addtf3.c', 'comparetf2.c', 'divti3.c', 'extenddftf2.c', 'extendsftf2.c',
-                 'fixdfti.c', 'fixsfti.c', 'fixtfdi.c', 'fixtfsi.c', 'fixtfti.c',
-                 'fixunsdfti.c', 'fixunssfti.c', 'fixunstfdi.c', 'fixunstfsi.c', 'fixunstfti.c',
-                 'floatditf.c', 'floatsitf.c', 'floattidf.c', 'floattisf.c',
-                 'floatunditf.c', 'floatunsitf.c', 'floatuntidf.c', 'floatuntisf.c',
-                 'modti3.c', 'multf3.c', 'multi3.c', 'subtf3.c', 'ashrdi3.c',
-                 'ashldi3.c', 'fixdfdi.c', 'floatdidf.c', 'lshrdi3.c', 'moddi3.c',
+    filenames = ['addtf3.c', 'comparetf2.c', 'divti3.c', 'extenddftf2.c',
+                 'extendsftf2.c', 'fixdfti.c', 'fixsfti.c', 'fixtfdi.c',
+                 'fixtfsi.c', 'fixtfti.c', 'fixunsdfti.c', 'fixunssfti.c',
+                 'fixunstfdi.c', 'fixunstfsi.c', 'fixunstfti.c', 'floatditf.c',
+                 'floatsitf.c', 'floattidf.c', 'floattisf.c', 'floatunditf.c',
+                 'floatunsitf.c', 'floatuntidf.c', 'floatuntisf.c', 'modti3.c',
+                 'multf3.c', 'multi3.c', 'subtf3.c', 'ashrdi3.c', 'ashldi3.c',
+                 'fixdfdi.c', 'floatdidf.c', 'lshrdi3.c', 'moddi3.c',
                  'trunctfdf2.c', 'umoddi3.c', 'fixunsdfdi.c', 'muldi3.c',
-                 'divdi3.c', 'divmoddi4.c', 'udivdi3.c', 'udivmoddi4.c']
+                 'divdi3.c', 'divmoddi4.c', 'udivdi3.c', 'udivmoddi4.c',
+                 'ashlti3.c', 'ashrti3.c', 'lshrti3.c']
     files = (os.path.join(srcdir, f) for f in filenames)
     o_s = []
     commands = []


### PR DESCRIPTION
128-bit integer support was added in #4294, but shifts were removed and I'm not sure why. Some torture tests fail without them, so add them.