### PR TITLE
dont_force_black_canvas

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -291,8 +291,6 @@ var LibraryBrowser = {
         if (contextHandle) {
           ctx = GL.getContext(contextHandle).GLctx;
         }
-        // Set the background of the WebGL canvas to black
-        canvas.style.backgroundColor = "black";
       } else {
         ctx = canvas.getContext('2d');
       }

--- a/src/shell.html
+++ b/src/shell.html
@@ -15,7 +15,7 @@
       div.emscripten { text-align: center; }      
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       #emscripten_logo {
         display: inline-block;

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       .spinner {
         height: 50px;

--- a/tests/canvas_style_proxy_shell.html
+++ b/tests/canvas_style_proxy_shell.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       .spinner {
         height: 50px;

--- a/tests/embind/shell.html
+++ b/tests/embind/shell.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
     </style>
   </head>
   <body>

--- a/tests/pthread/test_pthread_mandelbrot_shell.html
+++ b/tests/pthread/test_pthread_mandelbrot_shell.html
@@ -15,7 +15,7 @@
       div.emscripten { text-align: center; }      
       div.emscripten_border { border: 1px solid black; background: black;}
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       #emscripten_logo {
         display: inline-block;

--- a/tests/sdl_canvas_size.html
+++ b/tests/sdl_canvas_size.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
     </style>
   </head>
   <body>

--- a/tests/test_fflush.html
+++ b/tests/test_fflush.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       .spinner {
         height: 50px;

--- a/tests/test_html5_fullscreen.html
+++ b/tests/test_html5_fullscreen.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       .spinner {
         height: 50px;

--- a/tests/webgl_destroy_context_shell.html
+++ b/tests/webgl_destroy_context_shell.html
@@ -10,7 +10,7 @@
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; }
+      canvas.emscripten { border: 0px none; background-color: black; }
 
       .spinner {
         height: 50px;


### PR DESCRIPTION
Behavior change for setting black canvas background. Instead of Emscripten Browser.createContext() hardcoding to set the style, allow specifying the style in the CSS domain, where it's more flexible and pages can do how they please. Relates to #4350 and #4194 and #3406. Make black canvas the default style in the shells, to preserve the behavior like it used to be.