### PR TITLE
Allow a transparent background on the canvas

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -283,6 +283,9 @@ var LibraryBrowser = {
             contextAttributes[attribute] = webGLContextAttributes[attribute];
           }
         }
+#if TRANSPARENT_BACKGROUND
+        contextAttributes.alpha = true;
+#endif
 #if GL_TESTING
         contextAttributes.preserveDrawingBuffer = true;
 #endif
@@ -292,7 +295,9 @@ var LibraryBrowser = {
           ctx = GL.getContext(contextHandle).GLctx;
         }
         // Set the background of the WebGL canvas to black
+#if !TRANSPARENT_BACKGROUND
         canvas.style.backgroundColor = "black";
+#endif
       } else {
         ctx = canvas.getContext('2d');
       }

--- a/src/settings.js
+++ b/src/settings.js
@@ -746,4 +746,6 @@ var CYBERDWARF = 0; // see http://kripken.github.io/emscripten-site/docs/debuggi
 
 var BUNDLED_CD_DEBUG_FILE = ""; // Path to the CyberDWARF debug file passed to the compiler
 
+var TRANSPARENT_BACKGROUND = 0; //Allow a transparent background in the canvas
+
 // Reserved: variables containing POINTER_MASKING.


### PR DESCRIPTION
This is so that the rest of the webpage can show through areas that are not opaque.  In this instance, we were writing an 'avatar viewer', with a textured background behind the canvas render of the avatar (with options to change what is behind it with CSS).

The black background obviously prevented this, and there does not seem to be a way to set the contextAttributes.alpha value from EGL (although there is from some other rendering approaches), so I put that in to the same setting, since it would be required for that to work.