### PR TITLE
Add missing canOwn parameter to FS.createDataFile calls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -257,3 +257,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dominic Chen <d.c.ddcc@gmail.com> (copyright owned by Google, Inc.)
 * Junji Hashimoto <junji.hashimoto@gmail.com>
 * Heejin Ahn <aheejin@gmail.com> (copyright owned by Google, Inc.)
+* Andras Kucsma <andras.kucsma@gmail.com>

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -848,7 +848,7 @@ var LibraryBrowser = {
         try {
           FS.unlink(_file);
         } catch (e) {}
-        FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(http.response), true, true);
+        FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(http.response), true, true, false);
         if (onload) {
           var stack = Runtime.stackSave();
           Runtime.dynCall('viii', onload, [handle, arg, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK)]);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4980,7 +4980,7 @@ def process(filename):
       'preRun': function() {
         FS.createLazyFile('/', 'test.file', 'test.file', true, false);
         // Test FS_* exporting
-        Module['FS_createDataFile']('/', 'somefile.binary', [100, 200, 50, 25, 10, 77, 123], true, false);  // 200 becomes -56, since signed chars are used in memory
+        Module['FS_createDataFile']('/', 'somefile.binary', [100, 200, 50, 25, 10, 77, 123], true, false, false);  // 200 becomes -56, since signed chars are used in memory
         var test_files_input = 'hi there!';
         var test_files_input_index = 0;
         FS.init(function() {
@@ -5215,7 +5215,7 @@ name: .
 def process(filename):
   src = open(filename, 'r').read().replace(
     '// {{PRE_RUN_ADDITIONS}}',
-    "FS.createDataFile('/', 'test', 'abcdef', true, true);"
+    "FS.createDataFile('/', 'test', 'abcdef', true, true, false);"
   )
   open(filename, 'w').write(src)
 '''
@@ -5235,7 +5235,7 @@ def process(filename):
 def process(filename):
   src = open(filename, 'r').read().replace(
     '// {{PRE_RUN_ADDITIONS}}',
-    "FS.createDataFile('/', 'test', 'abcdef', true, true);"
+    "FS.createDataFile('/', 'test', 'abcdef', true, true, false);"
   )
   open(filename, 'w').write(src)
 '''
@@ -5252,7 +5252,7 @@ def process(filename):
       var dummy_device = FS.makedev(64, 0);
       FS.registerDevice(dummy_device, {});
 
-      FS.createDataFile('/', 'file', 'abcdef', true, true);
+      FS.createDataFile('/', 'file', 'abcdef', true, true, false);
       FS.mkdev('/device', dummy_device);
     \'\'\'
   )
@@ -6250,7 +6250,7 @@ def process(filename):
   # Embed the font into the document
   src = open(filename, 'r').read().replace(
     '// {{PRE_RUN_ADDITIONS}}',
-    "FS.createDataFile('/', 'font.ttf', %s, true, false);" % str(
+    "FS.createDataFile('/', 'font.ttf', %s, true, false, false);" % str(
       map(ord, open(shared.path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), 'rb').read())
     )
   )
@@ -6407,7 +6407,7 @@ def process(filename):
   src = open(filename, 'a')
   src.write(
     \'\'\'
-      FS.createDataFile('/', 'paper.pdf', eval(Module.read('paper.pdf.js')), true, false);
+      FS.createDataFile('/', 'paper.pdf', eval(Module.read('paper.pdf.js')), true, false, false);
       Module.callMain(Module.arguments);
       Module.print("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']).map(function(x) { return unSign(x, 8) })));
     \'\'\'
@@ -6463,7 +6463,7 @@ def process(filename):
   original_j2k = shared.path_from_root('tests', 'openjpeg', 'syntensity_lobby_s.j2k')
   src = open(filename, 'r').read().replace(
     '// {{PRE_RUN_ADDITIONS}}',
-    "FS.createDataFile('/', 'image.j2k', %s, true, false);" % shared.line_splitter(str(
+    "FS.createDataFile('/', 'image.j2k', %s, true, false, false);" % shared.line_splitter(str(
       map(ord, open(original_j2k, 'rb').read())
     ))
   ).replace(

--- a/third_party/wasm-polyfill/src/pack-asmjs.js
+++ b/third_party/wasm-polyfill/src/pack-asmjs.js
@@ -2,7 +2,7 @@
 var inputFile = Module['arguments'][0];
 var outputFile = Module['arguments'][1];
 
-FS.createDataFile('/', 'input.js', Module['readBinary'](inputFile), true, false);
+FS.createDataFile('/', 'input.js', Module['readBinary'](inputFile), true, false, false);
 
 __ATEXIT__.push(function() {
   Module.print(JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents[outputFile]).map(function(x) { return unSign(x, 8) })));

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -485,7 +485,7 @@ for file_ in data_files:
         parts.append('''fileData%d.push.apply(fileData%d, %s);\n''' % (counter, counter, str(data[start:start+chunk_size])))
         start += chunk_size
       code += ''.join(parts)
-    code += '''Module['FS_createDataFile']('%s', '%s', fileData%d, true, true);\n''' % (dirname, basename, counter)
+    code += '''Module['FS_createDataFile']('%s', '%s', fileData%d, true, true, false);\n''' % (dirname, basename, counter)
     counter += 1
   elif file_['mode'] == 'preload':
     # Preload


### PR DESCRIPTION
`FS.createDataFile` takes 6 parameters, but at a couple of places only 5 was passed. The last one, `canOwn` being implicitly `undefined`. I used `false` everywhere to avoid functional changes (since `undefined` is falsy)

FS.createDataFile definition: https://github.com/kripken/emscripten/blob/777bc91e7b7c3a5291760ea8927ba5360933b779/src/library_fs.js#L1484