### PR TITLE
Fix inlining bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -256,3 +256,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Régis Fénéon <regis.feneon@gmail.com>
 * Dominic Chen <d.c.ddcc@gmail.com> (copyright owned by Google, Inc.)
 * Junji Hashimoto <junji.hashimoto@gmail.com>
+* Heejin Ahn <aheejin@gmail.com> (copyright owned by Google, Inc.)

--- a/emcc.py
+++ b/emcc.py
@@ -1245,6 +1245,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       args = [call] + newargs + input_files
       if file_ending.endswith(CXX_ENDINGS):
         args += shared.EMSDK_CXX_OPTS
+      if not shared.Building.can_inline():
+        args.append('-fno-inline-functions')
       args = system_libs.process_args(args, shared.Settings)
       return args
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6480,7 +6480,7 @@ int main() {
 
     # To this test to be successful, foo() shouldn't have been inlined above and
     # foo() should be in the function list
-    syms = Building.llvm_nm('test.bc')
+    syms = Building.llvm_nm('test.bc', include_internal=True)
     assert 'foo' in syms.defs, 'foo() should not be inlined'
     try_delete('test.c')
     try_delete('test.bc')


### PR DESCRIPTION
Currently INLINING_LIMIT option does not do anything for clang. (And in
opt, emcc only checks whether it is 0 or not, so the limit number given
actually does not matter unless it is 0.)
So we give -O2, clang inlines short functions even if INLINING_LIMIT is
nonzero. This patch fixes this bug.