### PR TITLE
Disable test_autodebug for V8

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5741,7 +5741,9 @@ def process(filename):
     Building.llvm_dis(filename)
 
   def test_autodebug(self):
-    self.banned_js_engines = [V8_ENGINE] # Broken on V8 but not node; wasm-only
+    if self.is_wasm():
+      # Broken on V8 but not node; wasm-only
+      self.banned_js_engines = [V8_ENGINE]
     if Building.LLVM_OPTS: return self.skip('LLVM opts mess us up')
     Building.COMPILER_TEST_OPTS += ['--llvm-opts', '0']
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5744,6 +5744,10 @@ def process(filename):
     if self.is_wasm():
       # Broken on V8 but not node; wasm-only
       self.banned_js_engines = [V8_ENGINE]
+      if not self.filtered_js_engines():
+        # Return early to not run into asserts
+        return self.skip('wasm on V8 currently fails')
+
     if Building.LLVM_OPTS: return self.skip('LLVM opts mess us up')
     Building.COMPILER_TEST_OPTS += ['--llvm-opts', '0']
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5740,9 +5740,8 @@ def process(filename):
     Building.llvm_as(filename)
     Building.llvm_dis(filename)
 
-  # Broken on V8 but not node
-  @no_wasm_backend()
   def test_autodebug(self):
+    self.banned_js_engines = [V8_ENGINE] # Broken on V8 but not node; wasm-only
     if Building.LLVM_OPTS: return self.skip('LLVM opts mess us up')
     Building.COMPILER_TEST_OPTS += ['--llvm-opts', '0']
 


### PR DESCRIPTION
test_autodebug is inaccurately marked no_wasm_backend(), when really it
doesn't work in v8, with either backend or asm2wasm.
v8 does work with asmjs, but just banning v8 is more accurate than not
disabling this test for asm2wasm.

We'd like to test asm2wasm against the emscripten testsuite on the wasm waterfall using v8, and this is the only failing test in that case.