### PR TITLE
sab_not_in_transfer_list

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -326,7 +326,7 @@ var LibraryPThread = {
             DYNAMIC_BASE: DYNAMIC_BASE,
             DYNAMICTOP_PTR: DYNAMICTOP_PTR,
             PthreadWorkerInit: PthreadWorkerInit
-          }, [HEAPU8.buffer]);
+          });
         PThread.unusedWorkerPool.push(worker);
       }
     },


### PR DESCRIPTION
Remove HEAPU8.buffer from transfer list in postMessage(). See https://bugzilla.mozilla.org/show_bug.cgi?id=1302036 and https://github.com/tc39/ecmascript_sharedmem/issues/98

The transfer list in `postMessage` has originally had a semantic that it transfer the object (without copying) to the worker, in a way that the object is detached from the worker that called `postMessage`, meaning that the caller can no longer access the transfered object. The consensus is that overloading this term of transfering to mean sharing was not intentional, and the desired syntax is to not use the transfer list when passing SABs to other workers.

This is a breaking change, but ok since SAB spec is not yet stable. However let's wait a bit until merging to give a window of FF Nightlies to roll in that have the change. FF Nightly will for some time keep accepting the old syntax, but with raising a warning message in page console, so eventually pages will need to be rebuilt to roll in the change.
