### PR TITLE
Backport fix for warning in llvm/clang for libmusl operator-precidence

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,3 +252,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Harald Reingruber <code*at*h-reingruber.at>
 * Aiden Koss <madd0131@umn.edu>
 * Dustin VanLerberghe <good_ol_dv@hotmail.com>
+* Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)

--- a/system/lib/libc/README.md
+++ b/system/lib/libc/README.md
@@ -1,0 +1,6 @@
+This folder contains the musl version of libc at `/musl`.  The upstream version can be found at http://www.musl-libc.org/
+
+Some changes have been made to the version that was taken from upstream, including:
+* A large number of emscripten-specific changes (from before this readme existed)
+* Backporting an operator-precedence warning fix from 6e76e1540fc58a418494bf5eb832b556f9c5763e in the upstream version
+

--- a/system/lib/libc/musl/src/math/fma.c
+++ b/system/lib/libc/musl/src/math/fma.c
@@ -273,7 +273,7 @@ static inline double add_and_denormalize(double a, double b, int scale)
 	if (sum.lo != 0) {
 		uhi.f = sum.hi;
 		bits_lost = -((int)(uhi.i >> 52) & 0x7ff) - scale + 1;
-		if (bits_lost != 1 ^ (int)(uhi.i & 1)) {
+		if ((bits_lost != 1) ^ (int)(uhi.i & 1)) {
 			/* hibits += (int)copysign(1.0, sum.hi * sum.lo) */
 			ulo.f = sum.lo;
 			uhi.i += 1 - (((uhi.i ^ ulo.i) >> 62) & 2);


### PR DESCRIPTION
A bit of googling suggests that @juj mentioned this to the upstream libmusl a while ago, and they implemented a fix:

[Upstream Commit](http://git.musl-libc.org/cgit/musl/commit/src/math/fma.c?id=6e76e1540fc58a418494bf5eb832b556f9c5763e)