### PR TITLE
no_load_store_3

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -574,7 +574,7 @@ function _emscripten_asm_const_%s(%s) {
                          'equal', 'lessThan', 'greaterThan',
                          'notEqual', 'lessThanOrEqual', 'greaterThanOrEqual',
                          'select', 'swizzle', 'shuffle',
-                         'load', 'store', 'load1', 'store1', 'load2', 'store2', 'load3', 'store3']
+                         'load', 'store', 'load1', 'store1', 'load2', 'store2']
     simdintboolfuncs = ['and', 'xor', 'or', 'not']
     if metadata['simdUint8x16']:
       simdinttypes += ['Uint8x16']
@@ -830,7 +830,7 @@ function ftCall_%s(%s) {%s
         return False
       nonexisting_simd_symbols = ['Int8x16_fromInt8x16', 'Uint8x16_fromUint8x16', 'Int16x8_fromInt16x8', 'Uint16x8_fromUint16x8', 'Int32x4_fromInt32x4', 'Uint32x4_fromUint32x4', 'Float32x4_fromFloat32x4', 'Float64x2_fromFloat64x2']
       nonexisting_simd_symbols += ['Int32x4_addSaturate', 'Int32x4_subSaturate', 'Uint32x4_addSaturate', 'Uint32x4_subSaturate']
-      nonexisting_simd_symbols += [(x + '_' + y) for x in ['Int8x16', 'Uint8x16', 'Int16x8', 'Uint16x8', 'Float64x2'] for y in ['load2', 'load3', 'store2', 'store3']]
+      nonexisting_simd_symbols += [(x + '_' + y) for x in ['Int8x16', 'Uint8x16', 'Int16x8', 'Uint16x8', 'Float64x2'] for y in ['load2', 'store2']]
       nonexisting_simd_symbols += [(x + '_' + y) for x in ['Int8x16', 'Uint8x16', 'Int16x8', 'Uint16x8'] for y in ['load1', 'store1']]
 
       asm_global_funcs += ''.join(['  var SIMD_' + ty + '=global' + access_quote('SIMD') + access_quote(ty) + ';\n' for ty in simdtypes])

--- a/system/include/emscripten/vector.h
+++ b/system/include/emscripten/vector.h
@@ -122,11 +122,9 @@ inline float32x4 emscripten_float32x4_replaceLane(float32x4 __a, int __lane, flo
 void emscripten_float32x4_store(const void *__p, float32x4 __a) __attribute__((__nothrow__));
 void emscripten_float32x4_store1(const void *__p, float32x4 __a) __attribute__((__nothrow__));
 void emscripten_float32x4_store2(const void *__p, float32x4 __a) __attribute__((__nothrow__));
-void emscripten_float32x4_store3(const void *__p, float32x4 __a) __attribute__((__nothrow__));
 float32x4 emscripten_float32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
 float32x4 emscripten_float32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
 float32x4 emscripten_float32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
-float32x4 emscripten_float32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
 inline float32x4 emscripten_float32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
 inline float32x4 emscripten_float32x4_fromInt32x4Bits(int32x4 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
 inline float32x4 emscripten_float32x4_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (float32x4)__a; }
@@ -178,11 +176,9 @@ inline int32x4 emscripten_int32x4_replaceLane(int32x4 __a, int __lane, int __s) 
 void emscripten_int32x4_store(const void *__p, int32x4 __a) __attribute__((__nothrow__));
 void emscripten_int32x4_store1(const void *__p, int32x4 __a) __attribute__((__nothrow__));
 void emscripten_int32x4_store2(const void *__p, int32x4 __a) __attribute__((__nothrow__));
-void emscripten_int32x4_store3(const void *__p, int32x4 __a) __attribute__((__nothrow__));
 int32x4 emscripten_int32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
 int32x4 emscripten_int32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
 int32x4 emscripten_int32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
-int32x4 emscripten_int32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
 inline int32x4 emscripten_int32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
 inline int32x4 emscripten_int32x4_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
 inline int32x4 emscripten_int32x4_fromUint32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (int32x4)__a; }
@@ -235,11 +231,9 @@ inline uint32x4 emscripten_uint32x4_replaceLane(uint32x4 __a, int __lane, int __
 void emscripten_uint32x4_store(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
 void emscripten_uint32x4_store1(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
 void emscripten_uint32x4_store2(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
-void emscripten_uint32x4_store3(const void *__p, uint32x4 __a) __attribute__((__nothrow__));
 uint32x4 emscripten_uint32x4_load(const void *__p) __attribute__((__nothrow__, __pure__));
 uint32x4 emscripten_uint32x4_load1(const void *__p) __attribute__((__nothrow__, __pure__));
 uint32x4 emscripten_uint32x4_load2(const void *__p) __attribute__((__nothrow__, __pure__));
-uint32x4 emscripten_uint32x4_load3(const void *__p) __attribute__((__nothrow__, __pure__));
 inline uint32x4 emscripten_uint32x4_fromFloat64x2Bits(float64x2 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
 inline uint32x4 emscripten_uint32x4_fromFloat32x4Bits(float32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }
 inline uint32x4 emscripten_uint32x4_fromInt32x4Bits(uint32x4 __a) __attribute__((__nothrow__, __const__)) { return (uint32x4)__a; }

--- a/tests/core/test_simd_float32x4.c
+++ b/tests/core/test_simd_float32x4.c
@@ -73,15 +73,11 @@ int main()
     memset(bytes, 0xFF, sizeof(bytes));
     emscripten_float32x4_store2(bytes, v);
     DUMPBYTES("emscripten_float32x4_store2", bytes);
-    memset(bytes, 0xFF, sizeof(bytes));
-    emscripten_float32x4_store3(bytes, v);
-    DUMPBYTES("emscripten_float32x4_store3", bytes);
 
     emscripten_float32x4_store(bytes, v);
     DUMP(emscripten_float32x4_load(bytes));
     DUMP(emscripten_float32x4_load1(bytes));
     DUMP(emscripten_float32x4_load2(bytes));
-    DUMP(emscripten_float32x4_load3(bytes));
     // TODO: emscripten_float32x4_fromFloat64x2Bits
     // TODO: emscripten_float32x4_fromInt32x4Bits
     // TODO: emscripten_float32x4_fromUint32x4Bits

--- a/tests/core/test_simd_float32x4.out
+++ b/tests/core/test_simd_float32x4.out
@@ -29,11 +29,9 @@ emscripten_float32x4_replaceLane(v, 3, -0.f): -1.000000 0.000000 1.000000 -0.000
 emscripten_float32x4_store: 00 00 80 BF 00 00 00 00 00 00 80 3F 00 00 60 40
 emscripten_float32x4_store1: 00 00 80 BF FF FF FF FF FF FF FF FF FF FF FF FF
 emscripten_float32x4_store2: 00 00 80 BF 00 00 00 00 FF FF FF FF FF FF FF FF
-emscripten_float32x4_store3: 00 00 80 BF 00 00 00 00 00 00 80 3F FF FF FF FF
 emscripten_float32x4_load(bytes): -1.000000 0.000000 1.000000 3.500000
 emscripten_float32x4_load1(bytes): -1.000000 0.000000 0.000000 0.000000
 emscripten_float32x4_load2(bytes): -1.000000 0.000000 0.000000 0.000000
-emscripten_float32x4_load3(bytes): -1.000000 0.000000 1.000000 0.000000
 emscripten_float32x4_swizzle(v, 0, 1, 2, 3): -1.000000 0.000000 1.000000 3.500000
 emscripten_float32x4_swizzle(v, 3, 2, 1, 0): 3.500000 1.000000 0.000000 -1.000000
 emscripten_float32x4_swizzle(v, 0, 0, 0, 0): -1.000000 -1.000000 -1.000000 -1.000000

--- a/tests/core/test_simd_int32x4.c
+++ b/tests/core/test_simd_int32x4.c
@@ -69,15 +69,11 @@ int main()
     memset(bytes, 0xFF, sizeof(bytes));
     emscripten_int32x4_store2(bytes, v);
     DUMPBYTES("emscripten_int32x4_store2", bytes);
-    memset(bytes, 0xFF, sizeof(bytes));
-    emscripten_int32x4_store3(bytes, v);
-    DUMPBYTES("emscripten_int32x4_store3", bytes);
 
     emscripten_int32x4_store(bytes, v);
     DUMP(emscripten_int32x4_load(bytes));
     DUMP(emscripten_int32x4_load1(bytes));
     DUMP(emscripten_int32x4_load2(bytes));
-    DUMP(emscripten_int32x4_load3(bytes));
     // TODO: emscripten_int32x4_fromFloat64x2Bits
     // TODO: emscripten_int32x4_fromInt32x4Bits
     // TODO: emscripten_int32x4_fromUint32x4Bits

--- a/tests/core/test_simd_int32x4.out
+++ b/tests/core/test_simd_int32x4.out
@@ -34,11 +34,9 @@ emscripten_int32x4_replaceLane(v, 3, 91): 1 0 1 91
 emscripten_int32x4_store: 01 00 00 00 00 00 00 00 01 00 00 00 04 00 00 00
 emscripten_int32x4_store1: 01 00 00 00 FF FF FF FF FF FF FF FF FF FF FF FF
 emscripten_int32x4_store2: 01 00 00 00 00 00 00 00 FF FF FF FF FF FF FF FF
-emscripten_int32x4_store3: 01 00 00 00 00 00 00 00 01 00 00 00 FF FF FF FF
 emscripten_int32x4_load(bytes): 1 0 1 4
 emscripten_int32x4_load1(bytes): 1 0 0 0
 emscripten_int32x4_load2(bytes): 1 0 0 0
-emscripten_int32x4_load3(bytes): 1 0 1 0
 emscripten_int32x4_swizzle(v, 0, 1, 2, 3): 1 0 1 4
 emscripten_int32x4_swizzle(v, 3, 2, 1, 0): 4 1 0 1
 emscripten_int32x4_swizzle(v, 0, 0, 0, 0): 1 1 1 1


### PR DESCRIPTION
Remove SIMD {Float,Int}32x4.{load,store}3() functions, which don't validate as asm.js. See #4645.