### PR TITLE
Fix copy paste error in test_workerfs_read.c

### DIFF
--- a/tests/fs/test_workerfs_read.c
+++ b/tests/fs/test_workerfs_read.c
@@ -42,7 +42,7 @@ int main() {
   }
 
   fd2 = open("/work/file.txt", O_RDONLY, 0666);
-  if (fd == -1) {
+  if (fd2 == -1) {
     result = -5000 - errno;
     goto exit;
   }


### PR DESCRIPTION
The wrong fd was tested here. It was probably copy pasted from a few lines above.

The test is still green.