### PR TITLE
Fix module pollution

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -261,3 +261,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mateusz Borycki <mateuszborycki@gmail.com>
 * Franklin Ta <fta2012@gmail.com>
 * Jacob Gravelle <jgravelle@google.com> (copyright owned by Google, Inc.)
+* Kagami Sascha Rosylight <saschanaz@outlook.com>

--- a/emcc.py
+++ b/emcc.py
@@ -1854,12 +1854,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       src = open(final).read()
       final = final + '.modular.js'
       f = open(final, 'w')
-      f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(Module) {\n')
-      f.write('  Module = Module || {};\n')
+      f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
+      f.write('  ' + shared.Settings.EXPORT_NAME + ' = ' + shared.Settings.EXPORT_NAME + ' || {};\n')
       f.write('\n')
       f.write(src)
       f.write('\n')
-      f.write('  return Module;\n')
+      f.write('  return ' + shared.Settings.EXPORT_NAME + ';\n')
       f.write('};\n')
       f.close()
       src = None

--- a/src/shell.js
+++ b/src/shell.js
@@ -15,7 +15,7 @@
 // can continue to use Module afterwards as well.
 var Module;
 #if USE_CLOSURE_COMPILER
-if (!Module) Module = eval('(function() { try { return {{{ EXPORT_NAME }}} || {} } catch(e) { return {} } })()');
+if (!Module) Module = eval('(function() { try { return Module || {} } catch(e) { return {} } })()');
 #else
 if (!Module) Module = (typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : null) || {};
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -15,7 +15,7 @@
 // can continue to use Module afterwards as well.
 var Module;
 #if USE_CLOSURE_COMPILER
-if (!Module) Module = eval('(function() { try { return Module || {} } catch(e) { return {} } })()');
+if (!Module) Module = eval('(function() { try { return {{{ EXPORT_NAME }}} || {} } catch(e) { return {} } })()');
 #else
 if (!Module) Module = (typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : null) || {};
 #endif

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2718,13 +2718,8 @@ window.close = function() {
         ([], 'Module();'), # defaults
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           if (typeof Module !== "undefined") throw "what?!"; // do not pollute the global scope, we are modularized!
+          HelloWorld.noInitialRun = true; // errorneous module capture will load this and cause timeout
           HelloWorld();
-          if (HelloWorld.Pointer_stringify) { // module constructor should not be polluted
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', 'http://localhost:8888/report_result?1', true);
-            xhr.send();
-            setTimeout(function() { window.close() }, 1000);
-          }
         '''), # use EXPORT_NAME
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           var hello = HelloWorld({ noInitialRun: true, onRuntimeInitialized: function() {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2713,12 +2713,18 @@ window.close = function() {
     self.btest('emterpreter_async_iostream.cpp', '1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
 
   def test_modularize(self):
-    for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2']]:
+    for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2'], ['-O2', '--closure', '1']]:
       for args, code in [
         ([], 'Module();'), # defaults
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           if (typeof Module !== "undefined") throw "what?!"; // do not pollute the global scope, we are modularized!
           HelloWorld();
+          if (HelloWorld.Pointer_stringify) { // module constructor should not be polluted
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'http://localhost:8888/report_result?1', true);
+            xhr.send();
+            setTimeout(function() { window.close() }, 1000);
+          }
         '''), # use EXPORT_NAME
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           var hello = HelloWorld({ noInitialRun: true, onRuntimeInitialized: function() {


### PR DESCRIPTION
Fixes #4538, replaces #4549

Current:

```js
var test = function(Module) {
  Module = Module || {};

var d;d||(d=eval("(function() { try { return test || {} } catch(e) { return {} } })()"));
/* ... */

  return Module;
};
```

Fix:

```js
var test = function(test) {
  test = test || {};

var d;d||(d=eval("(function() { try { return test || {} } catch(e) { return {} } })()"));
/* ... */

  return test;
};
```