### PR TITLE
Handle missing connection to IndexedDB

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -42,6 +42,9 @@ mergeInto(LibraryManager.library, {
       } catch (e) {
         return callback(e);
       }
+      if (!req) {
+        return callback("Unable to connect to IndexedDB");
+      }
       req.onupgradeneeded = function(e) {
         var db = e.target.result;
         var transaction = e.target.transaction;


### PR DESCRIPTION
As we tested on Safari 9.1.1. In a private mode a `req` might be `null` and no Error is thrown during `open`. 
This patch prevents throwing an exception that `req` is a null object.