### PR TITLE
Tiny fixes for native wasm support

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1999,6 +1999,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # remove and forget about the mem init file in later processing; it does not need to be prefetched in the html, etc.
           os.unlink(memfile)
           memory_init_file = False
+      if shared.Settings.BINARYEN_PASSES:
+        shutil.move(wasm_text_target, wasm_text_target + '.pre')
+        cmd = [os.path.join(binaryen_bin, 'wasm-opt'), wasm_text_target + '.pre', '-o', wasm_text_target] + map(lambda p: '--' + p, shared.Settings.BINARYEN_PASSES.split(','))
+        logging.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))
+        subprocess.check_call(cmd)
+      if 'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD:
+        cmd = [os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target]
+        if debug_level >= 2 or profiling_funcs: cmd += ['-g']
+        logging.debug('wasm-as (text => binary): ' + ' '.join(cmd))
+        subprocess.check_call(cmd)
       if shared.Settings.BINARYEN_SCRIPTS:
         binaryen_scripts = os.path.join(shared.Settings.BINARYEN_ROOT, 'scripts')
         script_env = os.environ.copy()
@@ -2010,16 +2020,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         for script in shared.Settings.BINARYEN_SCRIPTS.split(','):
           logging.debug('running binaryen script: ' + script)
           subprocess.check_call([shared.PYTHON, os.path.join(binaryen_scripts, script), js_target, wasm_text_target], env=script_env)
-      if shared.Settings.BINARYEN_PASSES:
-        shutil.move(wasm_text_target, wasm_text_target + '.pre')
-        cmd = [os.path.join(binaryen_bin, 'wasm-opt'), wasm_text_target + '.pre', '-o', wasm_text_target] + map(lambda p: '--' + p, shared.Settings.BINARYEN_PASSES.split(','))
-        logging.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))
-        subprocess.check_call(cmd)
-      if 'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD:
-        cmd = [os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target]
-        if debug_level >= 2 or profiling_funcs: cmd += ['-g']
-        logging.debug('wasm-as (text => binary): ' + ' '.join(cmd))
-        subprocess.check_call(cmd)
 
     # If we were asked to also generate HTML, do that
     if final_suffix == 'html':

--- a/emscripten.py
+++ b/emscripten.py
@@ -691,6 +691,9 @@ function _emscripten_asm_const_%s(%s) {
       basic_funcs += ['setTempRet0', 'getTempRet0']
       asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
 
+    if settings['BINARYEN']:
+      asm_setup += "\nModule['wasmTableSize'] = %d;\n" % sum(map(lambda table: table.count(',') + 1, last_forwarded_json['Functions']['tables'].values()))
+
     # See if we need ASYNCIFY functions
     # We might not need them even if ASYNCIFY is enabled
     need_asyncify = '_emscripten_alloc_async_context' in exported_implemented_functions

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -631,6 +631,9 @@ class RunnerCore(unittest.TestCase):
     for engine in js_engines: assert type(engine) == list
     for engine in self.banned_js_engines: assert type(engine) == list
     js_engines = filter(lambda engine: engine[0] not in map(lambda engine: engine[0], self.banned_js_engines), js_engines)
+    if 'BINARYEN_METHOD="native-wasm"' in self.emcc_args:
+      # when testing native wasm support, must use a vm with support
+      js_engines = filter(lambda engine: engine == SPIDERMONKEY_ENGINE or engine == V8_ENGINE, js_engines)
     if len(js_engines) == 0: return self.skip('No JS engine present to run this test with. Check %s and the paths therein.' % EM_CONFIG)
     if len(js_engines) > 1 and not self.use_all_engines:
       if SPIDERMONKEY_ENGINE in js_engines: # make sure to get asm.js validation checks, using sm


### PR DESCRIPTION
There is now an almost-working path to running wasm natively (binaryen+spidermonkify.py script), which is allowing me to find a bunch of tiny issues.