### PR TITLE
ignore the memory growth function in eliminateDeadGlobals

### DIFF
--- a/tests/optimizer/eliminateDeadGlobals-output.js
+++ b/tests/optimizer/eliminateDeadGlobals-output.js
@@ -2,7 +2,12 @@ var Module = {};
 Module["asm"] = (function(global, env, buffer) {
  "use asm";
  var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
  var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
  var HEAPF64 = new global.Float64Array(buffer);
  var STACKTOP = env.STACKTOP | 0;
  var _atoi = env._atoi;
@@ -12,6 +17,19 @@ Module["asm"] = (function(global, env, buffer) {
  var _memcpy = env._memcpy;
  var __ZdaPv = env.__ZdaPv;
  var __ZdlPv = env.__ZdlPv;
+ function _emscripten_replace_memory(newBuffer) {
+  if (byteLength(newBuffer) & 16777215 || byteLength(newBuffer) <= 16777215 || byteLength(newBuffer) > 2147483648) return false;
+  HEAP8 = new Int8View(newBuffer);
+  HEAP16 = new Int16View(newBuffer);
+  HEAP32 = new Int32View(newBuffer);
+  HEAPU8 = new Uint8View(newBuffer);
+  HEAPU16 = new Uint16View(newBuffer);
+  HEAPU32 = new Uint32View(newBuffer);
+  HEAPF32 = new Float32View(newBuffer);
+  HEAPF64 = new Float64View(newBuffer);
+  buffer = newBuffer;
+  return true;
+ }
  function _main(i1, i2) {
   i1 = i1 | 0;
   i2 = i2 | 0;
@@ -168,7 +186,10 @@ Module["asm"] = (function(global, env, buffer) {
   return;
  }
  return {
-  _main: _main
+  _main: _main,
+  _emscripten_replace_memory: _emscripten_replace_memory
  };
 });
+
+
 

--- a/tests/optimizer/eliminateDeadGlobals.js
+++ b/tests/optimizer/eliminateDeadGlobals.js
@@ -242,6 +242,6 @@ function runPostSets() {}
 // EMSCRIPTEN_END_FUNCS
 
 
-  return { _main: _main };
+  return { _main: _main, _emscripten_replace_memory: _emscripten_replace_memory };
 })
 ;

--- a/tests/optimizer/eliminateDeadGlobals.js
+++ b/tests/optimizer/eliminateDeadGlobals.js
@@ -65,6 +65,20 @@ Module["asm"] =  (function(global,env,buffer) {
   var __ZdlPv=env.__ZdlPv;
   var tempFloat = 0.0;
 
+ function _emscripten_replace_memory(newBuffer) {
+  if (byteLength(newBuffer) & 16777215 || byteLength(newBuffer) <= 16777215 || byteLength(newBuffer) > 2147483648) return false;
+  HEAP8 = new Int8View(newBuffer);
+  HEAP16 = new Int16View(newBuffer);
+  HEAP32 = new Int32View(newBuffer);
+  HEAPU8 = new Uint8View(newBuffer);
+  HEAPU16 = new Uint16View(newBuffer);
+  HEAPU32 = new Uint32View(newBuffer);
+  HEAPF32 = new Float32View(newBuffer);
+  HEAPF64 = new Float64View(newBuffer);
+  buffer = newBuffer;
+  return true;
+ }
+
 // EMSCRIPTEN_START_FUNCS
 function _main(i1, i2) {
  i1 = i1 | 0;

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7713,7 +7713,11 @@ function eliminateDeadGlobals(ast) {
     for (var i = 0; i < stats.length; i++) {
       var asmFunc = stats[i];
       if (asmFunc[0] === 'defun') {
-        if (asmFunc[1] === '_emscripten_replace_memory') return; // the memory growth function does not contain valid asm.js
+        if (asmFunc[1] === '_emscripten_replace_memory') {
+          // the memory growth function does not contain valid asm.js, and can be ignored
+          stats[i] = emptyNode();
+          continue;
+        }
         var asmData = normalizeAsm(asmFunc);
         traverse(asmFunc, function(node, type) {
           if (type == 'name') {

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7713,6 +7713,7 @@ function eliminateDeadGlobals(ast) {
     for (var i = 0; i < stats.length; i++) {
       var asmFunc = stats[i];
       if (asmFunc[0] === 'defun') {
+        if (asmFunc[1] === '_emscripten_replace_memory') return; // the memory growth function does not contain valid asm.js
         var asmData = normalizeAsm(asmFunc);
         traverse(asmFunc, function(node, type) {
           if (type == 'name') {


### PR DESCRIPTION
It cant handle it properly, and doesn't need to anyhow.