### PR TITLE
Use WebAssembly.Memory in BINARYEN mode.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1184,6 +1184,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
 
     if shared.Settings.BINARYEN:
+      shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
       debug_level = max(1, debug_level) # keep whitespace readable, for asm.js parser simplicity
       shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
       assert not shared.Settings.SPLIT_MEMORY, 'WebAssembly does not support split memory'


### PR DESCRIPTION
Corresponds to https://github.com/WebAssembly/binaryen/pull/752.

Note that this disables asm.js validation in binaryen mode, since a Memory [is not compatible with asm.js](https://bugzilla.mozilla.org/show_bug.cgi?id=1308360) in at least Firefox. That means that a single build that does either asm.js or wasm will have the asm.js side run as normal JS. I mainly use that mode for testing and debugging, but if people want it in production (instead of 2 separate builds) then we should optimize it.