### PR TITLE
Add document.currentScript and Atomics to closure externs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,3 +252,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Harald Reingruber <code*at*h-reingruber.at>
 * Aiden Koss <madd0131@umn.edu>
 * Dustin VanLerberghe <good_ol_dv@hotmail.com>
+* Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -168,3 +168,28 @@ navigator.mozGamepads = function() {};
  * @return {Array.<Gamepad>}
  */
 navigator.gamepads = function() {};
+
+/**
+ * Backported from latest closure...
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript
+ */
+Document.prototype.currentScript;
+
+//Atomics library (not yet in latest closure):
+//See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics
+var Atomics;
+Atomics.prototype.NOTEQUAL = -1;
+Atomics.prototype.OK = 0;
+Atomics.prototype.TIMEDOUT = -2;
+Atomics.prototype.add = function(typedArray, index, value) {};
+Atomics.prototype.and = function(typedArray, index, value) {};
+Atomics.prototype.compareExchange = function(typedArray, index, expectedValue, replacementValue) {};
+Atomics.prototype.exchange = function(typedArray, index, value) {};
+Atomics.prototype.load = function(typedArray, index) {};
+Atomics.prototype.or = function(typedArray, index, value) {};
+Atomics.prototype.store = function(typedArray, index, value) {};
+Atomics.prototype.sub = function(typedArray, index, value) {};
+Atomics.prototype.xor = function(typedArray, index, value) {};
+Atomics.prototype.wait = function(typedArray, index, valuei, timeout) {};
+Atomics.prototype.wake = function(typedArray, index, value) {};
+Atomics.prototype.isLockFree = function(size) {};


### PR DESCRIPTION
Document.prototype.currentScript is in upstream closure and Atomics isn't yet.

This doesn't make closure builds work with pthreads - pthread-main.js is not run through closure, which means that it will not work correctly (as it won't know how to talk to the main thread as the postMessage objects will be differently named, and it tries to call into functions it has loaded via importScript that are named differently to how it was expecting).  This could be fixed with the --module argument to the closure compiler, which may still be useful even with wasm for JavaScript that is called from C++ code.