### PR TITLE
Ban V8 from test_demangle_stacks

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6121,7 +6121,8 @@ def process(filename):
 
   @no_wasm_backend()
   def test_demangle_stacks(self):
-    self.banned_js_engines = [V8_ENGINE] # https://bugs.chromium.org/p/v8/issues/detail?id=5632
+    if self.is_wasm():
+      self.banned_js_engines = [V8_ENGINE] # https://bugs.chromium.org/p/v8/issues/detail?id=5632
     Settings.DEMANGLE_SUPPORT = 1
     if '-O' in str(self.emcc_args):
       self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6121,6 +6121,7 @@ def process(filename):
 
   @no_wasm_backend()
   def test_demangle_stacks(self):
+    self.banned_js_engines = [V8_ENGINE] # https://bugs.chromium.org/p/v8/issues/detail?id=5632
     Settings.DEMANGLE_SUPPORT = 1
     if '-O' in str(self.emcc_args):
       self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']


### PR DESCRIPTION
It hasn't been fully updated for 0xd "names" section yet.