### PR TITLE
modularize feature : fix regression since commit c5af8f6 

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1894,6 +1894,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         f = open(final, 'w')
         f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
         f.write('  ' + shared.Settings.EXPORT_NAME + ' = ' + shared.Settings.EXPORT_NAME + ' || {};\n')
+        f.write('  var Module = ' + shared.Settings.EXPORT_NAME + ';\n')
         f.write('\n')
         f.write(src)
         f.write('\n')


### PR DESCRIPTION
Ensure a local 'Module' variable exists in the scope of the function wrapping the module and points to the renamed module object when using the modularize feature.

That small fix prevents unwanted behaviours. For instance, when using the '--preload-file' option,
some code is added at the top of the generated module for loading the '.data' file containing resources.
That code begins with:

var Module;
if (typeof Module === 'undefined') Module = {};

But when using the modularize feature and since commit c5af8f6, the Module variable is undefined so this will create a new one initialized to an empty object. We do not want that to happen as if we pass a non empty object to the module wrapping function (for instance specifying 'modulePrefixURL' or 'TOTAL_MEMORY' properties), its properties values will not be used by emscripten code who always use the 'Module' variable.

