### PR TITLE
Use WebGL context version to construct GL_VERSION and GL_SHADING_LANGUAGE_VERSION

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -715,8 +715,19 @@ var LibraryGL = {
     switch(name_) {
       case 0x1F00 /* GL_VENDOR */:
       case 0x1F01 /* GL_RENDERER */:
-      case 0x1F02 /* GL_VERSION */:
         ret = allocate(intArrayFromString(GLctx.getParameter(name_)), 'i8', ALLOC_NORMAL);
+        break;
+      case 0x1F02 /* GL_VERSION */:
+        var glVersion = GLctx.getParameter(GLctx.VERSION);
+        // return GLES version string corresponding to the version of the WebGL context
+#if USE_WEBGL2
+        if (GLctx.canvas.GLctxObject.version >= 2) glVersion = 'OpenGL ES 3.0 (' + glVersion + ')';
+        else
+#endif
+        {
+          glVersion = 'OpenGL ES 2.0 (' + glVersion + ')';
+        }
+        ret = allocate(intArrayFromString(glVersion), 'i8', ALLOC_NORMAL);
         break;
       case 0x1F03 /* GL_EXTENSIONS */:
         var exts = GLctx.getSupportedExtensions();


### PR DESCRIPTION
This actually fixes the GL_VERSION string that must be of the form "OpenGL ES N.M ..." (OpenGL ES 2 and 3 specifications sections 6.1.5/6.1.6 resp.).
This also fixes the GL_SHADING_LANGUAGE_VERSION string in the case where the WebGL version string is not valid, especially with Microsoft Edge which returns a version of 0.96 instead of 1.0.
The WebGL version information is returned in the vendor-specific information field.