### PR TITLE
add GL_EXT_disjoint_timer_query to extensions enabled by default

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -625,7 +625,7 @@ var LibraryGL = {
                                              "OES_texture_float_linear", "OES_texture_half_float_linear", "WEBGL_compressed_texture_atc",
                                              "WEBGL_compressed_texture_pvrtc", "EXT_color_buffer_half_float", "WEBGL_color_buffer_float",
                                              "EXT_frag_depth", "EXT_sRGB", "WEBGL_draw_buffers", "WEBGL_shared_resources",
-                                             "EXT_shader_texture_lod", "EXT_color_buffer_float"];
+                                             "EXT_shader_texture_lod", "EXT_color_buffer_float", "EXT_disjoint_timer_query"];
 
       function shouldEnableAutomatically(extension) {
         var ret = false;


### PR DESCRIPTION
GL extension `GL_EXT_disjoint_timer_query` is pretty common nowadays, wondering if we could enable it by default?