### PR TITLE
Make embind mostly work with wasm_backend

### DIFF
--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -379,6 +379,14 @@ namespace emscripten {
         auto toWireType(T&& v) -> typename BindingType<T>::WireType {
             return BindingType<T>::toWireType(std::forward<T>(v));
         }
+
+        template<typename T>
+        constexpr bool typeSupportsMemoryView() {
+            return (std::is_floating_point<T>::value &&
+                        (sizeof(T) == 4 || sizeof(T) == 8)) ||
+                    (std::is_integral<T>::value &&
+                        (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4));
+        }
     }
 
     template<typename ElementType>
@@ -399,6 +407,8 @@ namespace emscripten {
     // as it merely aliases the C heap.
     template<typename T>
     inline memory_view<T> typed_memory_view(size_t size, const T* data) {
+        static_assert(internal::typeSupportsMemoryView<T>(),
+            "type of typed_memory_view is invalid");
         return memory_view<T>(size, data);
     }
 

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -7,6 +7,7 @@
 #include <typeinfo>
 #include <algorithm>
 #include <emscripten/emscripten.h>
+#include <emscripten/wire.h>
 #include <climits>
 #include <limits>
 
@@ -71,9 +72,7 @@ namespace {
 
     template<typename T>
     constexpr TypedArrayIndex getTypedArrayIndex() {
-        static_assert(
-            (std::is_floating_point<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)) ||
-            (std::is_integral<T>::value && (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4)),
+        static_assert(internal::typeSupportsMemoryView<T>(),
             "type does not map to a typed array");
         return std::is_floating_point<T>::value
             ? (sizeof(T) == 4
@@ -144,5 +143,7 @@ EMSCRIPTEN_BINDINGS(native_and_builtin_types) {
 
     register_memory_view<float>("emscripten::memory_view<float>");
     register_memory_view<double>("emscripten::memory_view<double>");
+#if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
     register_memory_view<long double>("emscripten::memory_view<long double>");
+#endif
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1474,7 +1474,7 @@ int main() {
   def test_mod_globalstruct(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_mod_globalstruct')
 
-  @no_wasm_backend('long doubles are f64s in wasm backend')
+  @no_wasm_backend('long doubles are f128s in wasm backend')
   def test_pystruct(self):
       def test():
         self.do_run_in_out_file_test('tests', 'test_pystruct')
@@ -6222,7 +6222,6 @@ def process(filename):
     Settings.ASSERTIONS = 1
     self.do_run(src, output)
 
-  @no_wasm_backend()
   def test_embind(self):
     Building.COMPILER_TEST_OPTS += ['--bind']
 
@@ -6244,7 +6243,6 @@ def process(filename):
     '''
     self.do_run(src, 'abs(-10): 10\nabs(-11): 11');
 
-  @no_wasm_backend()
   def test_embind_2(self):
     Settings.NO_EXIT_RUNTIME = 1 # we emit some post.js that we need to see
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
@@ -6267,7 +6265,6 @@ def process(filename):
     '''
     self.do_run(src, 'lerp 166');
 
-  @no_wasm_backend()
   def test_embind_3(self):
     Settings.NO_EXIT_RUNTIME = 1 # we emit some post.js that we need to see
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
@@ -6296,6 +6293,39 @@ def process(filename):
       }
     '''
     self.do_run(src, 'UnboundTypeError: Cannot call compute due to unbound types: Pi');
+
+  @no_wasm_backend('long doubles are f128s in wasm backend')
+  def test_embind_4(self):
+    Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
+    open('post.js', 'w').write('''
+      function printFirstElement() {
+        Module.print(Module.getBufferView()[0]);
+      }
+    ''')
+    src = r'''
+      #include <emscripten.h>
+      #include <emscripten/bind.h>
+      #include <emscripten/val.h>
+      #include <stdio.h>
+      using namespace emscripten;
+
+      const size_t kBufferSize = 1024;
+      long double buffer[kBufferSize];
+      val getBufferView(void) {
+          val v = val(typed_memory_view(kBufferSize, buffer));
+          return v;
+      }
+      EMSCRIPTEN_BINDINGS(my_module) {
+          function("getBufferView", &getBufferView);
+      }
+
+      int main(int argc, char **argv) {
+        buffer[0] = 107;
+        EM_ASM(printFirstElement());
+        return 0;
+      }
+    '''
+    self.do_run(src, '107')
 
   @no_wasm_backend()
   def test_scriptaclass(self):


### PR DESCRIPTION
Disables registering a long double memory view on wasm backend.
Adds a test to verify long double breaks for wasm backend but not other
targets.
Adds a static assert to typed_memory_view to move a user-facing failure
from runtime to compile time, with a clearer error message.