### PR TITLE
Normalize #include statements to have a space before < or ".

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -158,8 +158,8 @@ Say you have a C library that exposes some procedures:
 .. code:: c
 
     //api_example.c
-    #include<stdio.h>
-    #include<emscripten.h>
+    #include <stdio.h>
+    #include <emscripten.h>
 
     EMSCRIPTEN_KEEPALIVE
     void sayHi() {

--- a/tests/browser_test_hello_world.c
+++ b/tests/browser_test_hello_world.c
@@ -1,6 +1,6 @@
-#include<stdio.h>
+#include <stdio.h>
 
-#include<emscripten.h>
+#include <emscripten.h>
 
 int main() {
   EM_ASM({

--- a/tests/core/test_intentional_fault.c
+++ b/tests/core/test_intentional_fault.c
@@ -1,4 +1,4 @@
-#include<stdio.h>
+#include <stdio.h>
 int main () {
   *(volatile char *)0 = 0;
   return *(volatile char *)0;

--- a/tests/emscripten_api_browser.cpp
+++ b/tests/emscripten_api_browser.cpp
@@ -1,9 +1,9 @@
-#include<stdio.h>
-#include<math.h>
-#include<stdlib.h>
-#include<SDL.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <SDL.h>
+#include <emscripten.h>
+#include <assert.h>
 
 int last = 0;
 

--- a/tests/emscripten_api_browser2.cpp
+++ b/tests/emscripten_api_browser2.cpp
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include<emscripten.h>
+#include <emscripten.h>
 
 int value = 0;
 

--- a/tests/emscripten_fs_api_browser2.cpp
+++ b/tests/emscripten_fs_api_browser2.cpp
@@ -1,9 +1,9 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
-#include<string.h>
-#include<SDL/SDL.h>
-#include"SDL/SDL_image.h"
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
+#include <string.h>
+#include <SDL/SDL.h>
+#include "SDL/SDL_image.h"
  
 extern "C" {
 

--- a/tests/emscripten_main_loop.cpp
+++ b/tests/emscripten_main_loop.cpp
@@ -1,7 +1,7 @@
-#include<stdlib.h>
-#include<stdio.h>
-#include<assert.h>
-#include<emscripten.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
 
 double prevTime = -1.0;
 int frame = 0;

--- a/tests/emscripten_main_loop_and_blocker.cpp
+++ b/tests/emscripten_main_loop_and_blocker.cpp
@@ -1,7 +1,7 @@
-#include<stdlib.h>
-#include<stdio.h>
-#include<assert.h>
-#include<emscripten.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
 
 double prevTime = -1.0;
 int frame = 0;

--- a/tests/emterpreter_advise.cpp
+++ b/tests/emterpreter_advise.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 void print(const char *c) {
   EM_ASM_({ Module.print($0) }, c);

--- a/tests/emterpreter_advise_funcptr.cpp
+++ b/tests/emterpreter_advise_funcptr.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 void print1(const char *c, int x) {
   EM_ASM_({ Module.print([$0, $1]) }, c, x);

--- a/tests/emterpreter_async.cpp
+++ b/tests/emterpreter_async.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 int main() {
   // infinite main loop, turned async using emterpreter

--- a/tests/emterpreter_async_2.cpp
+++ b/tests/emterpreter_async_2.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 int calc(int x) {
   printf("..%d..\n", x);

--- a/tests/emterpreter_async_bad.cpp
+++ b/tests/emterpreter_async_bad.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 extern "C" {
 

--- a/tests/emterpreter_async_mainloop.cpp
+++ b/tests/emterpreter_async_mainloop.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 extern "C" {
 

--- a/tests/emterpreter_async_with_manual.cpp
+++ b/tests/emterpreter_async_with_manual.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<emscripten.h>
-#include<assert.h>
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
 
 extern "C" {
 

--- a/tests/fs/test_append.c
+++ b/tests/fs/test_append.c
@@ -1,5 +1,5 @@
-#include<assert.h>
-#include<stdio.h>
+#include <assert.h>
+#include <stdio.h>
 
 int main (int argc, char *argv[])
 {

--- a/tests/glfw_minimal.c
+++ b/tests/glfw_minimal.c
@@ -1,8 +1,8 @@
-#include<stdio.h>
-#include<stdlib.h>
-#include<emscripten/emscripten.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <emscripten/emscripten.h>
 #define GLFW_INCLUDE_ES2 
-#include<GL/glfw.h>
+#include <GL/glfw.h>
 
 int main() {
     printf("main function started\n");

--- a/tests/hello_malloc.cpp
+++ b/tests/hello_malloc.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<stdlib.h>
-#include<assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
 
 int main() {
   // Check that a real malloc is used by allocating, freeing, then seeing that we did actually free by a new allocation going to the original place

--- a/tests/hello_world.c
+++ b/tests/hello_world.c
@@ -1,4 +1,4 @@
-#include<stdio.h>
+#include <stdio.h>
 
 int main() {
   printf("hello, world!\n");

--- a/tests/hello_world.cpp
+++ b/tests/hello_world.cpp
@@ -1,4 +1,4 @@
-#include<stdio.h>
+#include <stdio.h>
 
 class Test {}; // This will fail in C mode
 

--- a/tests/hello_world_fopen.c
+++ b/tests/hello_world_fopen.c
@@ -1,4 +1,4 @@
-#include<stdio.h>
+#include <stdio.h>
 
 int main() {
   FILE* f = fopen("/dev/stdout", "w");

--- a/tests/hello_world_loop.cpp
+++ b/tests/hello_world_loop.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<string.h>
-#include<stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 extern "C" {
   void dump(char *s) {

--- a/tests/hello_world_loop_malloc.cpp
+++ b/tests/hello_world_loop_malloc.cpp
@@ -1,6 +1,6 @@
-#include<stdio.h>
-#include<string.h>
-#include<stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 extern "C" {
   void dump(char *s) {

--- a/tests/in_flight_memfile_request.c
+++ b/tests/in_flight_memfile_request.c
@@ -1,5 +1,5 @@
-#include<stdio.h>
-#include<emscripten.h>
+#include <stdio.h>
+#include <emscripten.h>
 
 int main() {
   int result = EM_ASM_INT_V({

--- a/tests/primes.cpp
+++ b/tests/primes.cpp
@@ -1,5 +1,5 @@
-#include<stdio.h>
-#include<math.h>
+#include <stdio.h>
+#include <math.h>
 int main(int argc, char **argv) {
   int arg = argc > 1 ? argv[1][0] - '0' : 3;
   switch(arg) {

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -197,8 +197,8 @@ class benchmark(RunnerCore):
 
   def test_primes(self):
     src = r'''
-      #include<stdio.h>
-      #include<math.h>
+      #include <stdio.h>
+      #include <math.h>
       int main(int argc, char **argv) {
         int arg = argc > 1 ? argv[1][0] - '0' : 3;
         switch(arg) {
@@ -233,9 +233,9 @@ class benchmark(RunnerCore):
 
   def test_memops(self):
     src = '''
-      #include<stdio.h>
-      #include<string.h>
-      #include<stdlib.h>
+      #include <stdio.h>
+      #include <string.h>
+      #include <stdlib.h>
       int main(int argc, char **argv) {
         int N, M;
         int arg = argc > 1 ? argv[1][0] - '0' : 3;
@@ -266,9 +266,9 @@ class benchmark(RunnerCore):
 
   def zzztest_files(self):
     src = r'''
-      #include<stdio.h>
-      #include<stdlib.h>
-      #include<assert.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <assert.h>
       #include <unistd.h>
 
       int main() {
@@ -309,7 +309,7 @@ class benchmark(RunnerCore):
 
   def test_copy(self):
     src = r'''
-      #include<stdio.h>
+      #include <stdio.h>
       struct vec {
         int x, y, z;
         int r, g, b;
@@ -464,8 +464,8 @@ class benchmark(RunnerCore):
 
   def test_corrections(self):
     src = r'''
-      #include<stdio.h>
-      #include<math.h>
+      #include <stdio.h>
+      #include <math.h>
       int main(int argc, char **argv) {
         int N, M;
         int arg = argc > 1 ? argv[1][0] - '0' : 3;
@@ -497,9 +497,9 @@ class benchmark(RunnerCore):
 
   def zzz_test_corrections64(self):
     src = r'''
-      #include<stdio.h>
-      #include<math.h>
-      #include<stdint.h>
+      #include <stdio.h>
+      #include <math.h>
+      #include <stdint.h>
       int main(int argc, char **argv) {
         int64_t N, M;
         int arg = argc > 1 ? argv[1][0] - '0' : 3;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2297,8 +2297,8 @@ open(filename, 'w').write(replaced)
 
     # verify that the mem init request succeeded in the latter case
     open('src.cpp', 'w').write(self.with_report_result(r'''
-#include<stdio.h>
-#include<emscripten.h>
+#include <stdio.h>
+#include <emscripten.h>
 
 int main() {
   int result = EM_ASM_INT_V({

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -248,7 +248,7 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
   def test_unaligned(self):
       return self.skip('LLVM marks the reads of s as fully aligned, making this test invalid')
       src = r'''
-        #include<stdio.h>
+        #include <stdio.h>
 
         struct S {
           double x;
@@ -6213,8 +6213,8 @@ def process(filename):
     Building.COMPILER_TEST_OPTS += ['--bind']
 
     src = r'''
-      #include<stdio.h>
-      #include<emscripten/val.h>
+      #include <stdio.h>
+      #include <emscripten/val.h>
 
       using namespace emscripten;
 
@@ -6630,8 +6630,8 @@ Module.printErr = Module['printErr'] = function(){};
     if Building.LLVM_OPTS: return self.skip('LLVM can optimize away the intermediate |x|')
 
     src = '''
-      #include<stdio.h>
-      #include<stdlib.h>
+      #include <stdio.h>
+      #include <stdlib.h>
       int main() { int *x = (int*)malloc(sizeof(int));
         *x = 20;
         float *y = (float*)x;
@@ -6652,8 +6652,8 @@ Module.printErr = Module['printErr'] = function(){};
     # Linking multiple files should work too
 
     module = '''
-      #include<stdio.h>
-      #include<stdlib.h>
+      #include <stdio.h>
+      #include <stdlib.h>
       void callFunc() { int *x = (int*)malloc(sizeof(int));
         *x = 20;
         float *y = (float*)x;
@@ -6664,8 +6664,8 @@ Module.printErr = Module['printErr'] = function(){};
     open(module_name, 'w').write(module)
 
     main = '''
-      #include<stdio.h>
-      #include<stdlib.h>
+      #include <stdio.h>
+      #include <stdlib.h>
       extern void callFunc();
       int main() { callFunc();
         int *x = (int*)malloc(sizeof(int));

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -986,7 +986,7 @@ This pointer might make sense in another type signature:''', '''Invalid function
     main_name = os.path.join(self.get_dir(), 'main.cpp')
     open(main_name, 'w').write(r'''
       #include <stdio.h>
-      #include<emscripten/val.h>
+      #include <emscripten/val.h>
       using namespace emscripten;
       extern "C" int x();
       int main() {
@@ -1297,7 +1297,7 @@ int f() {
       }
     ''')
     open(os.path.join(self.get_dir(), 'bar', 'main.cpp'), 'w').write('''
-      #include<stdio.h>
+      #include <stdio.h>
       void printey() { printf("hello there\\n"); }
     ''')
 
@@ -4679,7 +4679,7 @@ pass: error == ENOTDIR
     assert 'emterpret' not in self.get_func(src, '_atoi'), 'atoi is not in whitelist, so it is not emterpreted'
 
     do_test(r'''
-#include<stdio.h>
+#include <stdio.h>
 
 int main() {
   volatile float f;
@@ -4691,7 +4691,7 @@ int main() {
 ''', [], 'hello, world! -10')
 
     do_test(r'''
-#include<stdio.h>
+#include <stdio.h>
 
 int main() {
   volatile float f;
@@ -5426,7 +5426,7 @@ int main() {
   def test_meminit_crc(self):
     with open('src.c', 'w') as f:
       f.write(r'''
-#include<stdio.h>
+#include <stdio.h>
 int main() { printf("Mary had a little lamb.\n"); }
 ''')
     out, err = Popen([PYTHON, EMCC, 'src.c', '-O2', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1']).communicate()
@@ -5530,8 +5530,8 @@ mergeInto(LibraryManager.library, {
 });
 ''')
     open('test.cpp', 'w').write('''
-#include<stdio.h>
-#include<stdlib.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 extern "C" {
   extern void my_js();
@@ -6342,8 +6342,8 @@ int main() {}
 
     def test(contents):
       open('src.cpp', 'w').write(r'''
-  #include<stdio.h>
-  #include<emscripten.h>
+  #include <stdio.h>
+  #include <emscripten.h>
   int main() {
     EM_ASM({ %s });
     printf("hello, world!\n");

--- a/tests/twopart_side.cpp
+++ b/tests/twopart_side.cpp
@@ -1,5 +1,5 @@
 
-#include<stdio.h>
+#include <stdio.h>
 
 void theFunc(char *str)
 {


### PR DESCRIPTION
I wonder how the convention `#include<foo>` and `#include"foo"` came to be, though looks like having a space after `#include` is more common in the codebase as well, so normalize to that convention. (The form without a space is throwing off syntax highlighting in Sublime Text, hence the change)