### PR TITLE
Fixes glfwGetMouseButton which isn't working if no callback function is set to glfwSetMouseButtonCallback

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -443,7 +443,7 @@ var LibraryGLFW = {
     },
 
     onMouseButtonChanged: function(event, status) {
-      if (!GLFW.active || !GLFW.active.mouseButtonFunc) return;
+      if (!GLFW.active) return;
 
       Browser.calculateMouseEvent(event);
 
@@ -459,6 +459,8 @@ var LibraryGLFW = {
       } else {  // GLFW_RELEASE
         GLFW.active.buttons &= ~(1 << eventButton);
       }
+
+      if (!GLFW.active.mouseButtonFunc) return;
 
 #if USE_GLFW == 2
       Runtime.dynCall('vii', GLFW.active.mouseButtonFunc, [eventButton, status]);


### PR DESCRIPTION
(Moved to a cleaner branch to simplify history.)

This issue wasn't detected when I did the changes in my previous PR. Sorry for that.
GLFW library implementation has been fixed, and unit tests extended to trap this case.

Hope it's not to late for the release.

Guillaume