### PR TITLE
validate_binaryen_method

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2008,6 +2008,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           print jsrun.run_js(shared.path_from_root('tools', 'js-optimizer.js'), shared.NODE_JS, args=[asm_target, 'eliminateDeadGlobals', 'last', 'asm'], stdout=open(temp, 'w'))
           shutil.move(temp, asm_target)
 
+      if shared.Settings.BINARYEN_METHOD:
+        methods = shared.Settings.BINARYEN_METHOD.split(',')
+        valid_methods = ['asmjs', 'native-wasm', 'interpret-s-expr', 'interpret-binary', 'interpret-asm2wasm']
+        for m in methods:
+          if not m.strip() in valid_methods:
+            logging.error('Unrecognized BINARYEN_METHOD "' + m.strip() + '" specified! Please pass a comma-delimited list containing one or more of: ' + ','.join(valid_methods))
+            sys.exit(1)
+
       if shared.Settings.BINARYEN:
         logging.debug('using binaryen, with method: ' + shared.Settings.BINARYEN_METHOD)
         binaryen_bin = os.path.join(shared.Settings.BINARYEN_ROOT, 'bin')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7012,6 +7012,11 @@ int main() {
     subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'TOTAL_MEMORY=' + str(16*1024*1024), '--pre-js', 'pre.js', '-s', 'ALLOW_MEMORY_GROWTH=1'])
     self.assertContained('hello, world!', run_js('a.out.js', engine=SPIDERMONKEY_ENGINE))
 
+  def test_binaryen_invalid_method(self):
+    proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', "BINARYEN_METHOD='invalid'"])
+    proc.communicate()
+    assert proc.returncode != 0
+
   def test_binaryen_default_method(self):
     if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey')
     subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'])


### PR DESCRIPTION
Explicitly reject -s BINARYEN_METHOD='someinvalidoption' modes that aren't recognized.