### PR TITLE
Add extra nodeJS check when running the JS optimizer

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1222,6 +1222,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if js_opts:
         shared.Settings.RUNNING_JS_OPTS = 1
 
+      if shared.Settings.RUNNING_JS_OPTS:
+        jsrun.require_engine(shared.NODE_JS)
+
       if shared.Settings.CYBERDWARF:
         newargs.append('-g')
         shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"


### PR DESCRIPTION
#4608 integrated the JS engine checks with the jsrun code to run JS
engines but it turns out that the JS optimizer doesn't even use that
common code. So add an extra check if the JS optimizer runs to give a
more useful error message.