### PR TITLE
Allow for empty EM_ASM consts

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -374,7 +374,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     for k, v in metadata['asmConsts'].iteritems():
       const = v[0].encode('utf-8')
       sigs = v[1]
-      if const[0] == '"' and const[-1] == '"':
+      if len(const) > 1 and const[0] == '"' and const[-1] == '"':
         const = const[1:-1]
       const = '{ ' + const + ' }'
       args = []
@@ -1507,7 +1507,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   for k, v in metadata['asmConsts'].iteritems():
     const = v[0].encode('utf-8')
     sigs = v[1]
-    if const[0] == '"' and const[-1] == '"':
+    if len(const) > 1 and const[0] == '"' and const[-1] == '"':
       const = const[1:-1]
     const = '{ ' + const + ' }'
     args = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4657,7 +4657,6 @@ def process(filename):
     expected = open(path_from_root('tests', 'unistd', 'login.out'), 'r').read()
     self.do_run(src, expected)
 
-  @no_wasm_backend()
   def test_unistd_unlink(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]


### PR DESCRIPTION
Dependency on https://github.com/WebAssembly/binaryen/pull/697 to successfully emit empty EM_ASMs.