### PR TITLE
Fix collision on `--closure 1 -s MODULARIZE=1 -s EXPORT_NAME="HelloWorld"`

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -15,7 +15,7 @@
 // can continue to use Module afterwards as well.
 var Module;
 #if USE_CLOSURE_COMPILER
-if (!Module) Module = eval('(function() { try { return {{{ EXPORT_NAME }}} || {} } catch(e) { return {} } })()');
+if (!Module) Module = eval('(function() { try { return Module } catch(e) { return {} } })()');
 #else
 if (!Module) Module = (typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : null) || {};
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -15,7 +15,7 @@
 // can continue to use Module afterwards as well.
 var Module;
 #if USE_CLOSURE_COMPILER
-if (!Module) Module = eval('(function() { try { return Module } catch(e) { return {} } })()');
+if (!Module) Module = eval('(function() { try { return Module || {} } catch(e) { return {} } })()');
 #else
 if (!Module) Module = (typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : null) || {};
 #endif

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2629,12 +2629,13 @@ window.close = function() {
     self.btest('emterpreter_async_iostream.cpp', '1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
 
   def test_modularize(self):
-    for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2']]:
+    for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2'], ['-O2', '--closure', '1']]:
       for args, code in [
         ([], 'Module();'), # defaults
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           if (typeof Module !== "undefined") throw "what?!"; // do not pollute the global scope, we are modularized!
           HelloWorld();
+          if (Module.Pointer_stringify !== undefined) throw "Unexpected member is detected!"; // module constructor should not be polluted
         '''), # use EXPORT_NAME
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           var hello = HelloWorld({ noInitialRun: true, onRuntimeInitialized: function() {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2635,7 +2635,7 @@ window.close = function() {
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           if (typeof Module !== "undefined") throw "what?!"; // do not pollute the global scope, we are modularized!
           HelloWorld();
-          if (Module.Pointer_stringify !== undefined) throw "Unexpected member is detected!"; // module constructor should not be polluted
+          if (HelloWorld.Pointer_stringify !== undefined) throw "Unexpected member is detected!"; // module constructor should not be polluted
         '''), # use EXPORT_NAME
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           var hello = HelloWorld({ noInitialRun: true, onRuntimeInitialized: function() {


### PR DESCRIPTION
Fixes #4538.

Current:

```js
var test = function(Module) {
  Module = Module || {};

var d;d||(d=eval("(function() { try { return test || {} } catch(e) { return {} } })()"));
/* ... */

  return Module;
};
```

Fix:

```js
var test = function(Module) {
  Module = Module || {};

var d;d||(d=eval("(function() { try { return Module || {} } catch(e) { return {} } })()"));
/* ... */

  return Module;
};
```