### PR TITLE
Update musl header to reflect Wasm backend using unsigned int as size_t

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -1,11 +1,4 @@
-// wasm breaks musl convention and defines size_t as long, to benefit wasm32/64 similarity
-// on wasm32, in practice it should be the same as asmjs's int.
-#ifdef __wasm__
-#define _Addr long
-#else
 #define _Addr int
-#endif
-
 #define _Int64 long long
 #define _Reg int
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1558,7 +1558,6 @@ int main() {
 
       self.do_run_from_file(src, output, output_processor=check_warnings)
 
-  @no_wasm_backend("For some reason wasm_backend doesn't link in new[] (aka _Znam) in its libcxx unless paired with a call to delete[]")
   def test_sizeof(self):
       # Has invalid writes between printouts
       Settings.SAFE_HEAP = 0


### PR DESCRIPTION
Also enable the unit test that this breaks

Depends on https://reviews.llvm.org/D24134