### PR TITLE
Disable Werror=absolute-value for system libs build

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -41,7 +41,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       symbols = filter(lambda symbol: symbol not in exclude, symbols)
     return set(symbols)
 
-  default_opts = ['-Werror']
+  default_opts = ['-Werror', '-Wno-error=absolute-value']
 
   # XXX We also need to add libc symbols that use malloc, for example strdup. It's very rare to use just them and not
   #     a normal malloc symbol (like free, after calling strdup), so we haven't hit this yet, but it is possible.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -41,7 +41,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       symbols = filter(lambda symbol: symbol not in exclude, symbols)
     return set(symbols)
 
-  default_opts = ['-Werror', '-Wno-error=absolute-value']
+  default_opts = ['-Werror']
 
   # XXX We also need to add libc symbols that use malloc, for example strdup. It's very rare to use just them and not
   #     a normal malloc symbol (like free, after calling strdup), so we haven't hit this yet, but it is possible.
@@ -62,6 +62,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     # Hide several musl warnings that produce a lot of spam to unit test build server logs.
     # TODO: When updating musl the next time, feel free to recheck which of their warnings might have been fixed, and which ones of these could be cleaned up.
     c_opts = ['-Wno-return-type', '-Wno-parentheses', '-Wno-ignored-attributes', '-Wno-shift-count-overflow', '-Wno-shift-negative-value', '-Wno-dangling-else', '-Wno-unknown-pragmas', '-Wno-shift-op-parentheses', '-Wno-string-plus-int', '-Wno-logical-op-parentheses', '-Wno-bitwise-op-parentheses', '-Wno-visibility', '-Wno-pointer-sign']
+    if shared.Settings.WASM_BACKEND:
+      c_opts.append('-Wno-error=absolute-value')
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
       commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes + default_opts + c_opts + lib_opts)


### PR DESCRIPTION
Currently the musl build has a warning where fabs() is called on a long
double. This gets us back to the status quo and unblocks other testing,
but without actually fixing the problem.