### PR TITLE
Eager tempfile deletion without atexit part1

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -63,10 +63,11 @@ and set up the location to the native optimizer in ~/.emscripten
 temp_files = shared.configuration.get_temp_files()
 
 def build(src, result_libs, args=[]):
-  temp = temp_files.get('.cpp').name
-  open(temp, 'w').write(src)
-  temp_js = temp_files.get('.js').name
-  shared.Building.emcc(temp, args, output_filename=temp_js)
+  with temp_files.get_file('.cpp') as temp:
+    open(temp, 'w').write(src)
+    temp_js = temp_files.get('.js').name
+    shared.Building.emcc(temp, args, output_filename=temp_js)
+
   assert os.path.exists(temp_js), 'failed to build file'
   if result_libs:
     for lib in result_libs:

--- a/emcc.py
+++ b/emcc.py
@@ -1890,9 +1890,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Separate out the asm.js code, if asked. Or, if necessary for another option
     if (separate_asm or shared.Settings.BINARYEN) and not shared.Settings.WASM_BACKEND:
       logging.debug('separating asm')
-      temp_target = misc_temp_files.get(suffix='.js').name
-      subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), js_target, asm_target, temp_target])
-      shutil.move(temp_target, js_target)
+      with misc_temp_files.get_file(suffix='.js') as temp_target:
+        subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), js_target, asm_target, temp_target])
+        shutil.move(temp_target, js_target)
 
       # extra only-my-code logic
       if shared.Settings.ONLY_MY_CODE:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6239,7 +6239,8 @@ struct C {
 C c;
 int main() {}
       ''')
-      out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE).communicate()
+      with clean_write_access_to_canonical_temp_dir():
+        out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE).communicate()
       self.assertContained('___syscall54', err) # the failing call should be mentioned
       self.assertContained('ctorEval.js', err) # with a stack trace
       self.assertContained('ctor_evaller: not successful', err) # with logging

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2763,7 +2763,8 @@ int main(int argc, char **argv) {
           (['-O3'], 'LLVM opts: -O3'),
         ]:
         print args, expect
-        output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).communicate()
+        with clean_write_access_to_canonical_temp_dir():
+          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).communicate()
         self.assertContained(expect, err)
         if '-O3' in args or '-Oz' in args or '-Os' in args:
           self.assertContained('registerizeHarder', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -22,8 +22,8 @@ class clean_write_access_to_canonical_temp_dir:
         os.unlink(os.path.join(CANONICAL_TEMP_DIR, x))
 
   def __enter__(self):
-    CANONICAL_TEMP_DIR_exists = os.path.exists(CANONICAL_TEMP_DIR)
-    if not CANONICAL_TEMP_DIR_exists:
+    self.CANONICAL_TEMP_DIR_exists = os.path.exists(CANONICAL_TEMP_DIR)
+    if not self.CANONICAL_TEMP_DIR_exists:
       os.makedirs(CANONICAL_TEMP_DIR)
     else:
       # Delete earlier files in the canonical temp directory so that
@@ -32,7 +32,11 @@ class clean_write_access_to_canonical_temp_dir:
       self.clean_emcc_files_in_temp_dir()
 
   def __exit__(self, type, value, traceback):
-    self.clean_emcc_files_in_temp_dir()
+    if not self.CANONICAL_TEMP_DIR_exists:
+      try_delete(CANONICAL_TEMP_DIR)
+      pass
+    else:
+      self.clean_emcc_files_in_temp_dir()
 
 class other(RunnerCore):
   def test_emcc(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4828,7 +4828,8 @@ int main(void) {
       try:
         os.environ['EMCC_DEBUG'] = '1'
         os.environ['EMCC_NATIVE_OPTIMIZER'] = '1'
-        out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2',] + args, stderr=PIPE).communicate()
+        with clean_write_access_to_canonical_temp_dir():
+          out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2',] + args, stderr=PIPE).communicate()
       finally:
         if old_debug: os.environ['EMCC_DEBUG'] = old_debug
         else: del os.environ['EMCC_DEBUG']

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -125,6 +125,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           os.chdir(os.path.dirname(path))
           self.assertContained('hello, world!', run_js(os.path.basename(path)))
           os.chdir(last)
+          try_delete(path)
       finally:
         os.chdir(self.get_dir())
       self.clear()

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -8,17 +8,17 @@ DUPLICATE_FUNCTION_ELIMINATOR = path_from_root('tools', 'eliminate-duplicate-fun
 def process_shell(js, js_engine, shell, equivalentfn_hash_info=None):
   suffix = '.eliminatedupes'
 
-  temp_file = temp_files.get(suffix + '.js').name
-  f = open(temp_file, 'w')
-  f.write(shell)
-  f.write('\n')
+  with temp_files.get_file(suffix + '.js') as temp_file:
+    f = open(temp_file, 'w')
+    f.write(shell)
+    f.write('\n')
 
-  f.write(equivalentfn_hash_info)
-  f.close()
+    f.write(equivalentfn_hash_info)
+    f.close()
 
-  (output,error) = subprocess.Popen(js_engine +
-      [DUPLICATE_FUNCTION_ELIMINATOR, temp_file, '--use-hash-info', '--no-minimize-whitespace'],
-      stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+    (output,error) = subprocess.Popen(js_engine +
+        [DUPLICATE_FUNCTION_ELIMINATOR, temp_file, '--use-hash-info', '--no-minimize-whitespace'],
+        stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
   assert len(output) > 0
   assert len(error) == 0
 

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -154,6 +154,8 @@ def write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename):
 # the global set of function implementation hashes. If set to
 # False, we assume that we have to use the global hash info to
 # reduce the set of duplicate functions
+# Returns the filename of the processed JS file, which is expected to be
+# deleted by the caller once done.
 def run_on_js(filename, gen_hash_info=False):
   js_engine=shared.NODE_JS
 
@@ -354,11 +356,12 @@ def eliminate_duplicate_funcs(file_name):
 
     # Generate the JSON for the equivalent hash first
     processed_file = run_on_js(filename=file_name, gen_hash_info=True)
-
-    save_temp_file(processed_file)
-
-    # Use the hash to reduce the JS file
-    final_file = run_on_js(filename=processed_file, gen_hash_info=False)
+    try:
+      save_temp_file(processed_file)
+      # Use the hash to reduce the JS file
+      final_file = run_on_js(filename=processed_file, gen_hash_info=False)
+    finally:
+      os.remove(processed_file)
 
     save_temp_file(final_file)
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -764,12 +764,12 @@ if __name__ == '__main__':
   tabled_funcs = asm.get_table_funcs()
   exported_funcs = [func.split(':')[0] for func in asm.exports]
 
-  temp = temp_files.get('.js').name # infile + '.tmp.js'
 
   # find emterpreted functions reachable by non-emterpreted ones, we will force a trampoline for them later
 
-  shared.Building.js_optimizer(infile, ['findReachable'], extra_info={ 'blacklist': list(emterpreted_funcs) }, output_filename=temp, just_concat=True)
-  asm = asm_module.AsmModule(temp)
+  with temp_files.get_file('.js') as temp: # infile + '.tmp.js'
+    shared.Building.js_optimizer(infile, ['findReachable'], extra_info={ 'blacklist': list(emterpreted_funcs) }, output_filename=temp, just_concat=True)
+    asm = asm_module.AsmModule(temp)
   lines = asm.funcs_js.split('\n')
 
   reachable_funcs = set([])
@@ -782,10 +782,10 @@ if __name__ == '__main__':
   external_emterpreted_funcs = filter(lambda func: func in tabled_funcs or func in exported_funcs or func in reachable_funcs, emterpreted_funcs)
 
   # process functions, generating bytecode
-  shared.Building.js_optimizer(infile, ['emterpretify'], extra_info={ 'emterpretedFuncs': list(emterpreted_funcs), 'externalEmterpretedFuncs': list(external_emterpreted_funcs), 'opcodes': OPCODES, 'ropcodes': ROPCODES, 'ASYNC': ASYNC, 'PROFILING': PROFILING, 'ASSERTIONS': ASSERTIONS }, output_filename=temp, just_concat=True)
-
-  # load the module and modify it
-  asm = asm_module.AsmModule(temp)
+  with temp_files.get_file('.js') as temp:
+    shared.Building.js_optimizer(infile, ['emterpretify'], extra_info={ 'emterpretedFuncs': list(emterpreted_funcs), 'externalEmterpretedFuncs': list(external_emterpreted_funcs), 'opcodes': OPCODES, 'ropcodes': ROPCODES, 'ASYNC': ASYNC, 'PROFILING': PROFILING, 'ASSERTIONS': ASSERTIONS }, output_filename=temp, just_concat=True)
+    # load the module and modify it
+    asm = asm_module.AsmModule(temp)
 
   relocations = [] # list of places that need to contain absolute offsets, we will add eb to them at runtime to relocate them
 

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -39,13 +39,26 @@ class TempFiles:
     self.to_clean.append(filename)
 
   def get(self, suffix):
-    """Returns a named temp file  with the given prefix."""
+    """Returns a named temp file with the given prefix."""
     named_file = tempfile.NamedTemporaryFile(dir=self.tmp, suffix=suffix, delete=False)
     self.note(named_file.name)
     return named_file
 
+  def get_file(self, suffix):
+    """Returns an object representing a temp file, that has convenient pythonesque semantics for being
+    used via a construct 'with TempFiles.get_file(..) as filename:'. The file will be deleted immediately
+    once the with block is exited."""
+    class TempFileObject:
+      def __enter__(self_):
+        self_.file = tempfile.NamedTemporaryFile(dir=self.tmp, suffix=suffix, delete=False)
+        return self_.file.name
+
+      def __exit__(self_, type, value, traceback):
+        try_delete(self_.file.name)
+    return TempFileObject()
+
   def get_dir(self):
-    """Returns a named temp file  with the given prefix."""
+    """Returns a named temp directory with the given prefix."""
     directory = tempfile.mkdtemp(dir=self.tmp)
     self.note(directory)
     return directory

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -45,12 +45,13 @@ class TempFiles:
     return named_file
 
   def get_file(self, suffix):
-    """Returns an object representing a temp file, that has convenient pythonesque semantics for being
-    used via a construct 'with TempFiles.get_file(..) as filename:'. The file will be deleted immediately
-    once the with block is exited."""
+    """Returns an object representing a RAII-like access to a temp file, that has convenient pythonesque
+    semantics for being used via a construct 'with TempFiles.get_file(..) as filename:'. The file will be
+    deleted immediately once the 'with' block is exited."""
     class TempFileObject:
       def __enter__(self_):
         self_.file = tempfile.NamedTemporaryFile(dir=self.tmp, suffix=suffix, delete=False)
+        self_.file.close() # NamedTemporaryFile passes out open file handles, but callers prefer filenames (and open their own handles manually if needed)
         return self_.file.name
 
       def __exit__(self_, type, value, traceback):


### PR DESCRIPTION
Makes a number of call sites that use temp files to explicitly manager their use of the files, and immediately clean them up after done. Closes #4446.

This is part 1 of the work, part 2 is less critical but something that I'd like to do in the future, which is to deprecate the `temp_files.note()` altogether and remove relying on Python atexit behavior for the cleanup. There are still a few places where this is done after this PR, but none which currently interact with `multiprocessing.Pool` I think, which is why the `other` suite will successfully run without leaks after this.

Also fixes few real temp file leaks that existed in the test suite and in duplicate_function_eliminator.py.
