### PR TITLE
Add missing error check to IDBStore.getStore

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,3 +255,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Philip Bielby <pmb45-github@srcf.ucam.org> (copyright owned by Jagex Ltd.)
 * Régis Fénéon <regis.feneon@gmail.com>
 * Dominic Chen <d.c.ddcc@gmail.com> (copyright owned by Google, Inc.)
+* Mateusz Borycki <mateuszborycki@gmail.com>

--- a/src/IDBStore.js
+++ b/src/IDBStore.js
@@ -45,6 +45,7 @@
   },
   getStore: function(dbName, type, callback) {
     IDBStore.getDB(dbName, function(error, db) {
+      if (error) return callback(error);
       var transaction = db.transaction([IDBStore.DB_STORE_NAME], type);
       transaction.onerror = function(e) {
         callback(this.error || 'unknown error');


### PR DESCRIPTION
When IDBStore.getDB was unsuccessful, provided error was ignored, and db was null, so  `db.transaction` raised exception. With this change, error seems to be properly propagated to `FS.syncfs`.

I encountered this when downgrading FF from nightly to stable. Apparently, IDB isn't migrated, and can't be opened by previous version of FF, with rather unhelpful "The operation failed for reasons unrelated to the database itself and not covered by any other error code.".