### PR TITLE
trace_ffi_calls

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -873,7 +873,19 @@ function ftCall_%s(%s) {%s
 
     # sent data
     the_global = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in fundamentals]) + ' }'
-    sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in basic_funcs + global_funcs + basic_vars + basic_float_vars + global_vars]) + ' }'
+    asm_library_args = {}
+    for f in basic_funcs + global_funcs:
+      if settings['TRACE_FFI_CALLS']:
+        asm_library_args[f] = 'traced_ffi_call("' + f + '", ' + f + ')'
+      else:
+        asm_library_args[f] = f
+    for v in basic_vars + basic_float_vars + global_vars:
+      asm_library_args[v] = v
+
+    sending = []
+    for key, value in asm_library_args.iteritems():
+      sending += ['"' + math_fix(key) + '": ' + value]
+    sending = '{ ' + ', '.join(sending) + ' }'
     # received
     receiving = ''
     if settings['ASSERTIONS']:

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2029,4 +2029,13 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
 var cyberDWARFFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
 #endif
 
+#if TRACE_FFI_CALLS
+function traced_ffi_call(funcname, func) {
+  return function() {
+    console.log(funcname);
+    return func.apply(null, arguments);
+  }
+}
+#endif
+
 // === Body ===

--- a/src/settings.js
+++ b/src/settings.js
@@ -779,4 +779,6 @@ var OFFSCREENCANVAS_SUPPORT = 0; // If set to 1, enables support for transferrin
                                  // as well as explicit swap control for GL contexts. This needs browser support for the OffscreenCanvas
                                  // specification.
 
+var TRACE_FFI_CALLS = 0; // If set to 1, all FFI calls from within asm.js are logged to console. Useful for debugging where FFI calls occur from.
+
 // Reserved: variables containing POINTER_MASKING.


### PR DESCRIPTION
Adds a mechanism to trace FFI calls. Useful for reviewing FFIs for the planned "wasm pure threads" mode.