### PR TITLE
Fix broken symlink

### DIFF
--- a/system/include/libc/bits
+++ b/system/include/libc/bits
@@ -1,1 +1,1 @@
-../arch/emscripten/bits
+../../lib/libc/musl/arch/emscripten/bits


### PR DESCRIPTION
When working with another project that required Emscripten, I noticed that the build was failing due to a broken symoblic link (see commit). I had to manually fix the link to point to the "bits" directory that is supplied with Emscripten.

I'm not sure how/why this symlink is broken as it seems the place it's pointing has never existed - but just in case this is not somehow intended functionality (perhaps the local system is supposed to fulfil the symlink at compile time or something?) I've provided a fix here.