### PR TITLE
Export malloc and free from wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1066,7 +1066,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.ONLY_MY_CODE:
       if type(shared.Settings.EXPORTED_FUNCTIONS) in (list, tuple):
         # always need malloc and free to be kept alive and exported, for internal use and other modules
-        for required_export in ['_malloc', '_free']:
+        # _malloc and _free are for asm.js, malloc and free are for wasm
+        # (Wasm does not append an underscore to function names)
+        for required_export in ['_malloc', '_free', 'malloc', 'free']:
           if required_export not in shared.Settings.EXPORTED_FUNCTIONS:
             shared.Settings.EXPORTED_FUNCTIONS.append(required_export)
       else:


### PR DESCRIPTION
In function _sbrk, it sets Runtime.dynamicAlloc function to some error
function to prevent reentrance. But it does not set Runtime.dynamicAlloc
to the original dynamicAlloc function anywhere. So, effectively, once
_sbrk is called, we cannot call _malloc ever again, because _malloc
calls Runtime.dynamicAlloc.

In asm.js, this problem did not appear because there are two _malloc
functions in the resulting js code, where one is _malloc from library.js
and the other is _malloc compiled from libc. And all calls to _malloc
called the version in libc, which does not call Runtime.dynamicAlloc.

But in WebAssembly, some functions in js code (like
___cxa_find_matching_catch) calls _malloc and this calls _malloc in
library.js, because there is no other _malloc in this case.
So this fails:
_sbrk(N);
_malloc(M);
where N and M is any number.