### PR TITLE
Binaryen stack branch support

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1613,7 +1613,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if DEBUG:
           # Copy into temp dir as well, so can be run there too
           shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-        return 'memoryInitializer = "%s";' % os.path.basename(memfile)
+        if not shared.Settings.BINARYEN:
+          return 'memoryInitializer = "%s";' % os.path.basename(memfile)
+        else:
+          # with wasm, we may have the mem init file in the wasm binary already
+          return 'memoryInitializer = Module["wasmJSMethod"].indexOf("asmjs") >= 0 || Module["wasmJSMethod"].indexOf("interpret-asm2wasm") >= 0 ? "%s" : null;' % os.path.basename(memfile)
       src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
       open(final + '.mem.js', 'w').write(src)
       final += '.mem.js'
@@ -1953,10 +1957,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           cmd += ['--imprecise']
         if opt_level == 0:
           cmd += ['--no-opts']
+        # import mem init file if it exists, and if we will not be using asm.js as a binaryen method (as it needs the mem init file, of course)
+        import_mem_init = memory_init_file and os.path.exists(memfile) and 'asmjs' not in shared.Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD
+        if import_mem_init:
+          cmd += ['--mem-init=' + memfile]
         logging.debug('asm2wasm (asm.js => WebAssembly): ' + ' '.join(cmd))
         TimeLogger.update()
         subprocess.check_call(cmd, stdout=open(wasm_text_target, 'w'))
         log_time('asm2wasm')
+        if import_mem_init:
+          # remove and forget about the mem init file in later processing; it does not need to be prefetched in the html, etc.
+          os.unlink(memfile)
+          memory_init_file = False
       if shared.Settings.BINARYEN_SCRIPTS:
         binaryen_scripts = os.path.join(shared.Settings.BINARYEN_ROOT, 'scripts')
         script_env = os.environ.copy()

--- a/emcc.py
+++ b/emcc.py
@@ -1948,7 +1948,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         combined.close()
       # finish compiling to WebAssembly, using asm2wasm, if we didn't already emit WebAssembly directly using the wasm backend.
       if not shared.Settings.WASM_BACKEND:
-        cmd = [os.path.join(binaryen_bin, 'asm2wasm'), asm_target, '--mapped-globals=' + wasm_text_target + '.mappedGlobals', '--total-memory=' + str(shared.Settings.TOTAL_MEMORY)]
+        cmd = [os.path.join(binaryen_bin, 'asm2wasm'), asm_target, '--total-memory=' + str(shared.Settings.TOTAL_MEMORY)]
         if shared.Settings.BINARYEN_IMPRECISE:
           cmd += ['--imprecise']
         if opt_level == 0:

--- a/emcc.py
+++ b/emcc.py
@@ -1182,6 +1182,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           pass
       if use_closure_compiler:
         logging.warning('closure compiler is known to have issues with binaryen (FIXME)')
+      # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
+      #  * if we also supported js mem inits we'd have 4 modes
+      #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
+      memory_init_file = True
 
     if shared.Settings.CYBERDWARF:
       newargs.append('-g')

--- a/src/shell.js
+++ b/src/shell.js
@@ -131,7 +131,7 @@ else if (ENVIRONMENT_IS_SHELL) {
   if (typeof read != 'undefined') {
     Module['read'] = read;
   } else {
-    Module['read'] = function read() { throw 'no read() available (jsc?)' };
+    Module['read'] = function read() { throw 'no read() available' };
   }
 
   Module['readBinary'] = function readBinary(f) {

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -141,7 +141,11 @@ while 1:
 
   def execute_js(engine):
     print '(run in %s)' % engine
-    js = shared.run_js(filename + '.js', engine=engine, check_timeout=True, assert_returncode=None)
+    try:
+      js = shared.run_js(filename + '.js', engine=engine, check_timeout=True, assert_returncode=None)
+    except:
+      print 'failed to run in primary'
+      return False
     js = js.split('\n')[0] + '\n' # remove any extra printed stuff (node workarounds)
     return correct1 == js or correct2 == js
 
@@ -168,7 +172,7 @@ while 1:
     try:
       js2 = shared.run_js(filename + '.js', stderr=PIPE, engine=engine2 + ['-w'], full_output=True, check_timeout=True, assert_returncode=None)
     except:
-      print 'failed to run in secondary', js2
+      print 'failed to run in secondary'
       break
 
     # asm.js testing

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7363,7 +7363,6 @@ int main(int argc, char **argv) {
     self.do_run(open(path_from_root('tests', 'stack_overflow.cpp'), 'r').read(), 'Stack overflow! Attempted to allocate')
 
   @no_wasm
-  @no_emterpreter
   def test_binaryen(self):
     self.emcc_args += ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"']
     self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_11'
+TAG = 'version_12'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
This branch works together with binaryen's `stack` branch in https://github.com/WebAssembly/binaryen/pull/678. We should merge them only together.

Nothing major here, just mem init file improvements (as binaryen can now import it into asm2wasm modules) and some fuzzing improvements.