### PR TITLE
Add zero-args version of emscripten_sync_run_in_main_thread

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -102,6 +102,7 @@ typedef struct em_queued_call
 } em_queued_call;
 
 void emscripten_sync_run_in_main_thread(em_queued_call *call);
+void *emscripten_sync_run_in_main_thread_0(int function);
 void *emscripten_sync_run_in_main_thread_1(int function, void *arg1);
 void *emscripten_sync_run_in_main_thread_2(int function, void *arg1, void *arg2);
 void *emscripten_sync_run_in_main_thread_3(int function, void *arg1, void *arg2, void *arg3);

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -314,6 +314,14 @@ void EMSCRIPTEN_KEEPALIVE emscripten_sync_run_in_main_thread(em_queued_call *cal
 	emscripten_set_current_thread_status(EM_THREAD_STATUS_RUNNING);
 }
 
+void * EMSCRIPTEN_KEEPALIVE emscripten_sync_run_in_main_thread_0(int function)
+{
+	em_queued_call q = { function, 0 };
+	q.returnValue.vp = 0;
+	emscripten_sync_run_in_main_thread(&q);
+	return q.returnValue.vp;
+}
+
 void * EMSCRIPTEN_KEEPALIVE emscripten_sync_run_in_main_thread_1(int function, void *arg1)
 {
 	em_queued_call q = { function, 0 };

--- a/system/lib/pthreads.symbols
+++ b/system/lib/pthreads.symbols
@@ -79,6 +79,7 @@
          U emscripten_is_main_runtime_thread
          T emscripten_main_thread_process_queued_calls
          T emscripten_sync_run_in_main_thread
+         T emscripten_sync_run_in_main_thread_0
          T emscripten_sync_run_in_main_thread_1
          T emscripten_sync_run_in_main_thread_2
          T emscripten_sync_run_in_main_thread_3


### PR DESCRIPTION
tzset is already trying to use this in library.js, but it is not implemented, so causes a runtime crash:
`if (ENVIRONMENT_IS_PTHREAD) return _emscripten_sync_run_in_main_thread_0({{{ cDefine('EM_PROXIED_TZSET') }}});`