### PR TITLE
relpaths_in_emscripten_async_wget

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -449,7 +449,7 @@ Functions
 	To use this function, you will need to compile your application with the linker flag ``-s ASYNCIFY=1``
 
 	:param const char* url: The URL to load.
-	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created.
+	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created. A relative pathname may be passed, which will be interpreted relative to the current working directory at the time of the call to this function.
 
 	
 .. c:function:: void emscripten_async_wget(const char* url, const char* file, em_str_callback_func onload, em_str_callback_func onerror)
@@ -461,7 +461,7 @@ Functions
 	When the file is ready the ``onload`` callback will be called. If any error occurs ``onerror`` will be called. The callbacks are called with the file as their argument.
 	
 	:param const char* url: The URL to load.
-	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created.
+	:param const char* file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created. A relative pathname may be passed, which will be interpreted relative to the current working directory at the time of the call to this function.
 	:param em_str_callback_func onload: Callback on successful load of the file. The callback function parameter value is:	
 	
 		- *(const char*)* : The name of the ``file`` that was loaded from the URL.
@@ -508,7 +508,7 @@ Functions
 	
 	:param url: The URL of the file to load.
 	:type url: const char* 
-	:param file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten.
+	:param file: The name of the file created and loaded from the URL. If the file already exists it will be overwritten. If the destination directory for the file does not exist on the filesystem, it will be created. A relative pathname may be passed, which will be interpreted relative to the current working directory at the time of the call to this function.
 	:type file: const char* 
 	:param requesttype: 'GET' or 'POST'.
 	:type requesttype: const char* 	

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -741,6 +741,7 @@ var LibraryBrowser = {
   emscripten_wget: function(url, file) {
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
+    _file = PATH.resolve(FS.cwd(), _file);
     asm.setAsync();
     Module['noExitRuntime'] = true;
     var destinationDirectory = PATH.dirname(_file);
@@ -770,6 +771,7 @@ var LibraryBrowser = {
 
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
+    _file = PATH.resolve(FS.cwd(), _file);
     function doCallback(callback) {
       if (callback) {
         var stack = Runtime.stackSave();
@@ -842,6 +844,7 @@ var LibraryBrowser = {
 
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
+    _file = PATH.resolve(FS.cwd(), _file);
     var _request = Pointer_stringify(request);
     var _param = Pointer_stringify(param);
     var index = _file.lastIndexOf('/');
@@ -852,6 +855,8 @@ var LibraryBrowser = {
 
     var handle = Browser.getNextWgetRequestHandle();
 
+    var destinationDirectory = PATH.dirname(_file);
+
     // LOAD
     http.onload = function http_onload(e) {
       if (http.status == 200) {
@@ -859,6 +864,9 @@ var LibraryBrowser = {
         try {
           FS.unlink(_file);
         } catch (e) {}
+        // if the destination directory does not yet exist, create it
+        FS.mkdirTree(destinationDirectory);
+
         FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(http.response), true, true, false);
         if (onload) {
           var stack = Runtime.stackSave();

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -633,6 +633,7 @@ mergeInto(LibraryManager.library, {
       var dirs = path.split('/');
       var d = '';
       for (var i = 0; i < dirs.length; ++i) {
+        if (!dirs[i]) continue;
         d += '/' + dirs[i];
         try {
           FS.mkdir(d, mode);

--- a/tests/emscripten_fs_api_browser.cpp
+++ b/tests/emscripten_fs_api_browser.cpp
@@ -1,9 +1,11 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
-#include<string.h>
-#include<SDL/SDL.h>
-#include"SDL/SDL_image.h"
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
+#include <string.h>
+#include <SDL/SDL.h>
+#include "SDL/SDL_image.h"
+#include <sys/stat.h>
+#include <unistd.h>
  
 extern "C" {
 
@@ -39,7 +41,7 @@ void wait_wgets() {
     counter = 0;
   }
 
-  if (get_count == 5) {
+  if (get_count == 6) {
     static bool fired = false;
     if (!fired) {
       fired = true;
@@ -54,18 +56,19 @@ void wait_wgets() {
         onLoadedData,
         onErrorData);
     }
-  } else if (get_count == 7) {
+  } else if (get_count == 8) {
     assert(IMG_Load("/tmp/screen_shot.png"));
     assert(data_ok == 1 && data_bad == 1);
     emscripten_cancel_main_loop();
     REPORT_RESULT();
   }
-  assert(get_count <= 7);
+  assert(get_count <= 8);
 }
 
 void onLoaded(const char* file) {
   if (strcmp(file, "/tmp/test.html") && strcmp(file, "/tmp/screen_shot.png")
-     && strcmp(file, "/this_directory_does_not_exist_and_should_be_created_by_wget/test.html")) {
+     && strcmp(file, "/this_directory_does_not_exist_and_should_be_created_by_wget/test.html")
+     && strcmp(file, "/path/this_directory_is_relative_to_cwd/test.html")) {
     result = 0;
   }
 
@@ -119,6 +122,16 @@ int main() {
   emscripten_async_wget(
     "http://localhost:8888/test.html",
     "/this_directory_does_not_exist_and_should_be_created_by_wget/test.html",
+    onLoaded,
+    onError);
+
+  mkdir("/path", 0777);
+  chdir("/path");
+
+  // Try downloading a file to a destination directory that is a nonexisting path relative to CWD.
+  emscripten_async_wget(
+    "http://localhost:8888/test.html",
+    "this_directory_is_relative_to_cwd/test.html",
     onLoaded,
     onError);
 


### PR DESCRIPTION
Add support to emscripten_async_wget() to download files to destination path names that are specified relative to the current working directory. Unify emscripten_async_wget2() behavior with destination paths to work the same way as with emscripten_async_wget(). Fixes #4646.