### PR TITLE
output_eol

### DIFF
--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -556,6 +556,13 @@ Options that are modified or new in *emcc* are listed below:
        checks. Note that this is only supported by Clang/LLVM, and
        indirect function call checking requires Clang/LLVM 3.9+.
 
+"--output-eol windows|linux"
+   Specifies the line ending to generate for the text files that are
+   outputted. If "--output-eol windows" is passed, the final output
+   files will have Windows \r\n line endings in them. With
+   "--output-eol linux", the final generated files will be written
+   with Unix \n line endings.
+
 Environment variables
 =====================
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -447,7 +447,9 @@ Options that are modified or new in *emcc* are listed below:
 ``--separate-asm``
 	Emits asm.js in one file, and the rest of the code in another, and emits HTML that loads the asm.js first, in order to reduce memory load during startup. See :ref:`optimizing-code-separating_asm`.
 
-	
+``--output-eol windows|linux``
+	Specifies the line ending to generate for the text files that are outputted. If "--output-eol windows" is passed, the final output files will have Windows \r\n line endings in them. With "--output-eol linux", the final generated files will be written with Unix \n line endings.
+
 .. _emcc-environment-variables:
 
 Environment variables

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5,6 +5,7 @@ import glob
 import tools.shared
 from tools.shared import *
 from runner import RunnerCore, path_from_root, get_zlib_library, get_bullet_library
+import tools.line_endings
 
 # Runs an emcc task (used from another process in test test_emcc_multiprocess_cache_access, needs to be at top level for it to be pickleable).
 def multiprocess_task(c_file, cache_dir_name):
@@ -6515,3 +6516,14 @@ int main() {
     assert 'foo' in syms.defs, 'foo() should not be inlined'
     try_delete('test.c')
     try_delete('test.bc')
+
+  def test_output_eol(self):
+    for params in [[], ['--separate-asm']]:
+      for eol in ['windows', 'linux']:
+        Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.html', '--output_eol', eol] + params).communicate()
+        for f in ['a.html', 'a.js', 'a.asm.js']:
+          if os.path.isfile(f):
+            print str(params) + ' ' + eol + ' ' + f
+            ret = tools.line_endings.check_line_endings(f, expect_only_specific_line_endings='\n' if eol == 'linux' else '\r\n')
+            assert ret == 0
+

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -1,9 +1,21 @@
-import sys
+import sys, shutil, os
+
+def convert_line_endings(text, from_eol, to_eol):
+  if from_eol == to_eol: return text
+  return text.replace(from_eol, to_eol)
+
+# if dst_filename is empty, operates in place on src_filename
+def convert_line_endings_in_file(filename, from_eol, to_eol):
+  if from_eol == to_eol: return # No conversion needed
+
+  text = open(filename, 'rb').read()
+  text = convert_line_endings(text, from_eol, to_eol)
+  open(filename, 'wb').write(text)
 
 # This function checks and prints out the detected line endings in the given file.
 # If the file only contains either Windows \r\n line endings or Unix \n line endings, it returns 0.
 # Otherwise, in the presence of old OSX or mixed/malformed line endings, a non-zero error code is returned.
-def check_line_endings(filename, print_errors=True):
+def check_line_endings(filename, expect_only_specific_line_endings=None, print_errors=True):
   try:
     data = open(filename, 'rb').read()
   except Exception, e:
@@ -49,6 +61,16 @@ def check_line_endings(filename, print_errors=True):
       print >> sys.stderr, "Content around a DOS line ending location: '" + dos_line_ending_example + "'"
       print >> sys.stderr, "Content around an UNIX line ending location: '" + unix_line_ending_example + "'"
     return 1 # Mixed line endings
+  if expect_only_specific_line_endings == '\n' and has_dos_line_endings:
+    if print_errors:
+      print >> sys.stderr, 'File \'' + filename + '\' contains DOS "\\r\\n" line endings! (' + str(dos_line_ending_count) + ' DOS line endings), but expected only UNIX line endings!'
+      print >> sys.stderr, "Content around a DOS line ending location: '" + dos_line_ending_example + "'"
+    return 1 # DOS line endings, but expected UNIX
+  if expect_only_specific_line_endings == '\r\n' and has_unix_line_endings:
+    if print_errors:
+      print >> sys.stderr, 'File \'' + filename + '\' contains UNIX "\\n" line endings! (' + str(unix_line_ending_count) + ' UNIX line endings), but expected only DOS line endings!'
+      print >> sys.stderr, "Content around a UNIX line ending location: '" + unix_line_ending_example + "'"
+    return 1 # UNIX line endings, but expected DOS
   else: return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add new emcc command line parameter --output-eol, which specifies the line endings to generate for the output files.

This feature was requested by @jechter and @marcounity.