### PR TITLE
Disable JS_OPTS earlier when using wasm backend

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,7 +46,6 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
   def is_wasm_backend(self):
     return LLVM_TARGET == WASM_TARGET
 
-  @no_wasm_backend
   def test_hello_world(self):
       test_path = path_from_root('tests', 'core', 'test_hello_world')
       src, output = (test_path + s for s in ('.in', '.out'))


### PR DESCRIPTION
Previously the JSOptimizer was just bailing for wasm when run, but this
PR disables it earlier, because some other things (e.g. emitting
EMSCRIPTEN_GENERATED_FUNCTIONS, which test_hello_world checks) are also
conditioned on shared.Settings.RUNNING_JS_OPTS.