### PR TITLE
Name memory initialisation file correctly

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1557,7 +1557,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     js_transform_tempfiles = [final]
 
     if shared.Settings.MEM_INIT_METHOD > 0:
-      memfile = target + '.mem'
+      memfile = unsuffixed(target) + '.mem.js'
       shared.try_delete(memfile)
       def repl(m):
         # handle chunking of the memory initializer


### PR DESCRIPTION
Rather than `html.mem` or `js.mem`, it should be `.mem.js` as expected elsewhere in emcc (such about 20 lines below where it does `open(final + '.mem.js', 'w').write(src)`).  This is also handled better by some proxy servers (as `.js` is a known extension).