### PR TITLE
add support for CFI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,3 +254,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dustin VanLerberghe <good_ol_dv@hotmail.com>
 * Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)
 * Régis Fénéon <regis.feneon@gmail.com>
+* Dominic Chen <d.c.ddcc@gmail.com> (copyright owned by Google, Inc.)

--- a/emcc.py
+++ b/emcc.py
@@ -436,6 +436,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     default_object_extension = '.o'
     valid_abspaths = []
     separate_asm = False
+    cfi = False
 
     def is_valid_abspath(path_name):
       # Any path that is underneath the emscripten repository root must be ok.
@@ -724,6 +725,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs.append('-D__SSSE3__=1')
         newargs.append('-D__SSE4_1__=1')
         newargs[i] = ''
+      elif newargs[i].startswith("-fsanitize=cfi"):
+        cfi = True
 
     if should_exit:
       sys.exit(0)
@@ -1442,6 +1445,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       else:
         # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
         link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
+
+      if cfi:
+        if use_cxx:
+           link_opts.append("-wholeprogramdevirt")
+        link_opts.append("-lowertypetests")
 
       if AUTODEBUG:
         # let llvm opt directly emit ll, to skip writing and reading all the bitcode

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -546,6 +546,15 @@ Options that are modified or new in *emcc* are listed below:
    load during startup. See Avoid memory spikes by separating out
    asm.js.
 
+"-fsanitize=<check>"
+   Instructs the compiler to turn on runtime checks for various forms
+   of undefined or suspicious behavior. For more information, refer
+   to the appropriate compiler documentation. Only the following have
+   been tested:
+
+     * "cfi": Enable [control flow integrity](http://clang.llvm.org/docs/ControlFlowIntegrity.html)
+       checks. Note that this is only supported by Clang/LLVM, and
+       indirect function call checking requires Clang/LLVM 3.9+.
 
 Environment variables
 =====================


### PR DESCRIPTION
This patch modifies emcc to check if CFI is enabled in Clang, and if so, tells opt to execute the appropriate passes