### PR TITLE
Allow glGetString to return values from the WEBGL_debug_renderer_info extension

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -715,6 +715,8 @@ var LibraryGL = {
     switch(name_) {
       case 0x1F00 /* GL_VENDOR */:
       case 0x1F01 /* GL_RENDERER */:
+      case 0x9245 /* UNMASKED_VENDOR_WEBGL */:
+      case 0x9246 /* UNMASKED_RENDERER_WEBGL */:
         ret = allocate(intArrayFromString(GLctx.getParameter(name_)), 'i8', ALLOC_NORMAL);
         break;
       case 0x1F02 /* GL_VERSION */:


### PR DESCRIPTION
The WebGL extension WEBGL_debug_renderer_info offers a couple of new parameters for glGetString, that this exposes.  You would still need to call emscripten_webgl_enable_extension to get at them.