### PR TITLE
emcc: IndexError: string index out of range

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1714,18 +1714,21 @@ class Building:
 
   @staticmethod
   def is_bitcode(filename):
-    # look for magic signature
-    b = open(filename, 'r').read(4)
-    if b[0] == 'B' and b[1] == 'C':
-      return True
-    # look for ar signature
-    elif Building.is_ar(filename):
-      return True
-    # on OS X, there is a 20-byte prefix
-    elif ord(b[0]) == 222 and ord(b[1]) == 192 and ord(b[2]) == 23 and ord(b[3]) == 11:
-      b = open(filename, 'r').read(24)
-      return b[20] == 'B' and b[21] == 'C'
-
+    try:
+        # look for magic signature
+        b = open(filename, 'r').read(4)
+        if b[0] == 'B' and b[1] == 'C':
+          return True
+        # look for ar signature
+        elif Building.is_ar(filename):
+          return True
+        # on OS X, there is a 20-byte prefix
+        elif ord(b[0]) == 222 and ord(b[1]) == 192 and ord(b[2]) == 23 and ord(b[3]) == 11:
+          b = open(filename, 'r').read(24)
+          return b[20] == 'B' and b[21] == 'C'
+    except IndexError:
+        # The caller function should display a error in the log
+        pass
     return False
 
   @staticmethod


### PR DESCRIPTION
Related to issue #4748
IndexError used to be thrown for a unknown file signature because it accessed a string in a bad position.
The caller function expects a Boolean result and not to catch a Exception.