### PR TITLE
Make malloc() re-entrant by using recursive locks

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -12,6 +12,7 @@
 /* Make malloc() and free() threadsafe by securing the memory allocations with pthread mutexes. */
 #if __EMSCRIPTEN_PTHREADS__
 #define USE_LOCKS 1
+#define USE_RECURSIVE_LOCKS 1
 #define USE_SPIN_LOCKS 0 // Ensure we use pthread_mutex_t.
 #endif
 


### PR DESCRIPTION
malloc() on the main thread can invoke processing of queued calls which might invoke malloc() again.

@juj, this is related to PR #4569 - discovered in actual use of the feature.