### PR TITLE
Do not use our clang to build binaryen natively, as it fails on some OS X setups

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -955,6 +955,7 @@ fi
   def test_binaryen(self):
     import tools.ports.binaryen as binaryen
     tag_file = Cache.get_path('binaryen_tag_' + binaryen.TAG + '.txt')
+
     def prep():
       wipe()
       self.do([PYTHON, EMCC, '--clear-ports'])
@@ -969,12 +970,14 @@ fi
     prep()
     subprocess.check_call([PYTHON, 'embuilder.py', 'build', 'binaryen'])
     assert os.path.exists(tag_file)
-    subprocess.check_call([PYTHON, 'emcc.py', 'tests/hello_world.c', '-s', 'BINARYEN=1'])
+    subprocess.check_call([PYTHON, 'emcc.py', 'tests/hello_world.c', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
-    print 'see if building with emmake works (should not break native compilation of binaryen port'
+    print 'see we show an error for emmake (we cannot build natively under emmake)'
     prep()
-    subprocess.check_call([PYTHON, 'emmake.py', EMCC, 'tests/hello_world.c', '-s', 'BINARYEN=1'])
-    assert os.path.exists(tag_file)
-    self.assertContained('hello, world!', run_js('a.out.js'))
+    try_delete('a.out.js')
+    out = self.do([PYTHON, 'emmake.py', EMCC, 'tests/hello_world.c', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
+    assert not os.path.exists(tag_file)
+    assert not os.path.exists('a.out.js')
+    self.assertContained('For example, for binaryen, do "python embuilder.py build binaryen"', out)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1215,6 +1215,15 @@ class Building:
     env['CROSS_COMPILE'] = path_from_root('em') # produces /path/to/emscripten/em , which then can have 'cc', 'ar', etc appended to it
     return env
 
+  # if we are in emmake mode, i.e., we changed the env to run emcc etc., then show the message and abort
+  @staticmethod
+  def ensure_no_emmake(message):
+    non_native = Building.get_building_env()
+    if os.environ.get('CC') == non_native.get('CC'):
+      # the environment CC is the one we change to when forcing our em* tools
+      logging.error(message)
+      sys.exit(1)
+
   # Finds the given executable 'program' in PATH. Operates like the Unix tool 'which'.
   @staticmethod
   def which(program):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -583,8 +583,9 @@ class Ports:
 
   @staticmethod
   def build_native(subdir):
+    shared.Building.ensure_no_emmake('We cannot build the native system library in "%s" when under the influence of emmake/emconfigure. To avoid this, create system dirs beforehand, so they are not auto-built on demand. For example, for binaryen, do "python embuilder.py build binaryen"' % subdir)
+
     old = os.getcwd()
-    env = shared.Building.get_building_env(native=True)
 
     try:
       os.chdir(subdir)
@@ -592,7 +593,7 @@ class Ports:
       cmake_build_type = 'Release'
 
       # Configure
-      subprocess.check_call(['cmake', '-DCMAKE_BUILD_TYPE=' + cmake_build_type, '.'], env=env)
+      subprocess.check_call(['cmake', '-DCMAKE_BUILD_TYPE=' + cmake_build_type, '.'])
 
       # Check which CMake generator CMake used so we know which form to pass parameters to make/msbuild/etc. build tool.
       generator = re.search('CMAKE_GENERATOR:INTERNAL=(.*)$', open('CMakeCache.txt', 'r').read(), re.MULTILINE).group(1)
@@ -604,7 +605,7 @@ class Ports:
       elif 'Visual Studio' in generator: make_args = ['--config', cmake_build_type, '--', '/maxcpucount:' + num_cores]
 
       # Kick off the build.
-      subprocess.check_call(['cmake', '--build', '.'] + make_args, env=env)
+      subprocess.check_call(['cmake', '--build', '.'] + make_args)
     finally:
       os.chdir(old)
 


### PR DESCRIPTION
Followup for #4676. See https://github.com/WebAssembly/binaryen/issues/822