### PR TITLE
webgl2_garbage_free_entrypoints

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2187,6 +2187,10 @@ Module["preRun"].push(function () {
   def test_webgl2_ubos(self):
     self.btest(path_from_root('tests', 'webgl2_ubos.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'], expected='0')
 
+  def test_webgl2_garbage_free_entrypoints(self):
+    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1'], expected='1')
+    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), expected='1')
+
   def test_webgl_with_closure(self):
     self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
 


### PR DESCRIPTION
Implement support for calling the new garbage-free WebGL2 API entrypoints for better performance. Remove temporary pthreads shared view related casts in GL library, those are no longer needed.

Also do some other minor optimizations and code simplifications.

Also fix a horrible typo bug we had that the function `glCompressedTexSubImage3D` actually called underlying `glCompressedTexSubImage2D` function. Guess nobody's been using compressed 3D textures so far..