### PR TITLE
Heap corruption check

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -912,6 +912,8 @@ function checkStackCookie() {
   if (HEAPU32[(STACK_MAX >> 2)-1] != 0x02135467 || HEAPU32[(STACK_MAX >> 2)-2] != 0x89BACDFE) {
     abort('Stack overflow! Stack cookie has been overwritten, expected hex dwords 0x89BACDFE and 0x02135467, but received 0x' + HEAPU32[(STACK_MAX >> 2)-2].toString(16) + ' ' + HEAPU32[(STACK_MAX >> 2)-1].toString(16));
   }
+  // Also test the global address 0 for integrity.
+  if (HEAP32[0] !== 0x63736d65 /* 'emsc' */) throw 'Runtime error: The application has corrupted its heap memory area (address zero)!';
 }
 
 function abortStackOverflow(allocSize) {
@@ -1425,11 +1427,14 @@ function setF64(ptr, value) {
 #if USE_PTHREADS
 if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
-  HEAP32[0] = 255;
+  HEAP32[0] = 0x63736d65; /* 'emsc' */
 #if USE_PTHREADS
+} else {
+  if (HEAP32[0] !== 0x63736d65) throw 'Runtime error: The application has corrupted its heap memory area (address zero)!';
 }
 #endif
-if (HEAPU8[0] !== 255 || HEAPU8[3] !== 0) throw 'Runtime error: either the current system is not little-endian, or it has corrupted its heap memory area (address zero)!';
+HEAP16[1] = 0x6373;
+if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
 #endif
 
 Module['HEAP'] = HEAP;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1422,8 +1422,14 @@ function setF64(ptr, value) {
 
 // Endianness check (note: assumes compiler arch was little-endian)
 #if SAFE_SPLIT_MEMORY == 0
-HEAP32[0] = 255;
-if (HEAPU8[0] !== 255 || HEAPU8[3] !== 0) throw 'Typed arrays 2 must be run on a little-endian system';
+#if USE_PTHREADS
+if (!ENVIRONMENT_IS_PTHREAD) {
+#endif
+  HEAP32[0] = 255;
+#if USE_PTHREADS
+}
+#endif
+if (HEAPU8[0] !== 255 || HEAPU8[3] !== 0) throw 'Runtime error: either the current system is not little-endian, or it has corrupted its heap memory area (address zero)!';
 #endif
 
 Module['HEAP'] = HEAP;


### PR DESCRIPTION
Update the error message of little endian check to avoid referring to typed arrays 2 mode, which is not relevant anymore. Also, only write 0x000000FF to address 0 in the beginning of the main thread so that the check has more power to detect memory corruption when pthread workers are spawned.