### PR TITLE
cleanup_first_time_experience

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -654,12 +654,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs[i] = ''
         newargs[i+1] = ''
       elif newargs[i] == '--clear-cache':
-        logging.warning('clearing cache')
+        logging.info('clearing cache as requested by --clear-cache')
         shared.Cache.erase()
         shared.check_sanity(force=True) # this is a good time for a sanity check
         should_exit = True
       elif newargs[i] == '--clear-ports':
-        logging.warning('clearing ports and cache')
+        logging.info('clearing ports and cache as requested by --clear-ports')
         system_libs.Ports.erase()
         shared.Cache.erase()
         shared.check_sanity(force=True) # this is a good time for a sanity check
@@ -1386,7 +1386,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
        not shared.Settings.ONLY_MY_CODE and \
        not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
       extra_files_to_link = system_libs.get_ports(shared.Settings)
-      extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout, stderr, forced=forced_stdlibs)
+      extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
 
     log_time('calculate system libraries')
 

--- a/system/lib/libcxx/include/config_elast.h
+++ b/system/lib/libcxx/include/config_elast.h
@@ -24,6 +24,8 @@
 #define _LIBCPP_ELAST 4095
 #elif defined(__APPLE__)
 // No _LIBCPP_ELAST needed on Apple
+#elif defined(__EMSCRIPTEN__)
+#define _LIBCPP_ELAST 256
 #elif defined(__sun__)
 #define _LIBCPP_ELAST ESTALE
 #elif defined(_WIN32)

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -89,13 +89,13 @@ class Cache:
       if what is None:
         if shortname.endswith(('.bc', '.so', '.a')): what = 'system library'
         else: what = 'system asset'
-      message = 'generating ' + what + ': ' + shortname + '...'
-      logging.warn(message)
+      message = 'generating ' + what + ': ' + shortname + '... (this will be cached in "' + cachename + '" for subsequent builds)'
+      logging.info(message)
       self.ensure()
       temp = creator()
       if temp != cachename:
         shutil.copyfile(temp, cachename)
-      logging.warn(' '*len(message) + 'ok')
+      logging.info(' - ok')
     finally:
       self.release_cache_lock()
 

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -20,7 +20,7 @@ def get(ports, settings, shared):
     return []
   ports.fetch_project('binaryen', 'https://github.com/WebAssembly/binaryen/archive/' + TAG + '.zip', 'binaryen-' + TAG)
   def create():
-    logging.warning('building port: binaryen')
+    logging.info('building port: binaryen')
     ports.build_native(os.path.join(ports.get_dir(), 'binaryen', 'binaryen-' + TAG))
     # the "output" of this port build is a tag file, saying which port we have
     tag_file = os.path.join(ports.get_dir(), 'binaryen', 'tag.txt')

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -16,7 +16,7 @@ def get(ports, settings, shared):
   if settings.USE_BULLET == 1:
     ports.fetch_project('bullet', 'https://github.com/emscripten-ports/bullet/archive/' + TAG + '.zip', 'Bullet-' + TAG)
     def create():
-      logging.warning('building port: bullet')
+      logging.info('building port: bullet')
      
       source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
       dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'bullet')

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -6,7 +6,7 @@ def get(ports, settings, shared):
   if settings.USE_LIBPNG == 1:
     ports.fetch_project('libpng', 'https://github.com/emscripten-ports/libpng/archive/' + TAG + '.zip', 'libpng-' + TAG)
     def create():
-      logging.warning('building port: libpng')
+      logging.info('building port: libpng')
 
       source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
       dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'libpng')

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -6,7 +6,7 @@ def get(ports, settings, shared):
   if settings.USE_OGG == 1:
     ports.fetch_project('ogg', 'https://github.com/emscripten-ports/ogg/archive/' + TAG + '.zip', 'Ogg-' + TAG)
     def create():
-      logging.warning('building port: ogg')
+      logging.info('building port: ogg')
       ports.clear_project_build('vorbis')
      
       source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)

--- a/tools/ports/sdl_net.py
+++ b/tools/ports/sdl_net.py
@@ -8,7 +8,7 @@ def get(ports, settings, shared):
     assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_net'
     ports.fetch_project('sdl2-net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG)
     def create():
-      logging.warning('building port: sdl2-net')
+      logging.info('building port: sdl2-net')
       shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_net.h'))
       shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_net.h'))
       srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split(' ')

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -6,7 +6,7 @@ def get(ports, settings, shared):
   if settings.USE_VORBIS == 1:
     ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG)
     def create():
-      logging.warning('building port: vorbis')
+      logging.info('building port: vorbis')
      
       source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
       dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -41,7 +41,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       symbols = filter(lambda symbol: symbol not in exclude, symbols)
     return set(symbols)
 
-  default_opts = []
+  default_opts = ['-Werror']
 
   # XXX We also need to add libc symbols that use malloc, for example strdup. It's very rare to use just them and not
   #     a normal malloc symbol (like free, after calling strdup), so we haven't hit this yet, but it is possible.
@@ -572,7 +572,7 @@ class Ports:
   @staticmethod
   def build_project(name, subdir, configure, generated_libs, post_create=None):
     def create():
-      logging.warning('building port: ' + name + '...')
+      logging.info('building port: ' + name + '...')
       port_build_dir = Ports.get_build_dir()
       shared.safe_ensure_dirs(port_build_dir)
       libs = shared.Building.build_library(name, port_build_dir, None, generated_libs, source_dir=os.path.join(Ports.get_dir(), name, subdir), copy_project=True,


### PR DESCRIPTION
Clean up last build warning on system libs. Closes #4393 and #4500. Show all warnings when building system libs and make warnings to be errors to ensure they don't go untracked in future system lib updates. Demote first time run system lib builds to info channel instead of warning channel to make it look more pleasing that new users are not greeted with warnings immediately on first install.