### PR TITLE
Emscripten wget fixes

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -449,7 +449,7 @@ Functions
 	To use this function, you will need to compile your application with the linker flag ``-s ASYNCIFY=1``
 
 	:param const char* url: The URL to load.
-	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten.
+	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created.
 
 	
 .. c:function:: void emscripten_async_wget(const char* url, const char* file, em_str_callback_func onload, em_str_callback_func onerror)
@@ -461,7 +461,7 @@ Functions
 	When the file is ready the ``onload`` callback will be called. If any error occurs ``onerror`` will be called. The callbacks are called with the file as their argument.
 	
 	:param const char* url: The URL to load.
-	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten.
+	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created.
 	:param em_str_callback_func onload: Callback on successful load of the file. The callback function parameter value is:	
 	
 		- *(const char*)* : The name of the ``file`` that was loaded from the URL.

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -628,10 +628,11 @@ var LibraryBrowser = {
     },
 
     asyncLoad: function(url, onload, onerror, noRunDep) {
+      var dep = !noRunDep ? getUniqueRunDependency('al ' + url) : '';
       Module['readAsync'](url, function(arrayBuffer) {
         assert(arrayBuffer, 'Loading data file "' + url + '" failed (no arrayBuffer).');
         onload(new Uint8Array(arrayBuffer));
-        if (!noRunDep) removeRunDependency('al ' + url);
+        if (dep) removeRunDependency(dep);
       }, function(event) {
         if (onerror) {
           onerror();
@@ -639,7 +640,7 @@ var LibraryBrowser = {
           throw 'Loading data file "' + url + '" failed.';
         }
       });
-      if (!noRunDep) addRunDependency('al ' + url);
+      if (dep) addRunDependency(dep);
     },
 
     resizeListeners: [],

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -742,12 +742,19 @@ var LibraryBrowser = {
     var _file = Pointer_stringify(file);
     asm.setAsync();
     Module['noExitRuntime'] = true;
+    var destinationDirectory = PATH.dirname(_file);
     FS.createPreloadedFile(
-      PATH.dirname(_file),
+      destinationDirectory,
       PATH.basename(_file),
       _url, true, true,
       _emscripten_async_resume,
-      _emscripten_async_resume
+      _emscripten_async_resume,
+      undefined, // dontCreateFile
+      undefined, // canOwn
+      function() { // preFinish
+        // if the destination directory does not yet exist, create it
+        FS.mkdirTree(destinationDirectory);
+      }
     );
   },
 #else
@@ -769,8 +776,9 @@ var LibraryBrowser = {
         Runtime.stackRestore(stack);
       }
     }
+    var destinationDirectory = PATH.dirname(_file);
     FS.createPreloadedFile(
-      PATH.dirname(_file),
+      destinationDirectory,
       PATH.basename(_file),
       _url, true, true,
       function() {
@@ -786,6 +794,8 @@ var LibraryBrowser = {
         try {
           FS.unlink(_file);
         } catch (e) {}
+        // if the destination directory does not yet exist, create it
+        FS.mkdirTree(destinationDirectory);
       }
     );
   },

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -628,6 +628,19 @@ mergeInto(LibraryManager.library, {
       mode |= {{{ cDefine('S_IFDIR') }}};
       return FS.mknod(path, mode, 0);
     },
+    // Creates a whole directory tree chain if it doesn't yet exist
+    mkdirTree: function(path, mode) {
+      var dirs = path.split('/');
+      var d = '';
+      for (var i = 0; i < dirs.length; ++i) {
+        d += '/' + dirs[i];
+        try {
+          FS.mkdir(d, mode);
+        } catch(e) {
+          if (e.errno != ERRNO_CODES.EEXIST) throw e;
+        }
+      }
+    },
     mkdev: function(path, mode, dev) {
       if (typeof(dev) === 'undefined') {
         dev = mode;

--- a/tests/emscripten_fs_api_browser.cpp
+++ b/tests/emscripten_fs_api_browser.cpp
@@ -39,7 +39,7 @@ void wait_wgets() {
     counter = 0;
   }
 
-  if (get_count == 3) {
+  if (get_count == 5) {
     static bool fired = false;
     if (!fired) {
       fired = true;
@@ -54,17 +54,18 @@ void wait_wgets() {
         onLoadedData,
         onErrorData);
     }
-  } else if (get_count == 5) {
+  } else if (get_count == 7) {
     assert(IMG_Load("/tmp/screen_shot.png"));
     assert(data_ok == 1 && data_bad == 1);
     emscripten_cancel_main_loop();
     REPORT_RESULT();
   }
-  assert(get_count <= 5);
+  assert(get_count <= 7);
 }
 
 void onLoaded(const char* file) {
-  if (strcmp(file, "/tmp/test.html") && strcmp(file, "/tmp/screen_shot.png")) {
+  if (strcmp(file, "/tmp/test.html") && strcmp(file, "/tmp/screen_shot.png")
+     && strcmp(file, "/this_directory_does_not_exist_and_should_be_created_by_wget/test.html")) {
     result = 0;
   }
 
@@ -104,6 +105,20 @@ int main() {
   emscripten_async_wget(
     "http://localhost:8888/test.html", 
     "/tmp/test.html",
+    onLoaded,
+    onError);
+
+  // Try downloading the same file a second time
+  emscripten_async_wget(
+    "http://localhost:8888/test.html",
+    "/tmp/test.html",
+    onLoaded,
+    onError);
+
+  // Try downloading a file to a destination directory that does not exist.
+  emscripten_async_wget(
+    "http://localhost:8888/test.html",
+    "/this_directory_does_not_exist_and_should_be_created_by_wget/test.html",
     onLoaded,
     onError);
 


### PR DESCRIPTION
Some fixes:

1. `emscripten_wget()` and `emscripten_async_wget()` always called `add/removeRunDependency()`, which is a bit silly since these are C APIs, so they are called after application runtime has already been initialized, so it's too late for the run dependencies. 
2. Attempting to simultaneously wget the same URL twice would throw an exception, because of the above got called with identical dependency IDs.
3. wgetting to a destination directory on the filesystem that does not exist would lead to an exception "file not found". This changes the semantics to create the destination directory tree instead.

Regarding 1), I'm not quite sure if it would be a good use case to have static data initializers be able to call emscripten_wget() to preload stuff before main() has been called? If that it something that would make sense, then perhaps the fix for 2) will need to be something different.