### PR TITLE
Binaryen opts

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2002,7 +2002,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           subprocess.check_call([shared.PYTHON, os.path.join(binaryen_scripts, script), js_target, wasm_text_target], env=script_env)
       if 'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD:
         logging.debug('wasm-as (wasm => binary)')
-        subprocess.check_call([os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target])
+        cmd = [os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target]
+        if debug_level >= 2 or profiling_funcs: cmd += ['-g']
+        subprocess.check_call(cmd)
 
     # If we were asked to also generate HTML, do that
     if final_suffix == 'html':

--- a/emcc.py
+++ b/emcc.py
@@ -1160,11 +1160,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         logging.error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS=1!')
         exit(1)
 
-    if shared.Settings.EVAL_CTORS or shared.Settings.OUTLINING_LIMIT:
+    if shared.Settings.OUTLINING_LIMIT:
       if not js_opts:
-        logging.debug('enabling js opts for optional requested functioanlity')
+        logging.debug('enabling js opts as optional functionality implemented as a js opt was requested')
         js_opts = True
       force_js_opts = True
+
+    if shared.Settings.EVAL_CTORS:
+      # this option is not a js optimizer pass, but does run the js optimizer internally, so
+      # we need to generate proper code for that
+      shared.Settings.RUNNING_JS_OPTS = 1
 
     if shared.Settings.WASM_BACKEND:
       js_opts = None
@@ -1823,11 +1828,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         JSOptimizer.flush()
         shared.Building.eliminate_duplicate_funcs(final)
 
-      if shared.Settings.EVAL_CTORS and memory_init_file and debug_level < 4:
-        JSOptimizer.flush()
-        shared.Building.eval_ctors(final, memfile)
-        if DEBUG: save_intermediate('eval-ctors', 'js')
+    if shared.Settings.EVAL_CTORS and memory_init_file and debug_level < 4:
+      JSOptimizer.flush()
+      shared.Building.eval_ctors(final, memfile)
+      if DEBUG: save_intermediate('eval-ctors', 'js')
 
+    if js_opts:
       if not shared.Settings.EMTERPRETIFY:
         do_minify()
 

--- a/emcc.py
+++ b/emcc.py
@@ -2003,8 +2003,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if 'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD:
         logging.debug('wasm-as (wasm => binary)')
         subprocess.check_call([os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target])
-        if os.path.exists(wasm_text_target + '.mappedGlobals'): # TODO: remove once we no longer use .mappedGlobals files at all, as binaryen is moving to https://github.com/WebAssembly/binaryen/issues/675
-          shutil.copyfile(wasm_text_target + '.mappedGlobals', wasm_binary_target + '.mappedGlobals')
 
     # If we were asked to also generate HTML, do that
     if final_suffix == 'html':

--- a/emcc.py
+++ b/emcc.py
@@ -1988,7 +1988,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         import_mem_init = memory_init_file and os.path.exists(memfile) and 'asmjs' not in shared.Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD
         if import_mem_init:
           cmd += ['--mem-init=' + memfile]
-        if 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        if shared.Building.is_wasm_only():
           cmd += ['--wasm-only'] # this asm.js is code not intended to run as asm.js, it is only ever going to be wasm, an can contain special fastcomp-wasm support
         logging.debug('asm2wasm (asm.js => WebAssembly): ' + ' '.join(cmd))
         TimeLogger.update()

--- a/emcc.py
+++ b/emcc.py
@@ -2015,9 +2015,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         logging.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))
         subprocess.check_call(cmd)
       if 'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD:
-        logging.debug('wasm-as (wasm => binary)')
         cmd = [os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target]
         if debug_level >= 2 or profiling_funcs: cmd += ['-g']
+        logging.debug('wasm-as (text => binary): ' + ' '.join(cmd))
         subprocess.check_call(cmd)
 
     # If we were asked to also generate HTML, do that

--- a/emcc.py
+++ b/emcc.py
@@ -1987,6 +1987,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         import_mem_init = memory_init_file and os.path.exists(memfile) and 'asmjs' not in shared.Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD
         if import_mem_init:
           cmd += ['--mem-init=' + memfile]
+        if 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+          cmd += ['--wasm-only'] # this asm.js is code not intended to run as asm.js, it is only ever going to be wasm, an can contain special fastcomp-wasm support
         logging.debug('asm2wasm (asm.js => WebAssembly): ' + ' '.join(cmd))
         TimeLogger.update()
         subprocess.check_call(cmd, stdout=open(wasm_text_target, 'w'))

--- a/emcc.py
+++ b/emcc.py
@@ -1197,7 +1197,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         except:
           pass
       # default precise-f32 to on, since it works well in wasm
