### PR TITLE
Emmake binaryen

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -638,7 +638,7 @@ var BINARYEN = 0; // Whether to use [Binaryen](https://github.com/WebAssembly/bi
                   // This will fetch the binaryen port and build it. (If, instead, you set
                   // BINARYEN_ROOT in your ~/.emscripten file, then we use that instead
                   // of the port, which can useful for local dev work on binaryen itself).
-var BINARYEN_METHOD = ""; // See binaryen's src/js/post.js for details.
+var BINARYEN_METHOD = ""; // See binaryen's src/js/wasm.js-post.js for details.
 var BINARYEN_SCRIPTS = ""; // An optional comma-separated list of script hooks to run after binaryen,
                            // in binaryen's /scripts dir.
 var BINARYEN_IMPRECISE = 0; // Whether to apply imprecise/unsafe binaryen optimizations. If enabled,

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -955,13 +955,26 @@ fi
   def test_binaryen(self):
     import tools.ports.binaryen as binaryen
     tag_file = Cache.get_path('binaryen_tag_' + binaryen.TAG + '.txt')
-    try_delete(tag_file)
-    # if BINARYEN_ROOT is set, we don't build the port. Check we do built it if not
-    restore()
-    config = open(CONFIG_FILE).read()
-    config = config.replace('BINARYEN_ROOT', '#')
-    open(CONFIG_FILE, 'w').write(config)
+    def prep():
+      wipe()
+      self.do([PYTHON, EMCC, '--clear-ports'])
+      try_delete(tag_file)
+      # if BINARYEN_ROOT is set, we don't build the port. Check we do built it if not
+      restore()
+      config = open(CONFIG_FILE).read()
+      config = config.replace('BINARYEN_ROOT', '#')
+      open(CONFIG_FILE, 'w').write(config)
+
+    print 'build using embuilder'
+    prep()
     subprocess.check_call([PYTHON, 'embuilder.py', 'build', 'binaryen'])
     assert os.path.exists(tag_file)
     subprocess.check_call([PYTHON, 'emcc.py', 'tests/hello_world.c', '-s', 'BINARYEN=1'])
     self.assertContained('hello, world!', run_js('a.out.js'))
+
+    print 'see if building with emmake works (should not break native compilation of binaryen port'
+    prep()
+    subprocess.check_call([PYTHON, 'emmake.py', EMCC, 'tests/hello_world.c', '-s', 'BINARYEN=1'])
+    assert os.path.exists(tag_file)
+    self.assertContained('hello, world!', run_js('a.out.js'))
+

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1202,7 +1202,7 @@ class Building:
       # the ones that a non-native would modify
       EMSCRIPTEN_MODIFIES = ['LDSHARED', 'AR', 'CROSS_COMPILE', 'NM', 'RANLIB']
       for dangerous in EMSCRIPTEN_MODIFIES:
-        if env[dangerous] == non_native[dangerous]:
+        if env.get(dangerous) and env.get(dangerous) == non_native.get(dangerous):
           del env[dangerous] # better to delete it than leave it, as the non-native one is definitely wrong
       return env
     env['CC'] = EMCC if not WINDOWS else 'python %r' % EMCC

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1197,6 +1197,13 @@ class Building:
       env['CXX'] = CLANG_CPP
       env['LD'] = CLANG
       env['CFLAGS'] = '-O2 -fno-math-errno'
+      # get a non-native one, and see if we have some of its effects - remove them if so
+      non_native = Building.get_building_env()
+      # the ones that a non-native would modify
+      EMSCRIPTEN_MODIFIES = ['LDSHARED', 'AR', 'CROSS_COMPILE', 'NM', 'RANLIB']
+      for dangerous in EMSCRIPTEN_MODIFIES:
+        if env[dangerous] == non_native[dangerous]:
+          del env[dangerous] # better to delete it than leave it, as the non-native one is definitely wrong
       return env
     env['CC'] = EMCC if not WINDOWS else 'python %r' % EMCC
     env['CXX'] = EMXX if not WINDOWS else 'python %r' % EMXX

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -584,6 +584,8 @@ class Ports:
   @staticmethod
   def build_native(subdir):
     old = os.getcwd()
+    env = shared.Building.get_building_env(native=True)
+    print env
 
     try:
       os.chdir(subdir)
@@ -591,7 +593,7 @@ class Ports:
       cmake_build_type = 'Release'
 
       # Configure
-      subprocess.check_call(['cmake', '-DCMAKE_BUILD_TYPE=' + cmake_build_type, '.'])
+      subprocess.check_call(['cmake', '-DCMAKE_BUILD_TYPE=' + cmake_build_type, '.'], env=env)
 
       # Check which CMake generator CMake used so we know which form to pass parameters to make/msbuild/etc. build tool.
       generator = re.search('CMAKE_GENERATOR:INTERNAL=(.*)$', open('CMakeCache.txt', 'r').read(), re.MULTILINE).group(1)
@@ -603,7 +605,7 @@ class Ports:
       elif 'Visual Studio' in generator: make_args = ['--config', cmake_build_type, '--', '/maxcpucount:' + num_cores]
 
       # Kick off the build.
-      subprocess.check_call(['cmake', '--build', '.'] + make_args)
+      subprocess.check_call(['cmake', '--build', '.'] + make_args, env=env)
     finally:
       os.chdir(old)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -585,7 +585,6 @@ class Ports:
   def build_native(subdir):
     old = os.getcwd()
     env = shared.Building.get_building_env(native=True)
-    print env
 
     try:
       os.chdir(subdir)


### PR DESCRIPTION
This attempts to fix, but does not yet succeed in fixing, a rather serious bug noted by a mame developer. Basically, they build `emmake make ..` and set up BINARYEN=1 in their scripts. The problem is that as it fetches the binaryen port, it trys to build it using emcc/em++, I presume due to emmake affecting the env vars. But it needs to be built natively.

This looks like a typical bug of using the wrong environment, so the commit here uses a native building environment instead. But that doesn't work - somehow cmake still decides to build using emcc/em++. @juj, do you know how cmake decides that?
