### PR TITLE
docs warning in preamble.js

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -246,8 +246,7 @@ Conversion functions — strings, pointers and arrays
 
 	Writes a JavaScript string to a specified address in the heap. 
 
-	.. warning:: This function is deprecated, you should call the function ``stringToUTF8`` instead, which provides a secure
-	bounded version of the same functionality instead.
+	.. warning:: This function is deprecated, you should call the function ``stringToUTF8`` instead, which provides a secure bounded version of the same functionality instead.
 	
 	.. code-block:: javascript
 	


### PR DESCRIPTION
the new line was rendered outside of the warning box

![screenshot from 2016-10-13 14-12-38](https://cloud.githubusercontent.com/assets/7273940/19348634/24c76bbc-914f-11e6-89de-5ee2c682a2e9.png)