### PR TITLE
force binary reading mode in file2json.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Charles Vaughn <cvaughn@tableau.com> (copyright owned by Tableau Software, Inc.)
 * Pierre Krieger <pierre.krieger1708@gmail.com>
 * Jakob Stoklund Olesen <stoklund@2pi.dk>
+* Aaron Ruß <aaron.russ@dfki.de> (copyright owned by DFKI GmbH)

--- a/tools/file2json.py
+++ b/tools/file2json.py
@@ -12,7 +12,7 @@ VARNAME - the variable to store it in (the output will be VARNAME = [...])
 
 import os, sys
 
-data = open(sys.argv[1], 'r').read()
+data = open(sys.argv[1], 'rb').read()
 sdata = map(lambda x: str(ord(x)) + ',', data)
 sdata[-1] = sdata[-1].replace(',', '')
 lined = []
@@ -31,7 +31,7 @@ else:
 '''
 or (but this fails, we get a string at runtime?)
 
-data = open(sys.argv[1], 'r').read()
+data = open(sys.argv[1], 'rb').read()
 counter = 0
 print '[',
 for i in range(len(data)):


### PR DESCRIPTION
explicitly set binary reading mode in file2json.py in order to avoid premature end of reading (can occur or Windows when binary mode is not explicitly set), fixing #4688