### PR TITLE
Fix Building.llvm_nm bug

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1650,7 +1650,7 @@ class Building:
           ret.undefs.append(symbol)
         elif status == 'C':
           ret.commons.append(symbol)
-        elif status == status.upper(): # all other uppercase statuses ('T', etc.) are normally defined symbols
+        elif status in ['W', 't', 'T', 'd', 'D']:
           ret.defs.append(symbol)
         # otherwise, not something we should notice
     ret.defs = set(ret.defs)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1627,7 +1627,7 @@ class Building:
   nm_cache = {} # cache results of nm - it can be slow to run
 
   @staticmethod
-  def llvm_nm(filename, stdout=PIPE, stderr=None):
+  def llvm_nm(filename, stdout=PIPE, stderr=None, **kwargs):
     if filename in Building.nm_cache:
       #logging.debug('loading nm results for %s from cache' % filename)
       return Building.nm_cache[filename]
@@ -1650,9 +1650,10 @@ class Building:
           ret.undefs.append(symbol)
         elif status == 'C':
           ret.commons.append(symbol)
-        elif status in ['W', 't', 'T', 'd', 'D']:
+        # If 'internal' option is set, include internal symbols too
+        elif kwargs.get('internal') and status in ['W', 't', 'T', 'd', 'D'] or \
+             not kwargs.get('internal') and status in ['W', 'T', 'D']:
           ret.defs.append(symbol)
-        # otherwise, not something we should notice
     ret.defs = set(ret.defs)
     ret.undefs = set(ret.undefs)
     ret.commons = set(ret.commons)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1627,7 +1627,7 @@ class Building:
   nm_cache = {} # cache results of nm - it can be slow to run
 
   @staticmethod
-  def llvm_nm(filename, stdout=PIPE, stderr=None, **kwargs):
+  def llvm_nm(filename, stdout=PIPE, stderr=None, include_internal=False):
     if filename in Building.nm_cache:
       #logging.debug('loading nm results for %s from cache' % filename)
       return Building.nm_cache[filename]
@@ -1650,9 +1650,8 @@ class Building:
           ret.undefs.append(symbol)
         elif status == 'C':
           ret.commons.append(symbol)
-        # If 'internal' option is set, include internal symbols too
-        elif kwargs.get('internal') and status in ['W', 't', 'T', 'd', 'D'] or \
-             not kwargs.get('internal') and status in ['W', 'T', 'D']:
+        elif include_internal and status in ['W', 't', 'T', 'd', 'D'] or \
+            not include_internal and status in ['W', 'T', 'D']:
           ret.defs.append(symbol)
     ret.defs = set(ret.defs)
     ret.undefs = set(ret.undefs)


### PR DESCRIPTION
In nm results, 't' means a defined but internalized function. But the current version Building.llvm_nm does not add 't' to the list of 'defs'. I am not really sure how to fix it, because I don't quiet understand what this code considers as 'defs'. Currently llvm-nm supports these:

```
U Named object is referenced but undefined in this bitcode file
C Common (multiple definitions link together into one def)
W Weak reference (multiple definitions link together into zero or one definitions)
t Local function (text) object
T Global function (text) object
d Local data object
D Global data object
? Something unrecognizable
```

I guess all symbols except C, U and ? should be considered as defs. Please let me know if I am mistaken.

@dschuff @jpporto