### PR TITLE
Fix RTLD_GLOBAL of dlopen

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1625,7 +1625,22 @@ LibraryManager.library = {
       if (flag & 256) { // RTLD_GLOBAL
         for (var ident in lib_module) {
           if (lib_module.hasOwnProperty(ident)) {
-            Module[ident] = lib_module[ident];
+            // When RTLD_GLOBAL is enable, the symbols defined by this shared object will be made
+            // available for symbol resolution of subsequently loaded shared objects.
+            //
+            // We should copy the symbols (which include methods and variables) from SIDE_MODULE to MAIN_MODULE.
+            //
+            // Module of SIDE_MODULE has not only the symbols (which should be copied)
+            // but also others (print*, asmGlobal*, FUNCTION_TABLE_**, NAMED_GLOBALS, and so on).
+            //
+            // When the symbol (which should be copied) is method, Module._* 's type becomes function.
+            // When the symbol (which should be copied) is variable, Module._* 's type becomes number.
+            //
+            // Except for the symbol prefix (_), there is no difference in the symbols (which should be copied) and others.
+            // So this just copies over compiled symbols (which start with _).
+            if (ident[0] == '_') {
+              Module[ident] = lib_module[ident];
+            }
           }
         }
       }


### PR DESCRIPTION
Hi,

`RTLD_GLOBAL` of dlopen copies following symbols of Module from SIDE_MODULE to MAIN_MODULE.

https://github.com/kripken/emscripten/blob/incoming/src/library.js#L1625-L1631
Current RTLD_GLOBAL's behavior

```
      if (flag & 256) { // RTLD_GLOBAL
        for (var ident in lib_module) {
          if (lib_module.hasOwnProperty(ident)) {
            Module[ident] = lib_module[ident];
          }
        }
      }
```

Copied symbols which my environment outputs

```
arguments
print
printErr
cleanups
asmGlobalArg
asmLibraryArg
runPostSets
_*** # some functions
dynCall_***
FUNCTION_TABLE_**
NAMED_GLOBALS
```

Coping FUNCTION_TABLE_*\* breaks function tables of MAIN_MODULE.
This PR only copies  function symbols which have prefix of '_'.
It prevents breaking function tables and other symbols.
