### PR TITLE
Use -O0, etc. options in asm2wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2015,7 +2015,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             cmd += ['--imprecise']
           # pass optimization level to asm2wasm (if not optimizing, or which passes we should run was overridden, do not optimize)
           if opt_level > 0 and not shared.Settings.BINARYEN_PASSES:
-            cmd.append(Building.opt_level_to_str(opt_level, shrink_level))
+            cmd.append(shared.Building.opt_level_to_str(opt_level, shrink_level))
           # import mem init file if it exists, and if we will not be using asm.js as a binaryen method (as it needs the mem init file, of course)
           import_mem_init = memory_init_file and os.path.exists(memfile) and 'asmjs' not in shared.Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD
           if import_mem_init:

--- a/emcc.py
+++ b/emcc.py
@@ -2013,8 +2013,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           cmd = [os.path.join(binaryen_bin, 'asm2wasm'), asm_target, '--total-memory=' + str(shared.Settings.TOTAL_MEMORY)]
           if shared.Settings.BINARYEN_IMPRECISE:
             cmd += ['--imprecise']
-          if opt_level == 0 or shared.Settings.BINARYEN_PASSES: # if not optimizing, or which passes we should run was overridden, do not optimize
-            cmd += ['--no-opts']
+          # pass optimization level to asm2wasm (if not optimizing, or which passes we should run was overridden, do not optimize)
+          if opt_level > 0 and not shared.Settings.BINARYEN_PASSES:
+            cmd.append(Building.opt_level_to_str(opt_level, shrink_level))
           # import mem init file if it exists, and if we will not be using asm.js as a binaryen method (as it needs the mem init file, of course)
           import_mem_init = memory_init_file and os.path.exists(memfile) and 'asmjs' not in shared.Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD
           if import_mem_init:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6587,7 +6587,7 @@ int main() {
           for f in files:
             try_delete(f)
 
-  def test_binaryen_and_js_opts(self):
+  def test_binaryen_opts(self):
     if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
  
     with clean_write_access_to_canonical_temp_dir():
@@ -6619,6 +6619,14 @@ int main() {
             i64s = wast.count('(i64.')
             print '    seen i64s:', i64s
             assert expect_only_wasm == (i64s > 30), 'i64 opts can be emitted in only-wasm mode, but not normally' # note we emit a few i64s even without wasm-only, when we replace udivmoddi (around 15 such)
+            asm2wasm_line = filter(lambda line: 'asm2wasm' in line, err.split('\n'))
+            asm2wasm_line = '' if not asm2wasm_line else asm2wasm_line[0]
+            if '-O0' in args or '-O' not in str(args):
+              assert '-O' not in asm2wasm_line, 'no opts should be passed to asm2wasm: ' + asm2wasm_line
+            else:
+              opts_str = args[0]
+              assert opts_str.startswith('-O')
+              assert opts_str in asm2wasm_line, 'expected opts: ' + asm2wasm_line
       finally:
         del os.environ['EMCC_DEBUG']
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6616,9 +6616,17 @@ int main() {
             assert expect_js_opts == ('applying js optimization passes:' in err), err
             assert expect_only_wasm == ('-emscripten-only-wasm' in err and '--wasm-only' in err), err # check both flag to fastcomp and to asm2wasm
             wast = open('a.out.wast').read()
+            # i64s
             i64s = wast.count('(i64.')
             print '    seen i64s:', i64s
             assert expect_only_wasm == (i64s > 30), 'i64 opts can be emitted in only-wasm mode, but not normally' # note we emit a few i64s even without wasm-only, when we replace udivmoddi (around 15 such)
+            selects = wast.count('(select')
+            print '    seen selects:', selects
+            if '-Os' in args or '-Oz' in args:
+              assert selects > 50, 'when optimizing for size we should create selects'
+            else:
+              assert selects < 10, 'when not optimizing for size we should not create selects'
+            # asm2wasm opt line
             asm2wasm_line = filter(lambda line: 'asm2wasm' in line, err.split('\n'))
             asm2wasm_line = '' if not asm2wasm_line else asm2wasm_line[0]
             if '-O0' in args or '-O' not in str(args):

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_16'
+TAG = 'version_17'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1785,11 +1785,11 @@ class Building:
     if opt_level == 0:
       return '-O0'
     if shrink_level == 1:
-      return ['-Os']
+      return '-Os'
     elif shrink_level >= 2:
-      return ['-Oz']
+      return '-Oz'
     else:
-      return ['-O' + str(min(opt_level, 3))]
+      return '-O' + str(min(opt_level, 3))
 
   @staticmethod
   def pick_llvm_opts(optimization_level):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1780,6 +1780,18 @@ class Building:
     return ['-internalize', internalize_public_api]
 
   @staticmethod
+  def opt_level_to_str(opt_level, shrink_level=0):
+    # convert opt_level/shrink_level pair to a string argument like -O1
+    if opt_level == 0:
+      return '-O0'
+    if shrink_level == 1:
+      return ['-Os']
+    elif shrink_level >= 2:
+      return ['-Oz']
+    else:
+      return ['-O' + str(min(opt_level, 3))]
+
+  @staticmethod
   def pick_llvm_opts(optimization_level):
     '''
       It may be safe to use nonportable optimizations (like -OX) if we remove the platform info from the .ll


### PR DESCRIPTION
This makes us pass -O0 etc. flags to asm2wasm in a consistent way (instead of previous `--no-opts` flag which is now deprecated).

Adds testing for this, in particular we create selects when optimizing for size.

Updates binaryen module, as this requires binaryen that can accept those -O0 etc. flags.