### PR TITLE
Binaryen opts update

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1191,6 +1191,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           shared.Settings.BINARYEN_ROOT = shared.BINARYEN_ROOT
         except:
           pass
+      # default precise-f32 to on, since it works well in wasm
+      if 'PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes:
+        shared.Settings.PRECISE_F32 = 1
       if js_opts and not force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
         js_opts = None
         logging.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')

--- a/emcc.py
+++ b/emcc.py
@@ -415,6 +415,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     tracing = False
     emit_symbol_map = False
     js_opts = None
+    force_js_opts = False
     llvm_opts = None
     llvm_lto = None
     use_closure_compiler = None
@@ -530,6 +531,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       elif newargs[i].startswith('--js-opts'):
         check_bad_eq(newargs[i])
         js_opts = eval(newargs[i+1])
+        if js_opts: force_js_opts = True
         newargs[i] = ''
         newargs[i+1] = ''
       elif newargs[i].startswith('--llvm-opts'):
@@ -1008,9 +1010,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
 
-    if shared.Settings.SAFE_HEAP and not js_opts:
-      js_opts = True
-      logging.debug('enabling js opts for SAFE_HEAP')
+    if shared.Settings.SAFE_HEAP:
+      if not js_opts:
+        logging.debug('enabling js opts for SAFE_HEAP')
+        js_opts = True
+      force_js_opts = True
 
     if debug_level > 1 and use_closure_compiler:
       logging.warning('disabling closure because debug info was requested')
@@ -1065,6 +1069,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not js_opts:
         js_opts = True
         logging.debug('enabling js opts for SPLIT_MEMORY')
+      force_js_opts = True
       if use_closure_compiler:
         use_closure_compiler = False
         logging.warning('cannot use closure compiler on split memory, for now, disabling')
@@ -1108,13 +1113,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
       shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
       if not js_opts:
-        js_opts = True
         logging.debug('enabling js opts for EMTERPRETIFY')
+        js_opts = True
+      force_js_opts = True
       assert use_closure_compiler is not 2, 'EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that'
 
-    if shared.Settings.DEAD_FUNCTIONS and not js_opts:
-      js_opts = True
-      logging.debug('enabling js opts for DEAD_FUNCTIONS')
+    if shared.Settings.DEAD_FUNCTIONS:
+      if not js_opts:
+        logging.debug('enabling js opts for DEAD_FUNCTIONS')
+        js_opts = True
+      force_js_opts = True
 
     if proxy_to_worker:
       shared.Settings.PROXY_TO_WORKER = 1
@@ -1152,6 +1160,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         logging.error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS=1!')
         exit(1)
 
+    if shared.Settings.EVAL_CTORS or shared.Settings.OUTLINING_LIMIT:
+      if not js_opts:
+        logging.debug('enabling js opts for optional requested functioanlity')
+        js_opts = True
+      force_js_opts = True
+
     if shared.Settings.WASM_BACKEND:
       js_opts = None
       shared.Settings.BINARYEN = 1
@@ -1163,9 +1177,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.EXPORTED_FUNCTIONS += ['_memcpy', '_memmove', '_memset']
       # to bootstrap struct_info, we need binaryen
       os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
-
-    if js_opts:
-      shared.Settings.RUNNING_JS_OPTS = 1
 
     if shared.Settings.BINARYEN:
       debug_level = max(1, debug_level) # keep whitespace readable, for asm.js parser simplicity
@@ -1180,12 +1191,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           shared.Settings.BINARYEN_ROOT = shared.BINARYEN_ROOT
         except:
           pass
+      if js_opts and not force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        js_opts = None
+        logging.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
       if use_closure_compiler:
         logging.warning('closure compiler is known to have issues with binaryen (FIXME)')
       # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
       #  * if we also supported js mem inits we'd have 4 modes
       #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
       memory_init_file = True
+
+    if js_opts:
+      shared.Settings.RUNNING_JS_OPTS = 1
 
     if shared.Settings.CYBERDWARF:
       newargs.append('-g')

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -111,6 +111,11 @@ while 1:
         js_args += ['-s', 'BINARYEN_METHOD="interpret-binary"']
       else:
         js_args += ['-s', 'BINARYEN_METHOD="interpret-asm2wasm"']
