### PR TITLE
Don't make opt_level 0 imply debug_level 3

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -777,7 +777,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if js_opts is None: js_opts = opt_level >= 2
       if llvm_opts is None: llvm_opts = LLVM_OPT_LEVEL[opt_level]
-      if opt_level == 0: debug_level = max(3, debug_level)
       if memory_init_file is None: memory_init_file = opt_level >= 2
 
       # TODO: support source maps with js_transform

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6908,7 +6908,7 @@ int main() {
   def test_binaryen_names(self):
     sizes = {}
     for args, expect_names in [
-        ([], True), # -O0 has debug info by default
+        ([], False),
         (['-g'], True),
         (['-O1'], False),
         (['-O2'], False),


### PR DESCRIPTION
This behavior is surprising because it is inconsistent with other
compilers, and also means that there is no way to generate a binary
without optimizations and without symbols. (A common use case for this
is a "fastbuild" mode).