### PR TITLE
llvm_ar_no_preserve_timestamps

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1496,7 +1496,7 @@ class Building:
             dirname = os.path.dirname(content)
             if dirname:
               safe_ensure_dirs(dirname)
-          Popen([LLVM_AR, 'xo', f], stdout=PIPE).communicate() # if absolute paths, files will appear there. otherwise, in this directory
+          Popen([LLVM_AR, 'x', f], stdout=PIPE).communicate() # if absolute paths, files will appear there. otherwise, in this directory
           contents = map(lambda content: os.path.join(temp_dir, content), contents)
           contents = filter(os.path.exists, map(os.path.abspath, contents))
           contents = filter(Building.is_bitcode, contents)


### PR DESCRIPTION
Remove 'o' option (preserve created file timestamps) when running llvm-ar to extract archive files, because of an LLVM bug that causes it to fail on FAT32 filesystems (https://llvm.org/bugs/show_bug.cgi?id=31389), and since the code path in question does not need the timestamps.