### PR TITLE
Disable hard requirement on node.js if the JS optimizer is not being used

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -985,7 +985,7 @@ if __name__ == '__main__':
 
   # Sanity checks
   total_engines = len(JS_ENGINES)
-  JS_ENGINES = filter(check_engine, JS_ENGINES)
+  JS_ENGINES = filter(lambda e: jsrun.check_engine(e, __rootpath__), JS_ENGINES)
   if len(JS_ENGINES) == 0:
     print 'WARNING: None of the JS engines in JS_ENGINES appears to work.'
   elif len(JS_ENGINES) < total_engines:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -985,7 +985,7 @@ if __name__ == '__main__':
 
   # Sanity checks
   total_engines = len(JS_ENGINES)
-  JS_ENGINES = filter(lambda e: jsrun.check_engine(e, __rootpath__), JS_ENGINES)
+  JS_ENGINES = filter(jsrun.check_engine, JS_ENGINES)
   if len(JS_ENGINES) == 0:
     print 'WARNING: None of the JS engines in JS_ENGINES appears to work.'
   elif len(JS_ENGINES) < total_engines:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6691,7 +6691,6 @@ int main() {
       self.assertContained('''output file "%s" has a wasm suffix, but we cannot emit wasm by itself''' % f, err)
 
   def test_check_engine(self):
-    #restore()
     compiler_engine = COMPILER_ENGINE
     bogus_engine = ['/fake/inline4']
     print compiler_engine

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6690,3 +6690,32 @@ int main() {
       assert process.returncode is not 0, 'wasm suffix is an error'
       self.assertContained('''output file "%s" has a wasm suffix, but we cannot emit wasm by itself''' % f, err)
 
+  def test_check_engine(self):
+    #restore()
+    compiler_engine = COMPILER_ENGINE
+    bogus_engine = ['/fake/inline4']
+    print compiler_engine
+    jsrun.WORKING_ENGINES = {}
+    # Test that engine check passes
+    assert jsrun.check_engine(COMPILER_ENGINE)
+    # Run it a second time (cache hit)
+    assert jsrun.check_engine(COMPILER_ENGINE)
+    # Test that engine check fails
+    assert not jsrun.check_engine(bogus_engine)
+    assert not jsrun.check_engine(bogus_engine)
+
+    # Test the other possible way (list vs string) to express an engine
+    if type(compiler_engine) is list:
+      engine2 = compiler_engine[0]
+    else:
+      engine2 = [compiler_engine]
+    assert jsrun.check_engine(engine2)
+
+    # Test that run_js requires the engine
+    jsrun.run_js(path_from_root('src', 'hello_world.js'), compiler_engine)
+    caught_exit = 0
+    try:
+      jsrun.run_js(path_from_root('src', 'hello_world.js'), bogus_engine)
+    except SystemExit as e:
+      caught_exit = e.code
+    self.assertEqual(1, caught_exit, 'Did not catch SystemExit with bogus JS engine')

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -286,6 +286,29 @@ class sanity(RunnerCore):
 
     self.check_working([EMCC, 'tests/hello_world.cpp', '-s', 'ASM_JS=0'], '''Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended''')
 
+  def test_check_engine(self):
+    restore()
+    compiler_engine = COMPILER_ENGINE
+    bogus_engine = ['/fake/inline4']
+    print compiler_engine
+    jsrun.WORKING_ENGINES = {}
+    # Test that engine check passes
+    assert jsrun.check_engine(COMPILER_ENGINE)
+    # Run it a second time (cache hit)
+    assert jsrun.check_engine(COMPILER_ENGINE)
+    # Test that engine check fails
+    assert not jsrun.check_engine(bogus_engine)
+    assert not jsrun.check_engine(bogus_engine)
+
+    # Test that run_js requires the engine
+    jsrun.run_js('hello_world.js', compiler_engine)
+    caught_exit = 0
+    try:
+      jsrun.run_js('hello_world.js', bogus_engine)
+    except SystemExit as e:
+      caught_exit = e.code
+    self.assertEqual(1, caught_exit, 'Did not catch SystemExit with bogus JS engine')
+
   def test_node(self):
     NODE_WARNING = 'node version appears too old'
     NODE_WARNING_2 = 'cannot check node version'

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -286,29 +286,6 @@ class sanity(RunnerCore):
 
     self.check_working([EMCC, 'tests/hello_world.cpp', '-s', 'ASM_JS=0'], '''Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended''')
 
-  def test_check_engine(self):
-    restore()
-    compiler_engine = COMPILER_ENGINE
-    bogus_engine = ['/fake/inline4']
-    print compiler_engine
-    jsrun.WORKING_ENGINES = {}
-    # Test that engine check passes
-    assert jsrun.check_engine(COMPILER_ENGINE)
-    # Run it a second time (cache hit)
-    assert jsrun.check_engine(COMPILER_ENGINE)
-    # Test that engine check fails
-    assert not jsrun.check_engine(bogus_engine)
-    assert not jsrun.check_engine(bogus_engine)
-
-    # Test that run_js requires the engine
-    jsrun.run_js('hello_world.js', compiler_engine)
-    caught_exit = 0
-    try:
-      jsrun.run_js('hello_world.js', bogus_engine)
-    except SystemExit as e:
-      caught_exit = e.code
-    self.assertEqual(1, caught_exit, 'Did not catch SystemExit with bogus JS engine')
-
   def test_node(self):
     NODE_WARNING = 'node version appears too old'
     NODE_WARNING_2 = 'cannot check node version'

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -770,7 +770,7 @@ fi
         os.chmod(test_engine_path, stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
 
         try:
-          out = jsrun.run_js(sample_script, engine=test_engine_path, args=['--foo'], full_output=True, assert_returncode=0)
+          out = jsrun.run_js(sample_script, engine=test_engine_path, args=['--foo'], full_output=True, assert_returncode=0, skip_check=True)
         except Exception as e:
           if 'd8' in filename:
             assert False, 'Your d8 version does not correctly parse command-line arguments, please upgrade or delete from ~/.emscripten config file: %s' % (e)

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -1,5 +1,5 @@
 from toolchain_profiler import ToolchainProfiler
-import time, os, sys, logging
+import time, os, sys, logging, json
 from subprocess import Popen, PIPE, STDOUT
 import cache
 
@@ -39,12 +39,32 @@ def make_command(filename, engine=None, args=[]):
 def check_engine(engine, rootpath):
   if type(engine) is list: # XXX wat? When is this not a list?
     engine_path = engine[0]
+  global ENGINES_WORK
   if engine_path in ENGINES_WORK:
     return ENGINES_WORK[engine_path]
   try:
+    temp_cache = cache.Cache(use_subdir=False)
+    def get_engine_cache():
+      saved_file = os.path.join(temp_cache.dirname, 'js_engine_check.txt')
+      with open(saved_file, 'w') as f:
+        print 'json!'
+        print ENGINES_WORK
+        json.dumps(ENGINES_WORK)
+        json.dump(ENGINES_WORK, f)
+      return saved_file
+    engine_file = temp_cache.get('js_engine_check', get_engine_cache, '.txt')
+    with open(engine_file) as f:
+      engine_cache = json.load(f)
+      print 'loadjson!'
+      print engine_cache
+      ENGINES_WORK = engine_cache
+    if engine_path in ENGINES_WORK:
+      return ENGINES_WORK[engine_path]
     logging.info('Checking JS engine %s' % engine)
     if 'hello, world!' in run_js(os.path.join(rootpath, 'src', 'hello_world.js'), engine, skip_check=True):
       ENGINES_WORK[engine_path] = True
+    with open(engine_file, 'w') as f:
+      json.dump(ENGINES_WORK, f)
   except Exception, e:
     logging.info('Checking JS engine %s failed. Check your config file. Details: %s' % (str(engine), str(e)))
     ENGINES_WORK[engine_path] = False

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -44,7 +44,7 @@ def check_engine(engine):
   if engine_path in WORKING_ENGINES:
     return WORKING_ENGINES[engine_path]
   try:
-    logging.info('Checking JS engine %s' % engine)
+    logging.debug('Checking JS engine %s' % engine)
     if 'hello, world!' in run_js(os.path.join(__rootpath__, 'src', 'hello_world.js'), engine, skip_check=True):
       WORKING_ENGINES[engine_path] = True
   except Exception, e:

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -40,6 +40,8 @@ def make_command(filename, engine=None, args=[]):
 def check_engine(engine):
   if type(engine) is list:
     engine_path = engine[0]
+  else:
+    engine_path = engine
   global WORKING_ENGINES
   if engine_path in WORKING_ENGINES:
     return WORKING_ENGINES[engine_path]
@@ -55,7 +57,8 @@ def check_engine(engine):
 
 def require_engine(engine):
   engine_path = engine[0]
-  assert engine_path in WORKING_ENGINES, 'JS engine %s should have been checked at startup' % engine
+  if engine_path not in WORKING_ENGINES:
+    check_engine(engine)
   if not WORKING_ENGINES[engine_path]:
     logging.critical('The JavaScript shell (%s) does not seem to work, check the paths in the config file' % engine)
     sys.exit(1)

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -47,16 +47,11 @@ def check_engine(engine, rootpath):
     def get_engine_cache():
       saved_file = os.path.join(temp_cache.dirname, 'js_engine_check.txt')
       with open(saved_file, 'w') as f:
-        print 'json!'
-        print ENGINES_WORK
-        json.dumps(ENGINES_WORK)
         json.dump(ENGINES_WORK, f)
       return saved_file
     engine_file = temp_cache.get('js_engine_check', get_engine_cache, '.txt')
     with open(engine_file) as f:
       engine_cache = json.load(f)
-      print 'loadjson!'
-      print engine_cache
       ENGINES_WORK = engine_cache
     if engine_path in ENGINES_WORK:
       return ENGINES_WORK[engine_path]

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -1,7 +1,6 @@
 from toolchain_profiler import ToolchainProfiler
 import time, os, sys, logging
 from subprocess import Popen, PIPE, STDOUT
-import cache
 
 TRACK_PROCESS_SPAWNS = True if (os.getenv('EM_BUILD_VERBOSE') and int(os.getenv('EM_BUILD_VERBOSE')) >= 3) else False
 WORKING_ENGINES = {} # Holds all configured engines and whether they work: maps path -> True/False

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -432,6 +432,7 @@ def check_fastcomp():
 EXPECTED_NODE_VERSION = (0,8,0)
 
 def check_node_version():
+  jsrun.check_engine(NODE_JS, __rootpath__)
   try:
     actual = Popen(NODE_JS + ['--version'], stdout=PIPE).communicate()[0].strip()
     version = tuple(map(int, actual.replace('v', '').replace('-pre', '').split('.')))
@@ -546,13 +547,8 @@ def check_sanity(force=False):
     logging.info('(Emscripten: Running sanity checks)')
 
     with ToolchainProfiler.profile_block('sanity compiler_engine'):
-      if not check_engine(COMPILER_ENGINE):
+      if not jsrun.check_engine(COMPILER_ENGINE, __rootpath__):
         logging.critical('The JavaScript shell used for compiling (%s) does not seem to work, check the paths in %s' % (COMPILER_ENGINE, EM_CONFIG))
-        sys.exit(1)
-
-    if NODE_JS != COMPILER_ENGINE and Settings.RUNNING_JS_OPTS:
-      if not check_engine(NODE_JS):
-        logging.critical('Node.js (%s) does not seem to work, check the paths in %s' % (NODE_JS, EM_CONFIG))
         sys.exit(1)
 
     with ToolchainProfiler.profile_block('sanity LLVM'):
@@ -1002,16 +998,6 @@ if not WINDOWS:
     pass
 
 # Utilities
-
-def check_engine(engine):
-  # TODO: we call this several times, perhaps cache the results?
-  try:
-    if not CONFIG_FILE:
-      return True # config stored directly in EM_CONFIG => skip engine check
-    return 'hello, world!' in run_js(path_from_root('src', 'hello_world.js'), engine)
-  except Exception, e:
-    print 'Checking JS engine %s failed. Check %s. Details: %s' % (str(engine), EM_CONFIG, str(e))
-    return False
 
 def make_js_command(filename, engine=None, *args):
   if engine is None:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -344,7 +344,7 @@ def check_llvm_version():
   try:
     check_clang_version()
   except Exception, e:
-    logging.warning('Could not verify LLVM version: %s' % str(e))
+    logging.critical('Could not verify LLVM version: %s' % str(e))
 
 # look for emscripten-version.txt files under or alongside the llvm source dir
 def get_fastcomp_src_dir():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -850,9 +850,6 @@ except:
   JAVA = 'java'
 
 
-for engine in JS_ENGINES:
-  jsrun.check_engine(engine)
-
 # Additional compiler options
 
 # Target choice.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -849,7 +849,6 @@ except:
   logging.debug('JAVA not defined in ' + hint_config_file_location() + ', using "java"')
   JAVA = 'java'
 
-
 # Additional compiler options
 
 # Target choice.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -849,6 +849,10 @@ except:
   logging.debug('JAVA not defined in ' + hint_config_file_location() + ', using "java"')
   JAVA = 'java'
 
+
+for engine in JS_ENGINES:
+  jsrun.check_engine(engine, __rootpath__)
+
 # Additional compiler options
 
 # Target choice.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -432,7 +432,7 @@ def check_fastcomp():
 EXPECTED_NODE_VERSION = (0,8,0)
 
 def check_node_version():
-  jsrun.check_engine(NODE_JS, __rootpath__)
+  jsrun.check_engine(NODE_JS)
   try:
     actual = Popen(NODE_JS + ['--version'], stdout=PIPE).communicate()[0].strip()
     version = tuple(map(int, actual.replace('v', '').replace('-pre', '').split('.')))
@@ -547,7 +547,7 @@ def check_sanity(force=False):
     logging.info('(Emscripten: Running sanity checks)')
 
     with ToolchainProfiler.profile_block('sanity compiler_engine'):
-      if not jsrun.check_engine(COMPILER_ENGINE, __rootpath__):
+      if not jsrun.check_engine(COMPILER_ENGINE):
         logging.critical('The JavaScript shell used for compiling (%s) does not seem to work, check the paths in %s' % (COMPILER_ENGINE, EM_CONFIG))
         sys.exit(1)
 
@@ -851,7 +851,7 @@ except:
 
 
 for engine in JS_ENGINES:
-  jsrun.check_engine(engine, __rootpath__)
+  jsrun.check_engine(engine)
 
 # Additional compiler options
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -550,7 +550,7 @@ def check_sanity(force=False):
         logging.critical('The JavaScript shell used for compiling (%s) does not seem to work, check the paths in %s' % (COMPILER_ENGINE, EM_CONFIG))
         sys.exit(1)
 
-    if NODE_JS != COMPILER_ENGINE:
+    if NODE_JS != COMPILER_ENGINE and Settings.RUNNING_JS_OPTS:
       if not check_engine(NODE_JS):
         logging.critical('Node.js (%s) does not seem to work, check the paths in %s' % (NODE_JS, EM_CONFIG))
         sys.exit(1)


### PR DESCRIPTION
This means that wasm users or buildbots who have d8 or SM don't necessarily
need node.
