### PR TITLE
Explicitly add unix defines to clang args

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1306,7 +1306,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           args += shared.EMSDK_CXX_OPTS
         if not shared.Building.can_inline():
           args.append('-fno-inline-functions')
-        args += ['-Dunix', '-D__unix', '-D__unix__']
         args = system_libs.process_args(args, shared.Settings)
         return args
 

--- a/emcc.py
+++ b/emcc.py
@@ -1306,6 +1306,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           args += shared.EMSDK_CXX_OPTS
         if not shared.Building.can_inline():
           args.append('-fno-inline-functions')
+        args += ['-Dunix', '-D__unix', '-D__unix__']
         args = system_libs.process_args(args, shared.Settings)
         return args
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5327,7 +5327,6 @@ def process(filename):
                  includes=[path_from_root('tests', 'sqlite')],
                  force_c=True)
 
-  @no_wasm_backend()
   def test_zlib(self):
     if '-O2' in self.emcc_args and 'ASM_JS=0' not in self.emcc_args and not self.is_wasm(): # without asm, closure minifies Math.imul badly
       self.emcc_args += ['--closure', '1'] # Use closure here for some additional coverage

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -928,7 +928,10 @@ COMPILER_OPTS = COMPILER_OPTS + [#'-fno-threadsafe-statics', # disabled due to i
 if LLVM_TARGET == WASM_TARGET:
   # wasm target does not automatically define emscripten stuff, so do it here.
   COMPILER_OPTS = COMPILER_OPTS + ['-DEMSCRIPTEN',
-                                   '-D__EMSCRIPTEN__']
+                                   '-D__EMSCRIPTEN__',
+                                   '-Dunix',
+                                   '-D__unix',
+                                   '-D__unix__']
 
 # Changes to default clang behavior
 


### PR DESCRIPTION
Fixes zlib for wasm backend.