### PR TITLE
OpenAL: Avoid to call PannerNode.setVelocity during AL_SOURCE_RELATIVE

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -504,7 +504,12 @@ var LibraryOpenAL = {
           panner.maxDistance = src.maxDistance;
           panner.rolloffFactor = src.rolloffFactor;
           panner.setPosition(src.position[0], src.position[1], src.position[2]);
-          panner.setVelocity(src.velocity[0], src.velocity[1], src.velocity[2]);
+          
+          // Panner.protorype.setVelocity was deprecated and removed in Chrome 55+
+          if (src.velocity[0] != 0.0 && src.velocity[1] != 0.0 && velocity[2] != 0.0) {
+            panner.setVelocity(src.velocity[0], src.velocity[1], src.velocity[2]);
+          }
+          
           panner.connect(AL.currentContext.gain);
 
           // Disconnect from the default source.

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -506,7 +506,7 @@ var LibraryOpenAL = {
           panner.setPosition(src.position[0], src.position[1], src.position[2]);
           
           // Panner.protorype.setVelocity was deprecated and removed in Chrome 55+
-          if (src.velocity[0] != 0.0 && src.velocity[1] != 0.0 && velocity[2] != 0.0) {
+          if (src.velocity[0] != 0.0 || src.velocity[1] != 0.0 || velocity[2] != 0.0) {
             panner.setVelocity(src.velocity[0], src.velocity[1], src.velocity[2]);
           }
           


### PR DESCRIPTION
The API has deprecated and removed in Chrome 56+ https://www.chromestatus.com/feature/5238926818148352 
Removed elements:
* AudioListener.dopplerFactor
* AudioListener.speedOfSound
* AudioListener.setVelocity()
* PannerNode.setVelocity()

Where, only AudioListener.setVelocity() and PannerNode.setVelocity() is used by OpenAL port. 

----

This is a 'soft' version of a patch, that doesn't change public API, so that if somebody will not call `alSource3f(mAlSourceId, AL_VELOCITY, ...)` explicitly, then the error shouldn't happen.

I would like to know your opinion about how to develop patch it.

------

For people that have already in production a code that uses either `AL_VELOCITY` or `AL_SOURCE_RELATIVE`.


Hack-Snippet to add a compatibility
```
// Stubs for missing setVelocity in Chromium 56+
try {
	if (typeof PannerNode.prototype.setVelocity == "undefined") {
		PannerNode.prototype.setVelocity = function() {}
	}
} catch (e) {}
try {
	if (typeof AudioListener.prototype.setVelocity == "undefined") {
		AudioListener.prototype.setVelocity = function() {}
	}
} catch (e) {}

```

Cheers,
Piotr