### PR TITLE
--cflags option

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -189,11 +189,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     debug_env['EMCC_DEBUG'] = '1'
     args = filter(lambda x: x != '--cflags', sys.argv)
     with misc_temp_files.get_file(suffix='.o') as temp_target:
-      out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', 'hello_world.c'), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env).communicate()
-      lines = filter(lambda x: 'running:' in x and 'clang' in x, err.split(os.linesep))
-      assert len(lines) == 1
-      parts = lines[0].split(' ')[2:]
-      parts = filter(lambda x: x != '-c' and x != '-o' and 'hello_world.c' not in x and temp_target not in x and '-emit-llvm' not in x, parts)
+      input_file = 'hello_world.c'
+      out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', input_file), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env).communicate()
+      lines = filter(lambda x: shared.CLANG_CC in x and input_file in x, err.split(os.linesep))
+      line = lines[0]
+      assert 'running:' in line
+      parts = line.split(' ')[2:]
+      parts = filter(lambda x: x != '-c' and x != '-o' and input_file not in x and temp_target not in x and '-emit-llvm' not in x, parts)
       print ' '.join(parts)
     exit(0)
 

--- a/emcc.py
+++ b/emcc.py
@@ -181,6 +181,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     print shared.get_llvm_target()
     exit(0)
 
+  elif '--cflags' in sys.argv:
+    print ' '.join(shared.COMPILER_OPTS + ['-emit-llvm', '-c'])
+    exit(0)
+
   def is_minus_s_for_emcc(newargs, i):
     assert newargs[i] == '-s'
     if i+1 < len(newargs) and '=' in newargs[i+1] and not newargs[i+1].startswith('-'): # -s OPT=VALUE is for us, -s by itself is a linker option

--- a/emcc.py
+++ b/emcc.py
@@ -115,6 +115,8 @@ def run():
   if len(sys.argv) <= 1 or ('--help' not in sys.argv and len(sys.argv) >= 2 and sys.argv[1] != '--version'):
     shared.check_sanity(force=DEBUG)
 
+  misc_temp_files = shared.configuration.get_temp_files()
+
   # Handle some global flags
 
   if len(sys.argv) == 1:
@@ -186,12 +188,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     debug_env = os.environ.copy()
     debug_env['EMCC_DEBUG'] = '1'
     args = filter(lambda x: x != '--cflags', sys.argv)
-    out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', 'hello_world.c'), '-c'], stderr=subprocess.PIPE, env=debug_env).communicate()
-    lines = filter(lambda x: 'running:' in x and 'clang' in x, err.split(os.linesep))
-    assert len(lines) == 1
-    parts = lines[0].split(' ')[2:]
-    parts = filter(lambda x: x != '-c' and x != '-o' and 'hello_world' not in x and '-emit-llvm' not in x, parts)
-    print ' '.join(parts)
+    with misc_temp_files.get_file(suffix='.o') as temp_target:
+      out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', 'hello_world.c'), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env).communicate()
+      lines = filter(lambda x: 'running:' in x and 'clang' in x, err.split(os.linesep))
+      assert len(lines) == 1
+      parts = lines[0].split(' ')[2:]
+      parts = filter(lambda x: x != '-c' and x != '-o' and 'hello_world.c' not in x and temp_target not in x and '-emit-llvm' not in x, parts)
+      print ' '.join(parts)
     exit(0)
 
   def is_minus_s_for_emcc(newargs, i):
@@ -409,8 +412,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       TimeLogger.update()
 
   use_cxx = True
-
-  misc_temp_files = shared.configuration.get_temp_files()
 
   try:
     with ToolchainProfiler.profile_block('parse arguments and setup'):

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -450,6 +450,9 @@ Options that are modified or new in *emcc* are listed below:
 ``--output-eol windows|linux``
 	Specifies the line ending to generate for the text files that are outputted. If "--output-eol windows" is passed, the final output files will have Windows \r\n line endings in them. With "--output-eol linux", the final generated files will be written with Unix \n line endings.
 
+``--cflags``
+	Prints out the flags ``emcc`` would pass to ``clang`` to compile source code to object/bitcode form. You can use this to invoke clang yourself, and then run ``emcc`` on those outputs just for the final linking+conversion to JS.
+
 .. _emcc-environment-variables:
 
 Environment variables

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -404,7 +404,7 @@ f.close()
     flags = output[0].strip()
     self.assertContained(' '.join(COMPILER_OPTS), flags)
     # check they work
-    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp'), '-o', 'a.bc'] + flags.split(' ')
+    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp'), '-o', 'a.bc'] + flags.split(' ') + ['-c', '-emit-llvm']
     subprocess.check_call(cmd)
     subprocess.check_call([PYTHON, EMCC, 'a.bc'])
     self.assertContained('hello, world!', run_js(self.in_dir('a.out.js')))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -404,7 +404,7 @@ f.close()
     flags = output[0].strip()
     self.assertContained(' '.join(COMPILER_OPTS), flags)
     # check they work
-    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp'), '-o', 'a.bc'] + flags.split(' ') + ['-c', '-emit-llvm']
+    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp')] + flags.split(' ') + ['-c', '-emit-llvm', '-o', 'a.bc']
     subprocess.check_call(cmd)
     subprocess.check_call([PYTHON, EMCC, 'a.bc'])
     self.assertContained('hello, world!', run_js(self.in_dir('a.out.js')))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -398,6 +398,17 @@ f.close()
       os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
       shutil.rmtree(tempdirname)
 
+  def test_emcc_cflags(self):
+    # see we print them out
+    output = Popen([PYTHON, EMCC, '--cflags'], stdout=PIPE, stderr=PIPE).communicate()
+    flags = output[0].strip()
+    self.assertContained(' '.join(COMPILER_OPTS), flags)
+    # check they work
+    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp'), '-o', 'a.bc'] + flags.split(' ')
+    subprocess.check_call(cmd)
+    subprocess.check_call([PYTHON, EMCC, 'a.bc'])
+    self.assertContained('hello, world!', run_js(self.in_dir('a.out.js')))
+
   def test_emar_em_config_flag(self):
     # We expand this in case the EM_CONFIG is ~/.emscripten (default)
     config = os.path.expanduser(EM_CONFIG)


### PR DESCRIPTION
This lets you get the flags emcc passes to clang, letting you then call clang yourself with them if you want. This was something that @sunfishcode and @dschuff noted to me as something that should be easier to do.