+      if random.random() < 0.5:
+        if random.random() < 0.5:
+          js_args += ['--js-opts', '0']
+        else:
+          js_args += ['--js-opts', '1']
     if random.random() < 0.5:
       js_args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
     if random.random() < 0.5 and 'ALLOW_MEMORY_GROWTH=1' not in js_args and 'BINARYEN=1' not in js_args:

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -122,7 +122,7 @@ while 1:
       js_args += ['-s', 'MAIN_MODULE=1']
     if random.random() < 0.25:
       js_args += ['-s', 'INLINING_LIMIT=1'] # inline nothing, for more call interaction
-    if random.random() < 0.333 and 'BINARYEN=1' not in js_args:
+    if random.random() < 0.333:
       js_args += ['-s', 'EMTERPRETIFY=1']
       if random.random() < 0.5:
         if random.random() < 0.5:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -146,7 +146,8 @@ class RunnerCore(unittest.TestCase):
     elif '--memory-init-file' in self.emcc_args:
       return int(self.emcc_args[self.emcc_args.index('--memory-init-file')+1])
     else:
-      return ('-O2' in self.emcc_args or '-O3' in self.emcc_args or '-Oz' in self.emcc_args) and not Settings.SIDE_MODULE
+      # side modules handle memory differently; binaryen puts the memory in the wasm module
+      return ('-O2' in self.emcc_args or '-O3' in self.emcc_args or '-Oz' in self.emcc_args) and not (Settings.SIDE_MODULE or Settings.BINARYEN)
 
   def setUp(self):
     Settings.reset()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7376,7 +7376,7 @@ asm2i = make_run("asm2i", compiler=CLANG, emcc_args=["-O2", '-s', 'EMTERPRETIFY=
 binaryen0 = make_run("binaryen0", compiler=CLANG, emcc_args=['-O0', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen1 = make_run("binaryen1", compiler=CLANG, emcc_args=['-O1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen2 = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
-binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
+binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '-s', 'ASSERTIONS=1', "-s", "PRECISE_F32=1"])
 
 binaryen2jo = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
 binaryen3jo = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6274,15 +6274,19 @@ def process(filename):
       self.emcc_args = orig_args + ['-s', 'EVAL_CTORS=1']
       test()
       ec_js_size = os.stat('src.cpp.o.js').st_size
-      ec_mem_size = os.stat('src.cpp.o.js.mem').st_size
+      if self.uses_memory_init_file():
+        ec_mem_size = os.stat('src.cpp.o.js.mem').st_size
       self.emcc_args = orig_args[:]
       test()
       js_size = os.stat('src.cpp.o.js').st_size
-      mem_size = os.stat('src.cpp.o.js.mem').st_size
+      if self.uses_memory_init_file():
+        mem_size = os.stat('src.cpp.o.js.mem').st_size
       print js_size, ' => ', ec_js_size
-      print mem_size, ' => ', ec_mem_size
+      if self.uses_memory_init_file():
+        print mem_size, ' => ', ec_mem_size
       assert ec_js_size < js_size
-      assert ec_mem_size > mem_size
+      if self.uses_memory_init_file():
+        assert ec_mem_size > mem_size
 
     print 'remove ctor of just assigns to memory'
     def test1():
@@ -6317,9 +6321,11 @@ def process(filename):
     if self.uses_memory_init_file():
       ec_mem_size = os.stat('src.cpp.o.js.mem').st_size
     print js_size, ' => ', ec_js_size
-    print mem_size, ' => ', ec_mem_size
+    if self.uses_memory_init_file():
+      print mem_size, ' => ', ec_mem_size
     assert ec_js_size < js_size
-    assert ec_mem_size > mem_size
+    if self.uses_memory_init_file():
+      assert ec_mem_size > mem_size
 
     print 'assertions too'
     Settings.ASSERTIONS = 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7366,10 +7366,17 @@ asm2f = make_run("asm2f", compiler=CLANG, emcc_args=["-Oz", "-s", "PRECISE_F32=1
 asm2g = make_run("asm2g", compiler=CLANG, emcc_args=["-O2", "-g", "-s", "ASSERTIONS=1", "-s", "SAFE_HEAP=1"])
 asm2i = make_run("asm2i", compiler=CLANG, emcc_args=["-O2", '-s', 'EMTERPRETIFY=1'])
 #asm2m = make_run("asm2m", compiler=CLANG, emcc_args=["-O2", "--memory-init-file", "0", "-s", "MEM_INIT_METHOD=2", "-s", "ASSERTIONS=1"])
+
 binaryen0 = make_run("binaryen0", compiler=CLANG, emcc_args=['-O0', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen1 = make_run("binaryen1", compiler=CLANG, emcc_args=['-O1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen2 = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
+
+binaryen2jo = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
+binaryen3jo = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
+
+binaryen2jo = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
+binaryen3jo = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
 
 # This only works when .emscripten specifies a JS_ENGINE with native wasm support.
 binaryen_native = make_run("binaryen_native", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])

--- a/tools/bisect_pair_wast.py
+++ b/tools/bisect_pair_wast.py
@@ -1,0 +1,89 @@
+'''
+Given two similar files, for example one with an additional optimization pass,
+and with different results, will bisect between them to find the smallest
+diff that makes the outputs different.
+'''
+
+import os, sys, shutil
+from subprocess import Popen, PIPE, STDOUT
+
+__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+def path_from_root(*pathelems):
+  return os.path.join(__rootpath__, *pathelems)
+exec(open(path_from_root('tools', 'shared.py'), 'r').read())
+
+file1 = open(sys.argv[1]).read()
+file2 = open(sys.argv[2]).read()
+
+leftf = open('left', 'w')
+leftf.write(file1)
+leftf.close()
+
+rightf = open('right', 'w')
+rightf.write(file2)
+rightf.close()
+
+def run_code(name):
+  shutil.copyfile(name, 'src.cpp.o.wast')
+  ret = run_js('src.cpp.o.js', stderr=PIPE, full_output=True, assert_returncode=None, engine=SPIDERMONKEY_ENGINE)
+  # fix stack traces
+  ret = filter(lambda line: not line.startswith('    at ') and not name in line, ret.split('\n'))
+  return '\n'.join(ret)
+
+print 'running files'
+left_result = run_code('left')
+right_result = run_code('right') # right as in left-right, not as in correct
+assert left_result != right_result
+
+# Calculate diff chunks
+print 'diffing'
+diff = Popen(['diff', '-U', '5', 'left', 'right'], stdout=PIPE).communicate()[0].split('\n')
+pre_diff = diff[:2]
+diff = diff[2:]
+
+chunks = []
+curr = []
+for i in range(len(diff)):
+  if diff[i].startswith('@'):
+    if len(curr) > 0:
+      chunks.append(curr)
+    curr = [diff[i]]
+  else:
+    curr.append(diff[i])
+if len(curr) > 0:
+  chunks.append(curr)
+
+# Bisect both sides of the span, until we have a single chunk
+high = len(chunks)
+
+print 'beginning bisection, %d chunks' % high
+
+for mid in range(high):
+  print '  current: %d' % mid,
+  # Take chunks from the middle and on. This is important because the eliminator removes variables, so starting from the beginning will add errors
+  curr_diff = '\n'.join(map(lambda parts: '\n'.join(parts), chunks[mid:])) + '\n'
+  difff = open('diff.diff', 'w')
+  difff.write(curr_diff)
+  difff.close()
+  shutil.copy('left', 'middle')
+  Popen(['patch', 'middle', 'diff.diff'], stdout=PIPE).communicate()
+  shutil.copyfile('middle', 'middle' + str(mid))
+  result = run_code('middle')
+  print result == left_result, result == right_result#, 'XXX', left_result, 'YYY', result, 'ZZZ', right_result
+  if mid == 0:
+    assert result == right_result, '<<< ' + result + ' ??? ' + right_result + ' >>>'
+    print 'sanity check passed (a)'
+  if mid == high-1:
+    assert result == left_result, '<<< ' + result + ' ??? ' + left_result + ' >>>'
+    print 'sanity check passed (b)'
+  if result != right_result:
+    print 'found where it changes: %d' % mid
+    found = mid
+    break
+
+critical = Popen(['diff', '-U', '5', 'middle' + str(mid-1), 'middle' + str(mid)], stdout=PIPE).communicate()[0]
+c = open('critical.diff', 'w')
+c.write(critical)
+c.close()
+print 'middle%d is like left, middle%d is like right, critical.diff is the difference that matters' % (mid-1, mid), 'diff:', critical
+

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_12'
+TAG = 'version_13'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
A bunch of optimization adjustments for binaryen output. In particular, this avoids using the js optimizer if it isn't needed, as when emitting wasm it is faster and better to use only the wasm optimizer at this point, see https://github.com/WebAssembly/binaryen/pull/695