### PR TITLE
Run the LLVM wasm backend with -asm-verbose=false.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1307,7 +1307,9 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
 
   temp_s = temp_files.get('.wb.s').name
   backend_compiler = os.path.join(shared.LLVM_ROOT, 'llc')
-  backend_args = [backend_compiler, infile, '-march=wasm32', '-filetype=asm', '-o', temp_s]
+  backend_args = [backend_compiler, infile, '-march=wasm32', '-filetype=asm',
+                  '-asm-verbose=false',
+                  '-o', temp_s]
   backend_args += ['-thread-model=single'] # no threads support in backend, tell llc to not emit atomics
   if DEBUG:
     logging.debug('emscript: llvm wasm backend: ' + ' '.join(backend_args))


### PR DESCRIPTION
This disables comments in the assembly code that will be consumed by
s2wasm, which doesn't care about comments.