-      if 'PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes:
+      # also always use f32s when asm.js is not in the picture
+      if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
         shared.Settings.PRECISE_F32 = 1
       if js_opts and not force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
         js_opts = None

--- a/emscripten.py
+++ b/emscripten.py
@@ -136,7 +136,7 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
         backend_args += ['-emscripten-no-exit-runtime']
       if settings['BINARYEN']:
         backend_args += ['-emscripten-wasm']
-        if 'asmjs' not in settings['BINARYEN_METHOD']:
+        if shared.Building.is_wasm_only():
           backend_args += ['-emscripten-only-wasm']
       if settings['CYBERDWARF']:
         backend_args += ['-enable-cyberdwarf']

--- a/emscripten.py
+++ b/emscripten.py
@@ -136,6 +136,8 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
         backend_args += ['-emscripten-no-exit-runtime']
       if settings['BINARYEN']:
         backend_args += ['-emscripten-wasm']
+        if 'asmjs' not in settings['BINARYEN_METHOD']:
+          backend_args += ['-emscripten-only-wasm']
       if settings['CYBERDWARF']:
         backend_args += ['-enable-cyberdwarf']
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -384,6 +384,7 @@ function JSify(data, functionsOnly) {
       if (USE_PTHREADS) print('if (!ENVIRONMENT_IS_PTHREAD) {\n // Only main thread initializes these, pthreads copy them over at thread worker init time (in pthread-main.js)');
       print('DYNAMICTOP_PTR = allocate(1, "i32", ALLOC_STATIC);\n');
       print('STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);\n');
+      if (STACK_START > 0) print('if (STACKTOP < ' + STACK_START + ') STACK_BASE = STACKTOP = Runtime.alignMemory(' + STACK_START + ');\n');
       print('STACK_MAX = STACK_BASE + TOTAL_STACK;\n');
       print('DYNAMIC_BASE = Runtime.alignMemory(STACK_MAX);\n');
       print('HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;\n');

--- a/src/settings.js
+++ b/src/settings.js
@@ -639,6 +639,9 @@ var BINARYEN_SCRIPTS = ""; // An optional comma-separated list of script hooks t
 var BINARYEN_IMPRECISE = 0; // Whether to apply imprecise/unsafe binaryen optimizations. If enabled,
                             // code will run faster, but some types of undefined behavior might
                             // trap in wasm.
+var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the binaryen optimizer,
+                          // for example, "dce,precompute,vacuum".
+                          // When set, this overrides the default passes we would normally run.
 var BINARYEN_ROOT = ""; // Directory where we can find Binaryen. Will be automatically set for you,
                         // but you can set it to override if you are a Binaryen developer.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -79,6 +79,11 @@ var ALLOW_MEMORY_GROWTH = 0; // If false, we abort with an error if we try to al
 
 var GLOBAL_BASE = -1; // where global data begins; the start of static memory. -1 means use the
                       // default, any other value will be used as an override
+var STACK_START = -1; // where the stack will begin. -1 means use the default. if the stack cannot
+                      // start at the value specified here, it may start at a higher location.
+                      // this is useful when debugging two builds that may differ in their static
+                      // allocations, by forcing the stack to start in the same place their
+                      // memory usage patterns would be the same.
 
 // Code embetterments
 var DOUBLE_MODE = 1; // How to load and store 64-bit doubles.

--- a/tests/cases/phiundefi64.ll
+++ b/tests/cases/phiundefi64.ll
@@ -1,0 +1,28 @@
+; ModuleID = 'tests/hello_world.bc'
+target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
+target triple = "asmjs-unknown-emscripten"
+
+@.str = private unnamed_addr constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1 type=[15 x i8]*]
+@.str2 = private unnamed_addr constant [15 x i8] c"hello!!world!\0A\00", align 1 ; [#uses=1 type=[15 x i8]*]
+
+define i32 @main() {
+  %retval = alloca i32, align 4
+  %a12 = zext i1 1 to i32
+  br label %L13
+
+L13:
+  %.0 = phi i64 [ undef, %0 ], [ 123, %L13 ]
+  %a14 = trunc i64 %.0 to i32
+  %call0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str, i32 0, i32 0))
+  %a15 = add nsw i32 %a14, 2
+  %a16 = icmp ne i32 %a15, 9
+  br i1 %a16, label %L17, label %L13
+
+L17:
+  %call1 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str2, i32 0, i32 0))
+  ret i32 1
+}
+
+; [#uses=1]
+declare i32 @printf(i8*, ...)
+

--- a/tests/cases/phiundefi64.txt
+++ b/tests/cases/phiundefi64.txt
@@ -1,0 +1,2 @@
+hello, world!
+hello!!world!

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -105,17 +105,43 @@ while 1:
     js_args = [shared.PYTHON, shared.EMCC, opts] + llvm_opts + [fullname, '-o', filename + '.js'] + CSMITH_CFLAGS + args + ['-w']
     if 0: # binaryen testing, off by default for now
       js_args += ['-s', 'BINARYEN=1']
-      if random.random() < 0.333:
+      r = random.random()
+      if r < 0.45:
         js_args += ['-s', 'BINARYEN_METHOD="interpret-s-expr"']
-      elif random.random() < 0.5:
+      elif r < 0.90:
         js_args += ['-s', 'BINARYEN_METHOD="interpret-binary"']
       else:
-        js_args += ['-s', 'BINARYEN_METHOD="interpret-asm2wasm"']
+        if random.random() < 0.5:
+          js_args += ['-s', 'BINARYEN_METHOD="interpret-binary,asmjs"']
+        else:
+          js_args += ['-s', 'BINARYEN_METHOD="interpret-s-expr,asmjs"']
       if random.random() < 0.5:
         if random.random() < 0.5:
           js_args += ['--js-opts', '0']
         else:
           js_args += ['--js-opts', '1']
+      if random.random() < 0.5:
+        # pick random passes
+        BINARYEN_PASSES = [
+          "duplicate-function-elimination",
+          "dce",
+          "remove-unused-brs",
+          "remove-unused-names",
+          "optimize-instructions",
+          "precompute",
+          "simplify-locals",
+          "vacuum",
+          "coalesce-locals",
+          "reorder-locals",
+          "merge-blocks",
+          "remove-unused-functions",
+        ]
+        passes = []
+        while 1:
+          passes.append(random.choice(BINARYEN_PASSES))
+          if random.random() < 0.1:
+            break
+        js_args += ['-s', 'BINARYEN_PASSES="' + ','.join(passes) + '"']
     if random.random() < 0.5:
       js_args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
     if random.random() < 0.5 and 'ALLOW_MEMORY_GROWTH=1' not in js_args and 'BINARYEN=1' not in js_args:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6148,21 +6148,23 @@ def process(filename):
       int main() {}
     ''', "constructing!\n");
 
+    code_file = 'src.cpp.o.js' if not Settings.BINARYEN else 'src.cpp.o.wasm'
+
     def do_test(test):
       self.emcc_args = orig_args + ['-s', 'EVAL_CTORS=1']
       test()
-      ec_js_size = os.stat('src.cpp.o.js').st_size
+      ec_code_size = os.stat(code_file).st_size
       if self.uses_memory_init_file():
         ec_mem_size = os.stat('src.cpp.o.js.mem').st_size
       self.emcc_args = orig_args[:]
       test()
-      js_size = os.stat('src.cpp.o.js').st_size
+      code_size = os.stat(code_file).st_size
       if self.uses_memory_init_file():
         mem_size = os.stat('src.cpp.o.js.mem').st_size
-      print js_size, ' => ', ec_js_size
+      print code_size, ' => ', ec_code_size
       if self.uses_memory_init_file():
         print mem_size, ' => ', ec_mem_size
-      assert ec_js_size < js_size
+      assert ec_code_size < code_size
       if self.uses_memory_init_file():
         assert ec_mem_size > mem_size
 
@@ -6185,25 +6187,14 @@ def process(filename):
       ''', "x: 11\n");
     do_test(test1)
 
