### PR TITLE
Compile __cxa_pure_virtual rather than providing it via JS.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1228,11 +1228,6 @@ LibraryManager.library = {
     Runtime.stackRestore(ret);
   },
 
-  __cxa_pure_virtual: function() {
-    ABORT = true;
-    throw 'Pure virtual function called!';
-  },
-
   llvm_flt_rounds: function() {
     return -1; // 'indeterminable' for FLT_ROUNDS
   },

--- a/system/lib/libcxxabi/symbols
+++ b/system/lib/libcxxabi/symbols
@@ -220,9 +220,11 @@
          T abort_message
          T __cxa_bad_cast
          T __cxa_bad_typeid
+         T __cxa_deleted_virtual
          T __cxa_demangle
          T __cxa_get_globals
          T __cxa_get_globals_fast
+         T __cxa_pure_virtual
          T __dynamic_cast
          t _ZL25default_terminate_handlerv
          t _ZL26default_unexpected_handlerv

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -182,6 +182,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       'cxa_guard.cpp',
       'cxa_new_delete.cpp',
       'cxa_handlers.cpp',
+      'cxa_virtual.cpp',
       'exception.cpp',
       'stdexcept.cpp',
       'typeinfo.cpp',


### PR DESCRIPTION
This allows wasm to use it as a normal function.