### PR TITLE
Fix recently-added cmake test

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -583,7 +583,7 @@ f.close()
       try:
         os.chdir(tempdirname)
 
-        configure = ['emcmake.bat' if WINDOWS else 'emcmake', 'cmake', path_from_root('tests', 'cmake', 'cmake_with_emval')] + args
+        configure = [path_from_root('emcmake.bat' if WINDOWS else 'emcmake'), 'cmake', path_from_root('tests', 'cmake', 'cmake_with_emval')] + args
         print str(configure)
         subprocess.check_call(configure)
         build = ['cmake', '--build', '.']


### PR DESCRIPTION
It assumed the emscripten dir was in the path, and failed for me locally. That test was added in 0c0c21618e26e3b4c4e2e7a3b92bc26a7adf170a.