### PR TITLE
Allow array fields in embind's value_object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -259,4 +259,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Heejin Ahn <aheejin@gmail.com> (copyright owned by Google, Inc.)
 * Andras Kucsma <andras.kucsma@gmail.com>
 * Mateusz Borycki <mateuszborycki@gmail.com>
+* Franklin Ta <fta2012@gmail.com>
 

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -800,7 +800,33 @@ namespace emscripten {
                 getContext(field));
             return *this;
         }
-    
+
+        template<typename InstanceType, typename ElementType, int N>
+        value_object& field(const char* fieldName, ElementType (InstanceType::*field)[N]) {
+            using namespace internal;
+
+            typedef std::array<ElementType, N> FieldType;
+            static_assert(sizeof(FieldType) == sizeof(ElementType[N]));
+
+            auto getter = &MemberAccess<InstanceType, FieldType>
+                ::template getWire<ClassType>;
+            auto setter = &MemberAccess<InstanceType, FieldType>
+                ::template setWire<ClassType>;
+
+            _embind_register_value_object_field(
+                TypeID<ClassType>::get(),
+                fieldName,
+                TypeID<FieldType>::get(),
+                getSignature(getter),
+                reinterpret_cast<GenericFunction>(getter),
+                getContext(field),
+                TypeID<FieldType>::get(),
+                getSignature(setter),
+                reinterpret_cast<GenericFunction>(setter),
+                getContext(field));
+            return *this;
+        }
+
         template<typename Getter, typename Setter>
         value_object& field(
             const char* fieldName,

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -1235,6 +1235,23 @@ module({
             assert.deepEqual({field: [1, 2, 3, 4]}, d);
         });
 
+        test("can pass and return arrays in structs", function() {
+            var d = cm.emval_test_take_and_return_ArrayInStruct({
+              field1: [1, 2],
+              field2: [
+                { x: 1, y: 2 },
+                { x: 3, y: 4 }
+              ]
+            });
+            assert.deepEqual({
+              field1: [1, 2],
+              field2: [
+                { x: 1, y: 2 },
+                { x: 3, y: 4 }
+              ]
+            }, d);
+        });
+
         test("can clone handles", function() {
             var a = new cm.ValHolder({});
             assert.equal(1, cm.count_emval_handles());

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -873,6 +873,18 @@ TupleInStruct emval_test_take_and_return_TupleInStruct(TupleInStruct cs) {
     return cs;
 }
 
+struct NestedStruct {
+    int x;
+    int y;
+};
+struct ArrayInStruct {
+    int field1[2];
+    NestedStruct field2[2];
+};
+ArrayInStruct emval_test_take_and_return_ArrayInStruct(ArrayInStruct cs) {
+    return cs;
+}
+
 enum Enum { ONE, TWO };
 
 Enum emval_test_take_and_return_Enum(Enum e) {
@@ -1708,6 +1720,26 @@ EMSCRIPTEN_BINDINGS(tests) {
         ;
 
     function("emval_test_take_and_return_TupleInStruct", &emval_test_take_and_return_TupleInStruct);
+
+
+    value_array<std::array<int, 2>>("array_int_2")
+        .element(index<0>())
+        .element(index<1>())
+        ;
+    value_array<std::array<NestedStruct, 2>>("array_NestedStruct_2")
+        .element(index<0>())
+        .element(index<1>())
+        ;
+    value_object<NestedStruct>("NestedStruct")
+        .field("x", &NestedStruct::x)
+        .field("y", &NestedStruct::y)
+        ;
+
+    value_object<ArrayInStruct>("ArrayInStruct")
+        .field("field1", &ArrayInStruct::field1)
+        .field("field2", &ArrayInStruct::field2)
+        ;
+    function("emval_test_take_and_return_ArrayInStruct", &emval_test_take_and_return_ArrayInStruct);
 
     class_<ValHolder>("ValHolder")
         .smart_ptr<std::shared_ptr<ValHolder>>("std::shared_ptr<ValHolder>")


### PR DESCRIPTION
If you have a struct with array members such as:

```
struct ArrayInStruct {
  int field[2];
};
```

and try binding it using:
```
value_object<ArrayInStruct>("ArrayInStruct")
  .field("field", &ArrayInStruct::field)
```
you will get the following errors:

```
wire.h:329:24: error: array 'new' cannot have initialization arguments
                return new T(v);

bind.h:531:28: error: array type 'int [2]' is not assignable
                ptr.*field = MemberBinding::fromWireType(value);
```

This PR hacks around this by treating T[N] as a std::array\<T, N\> which has the same memory layout but is copy assignable. I am not sure if this is the cleanest way to do it but it seems to work. One potentially confusing thing is that you will then also need to register the array:
```
value_array<std::array<int, 2>>("array_int_2")
  .element(index<0>())
  .element(index<1>());
```