### PR TITLE
Add missing symbols for llvm_round_* instructions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1477,8 +1477,8 @@ LibraryManager.library = {
   llvm_trunc_f64: 'Math_trunc',
   llvm_floor_f32: 'Math_floor',
   llvm_floor_f64: 'Math_floor',
-  llvm_round_f64: 'Math_round',
   llvm_round_f32: 'Math_round',
+  llvm_round_f64: 'Math_round',
 
   llvm_exp2_f32: function(x) {
     return Math.pow(2, x);

--- a/src/library.js
+++ b/src/library.js
@@ -1477,6 +1477,8 @@ LibraryManager.library = {
   llvm_trunc_f64: 'Math_trunc',
   llvm_floor_f32: 'Math_floor',
   llvm_floor_f64: 'Math_floor',
+  llvm_round_f64: 'Math_round',
+  llvm_round_f32: 'Math_round',
 
   llvm_exp2_f32: function(x) {
     return Math.pow(2, x);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1803,6 +1803,7 @@ var Math_floor = Math.floor;
 var Math_pow = Math.pow;
 var Math_imul = Math.imul;
 var Math_fround = Math.fround;
+var Math_round = Math.round;
 var Math_min = Math.min;
 var Math_clz32 = Math.clz32;
 var Math_trunc = Math.trunc;

--- a/tests/core/test_llvm_intrinsics.c
+++ b/tests/core/test_llvm_intrinsics.c
@@ -33,6 +33,9 @@ extern double llvm_floor_f64(double x);
 
 extern float llvm_copysign_f32(float x, float y);
 extern double llvm_copysign_f64(double x, double y);
+
+extern double llvm_round_f64(double x);
+extern double llvm_round_f32(double x);
 }
 
 int main(void) {
@@ -103,6 +106,18 @@ int main(void) {
   printf("llvm_floor_f64 %.1f\n", llvm_floor_f64(-1.4));
   printf("llvm_floor_f64 %.1f\n", llvm_floor_f64(-1.5));
   printf("llvm_floor_f64 %.1f\n", llvm_floor_f64(-1.6));
+
+  printf("llvm_round_f64 %.1f\n", llvm_round_f64(20.49));
+  printf("llvm_round_f64 %.1f\n", llvm_round_f64(20.5));
+  printf("llvm_round_f64 %.1f\n", llvm_round_f64(42));
+  printf("llvm_round_f64 %.1f\n", llvm_round_f64(-20.5));
+  printf("llvm_round_f64 %.1f\n", llvm_round_f64(-20.51));
+
+  printf("llvm_round_f32 %.1f\n", llvm_round_f32(20.49));
+  printf("llvm_round_f32 %.1f\n", llvm_round_f32(20.5));
+  printf("llvm_round_f32 %.1f\n", llvm_round_f32(42));
+  printf("llvm_round_f32 %.1f\n", llvm_round_f32(-20.5));
+  printf("llvm_round_f32 %.1f\n", llvm_round_f32(-20.51));
 
   printf("llvm_copysign_f32 %.1f\n", llvm_copysign_f32(-1.2, 3.4));
   printf("llvm_copysign_f32 %.1f\n", llvm_copysign_f32(5.6, -7.8));

--- a/tests/core/test_llvm_intrinsics.out
+++ b/tests/core/test_llvm_intrinsics.out
@@ -45,6 +45,16 @@ llvm_floor_f64 1.0
 llvm_floor_f64 -2.0
 llvm_floor_f64 -2.0
 llvm_floor_f64 -2.0
+llvm_round_f64 20.0
+llvm_round_f64 21.0
+llvm_round_f64 42.0
+llvm_round_f64 -20.0
+llvm_round_f64 -21.0
+llvm_round_f32 20.0
+llvm_round_f32 21.0
+llvm_round_f32 42.0
+llvm_round_f32 -20.0
+llvm_round_f32 -21.0
 llvm_copysign_f32 1.2
 llvm_copysign_f32 -5.6
 llvm_copysign_f32 -1.3


### PR DESCRIPTION
This was reported against [Rust code here](https://github.com/rust-lang/rust/issues/37185).
Tested the patch on both the provided example and through the added tests.