### PR TITLE
Add ignore-flags for realpath of musl and the test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,3 +255,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)
 * Régis Fénéon <regis.feneon@gmail.com>
 * Dominic Chen <d.c.ddcc@gmail.com> (copyright owned by Google, Inc.)
+* Junji Hashimoto <junji.hashimoto@gmail.com>

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -73,6 +73,8 @@ mergeInto(LibraryManager.library, {
       4098/*O_RDWR|O_DSYNC*/: 'rs+'
     },
     flagsToPermissionString: function(flags) {
+      flags &= ~010000000 /*O_PATH*/; // Ignore this flag from musl, otherwise node.js fails to open the file.
+      flags &= ~00004000 /*O_NONBLOCK*/; // Ignore this flag from musl, otherwise node.js fails to open the file.
       flags &= ~0100000 /*O_LARGEFILE*/; // Ignore this flag from musl, otherwise node.js fails to open the file.
       flags &= ~02000000 /*O_CLOEXEC*/; // Some applications may pass it; it makes no sense for a single process.
       if (flags in NODEFS.flagsToPermissionStringMap) {


### PR DESCRIPTION
Hi.

Close https://github.com/kripken/emscripten/pull/4458 and open this PR.
PR changes from ```master``` to  ```incoming``` branch.
Add test_realpath_nodefs.

Comment of https://github.com/kripken/emscripten/pull/4458 is below.


When nodefs, realpath of musl always fails

[flagsToPermissionString of library_nodefs.js] (https://github.com/kripken/emscripten/blob/07b87426f898d6e9c677db291d9088c839197291/src/library_nodefs.js#L76-L77)  ignores ```O_CLOEXEC|O_LARGEFILE```.
These ignore-flags are not enough.

[realpath](https://github.com/kripken/emscripten/blob/07b87426f898d6e9c677db291d9088c839197291/system/lib/libc/musl/src/misc/realpath.c#L25)  of musl uses ```O_PATH|O_NONBLOCK|O_CLOEXEC|O_LARGEFILE```.

To fix these difference, this PR masks ```O_PATH|O_NONBLOCK```.
