### PR TITLE
Implement asm.js style exception handling for Wasm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -123,9 +123,7 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
       if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
         backend_args += ['-enable-emscripten-cxx-exceptions']
         if settings['DISABLE_EXCEPTION_CATCHING'] == 2:
-          whitelist = \
-            ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['__fake'])
-          backend_args += ['-emscripten-cxx-exceptions-whitelist=' + whitelist]
+          backend_args += ['-emscripten-cxx-exceptions-whitelist=' + ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['fake'])]
       if settings['ASYNCIFY']:
         backend_args += ['-emscripten-asyncify']
         backend_args += ['-emscripten-asyncify-functions=' + ','.join(settings['ASYNCIFY_FUNCTIONS'])]

--- a/emscripten.py
+++ b/emscripten.py
@@ -123,7 +123,9 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
       if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
         backend_args += ['-enable-emscripten-cxx-exceptions']
         if settings['DISABLE_EXCEPTION_CATCHING'] == 2:
-          backend_args += ['-emscripten-cxx-exceptions-whitelist=' + ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['fake'])]
+          whitelist = \
+            ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['__fake'])
+          backend_args += ['-emscripten-cxx-exceptions-whitelist=' + whitelist]
       if settings['ASYNCIFY']:
         backend_args += ['-emscripten-asyncify']
         backend_args += ['-emscripten-asyncify-functions=' + ','.join(settings['ASYNCIFY_FUNCTIONS'])]
@@ -1318,7 +1320,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
     if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
       backend_args += ['-enable-emscripten-cxx-exceptions']
     if settings['DISABLE_EXCEPTION_CATCHING'] == 2:
-      whitelist = ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['fake'])
+      whitelist = ','.join(settings['EXCEPTION_CATCHING_WHITELIST'] or ['__fake'])
       backend_args += ['-emscripten-cxx-exceptions-whitelist=' + whitelist]
 
     if DEBUG:

--- a/src/library.js
+++ b/src/library.js
@@ -989,7 +989,12 @@ LibraryManager.library = {
       info.refcount--;
       if (info.refcount === 0) {
         if (info.destructor) {
+#if BINARYEN == 0
           Runtime.dynCall('vi', info.destructor, [ptr]);
+#else
+          // In Wasm, destructors return 'this' as in ARM
+          Runtime.dynCall('ii', info.destructor, [ptr]);
+#endif
         }
         delete EXCEPTIONS.infos[ptr];
         ___cxa_free_exception(ptr);

--- a/src/library.js
+++ b/src/library.js
@@ -989,7 +989,7 @@ LibraryManager.library = {
       info.refcount--;
       if (info.refcount === 0) {
         if (info.destructor) {
-#if BINARYEN == 0
+#if WASM_BACKEND == 0
           Runtime.dynCall('vi', info.destructor, [ptr]);
 #else
           // In Wasm, destructors return 'this' as in ARM

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -605,8 +605,6 @@ class RunnerCore(unittest.TestCase):
 
   ## Does a complete test - builds, runs, checks output, etc.
   def do_run(self, src, expected_output, args=[], output_nicerizer=None, output_processor=None, no_build=False, main_file=None, additional_files=[], js_engines=None, post_build=None, basename='src.cpp', libraries=[], includes=[], force_c=False, build_ll_hook=None, extra_emscripten_args=[], assert_returncode=None):
-    if Settings.DISABLE_EXCEPTION_CATCHING != 1 and self.is_wasm_backend():
-      return self.skip("wasm backend doesn't support exceptions yet")
     if Settings.ASYNCIFY == 1 and self.is_wasm_backend():
       return self.skip("wasm backend doesn't support ASYNCIFY yet")
     if force_c or (main_file is not None and main_file[-2:]) == '.c':


### PR DESCRIPTION
Add support for DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_WHITELIST options for wasm. This patch generates invoke wrappers (functions like invoke_vi, which uses JS try/catch to simulate exception behaviors) in wasm. Also this enables all exception-related tests for wasm too. All of exception-related test cases are supposed to pass. And the exception whitelist tests should pass once #4471 and #4488 are resolved.

The following PRs or revisions are related to the exception handling for wasm:
WebAssembly/binaryen#664
https://reviews.llvm.org/D22958
https://reviews.llvm.org/D23258
https://reviews.llvm.org/D23292