### PR TITLE
Fix windows node file eof read

### DIFF
--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -100,13 +100,17 @@ mergeInto(LibraryManager.library, {
             var buf = new Buffer(BUFSIZE);
             var bytesRead = 0;
 
+            var isPosixPlatform = (process.platform != 'win32'); // Node doesn't offer a direct check, so test by exclusion
+
             var fd = process.stdin.fd;
-            // Linux and Mac cannot use process.stdin.fd (which isn't set up as sync)
-            var usingDevice = false;
-            try {
-              fd = fs.openSync('/dev/stdin', 'r');
-              usingDevice = true;
-            } catch (e) {}
+            if (isPosixPlatform) {
+              // Linux and Mac cannot use process.stdin.fd (which isn't set up as sync)
+              var usingDevice = false;
+              try {
+                fd = fs.openSync('/dev/stdin', 'r');
+                usingDevice = true;
+              } catch (e) {}
+            }
 
             bytesRead = fs.readSync(fd, buf, 0, BUFSIZE, null);
 

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -112,7 +112,14 @@ mergeInto(LibraryManager.library, {
               } catch (e) {}
             }
 
-            bytesRead = fs.readSync(fd, buf, 0, BUFSIZE, null);
+            try {
+              bytesRead = fs.readSync(fd, buf, 0, BUFSIZE, null);
+            } catch(e) {
+              // Cross-platform differences: on Windows, reading EOF throws an exception, but on other OSes,
+              // reading EOF returns 0. Uniformize behavior by treating the EOF exception to return 0.
+              if (e.toString().indexOf('EOF') != -1) bytesRead = 0;
+              else throw e;
+            }
 
             if (usingDevice) { fs.closeSync(fd); }
             if (bytesRead > 0) {


### PR DESCRIPTION
Node.js has cross-platform behavioral differences that on Windows, fs.readSync() will throw an EOF exception when at end of file, but on Linux and OS X, the read will just return `null`. This would cause `EPERM` errno on Windows when trying to read end of file. Fix by catching the error and adapting to the expected null return behavior. Fixes #3282.

Also fixes dirty behavior that on Windows in node.js, the stdin read code would attempt to read hardcoded file `C:\dev\stdin`.