### PR TITLE
include_emscripten

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 #include <pthread.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/include/emscripten/xmmintrin.h
+++ b/system/include/emscripten/xmmintrin.h
@@ -1,7 +1,7 @@
 #ifndef __emscripten_xmmintrin_h__
 #define __emscripten_xmmintrin_h__
 
-#include <vector.h>
+#include <emscripten/vector.h>
 
 #include <math.h>
 #include <string.h>

--- a/tests/embind/embind_benchmark.cpp
+++ b/tests/embind/embind_benchmark.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <emscripten.h>
-#include <bind.h>
+#include <emscripten/bind.h>
 #include <memory>
 
 int counter = 0;

--- a/tests/emterpreter_async_iostream.cpp
+++ b/tests/emterpreter_async_iostream.cpp
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 using namespace std;
 

--- a/tests/keydown_preventdefault_proxy.cpp
+++ b/tests/keydown_preventdefault_proxy.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 static int result = 1;
 
 // The event handler functions can return 1 to suppress the event and disable the default action. That calls event.preventDefault();

--- a/tests/sdl_togglefullscreen.c
+++ b/tests/sdl_togglefullscreen.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <SDL.h>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 static enum {
     STATE_INITIAL,      /* Initial state, click needed to enter full screen */

--- a/tests/webgl2.cpp
+++ b/tests/webgl2.cpp
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <assert.h>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
 

--- a/tests/webgl_create_context.cpp
+++ b/tests/webgl_create_context.cpp
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <assert.h>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems) {
     std::stringstream ss(s);

--- a/tests/webgl_destroy_context.cpp
+++ b/tests/webgl_destroy_context.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <assert.h>
 #include <emscripten.h>
-#include <html5.h>
+#include <emscripten/html5.h>
 
 int result = 0;
 void report_result()


### PR DESCRIPTION
Use `#include <emscripten/foo.h>` instead of `#include <foo.h>` when referring to any files inside the Emscripten system include directory.