-    print 'libcxx'
+    print 'libcxx - remove 2 ctors from iostream code'
 
     src = open(path_from_root('tests', 'hello_libcxx.cpp')).read()
     output = 'hello, world!'
-    self.do_run(src, output)
-    js_size = os.stat('src.cpp.o.js').st_size
-    if self.uses_memory_init_file():
-      mem_size = os.stat('src.cpp.o.js.mem').st_size
-    self.emcc_args += ['-s', 'EVAL_CTORS=1']
-    self.do_run(src, output)
-    ec_js_size = os.stat('src.cpp.o.js').st_size
-    if self.uses_memory_init_file():
-      ec_mem_size = os.stat('src.cpp.o.js.mem').st_size
-    print js_size, ' => ', ec_js_size
-    if self.uses_memory_init_file():
-      print mem_size, ' => ', ec_mem_size
-    assert ec_js_size < js_size
-    if self.uses_memory_init_file():
-      assert ec_mem_size > mem_size
+
+    def test2():
+      self.do_run(src, output)
+    do_test(test2)
 
     print 'assertions too'
     Settings.ASSERTIONS = 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6163,10 +6163,13 @@ def process(filename):
       code_size = os.stat(code_file).st_size
       if self.uses_memory_init_file():
         mem_size = os.stat('src.cpp.o.js.mem').st_size
