### PR TITLE
Allows no-rethrow in node.js env

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -266,4 +266,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ray Brown <code@liquibits.com>
 * Christopher Serr <christopher.serr@gmail.com>
 * Aaron Ruß <aaron.russ@dfki.de> (copyright owned by DFKI GmbH)
-
+* Vilibald Wanča <vilibald@wvi.cz>

--- a/src/settings.js
+++ b/src/settings.js
@@ -295,6 +295,11 @@ var DISABLE_EXCEPTION_CATCHING = 0; // Disables generating code to actually catc
 var EXCEPTION_CATCHING_WHITELIST = [];  // Enables catching exception in the listed functions only, if
                                         // DISABLE_EXCEPTION_CATCHING = 2 is set
 
+var NODEJS_CATCH_EXIT = 1; // If disabled than in node.js environment the exit call will not be handled correctly it
+                           // will throw an exception directly. Usefull if using C/C++ code as a library so
+                           // exceptions thrown in the JS code are not caught and rethrown which obfuscates the
+                           // original issue.
+
 // For more explanations of this option, please visit
 // https://github.com/kripken/emscripten/wiki/Asyncify
 var ASYNCIFY = 0; // Whether to enable asyncify transformation

--- a/src/shell.js
+++ b/src/shell.js
@@ -115,12 +115,14 @@ if (ENVIRONMENT_IS_NODE) {
     module['exports'] = Module;
   }
 
+#if NODEJS_CATCH_EXIT
   process['on']('uncaughtException', function(ex) {
     // suppress ExitStatus exceptions from showing an error
     if (!(ex instanceof ExitStatus)) {
       throw ex;
     }
   });
+#endif
 
   Module['inspect'] = function () { return '[Emscripten Module object]'; };
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2555,6 +2555,39 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     try_delete(path_from_root('tests', 'Module-exports', 'test.js.map'))
     try_delete(path_from_root('tests', 'Module-exports', 'test.js.mem'))
 
+  def test_node_catch_exit(self):
+    # Test that in node.js exceptions are not caught if NODEJS_EXIT_CATCH=0
+    if NODE_JS not in JS_ENGINES:
+      return
+
+    open(os.path.join(self.get_dir(), 'count.c'), 'w').write('''
+      #include <string.h>
+      int count(const char *str) {
+          return (int)strlen(str);
+      }
+    ''')
+
+    open(os.path.join(self.get_dir(), 'index.js'), 'w').write('''
+      const count = require('./count.js');
+
+      console.log(xxx); //< here is the ReferenceError
+    ''')
+
+    reference_error_text = 'console.log(xxx); //< here is the ReferenceError';
+
+    subprocess.check_call([PYTHON, EMCC, os.path.join(self.get_dir(), 'count.c'), '-o', 'count.js'])
+
+    # Check that the ReferenceError is caught and rethrown and thus the original error line is masked
+    self.assertNotContained(reference_error_text,
+                            run_js ('index.js', engine=NODE_JS, stderr=STDOUT, assert_returncode=None))
+
+    subprocess.check_call([PYTHON, EMCC, os.path.join(self.get_dir(), 'count.c'), '-o', 'count.js', '-s', 'NODEJS_CATCH_EXIT=0'])
+
+    # Check that the ReferenceError is not caught
+    self.assertContained(reference_error_text,
+                         run_js ('index.js', engine=NODE_JS, stderr=STDOUT, assert_returncode=None))
+
+
   def test_fs_stream_proto(self):
     open('src.cpp', 'wb').write(r'''
 #include <stdio.h>


### PR DESCRIPTION
Adds option to disable catching exit and other exceptions in node.js environment to avoid re-throwing and thus obfuscating exceptions from JS.

Fixes #4643 


Where shall I put the test? Please give me some directions as I haven't found a good place to put it in.