### PR TITLE
Call `dynCall` on Runtime module

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4130,7 +4130,7 @@ LibraryManager.library = {
     var trace = _emscripten_get_callstack_js();
     var parts = trace.split('\n');
     for (var i = 0; i < parts.length; i++) {
-      var ret = Module.dynCall('iii', [0, arg]);
+      var ret = Runtime.dynCall('iii', [0, arg]);
       if (ret !== 0) return;
     }
   },


### PR DESCRIPTION
`dynCall` is not defined on `Module`, thus resulting in a `Module.dynCall is not a function` exception