### PR TITLE
Binaryen dynamic linking

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2024,7 +2024,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             cmd += ['--mem-init=' + memfile]
             if not shared.Settings.RELOCATABLE:
               cmd += ['--mem-base=' + str(shared.Settings.GLOBAL_BASE)]
-          if shared.Settings.RELOCATABLE or shared.Settings.RESERVED_FUNCTION_POINTERS:
+          # various options imply that the imported table may not be the exact size as the wasm module's own table segments
+          if shared.Settings.RELOCATABLE or shared.Settings.RESERVED_FUNCTION_POINTERS > 0 or shared.Settings.EMULATED_FUNCTION_POINTERS:
             cmd += ['--table-max=-1']
           if shared.Settings.SIDE_MODULE:
             cmd += ['--mem-max=-1']

--- a/emcc.py
+++ b/emcc.py
@@ -2024,7 +2024,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             cmd += ['--mem-init=' + memfile]
             if not shared.Settings.RELOCATABLE:
               cmd += ['--mem-base=' + str(shared.Settings.GLOBAL_BASE)]
-          if shared.Settings.RELOCATABLE:
+          if shared.Settings.RELOCATABLE or shared.Settings.RESERVED_FUNCTION_POINTERS:
             cmd += ['--table-max=-1']
           if shared.Settings.SIDE_MODULE:
             cmd += ['--mem-max=-1']

--- a/emcc.py
+++ b/emcc.py
@@ -2072,7 +2072,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if not shared.Settings.WASM_BACKEND:
           if shared.Settings.SIDE_MODULE:
             wso = shared.WebAssembly.make_shared_library(js_target, wasm_binary_target)
-            # replace the .js output with the shared library. TODO: emit a file with suffix .wso
+            # replace the wasm binary output with the dynamic library. TODO: use a specific suffix for such files?
             shutil.move(wso, wasm_binary_target)
             os.unlink(js_target) # we don't need the js, it can just confuse
             os.unlink(asm_target) # we don't need the asm.js, it can just confuse

--- a/emcc.py
+++ b/emcc.py
@@ -1166,11 +1166,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           js_opts = True
         force_js_opts = True
 
-      if shared.Settings.EVAL_CTORS:
-        # this option is not a js optimizer pass, but does run the js optimizer internally, so
-        # we need to generate proper code for that
-        shared.Settings.RUNNING_JS_OPTS = 1
-
       if shared.Settings.WASM:
         shared.Settings.BINARYEN = 1 # these are synonyms
 
@@ -1211,6 +1206,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         #  * if we also supported js mem inits we'd have 4 modes
         #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
         memory_init_file = True
+        if shared.Building.is_wasm_only() and shared.Settings.EVAL_CTORS:
+          logging.debug('disabling EVAL_CTORS, as in wasm-only mode it hurts more than it helps. TODO: a wasm version of it')
+          shared.Settings.EVAL_CTORS = 0
+
+      if shared.Settings.EVAL_CTORS:
+        # this option is not a js optimizer pass, but does run the js optimizer internally, so
+        # we need to generate proper code for that
+        shared.Settings.RUNNING_JS_OPTS = 1
 
       if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
         # this is an issue in asm.js, but not wasm

--- a/emcc.py
+++ b/emcc.py
@@ -2074,8 +2074,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             wso = shared.WebAssembly.make_shared_library(js_target, wasm_binary_target)
             # replace the wasm binary output with the dynamic library. TODO: use a specific suffix for such files?
             shutil.move(wso, wasm_binary_target)
-            os.unlink(js_target) # we don't need the js, it can just confuse
-            os.unlink(asm_target) # we don't need the asm.js, it can just confuse
+            if not DEBUG:
+              os.unlink(js_target) # we don't need the js, it can just confuse
+              os.unlink(asm_target) # we don't need the asm.js, it can just confuse
             sys.exit(0) # and we are done.
 
       # If we were asked to also generate HTML, do that

