### PR TITLE
Enhance support for wasm testing with emscripten test suite

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -603,7 +603,7 @@ class RunnerCore(unittest.TestCase):
   ## Does a complete test - builds, runs, checks output, etc.
   def do_run(self, src, expected_output, args=[], output_nicerizer=None, output_processor=None, no_build=False, main_file=None, additional_files=[], js_engines=None, post_build=None, basename='src.cpp', libraries=[], includes=[], force_c=False, build_ll_hook=None, extra_emscripten_args=[], assert_returncode=None):
     if Settings.DISABLE_EXCEPTION_CATCHING == 0 and self.is_wasm_backend():
-      return self.skip("Wasm backend doesn't support exceptions yet")
+      return self.skip("wasm backend doesn't support exceptions yet")
     if force_c or (main_file is not None and main_file[-2:]) == '.c':
       basename = 'src.c'
       Building.COMPILER = to_cc(Building.COMPILER)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -602,6 +602,8 @@ class RunnerCore(unittest.TestCase):
 
   ## Does a complete test - builds, runs, checks output, etc.
   def do_run(self, src, expected_output, args=[], output_nicerizer=None, output_processor=None, no_build=False, main_file=None, additional_files=[], js_engines=None, post_build=None, basename='src.cpp', libraries=[], includes=[], force_c=False, build_ll_hook=None, extra_emscripten_args=[], assert_returncode=None):
+    if Settings.DISABLE_EXCEPTION_CATCHING == 0 and self.is_wasm_backend():
+      return self.skip("Wasm backend doesn't support exceptions yet")
     if force_c or (main_file is not None and main_file[-2:]) == '.c':
       basename = 'src.c'
       Building.COMPILER = to_cc(Building.COMPILER)
@@ -1116,9 +1118,12 @@ if __name__ == '__main__':
     numFailures += len(names)
     resultMessages.append('Could not find %s tests' % (len(names),))
 
+  print 'Test suites:'
+  print [s[0] for s in suites]
   # Run the discovered tests
   testRunner = unittest.TextTestRunner(verbosity=2)
   for mod_name, suite in suites:
+    print 'Running %s: (%s tests)' % (mod_name, suite.countTestCases())
     res = testRunner.run(suite)
     msg = '%s: %s run, %s errors, %s failures, %s skipped' % (mod_name,
         res.testsRun, len(res.errors), len(res.failures), len(res.skipped)
@@ -1136,4 +1141,3 @@ if __name__ == '__main__':
   # Return the number of failures as the process exit code for automating success/failure reporting.
   exitcode = min(numFailures, 255)
   sys.exit(exitcode)
-

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -30,7 +30,7 @@ def make_command(filename, engine=None, args=[]):
   # label a path to nodejs containing a 'd8' as spidermonkey instead.
   jsengine = os.path.split(engine[0])[-1]
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
-  return engine + [filename] + (['--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
+  return engine + [filename] + (['--expose-wasm', '--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
 
 def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False, assert_returncode=0, error_limit=-1):
   #  # code to serialize out the test suite files
@@ -74,4 +74,3 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
   if assert_returncode is not None and proc.returncode is not assert_returncode:
     raise Exception('Expected the command ' + str(command) + ' to finish with return code ' + str(assert_returncode) + ', but it returned with code ' + str(proc.returncode) + ' instead! Output: ' + str(ret)[:error_limit])
   return ret
-


### PR DESCRIPTION
1) Add support for running tests with d8's native wasm support (instead
of the binaryen interpreter)
2) Skip setjmp/longjmp and exception handling tests when using the wasm
backend, as these are not supported yet.