### PR TITLE
Fix std::remove on folders

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -795,8 +795,6 @@ mergeInto(LibraryManager.library, {
       var node = FS.lookupNode(parent, name);
       var err = FS.mayDelete(parent, name, false);
       if (err) {
-        // POSIX says unlink should set EPERM, not EISDIR
-        if (err === ERRNO_CODES.EISDIR) err = ERRNO_CODES.EPERM;
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.unlink) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -795,6 +795,8 @@ mergeInto(LibraryManager.library, {
       var node = FS.lookupNode(parent, name);
       var err = FS.mayDelete(parent, name, false);
       if (err) {
+        // According to POSIX, we should map EISDIR to EPERM, but
+        // to be 'musl' compliant we have to forward Linux's error code.
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.unlink) {

--- a/tests/cstdio/test_remove.cpp
+++ b/tests/cstdio/test_remove.cpp
@@ -1,0 +1,61 @@
+#include <assert.h>
+#include <errno.h>
+#include <cstdio>
+#include <iostream>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
+  assert(fd >= 0);
+
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
+
+  close(fd);
+}
+
+void setup() {
+  create_file("file", "abcdef", 0777);
+  mkdir("dir", 0777);
+  create_file("dir/file", "abcdef", 0777);
+  mkdir("dir/subdir", 0777);
+}
+
+void cleanup() {
+  // make sure we get it all regardless of anything failing
+  unlink("file");
+  unlink("dir/file");
+  rmdir("dir/subdir");
+  rmdir("dir");
+}
+
+void test() {
+  int err;
+  
+  err = std::remove("dir/file");
+  assert(!err);
+
+  err = std::remove("file");
+  assert(!err);
+
+  // should fail, folder is not empty
+  err = std::remove("dir");
+  assert(err);
+
+  err = std::remove("dir/subdir");
+  assert(!err);
+
+  err = std::remove("dir");
+  assert(!err);
+
+  std::cout << "success";
+}
+
+int main() {
+  atexit(cleanup);
+  setup();
+  test();
+  return EXIT_SUCCESS;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1786,6 +1786,10 @@ value = real 0.00 imag 1.00''', force_c=True)
     src = open(path_from_root('tests', 'stdio', 'test_rename.c'), 'r').read()
     self.do_run(src, 'success', force_c=True)
 
+  def test_remove(self):
+    src = open(path_from_root('tests', 'cstdio', 'test_remove.cpp'), 'r').read()
+    self.do_run(src, 'success')
+
   def test_alloca_stack(self):
     test_path = path_from_root('tests', 'core', 'test_alloca_stack')
     src, output = (test_path + s for s in ('.in', '.out'))

--- a/tests/unistd/unlink.c
+++ b/tests/unistd/unlink.c
@@ -79,7 +79,9 @@ void test() {
 
   err = unlink("dir-readonly");
   assert(err == -1);
-#ifdef __linux__
+
+  // emscripten uses 'musl' what is an implementation of the standard library for Linux-based systems
+#if defined(__linux__) || defined(__EMSCRIPTEN__)
   assert(errno == EISDIR);
 #else
   assert(errno == EPERM);


### PR DESCRIPTION
`std::remove` expects `EISDIR` if it has been called on a directory: https://github.com/kripken/emscripten/blob/master/system/lib/libc/musl/src/stdio/remove.c
```cpp
int remove(const char *path)
{
	int r = syscall(SYS_unlink, path);
	return (r && errno == EISDIR) ? syscall(SYS_rmdir, path) : r;
}
```

This fix removes mapping from `EISDIR` to `EPERM` on `unlink`, it has been added long time ago: #1388

CC:
@inolen 
@kripken 

-----------

I wasn't able about C++ test, I did my best. 