--- a/emscripten.py
+++ b/emscripten.py
@@ -552,6 +552,7 @@ function _emscripten_asm_const_%s(%s) {
             code = 'return ' + shared.JS.make_coercion(code, sig[0], settings)
           code += ';'
           Counter.pre.append(make_func(clean_item + '__wrapper', code, params, coercions))
+          assert not sig == 'X', 'must know the signature in order to create a wrapper (TODO for shared wasm modules)'
           return clean_item + '__wrapper'
         return item if not newline else (item + '\n')
       if settings['ASSERTIONS'] >= 2:

--- a/emscripten.py
+++ b/emscripten.py
@@ -552,7 +552,7 @@ function _emscripten_asm_const_%s(%s) {
             code = 'return ' + shared.JS.make_coercion(code, sig[0], settings)
           code += ';'
           Counter.pre.append(make_func(clean_item + '__wrapper', code, params, coercions))
-          assert not sig == 'X', 'must know the signature in order to create a wrapper (TODO for shared wasm modules)'
+          assert not sig == 'X', 'must know the signature in order to create a wrapper for "%s" (TODO for shared wasm modules)' % item
           return clean_item + '__wrapper'
         return item if not newline else (item + '\n')
       if settings['ASSERTIONS'] >= 2:

--- a/emscripten.py
+++ b/emscripten.py
@@ -825,6 +825,9 @@ function ftCall_%s(%s) {%s
       # named globals in side wasm modules are exported globals from asm/wasm
       for k, v in metadata['namedGlobals'].iteritems():
         exports.append(quote('_' + str(k)) + ': ' + str(v))
+      # aliases become additional exports
+      for k, v in metadata['aliases'].iteritems():
+        exports.append(quote(str(k)) + ': ' + str(v))
     exports = '{ ' + ', '.join(exports) + ' }'
     # calculate globals
     try:

--- a/emscripten.py
+++ b/emscripten.py
@@ -539,8 +539,8 @@ function _emscripten_asm_const_%s(%s) {
         clean_item = item.replace("asm['", '').replace("']", '')
         # when emulating function pointers, we don't need wrappers
         # but if relocating, then we also have the copies in-module, and do
-        # also if binaryen, as wasm requires wrappers for the function table
-        if clean_item not in implemented_functions and not (settings['EMULATED_FUNCTION_POINTERS'] and not settings['RELOCATABLE'] and not settings['BINARYEN']):
+        # in wasm we never need wrappers though
+        if clean_item not in implemented_functions and not (settings['EMULATED_FUNCTION_POINTERS'] and not settings['RELOCATABLE']) and not settings['BINARYEN']:
           # this is imported into asm, we must wrap it
           call_ident = clean_item
           if call_ident in metadata['redirects']: call_ident = metadata['redirects'][call_ident]

--- a/emscripten.py
+++ b/emscripten.py
@@ -793,9 +793,10 @@ function ftCall_%s(%s) {%s
   return %s(%s);
 }
 ''' % (sig, ', '.join(full_args), prelude, table_read, ', '.join(args))
-        basic_funcs.append('ftCall_%s' % sig)
+        if not settings['BINARYEN']: # in wasm, emulated function pointers are just simple table calls
+          basic_funcs.append('ftCall_%s' % sig)
 
-        if settings.get('RELOCATABLE'):
+        if settings.get('RELOCATABLE') and not settings['BINARYEN']: # in wasm, emulated function pointers are just simple table calls
           params = ','.join(['ptr'] + ['p%d' % p for p in range(len(sig)-1)])
           coerced_params = ','.join([shared.JS.make_coercion('ptr', 'i', settings)] + [shared.JS.make_coercion('p%d', unfloat(sig[p+1]), settings) % p for p in range(len(sig)-1)])
           coercions = ';'.join(['ptr = ptr | 0'] + ['p%d = %s' % (p, shared.JS.make_coercion('p%d' % p, unfloat(sig[p+1]), settings)) for p in range(len(sig)-1)]) + ';'

--- a/emscripten.py
+++ b/emscripten.py
@@ -376,6 +376,9 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
            (('function ' + requested.encode('utf-8')) not in pre): # could be a js library func
           logging.warning('function requested to be exported, but not implemented: "%s"', requested)
 
+    if settings['BINARYEN'] and settings['SIDE_MODULE']:
+      assert len(metadata['asmConsts']) == 0, 'EM_ASM is not yet supported in shared wasm module (it cannot be stored in the wasm itself, need some solution)'
+
     asm_consts = [0]*len(metadata['asmConsts'])
     all_sigs = []
     for k, v in metadata['asmConsts'].iteritems():

--- a/emscripten.py
+++ b/emscripten.py
@@ -782,7 +782,6 @@ function jsCall_%s_%s(%s) {
         if settings['BINARYEN']:
           # wasm uses a Table, which means we have function pointer emulation capabilities all the time, at no cost. just call the table
           table_access = "Module['wasmTable']"
-        if settings['BINARYEN']:
           table_read = table_access + '.get(x)'
         else:
           table_read = table_access + '[x]'

--- a/emscripten.py
+++ b/emscripten.py
@@ -127,6 +127,9 @@ def get_and_parse_backend(infile, settings, temp_files, DEBUG):
         backend_args += ['-emscripten-global-base=0']
       elif settings['GLOBAL_BASE'] >= 0:
         backend_args += ['-emscripten-global-base=%d' % settings['GLOBAL_BASE']]
+      if settings['SIDE_MODULE']:
+        backend_args += ['-emscripten-side-module']
+      backend_args += ['-emscripten-stack-size=%d' % settings['TOTAL_STACK']]
       backend_args += ['-O' + str(settings['OPT_LEVEL'])]
       if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
         backend_args += ['-enable-emscripten-cxx-exceptions']
@@ -457,6 +460,7 @@ function _emscripten_asm_const_%s(%s) {
     in_table = set()
 
     def make_table(sig, raw):
+      if '[]' in raw: return ('', '') # empty table
       params = make_params(sig)
       coerced_params = make_coerced_params(sig)
       coercions = make_coercions(sig)
@@ -678,7 +682,9 @@ function _emscripten_asm_const_%s(%s) {
         basic_funcs += ['nullFunc_' + sig]
         asm_setup += '\nfunction nullFunc_' + sig + '(x) { ' + get_function_pointer_error(sig) + 'abort(x) }\n'
 
-    basic_vars = ['STACKTOP', 'STACK_MAX', 'DYNAMICTOP_PTR', 'tempDoublePtr', 'ABORT']
+    basic_vars = ['DYNAMICTOP_PTR', 'tempDoublePtr', 'ABORT']
+    if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
+      basic_vars += ['STACKTOP', 'STACK_MAX']
     basic_float_vars = []
 
     if metadata.get('preciseI64MathUsed'):
@@ -692,7 +698,9 @@ function _emscripten_asm_const_%s(%s) {
       if not settings['SIDE_MODULE']:
         asm_setup += 'var gb = Runtime.GLOBAL_BASE, fb = 0;\n'
 
-    asm_runtime_funcs = ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
+    asm_runtime_funcs = []
+    if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
+      asm_runtime_funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
     if not settings['RELOCATABLE']:
       asm_runtime_funcs += ['setTempRet0', 'getTempRet0']
     else:
@@ -700,7 +708,10 @@ function _emscripten_asm_const_%s(%s) {
       asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
 
     if settings['BINARYEN']:
-      asm_setup += "\nModule['wasmTableSize'] = %d;\n" % sum(map(lambda table: table.count(',') + 1, last_forwarded_json['Functions']['tables'].values()))
+      table_size = sum(map(lambda table: table.count(',') + 1, last_forwarded_json['Functions']['tables'].values()))
+      asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_size
+      if not settings['EMULATED_FUNCTION_POINTERS']:
+        asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_size
 
     # See if we need ASYNCIFY functions
     # We might not need them even if ASYNCIFY is enabled
@@ -767,13 +778,20 @@ function jsCall_%s_%s(%s) {
         table_access = 'FUNCTION_TABLE_' + sig
         if settings['SIDE_MODULE']:
           table_access = 'parentModule["' + table_access + '"]' # side module tables were merged into the parent, we need to access the global one
+        if settings['BINARYEN']:
+          # wasm uses a Table, which means we have function pointer emulation capabilities all the time, at no cost. just call the table
+          table_access = "Module['wasmTable']"
+        if settings['BINARYEN']:
+          table_read = table_access + '.get(x)'
+        else:
+          table_read = table_access + '[x]'
         prelude = '''
   if (x < 0 || x >= %s.length) { Module.printErr("Function table mask error (out of range)"); %s ; abort(x) }''' % (table_access, get_function_pointer_error(sig))
         asm_setup += '''
 function ftCall_%s(%s) {%s
-  return %s[x](%s);
+  return %s(%s);
 }
-''' % (sig, ', '.join(full_args), prelude, table_access, ', '.join(args))
+''' % (sig, ', '.join(full_args), prelude, table_read, ', '.join(args))
         basic_funcs.append('ftCall_%s' % sig)
 
         if settings.get('RELOCATABLE'):
@@ -802,6 +820,10 @@ function ftCall_%s(%s) {%s
     exports = []
     for export in all_exported:
       exports.append(quote(export) + ": " + export)
+    if settings['BINARYEN'] and settings['SIDE_MODULE']:
+      # named globals in side wasm modules are exported globals from asm/wasm
+      for k, v in metadata['namedGlobals'].iteritems():
+        exports.append(quote('_' + str(k)) + ': ' + str(v))
     exports = '{ ' + ', '.join(exports) + ' }'
     # calculate globals
     try:
@@ -874,6 +896,9 @@ function ftCall_%s(%s) {%s
       asm_global_funcs += ''.join(['  var Atomics_' + ty + '=global' + access_quote('Atomics') + access_quote(ty) + ';\n' for ty in ['load', 'store', 'exchange', 'compareExchange', 'add', 'sub', 'and', 'or', 'xor']])
     asm_global_vars = ''.join(['  var ' + g + '=env' + access_quote(g) + '|0;\n' for g in basic_vars + global_vars])
 
+    if settings['BINARYEN'] and settings['SIDE_MODULE']:
+      asm_global_vars += '\n  var STACKTOP = 0, STACK_MAX = 0;\n' # wasm side modules internally define their stack, these are set at module startup time
+
     # sent data
     the_global = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in fundamentals]) + ' }'
     sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in basic_funcs + global_funcs + basic_vars + basic_float_vars + global_vars]) + ' }'
@@ -887,7 +912,7 @@ assert(runtimeInitialized, 'you need to wait for the runtime to be ready (e.g. w
 assert(!runtimeExited, 'the runtime was exited (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
 return real_''' + s + '''.apply(null, arguments);
 };
-''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory']])
+''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory', '__start_module']])
 
     if not settings['SWAPPABLE_ASM_MODULE']:
       receiving += ';\n'.join(['var ' + s + ' = Module["' + s + '"] = asm["' + s + '"]' for s in exported_implemented_functions + function_tables])
@@ -895,7 +920,7 @@ return real_''' + s + '''.apply(null, arguments);
       receiving += 'Module["asm"] = asm;\n' + ';\n'.join(['var ' + s + ' = Module["' + s + '"] = function() { return Module["asm"]["' + s + '"].apply(null, arguments) }' for s in exported_implemented_functions + function_tables])
     receiving += ';\n'
 
-    if settings['EXPORT_FUNCTION_TABLES']:
+    if settings['EXPORT_FUNCTION_TABLES'] and not settings['BINARYEN']:
       for table in last_forwarded_json['Functions']['tables'].values():
         tableName = table.split()[1]
         table = table.replace('var ' + tableName, 'var ' + tableName + ' = Module["' + tableName + '"]')
@@ -907,10 +932,11 @@ return real_''' + s + '''.apply(null, arguments);
     if settings.get('EMULATED_FUNCTION_POINTERS'):
       asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'
       receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '') + '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in last_forwarded_json['Functions']['tables']])
-      for sig in last_forwarded_json['Functions']['tables'].keys():
-        name = 'FUNCTION_TABLE_' + sig
-        fullname = name if not settings['SIDE_MODULE'] else ('SIDE_' + name)
-        receiving += 'Module["' + name + '"] = ' + fullname + ';\n'
+      if not settings['BINARYEN']:
+        for sig in last_forwarded_json['Functions']['tables'].keys():
+          name = 'FUNCTION_TABLE_' + sig
+          fullname = name if not settings['SIDE_MODULE'] else ('SIDE_' + name)
+          receiving += 'Module["' + name + '"] = ' + fullname + ';\n'
 
       final_function_tables = final_function_tables.replace("asm['", '').replace("']", '').replace('var SIDE_FUNCTION_TABLE_', 'var FUNCTION_TABLE_').replace('var dynCall_', '//')
 
@@ -1608,7 +1634,7 @@ assert(runtimeInitialized, 'you need to wait for the runtime to be ready (e.g. w
 assert(!runtimeExited, 'the runtime was exited (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
 return real_''' + asmjs_mangle(s) + '''.apply(null, arguments);
 };
-''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory']])
+''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory', '__start_module']])
 
   if not settings['SWAPPABLE_ASM_MODULE']:
     receiving += ';\n'.join(['var ' + asmjs_mangle(s) + ' = Module["' + asmjs_mangle(s) + '"] = asm["' + s + '"]' for s in exported_implemented_functions])

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -68,6 +68,10 @@ function JSify(data, functionsOnly) {
           libFuncsToInclude.push(key);
         }
       }
+      // mark implemented functions as already added (so if memcpy is in the forced full JS library, but also done in C, we just need the C)
+      for (var added in IMPLEMENTED_FUNCTIONS) {
+        addedLibraryItems[added.substr(1)] = true;
+      }
     } else {
       libFuncsToInclude = DEFAULT_LIBRARY_FUNCS_TO_INCLUDE;
     }

--- a/src/library.js
+++ b/src/library.js
@@ -1624,7 +1624,7 @@ LibraryManager.library = {
 #if ASSERTIONS
         Module.printErr('Error in loading dynamic library: ' + e);
 #endif
-        DLFCN.errorMsg = 'Could not evaluate dynamic lib: ' + filename;
+        DLFCN.errorMsg = 'Could not evaluate dynamic lib: ' + filename + '\n' + e;
         return 0;
       }
 

--- a/src/library.js
+++ b/src/library.js
@@ -1607,7 +1607,7 @@ LibraryManager.library = {
       var lib_module;
       try {
 #if BINARYEN
-        // the shared library is a shared wasm library, a '.wso' (see tools/shared.py WebAssembly.make_shared_library)
+        // the shared library is a shared wasm library (see tools/shared.py WebAssembly.make_shared_library)
         var lib_data = FS.readFile(filename, { encoding: 'binary' });
         if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
         //Module.printErr('libfile ' + filename + ' size: ' + lib_data.length);

--- a/src/library.js
+++ b/src/library.js
@@ -1601,16 +1601,25 @@ LibraryManager.library = {
       if (!target || target.isFolder || target.isDevice) {
         DLFCN.errorMsg = 'Could not find dynamic lib: ' + filename;
         return 0;
-      } else {
-        FS.forceLoadFile(target);
-        var lib_data = FS.readFile(filename, { encoding: 'utf8' });
       }
+      FS.forceLoadFile(target);
 
+      var lib_module;
       try {
-        var lib_module = eval(lib_data)(
+#if BINARYEN
+        // the shared library is a shared wasm library, a '.wso' (see tools/shared.py WebAssembly.make_shared_library)
+        var lib_data = FS.readFile(filename, { encoding: 'binary' });
+        if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
+        //Module.printErr('libfile ' + filename + ' size: ' + lib_data.length);
+        lib_module = Runtime.loadWebAssemblyModule(lib_data);
+#else
+        // the shared library is a JS file, which we eval
+        var lib_data = FS.readFile(filename, { encoding: 'utf8' });
+        lib_module = eval(lib_data)(
           Runtime.alignFunctionTables(),
           Module
         );
+#endif
       } catch (e) {
 #if ASSERTIONS
         Module.printErr('Error in loading dynamic library: ' + e);
@@ -1705,6 +1714,7 @@ LibraryManager.library = {
         var result = lib.module[symbol];
         if (typeof result == 'function') {
           result = Runtime.addFunction(result);
+          //Module.printErr('adding function dlsym result for ' + symbol + ' => ' + result);
           lib.cached_functions = result;
         }
         return result;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -382,7 +382,7 @@ var Runtime = {
     // TODO: use only memoryBase and tableBase, need to update asm.js backend
     var table = Module['wasmTable'];
     var oldTableSize = table.length;
-    env['memoryBase'] = env['gb'] = Runtime.alignMemory(getMemory(memorySize)); // TODO: add to cleanups
+    env['memoryBase'] = env['gb'] = Runtime.alignMemory(getMemory(memorySize + Runtime.STACK_ALIGN), Runtime.STACK_ALIGN); // TODO: add to cleanups
     env['tableBase'] = env['fb'] = oldTableSize;
     //Module.printErr('using memoryBase ' + env['memoryBase'] + ', tableBase ' + env['tableBase']);
     //Module.printErr('growing table from size ' + oldTableSize + ' by ' + tableSize);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -413,8 +413,14 @@ var Runtime = {
       exports[e] = value;
     }
     // initialize the module
-    if (exports['__start_module']) {
-      exports['__start_module']();
+    var init = exports['__start_module'];
+    if (init) {
+      if (runtimeInitialized) {
+        init();
+      } else {
+        // we aren't ready to run compiled code yet
+        __ATINIT__.push(init);
+      }
     }
     return exports;
   },

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -434,7 +434,7 @@ var Runtime = {
       exports[e] = value;
     }
     // initialize the module
-    var init = exports['__start_module'];
+    var init = exports['__post_instantiate'];
     if (init) {
       if (runtimeInitialized) {
         init();

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -384,6 +384,10 @@ var Runtime = {
     var oldTableSize = table.length;
     env['memoryBase'] = env['gb'] = Runtime.alignMemory(getMemory(memorySize + Runtime.STACK_ALIGN), Runtime.STACK_ALIGN); // TODO: add to cleanups
     env['tableBase'] = env['fb'] = oldTableSize;
+    // zero-initialize memory TODO: in some cases we can tell it is already zero initialized
+    for (var i = env['memoryBase']; i < env['memoryBase'] + memorySize; i++) {
+      HEAP8[i] = 0;
+    }
     //Module.printErr('using memoryBase ' + env['memoryBase'] + ', tableBase ' + env['tableBase']);
     //Module.printErr('growing table from size ' + oldTableSize + ' by ' + tableSize);
     var originalTable = table;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -386,6 +386,7 @@ var Runtime = {
       oldTable.push(table.get(i));
     }
 #endif
+    // create a module from the instance
     wasm = new WebAssembly.Instance(new WebAssembly.Module(wasm), info);
 #if ASSERTIONS
     // the table should be unchanged

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -360,9 +360,9 @@ var Runtime = {
       var mul = 1;
       while (1) {
         var byte = wasm[next++];
-        ret += ((byte & 127) * mul);
-        mul *= 128;
-        if (!(byte & 128)) break;
+        ret += ((byte & 0x7f) * mul);
+        mul *= 0x80;
+        if (!(byte & 0x80)) break;
       }
       return ret;
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -191,7 +191,8 @@ var ALIASING_FUNCTION_POINTERS = 0; // Whether to allow function pointers to ali
                                     // a different type. This can greatly decrease table sizes
                                     // in asm.js, but can break code that compares function
                                     // pointers across different types.
-var EMULATED_FUNCTION_POINTERS = 0; // By default we implement function pointers using asm.js
+var EMULATED_FUNCTION_POINTERS = 0; // asm.js:
+                                    // By default we implement function pointers using asm.js
                                     // function tables, which is very fast. With this option,
                                     // we implement them more flexibly by emulating them: we
                                     // call out into JS, which handles the function tables.
@@ -205,6 +206,15 @@ var EMULATED_FUNCTION_POINTERS = 0; // By default we implement function pointers
                                     //     if the fp is in the right range. Shared modules
                                     //     (MAIN_MODULE, SIDE_MODULE) do this by default.
                                     //     This requires RELOCATABLE to be set.
+                                    // wasm:
+                                    // By default we use a wasm Table for function pointers,
+                                    // which is fast and efficient. When enabling emulation,
+                                    // we also use the Table *outside* the wasm module,
+                                    // exactly as when emulating in asm.js, just replacing
+                                    // the plain JS array with a Table. However, Tables have
+                                    // some limitations currently, like not being able to
+                                    // assign an arbitrary JS method to them, which we have
+                                    // yet to work around.
 var EMULATE_FUNCTION_POINTER_CASTS = 0; // Allows function pointers to be cast, wraps each
                                         // call of an incorrect type with a runtime correction.
                                         // This adds overhead and should not be used normally.

--- a/src/settings.js
+++ b/src/settings.js
@@ -214,7 +214,8 @@ var EMULATED_FUNCTION_POINTERS = 0; // asm.js:
                                     // the plain JS array with a Table. However, Tables have
                                     // some limitations currently, like not being able to
                                     // assign an arbitrary JS method to them, which we have
-                                    // yet to work around.
+                                    // yet to work around. Another limitation is that this
+                                    // cannot yet mix with EMULATE_FUNCTION_POINTER_CASTS.
 var EMULATE_FUNCTION_POINTER_CASTS = 0; // Allows function pointers to be cast, wraps each
                                         // call of an incorrect type with a runtime correction.
                                         // This adds overhead and should not be used normally.

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -282,7 +282,7 @@ class RunnerCore(unittest.TestCase):
     if post2: post2(filename + '.o.js')
 
   # Build JavaScript code from source code
-  def build(self, src, dirname, filename, output_processor=None, main_file=None, additional_files=[], libraries=[], includes=[], build_ll_hook=None, extra_emscripten_args=[], post_build=None):
+  def build(self, src, dirname, filename, output_processor=None, main_file=None, additional_files=[], libraries=[], includes=[], build_ll_hook=None, extra_emscripten_args=[], post_build=None, js_outfile=True):
 
     Building.pick_llvm_opts(3) # pick llvm opts here, so we include changes to Settings in the test case code
 
@@ -354,12 +354,13 @@ class RunnerCore(unittest.TestCase):
              all_files + \
              ['-o', filename + '.o.js']
       output = subprocess.check_call(args, stderr=self.stderr_redirect if not DEBUG else None)
-      assert os.path.exists(filename + '.o.js')
+      if js_outfile:
+        assert os.path.exists(filename + '.o.js')
 
     if output_processor is not None:
       output_processor(open(filename + '.o.js').read())
 
-    if self.emcc_args is not None:
+    if self.emcc_args is not None and js_outfile:
       src = open(filename + '.o.js').read()
       if self.uses_memory_init_file():
         # side memory init file, or an empty one in the js

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2489,7 +2489,7 @@ def process(filename):
       if 'asm' in out:
         self.validate_asmjs(out)
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm_backend('todo: dynamic linking')
   def test_dlfcn_data_and_fptr(self):
     if not self.can_dlfcn(): return
 
@@ -2889,7 +2889,7 @@ ok
     Settings.EXPORTED_FUNCTIONS = ['_main', '_malloc', '_free']
     self.do_run(src, '''*294,153*''', force_c=True, post_build=self.dlfcn_post_build)
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm_backend('todo: dynamic linking')
   def test_dlfcn_longjmp(self):
     if not self.can_dlfcn(): return
 
@@ -3214,7 +3214,7 @@ var Module = {
       void second();
     ''', need_reverse=False, auto_load=False)
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_funcpointers_wrapper(self):
     self.dylink_test(r'''
       #include <stdio.h>
@@ -3505,7 +3505,7 @@ var Module = {
       }
     ''', expected=['simple.\nsimple.\nsimple.\nsimple.\n'])
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm # todo
   def test_dylink_syslibs(self): # one module uses libcxx, need to force its inclusion when it isn't the main
     if not self.can_dlfcn(): return
 
@@ -3548,7 +3548,7 @@ var Module = {
     Settings.ASSERTIONS = 1
     test('', expect_pass=False, need_reverse=False)
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_iostream(self):
     try:
       os.environ['EMCC_FORCE_STDLIBS'] = 'libcxx'
@@ -3569,7 +3569,7 @@ var Module = {
     finally:
       del os.environ['EMCC_FORCE_STDLIBS']
 
-  @no_wasm # TODO: wrappers for wasm side modules
+  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_dynamic_cast(self): # issue 3465
     self.dylink_test(header=r'''
       class Base {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6136,7 +6136,7 @@ def process(filename):
 
     self.do_run_in_out_file_test('tests', 'core', 'test_tracing')
 
-  @no_wasm_backend()
+  @no_wasm # TODO: ctor evaller in binaryen
   def test_eval_ctors(self):
     if '-O2' not in str(self.emcc_args) or '-O1' in str(self.emcc_args): return self.skip('need js optimizations')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2278,6 +2278,15 @@ def process(filename):
   open(filename, 'w').write(src)
 '''
 
+  def build_dlfcn_lib(self, lib_src, dirname, filename):
+    if Settings.BINARYEN:
+      # emcc emits a wasm in this case
+      self.build(lib_src, dirname, filename, js_outfile=False)
+      shutil.move(filename + '.o.wasm', os.path.join(dirname, 'liblib.so'))
+    else:
+      self.build(lib_src, dirname, filename)
+      shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+
   def test_dlfcn_basic(self):
     if not self.can_dlfcn(): return
 
@@ -2296,8 +2305,7 @@ def process(filename):
       '''
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.cpp')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = '''
@@ -2334,8 +2342,7 @@ def process(filename):
       '''
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     Settings.EXPORTED_FUNCTIONS = ['_main']
@@ -2381,8 +2388,7 @@ def process(filename):
       Foo global;
       '''
     filename = 'liblib.cpp'
-    self.build(lib_src, self.get_dir(), filename)
-    shutil.move(filename + '.o.js', 'liblib.so')
+    self.build_dlfcn_lib(lib_src, self.get_dir(), filename)
 
     self.prep_dlfcn_main()
     src = '''
@@ -2426,8 +2432,7 @@ def process(filename):
       '''
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.cpp')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     Settings.EXPORTED_FUNCTIONS = ['_main', '_malloc']
@@ -2521,8 +2526,7 @@ def process(filename):
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.cpp')
     Settings.EXPORTED_FUNCTIONS = ['_func']
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     Settings.LINKABLE = 1
@@ -2600,8 +2604,7 @@ def process(filename):
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.cpp')
     Settings.EXPORTED_FUNCTIONS = ['_func']
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = r'''
@@ -2673,8 +2676,7 @@ def process(filename):
     Settings.EXPORTED_FUNCTIONS = ['_myfunc']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = '''
@@ -2725,8 +2727,7 @@ def process(filename):
     Settings.EXPORTED_FUNCTIONS = ['_myfunc']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = '''
@@ -2801,8 +2802,7 @@ def process(filename):
     Settings.EXPORTED_FUNCTIONS = ['_callvoid', '_callint', '_getvoid', '_getint']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = r'''
@@ -2881,8 +2881,7 @@ ok
     Settings.EXPORTED_FUNCTIONS = ['_mallocproxy', '_freeproxy']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = open(path_from_root('tests', 'dlmalloc_proxy.c')).read()
@@ -2908,8 +2907,7 @@ ok
     Settings.EXPORTED_FUNCTIONS = ['_jumpy']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.c')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = r'''
@@ -2974,8 +2972,7 @@ out!
     Settings.EXPORTED_FUNCTIONS = ['_ok', '_fail']
     dirname = self.get_dir()
     filename = os.path.join(dirname, 'liblib.cpp')
-    self.build(lib_src, dirname, filename)
-    shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
+    self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
     src = r'''
@@ -3039,21 +3036,22 @@ ok
       # side settings
       Settings.MAIN_MODULE = 0
       Settings.SIDE_MODULE = 1
+      side_suffix = 'js' if not self.is_wasm() else 'wasm'
       if type(side) == str:
         base = 'liblib.cpp' if not force_c else 'liblib.c'
-        try_delete(base + '.o.js')
-        self.build(side, self.get_dir(), base)
+        try_delete(base + '.o.' + side_suffix)
+        self.build(side, self.get_dir(), base, js_outfile=(side_suffix == 'js'))
         if force_c:
-          shutil.move(base + '.o.js', 'liblib.cpp.o.js')
+          shutil.move(base + '.o.' + side_suffix, 'liblib.cpp.o.' + side_suffix)
       else:
         # side is just a library
-        try_delete('liblib.cpp.o.js')
-        Popen([PYTHON, EMCC] + side + self.emcc_args + Settings.serialize() + ['-o', os.path.join(self.get_dir(), 'liblib.cpp.o.js')]).communicate()
+        try_delete('liblib.cpp.o.' + side_suffix)
+        Popen([PYTHON, EMCC] + side + self.emcc_args + Settings.serialize() + ['-o', os.path.join(self.get_dir(), 'liblib.cpp.o.' + side_suffix)]).communicate()
       if SPIDERMONKEY_ENGINE and os.path.exists(SPIDERMONKEY_ENGINE[0]) and not self.is_wasm():
         out = run_js('liblib.cpp.o.js', engine=SPIDERMONKEY_ENGINE, full_output=True, stderr=STDOUT)
         if 'asm' in out:
           self.validate_asmjs(out)
-      shutil.move('liblib.cpp.o.js', 'liblib.so')
+      shutil.move('liblib.cpp.o.' + side_suffix, 'liblib.so')
 
       # main settings
       Settings.MAIN_MODULE = 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2494,7 +2494,6 @@ def process(filename):
       if 'asm' in out:
         self.validate_asmjs(out)
 
-  @no_wasm_backend('todo: dynamic linking')
   def test_dlfcn_data_and_fptr(self):
     if not self.can_dlfcn(): return
 
@@ -2888,7 +2887,6 @@ ok
     Settings.EXPORTED_FUNCTIONS = ['_main', '_malloc', '_free']
     self.do_run(src, '''*294,153*''', force_c=True, post_build=self.dlfcn_post_build)
 
-  @no_wasm_backend('todo: dynamic linking')
   def test_dlfcn_longjmp(self):
     if not self.can_dlfcn(): return
 
@@ -3212,7 +3210,6 @@ var Module = {
       void second();
     ''', need_reverse=False, auto_load=False)
 
-  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_funcpointers_wrapper(self):
     self.dylink_test(r'''
       #include <stdio.h>
@@ -3546,7 +3543,6 @@ var Module = {
     Settings.ASSERTIONS = 1
     test('', expect_pass=False, need_reverse=False)
 
-  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_iostream(self):
     try:
       os.environ['EMCC_FORCE_STDLIBS'] = 'libcxx'
@@ -3567,7 +3563,6 @@ var Module = {
     finally:
       del os.environ['EMCC_FORCE_STDLIBS']
 
-  @no_wasm_backend('todo: dynamic linking')
   def test_dylink_dynamic_cast(self): # issue 3465
     self.dylink_test(header=r'''
       class Base {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2881,6 +2881,7 @@ ok
     Settings.EXPORTED_FUNCTIONS = ['_main', '_malloc', '_free']
     self.do_run(src, '''*294,153*''', force_c=True, post_build=self.dlfcn_post_build)
 
+  @no_wasm # TODO: wrappers for wasm side modules
   def test_dlfcn_longjmp(self):
     if not self.can_dlfcn(): return
 
@@ -3143,6 +3144,7 @@ var Module = {
       int sidey(voidfunc f) { if (f) f(); return 1; }
     ''', 'hello 1\n', header='typedef void (*voidfunc)();')
 
+  @no_wasm # uses function tables in an asm.js specific way
   def test_dylink_funcpointers2(self):
     self.dylink_test(r'''
       #include "header.h"
@@ -3204,6 +3206,7 @@ var Module = {
       void second();
     ''', need_reverse=False, auto_load=False)
 
+  @no_wasm # TODO: wrappers for wasm side modules
   def test_dylink_funcpointers_wrapper(self):
     self.dylink_test(r'''
       #include <stdio.h>
@@ -3226,6 +3229,7 @@ var Module = {
       extern charfunc get();
     ''')
 
+  @no_wasm # TODO: this needs to import asm2wasm helper stuff, imprecise opts might remove that need
   def test_dylink_funcpointers_float(self):
     self.dylink_test(r'''
       #include <stdio.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6056,10 +6056,11 @@ def process(filename):
       self.emcc_args += ['--closure', '1']
       self.do_run_from_file(src, expected)
 
-    print 'function pointer emulation'
-    Settings.RESERVED_FUNCTION_POINTERS = 0
-    Settings.EMULATED_FUNCTION_POINTERS = 1 # with emulation, we don't need to reserve
-    self.do_run_from_file(src, expected)
+    if not self.is_wasm(): # when emulating, we use a wasm Table, but we can't just assign a JS function to it, TODO: wrap the JS in wasm, see settings.js
+      print 'function pointer emulation'
+      Settings.RESERVED_FUNCTION_POINTERS = 0
+      Settings.EMULATED_FUNCTION_POINTERS = 1 # with emulation, we don't need to reserve
+      self.do_run_from_file(src, expected)
 
   @no_wasm_backend('requires EM_ASM args support in wasm backend')
   def test_getFuncWrapper_sig_alias(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3282,7 +3282,7 @@ var Module = {
       ''', expected=['new main\nnew side\n', 'new side\nnew main\n'])
     test()
 
-    if Settings.ASSERTIONS == 1:
+    if Settings.ASSERTIONS == 1 and not self.is_wasm(): # TODO: this in wasm
       print 'check warnings'
       Settings.ASSERTIONS = 2
       test()
@@ -3408,6 +3408,7 @@ var Module = {
       }
     ''', expected=['hello through side\n'])
 
+  @no_wasm # TODO: this needs to import asm2wasm helper stuff, imprecise opts might remove that need
   def test_dylink_jslib(self):
     open('lib.js', 'w').write(r'''
       mergeInto(LibraryManager.library, {
@@ -3496,6 +3497,7 @@ var Module = {
       }
     ''', expected=['simple.\nsimple.\nsimple.\nsimple.\n'])
 
+  @no_wasm # TODO: wrappers for wasm side modules
   def test_dylink_syslibs(self): # one module uses libcxx, need to force its inclusion when it isn't the main
     if not self.can_dlfcn(): return
 
@@ -3538,6 +3540,7 @@ var Module = {
     Settings.ASSERTIONS = 1
     test('', expect_pass=False, need_reverse=False)
 
+  @no_wasm # TODO: wrappers for wasm side modules
   def test_dylink_iostream(self):
     try:
       os.environ['EMCC_FORCE_STDLIBS'] = 'libcxx'
@@ -3558,6 +3561,7 @@ var Module = {
     finally:
       del os.environ['EMCC_FORCE_STDLIBS']
 
+  @no_wasm # TODO: wrappers for wasm side modules
   def test_dylink_dynamic_cast(self): # issue 3465
     self.dylink_test(header=r'''
       class Base {
@@ -3606,6 +3610,7 @@ var Module = {
       }
     ''', expected=['starting main\nBase\nDerived\nOK'])
 
+  @no_wasm # TODO
   def test_dylink_hyper_dupe(self):
     if not self.can_dlfcn(): return
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -204,6 +204,7 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
     # extra coverages
     for emulate_casts in [0, 1]:
       for emulate_fps in [0, 1, 2]:
+        if self.is_wasm() and emulate_casts and emulate_fps: continue # in wasm we can't do both
         print emulate_casts, emulate_fps
         Settings.EMULATE_FUNCTION_POINTER_CASTS = emulate_casts
         Settings.EMULATED_FUNCTION_POINTERS = emulate_fps

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7010,20 +7010,22 @@ int main() {
     open('src.cpp', 'w').write(r'''
       #include <stdio.h>
       struct A {
-        A() { printf("constructing A!\n"); }
+        A() { puts("constructing A!"); }
       };
       A a;
       struct B {
-        B() { printf("constructing B!\n"); }
+        B() { puts("constructing B!"); }
       };
       B b;
       int main() {}
     ''')
     subprocess.check_call([PYTHON, EMCC, 'src.cpp'])
     correct = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE)
-    subprocess.check_call([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=1'])
-    seen = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE)
-    assert correct == seen, correct + '\n vs \n' + seen
+    for args in [[], ['-s', 'RELOCATABLE=1'], ['-s', 'MAIN_MODULE=1']]:
+      print args
+      subprocess.check_call([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=1', '-o', 'b.out.js'] + args)
+      seen = run_js('b.out.js', engine=SPIDERMONKEY_ENGINE)
+      assert correct == seen, correct + '\n vs \n' + seen
 
   def test_wasm_targets(self):
     for f in ['a.wasm', 'a.wast']:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7004,6 +7004,27 @@ int main() {
           else:
             assert parts[6] == str(expect_max)
 
+  def test_binaryen_ctors(self):
+    if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey')
+    # ctor order must be identical to js builds, deterministically
+    open('src.cpp', 'w').write(r'''
+      #include <stdio.h>
+      struct A {
+        A() { printf("constructing A!\n"); }
+      };
+      A a;
+      struct B {
+        B() { printf("constructing B!\n"); }
+      };
+      B b;
+      int main() {}
+    ''')
+    subprocess.check_call([PYTHON, EMCC, 'src.cpp'])
+    correct = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE)
+    subprocess.check_call([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=1'])
+    seen = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE)
+    assert correct == seen, correct + '\n vs \n' + seen
+
   def test_wasm_targets(self):
     for f in ['a.wasm', 'a.wast']:
       process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', f], stdout=PIPE, stderr=PIPE)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6879,12 +6879,12 @@ int main() {
             (['-O2'], False, True),
             (['-O2', '--js-opts', '1'], True, False), # user asked
             (['-O2', '-s', 'EMTERPRETIFY=1'], True, False), # option forced
-            (['-O2', '-s', 'EVAL_CTORS=1'], False, False), # ctor evaller uses js opts, but is not a js opt, and doesn't force other js opts
+            (['-O2', '-s', 'EVAL_CTORS=1'], False, True), # ctor evaller turned off since only-wasm
             (['-O2', '-s', 'OUTLINING_LIMIT=1000'], True, False), # option forced
             (['-O2', '-s', "BINARYEN_METHOD='interpret-s-expr,asmjs'"], True, False), # asmjs in methods means we need good asm.js
             (['-O3'], False, True),
             (['-Os'], False, True),
-            (['-Oz'], False, False), # even though we run ctor evaller, don't run js opts, but we can't only-wasm due to ctor-evaller running js opts internally
+            (['-Oz'], False, True), # ctor evaller turned off since only-wasm
           ]:
           for option in ['BINARYEN', 'WASM']: # the two should be identical
             try_delete('a.out.js')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7033,7 +7033,16 @@ int main() {
       out, err = process.communicate()
       print err
       assert process.returncode is not 0, 'wasm suffix is an error'
-      self.assertContained('''output file "%s" has a wasm suffix, but we cannot emit wasm by itself''' % f, err)
+      self.assertContained('''output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library''' % f, err)
+    # side modules do allow a wasm target
+    for opts, target in [([], 'a.out.wasm'), (['-o', 'lib.wasm'], 'lib.wasm')]:
+      # specified target
+      print target
+      self.clear()
+      subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-s', 'SIDE_MODULE=1'] + opts)
+      assert 'dylink' in open(target).read()
+      for x in os.listdir('.'):
+        assert not x.endswith('.js'), 'we should not emit js when making a wasm side module'
 
   def test_check_engine(self):
     compiler_engine = COMPILER_ENGINE

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_21'
+TAG = 'version_22'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2235,7 +2235,7 @@ class WebAssembly:
     mem_size = int(m.group(1))
     m = re.search("Module\['wasmTableSize'\] = (\d+);", js)
     table_size = int(m.group(1))
-    logging.debug('creating .wso with mem size %d, table size %d' % (mem_size, table_size))
+    logging.debug('creating wasm dynamic library with mem size %d, table size %d' % (mem_size, table_size))
     wso = js_file + '.wso'
     # write the binary
     wasm = open(wasm_file, 'rb').read()


### PR DESCRIPTION
This together with a binaryen and fastcomp PRs implements dynamic linking in wasm. See

https://github.com/kripken/emscripten-fastcomp/pull/162
https://github.com/WebAssembly/binaryen/pull/859

This emscripten PR does 4 main things:

 * implement the dynamic library loader, see runtime.js,
 * create a dynamic library, see shared.py
 * support for wasm side modules, which are our dynamic libraries. this is a bunch of small changes to emscripten.py etc., needed since they are just wasms, so they must create their own stack, handle metadata from the backend differently (e.g. turn aliases into more exports), etc., and also this is a mode where we don't need to emit JS which required some small changes too.
 * update and refactor linking tests
