### PR TITLE
Enable binaryen tests in runner.py

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -104,7 +104,12 @@ test_modes = [
   'asm2f',
   'asm2g',
   'asm2i',
-  'asm2nn'
+  'asm2nn',
+  'binaryen0',
+  'binaryen1',
+  'binaryen2',
+  'binaryen3',
+  'binaryen_native'
 ]
 test_index = 0
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -104,7 +104,9 @@ test_modes = [
   'asm2f',
   'asm2g',
   'asm2i',
-  'asm2nn',
+  'asm2nn'
+]
+nondefault_test_modes = [
   'binaryen0',
   'binaryen1',
   'binaryen2',
@@ -1007,7 +1009,8 @@ if __name__ == '__main__':
 
   # Create a list of all known tests so that we can choose from them based on a wildcard search
   all_tests = []
-  suites = test_modes + ['other', 'browser', 'sanity', 'sockets', 'interactive']
+  suites = test_modes + nondefault_test_modes + \
+           ['other', 'browser', 'sanity', 'sockets', 'interactive']
   for m in modules:
     for s in suites:
       if hasattr(m, s):


### PR DESCRIPTION
Enable binaryen tests (binaryen0~3, binaryen_native) in runner.py so you can run them in command line, like
`python runner.py binaryen0.tests_whatever`

@dschuff @jpporto