-      print code_size, ' => ', ec_code_size
+      # if we are wasm, then eval-ctors disables wasm-only, losing i64 opts, increasing size
+      code_size_should_shrink = not self.is_wasm()
+      print code_size, ' => ', ec_code_size, ', are we testing code size?', code_size_should_shrink
       if self.uses_memory_init_file():
         print mem_size, ' => ', ec_mem_size
-      assert ec_code_size < code_size
+      if code_size_should_shrink:
+        assert ec_code_size < code_size
       if self.uses_memory_init_file():
         assert ec_mem_size > mem_size
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7247,11 +7247,8 @@ binaryen1 = make_run("binaryen1", compiler=CLANG, emcc_args=['-O1', '-s', 'BINAR
 binaryen2 = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '-s', 'ASSERTIONS=1', "-s", "PRECISE_F32=1"])
 
-binaryen2jo = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
-binaryen3jo = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
-
-binaryen2jo = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
-binaryen3jo = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '--js-opts', '1'])
+binaryen2jo = make_run("binaryen2jo", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary,asmjs"'])
+binaryen3jo = make_run("binaryen3jo", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary,asmjs"'])
 
 # This only works when .emscripten specifies a JS_ENGINE with native wasm support.
 binaryen_native = make_run("binaryen_native", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5278,6 +5278,7 @@ def process(filename):
                    libraries=self.get_freetype(),
                    includes=[path_from_root('tests', 'freetype', 'include')],
                    post_build=post)
+      Settings.OUTLINING_LIMIT = 0
 
     # github issue 324
     print '[issue 324]'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5650,6 +5650,7 @@ def process(filename):
           continue
         if self.is_wasm() and os.path.basename(shortname) in [
           'i1282vecnback', # uses simd
+          'call_inttoptr_i64', # casts a function pointer from (i32, i32)* to (i64)*, which happens to work in asm.js but is a general function pointer undefined behavior
         ]:
           continue
         if os.path.basename(shortname) in need_no_leave_inputs_raw:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6619,12 +6619,6 @@ int main() {
       del os.environ['EMCC_DEBUG']
 
   def test_binaryen_names(self):
-    binaryen_bin = os.path.join(Settings.BINARYEN_ROOT, 'bin')
-    if not Settings.BINARYEN_ROOT:
-      try:
-        binaryen_bin = os.path.join(BINARYEN_ROOT, 'bin')
-      except:
-        pass
     sizes = {}
     for args, expect_names in [
         ([], True), # -O0 has debug info by default
@@ -6640,11 +6634,8 @@ int main() {
       print args, expect_names
       try_delete('a.out.js')
       subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
-      cmd = [os.path.join(binaryen_bin, 'wasm-dis'), 'a.out.wasm', '-o', 'text']
-      print cmd
-      subprocess.check_call(cmd)
-      text = open('text').read()
-      assert ('$_main' in text or '$main' in text) == expect_names, 'name expectation must match'
+      code = open('a.out.wasm', 'rb').read()
+      assert ('__fflush_unlocked' in code) == expect_names, 'an internal function not exported nor imported must only appear in the binary if we have a names section'
       sizes[str(args)] = os.stat('a.out.wasm').st_size
       self.assertContained('hello, world!', run_js('a.out.js'))
     print sizes

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6604,7 +6604,8 @@ int main() {
       os.environ['EMCC_DEBUG'] = '1'
       for args, expect in [
           ([], True),
-          (['-s', 'PRECISE_F32=0'], False), # explicitly disabled
+          (['-s', 'PRECISE_F32=0'], True), # disabled, but no asm.js, so we definitely want f32
+          (['-s', 'PRECISE_F32=0', '-s', 'BINARYEN_METHOD="asmjs"'], False), # disabled, and we need the asm.js
           (['-s', 'PRECISE_F32=1'], True),
           (['-s', 'PRECISE_F32=2'], True),
         ]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6578,11 +6578,11 @@ int main() {
           (['-O2'], False),
           (['-O2', '--js-opts', '1'], True), # user asked
           (['-O2', '-s', 'EMTERPRETIFY=1'], True), # option forced
-          (['-O2', '-s', 'EVAL_CTORS=1'], True), # option forced
+          (['-O2', '-s', 'EVAL_CTORS=1'], False), # ctor evaller uses js opts, but is not a js opt, and doesn't force other js opts
           (['-O2', '-s', 'OUTLINING_LIMIT=1000'], True), # option forced
           (['-O2', '-s', "BINARYEN_METHOD='interpret-binary,asmjs'"], True), # asmjs in methods means we need good asm.js
           (['-O3'], False),
-          (['-Oz'], True), # for removing duplicate funcs
+          (['-Oz'], False), # even though we run ctor evaller, don't run js opts
         ]:
         print args, expect
         try_delete('a.out.js')

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_13'
+TAG = 'version_14'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2016,6 +2016,18 @@ class JS:
       return value
 
   @staticmethod
+  def legalize_sig(sig):
+    ret = [sig[0]]
+    for s in sig[1:]:
+      if s != 'j':
+        ret.append(s)
+      else:
+        # an i64 is legalized into i32, i32
+        ret.append('i')
+        ret.append('i')
+    return ''.join(ret)
+
+  @staticmethod
   def make_extcall(sig, named=True):
     args = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if args else '') + args
@@ -2036,7 +2048,8 @@ class JS:
 
   @staticmethod
   def make_invoke(sig, named=True):
-    args = ','.join(['a' + str(i) for i in range(1, len(sig))])
+    legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
+    args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
     args = 'index' + (',' if args else '') + args
     # C++ exceptions are numbers, and longjmp is a string 'longjmp'
     ret = '''function%s(%s) {

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1742,8 +1742,10 @@ class Building:
   @staticmethod
   def is_wasm_only():
     # if the asm.js code will not run, and won't be run through the js optimizer, then
-    # fastcomp can emit wasm-only code
-    return 'asmjs' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS
+    # fastcomp can emit wasm-only code.
+    # also disable this mode if it depends on special optimizations that are not yet
+    # compatible with it.
+    return 'asmjs' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS and not Settings.EMULATED_FUNCTION_POINTERS and not Settings.EMULATE_FUNCTION_POINTER_CASTS
 
   @staticmethod
   def get_safe_internalize():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1745,7 +1745,7 @@ class Building:
     # fastcomp can emit wasm-only code.
     # also disable this mode if it depends on special optimizations that are not yet
     # compatible with it.
-    return 'asmjs' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS and not Settings.EMULATED_FUNCTION_POINTERS and not Settings.EMULATE_FUNCTION_POINTER_CASTS
+    return 'asmjs' not in Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS and not Settings.EMULATED_FUNCTION_POINTERS and not Settings.EMULATE_FUNCTION_POINTER_CASTS
 
   @staticmethod
   def get_safe_internalize():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1740,6 +1740,12 @@ class Building:
     return Settings.INLINING_LIMIT == 0
 
   @staticmethod
+  def is_wasm_only():
+    # if the asm.js code will not run, and won't be run through the js optimizer, then
+    # fastcomp can emit wasm-only code
+    return 'asmjs' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS
+
+  @staticmethod
   def get_safe_internalize():
     if not Building.can_build_standalone(): return [] # do not internalize anything
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1965,7 +1965,7 @@ class JS:
     elif sig == 'j':
       if settings:
         assert settings['BINARYEN'], 'j aka i64 only makes sense in wasm-only mode in binaryen'
-      return 'i64()'
+      return 'i64(0)'
     elif sig == 'F':
       return 'SIMD_Float32x4_check(SIMD_Float32x4(0,0,0,0))'
     elif sig == 'D':

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1962,6 +1962,10 @@ class JS:
       return '0'
     elif sig == 'f' and settings.get('PRECISE_F32'):
       return 'Math_fround(0)'
+    elif sig == 'j':
+      if settings:
+        assert settings['BINARYEN'], 'j aka i64 only makes sense in wasm-only mode in binaryen'
+      return 'i64()'
     elif sig == 'F':
       return 'SIMD_Float32x4_check(SIMD_Float32x4(0,0,0,0))'
     elif sig == 'D':
@@ -1994,6 +1998,10 @@ class JS:
         return 'Math_fround(' + value + ')'
     elif sig == 'd' or sig == 'f':
       return '+' + value
+    elif sig == 'j':
+      if settings:
+        assert settings['BINARYEN'], 'j aka i64 only makes sense in wasm-only mode in binaryen'
+      return 'i64(' + value + ')'
     elif sig == 'F':
       return 'SIMD_Float32x4_check(' + value + ')'
     elif sig == 'D':


### PR DESCRIPTION
A bunch of minor tweaks for binaryen optimizations and changes, like binaryen `-g`, `--only-wasm` (https://github.com/WebAssembly/binaryen/pull/723), etc. Also some testing improvements (an option to run specific binaryen passes, useful for fuzzing).

Before this lands it needs to update the binaryen port, as it requires latest binaryen master.