### PR TITLE
Fix handling invalid path of chdir

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1227,6 +1227,9 @@ mergeInto(LibraryManager.library, {
     },
     chdir: function(path) {
       var lookup = FS.lookupPath(path, { follow: true });
+      if (lookup.node === null) {
+        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+      }
       if (!FS.isDir(lookup.node.mode)) {
         throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
       }

--- a/tests/unistd/curdir.c
+++ b/tests/unistd/curdir.c
@@ -31,6 +31,26 @@ int main() {
   errno = 0;
   printf("\n");
 
+  printf("chdir(dir): %d\n", chdir("/dir"));
+  printf("errno: %d\n", errno);
+  if (!errno) {
+    errno = 0;
+    printf("getcwd: %s\n", getcwd(buffer, 256));
+    printf("errno: %d\n", errno);
+  }
+  errno = 2;
+  printf("\n");
+
+  printf("chdir(\"\"): %d\n", chdir(""));
+  printf("errno: %d\n", errno);
+  if (!errno) {
+    errno = 0;
+    printf("getcwd: %s\n", getcwd(buffer, 256));
+    printf("errno: %d\n", errno);
+  }
+  errno = 2;
+  printf("\n");
+
   printf("chdir(device): %d\n", chdir("/device"));
   printf("errno: %d\n", errno);
   if (!errno) {

--- a/tests/unistd/curdir.out
+++ b/tests/unistd/curdir.out
@@ -4,6 +4,12 @@ errno: 0
 chdir(file): -1
 errno: 20
 
+chdir(dir): -1
+errno: 2
+
+chdir(""): -1
+errno: 2
+
 chdir(device): -1
 errno: 20
 


### PR DESCRIPTION
Current ```chdir``` throws following exception when a path of chdir(path) is invalid.
This is because ```lookupPath``` returns ```node``` of ```null```, see https://github.com/kripken/emscripten/blob/incoming/src/library_fs.js#L47.
This PR fixes it to work like linux. 

```
[TypeError: Cannot read property 'mode' of null]

/tmp/emscripten_test_default_YmBq7Y/src.cpp.o.js:110
      throw ex;
      ^
abort({}) at Error
    at jsStackTrace (/tmp/emscripten_test_default_YmBq7Y/src.cpp.o.js:1092:13)
    at stackTrace (/tmp/emscripten_test_default_YmBq7Y/src.cpp.o.js:1109:12)
    at abort (/tmp/emscripten_test_default_YmBq7Y/src.cpp.o.js:12819:44)
    at ___syscall12 (/tmp/emscripten_test_default_YmBq7Y/src.cpp.o.js:4697:69)
```