### PR TITLE
Fix typo in gl2ext.h

### DIFF
--- a/system/include/GLES2/gl2ext.h
+++ b/system/include/GLES2/gl2ext.h
@@ -674,7 +674,7 @@ GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleIMG (GLenum, GLsizei
 GL_APICALL void GL_APIENTRY glFramebufferTexture2DMultisampleIMG (GLenum, GLenum, GLenum, GLuint, GLint, GLsizei);
 #endif
 typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLEIMG) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLCLIPPLANEXIMG) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
+typedef void (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEIMG) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
 #endif
 
 /*------------------------------------------------------------------------*


### PR DESCRIPTION
There is a wrong definition in gl2ext.h (line 677). It should be a function type declaration for glFramebufferTexture2DMultisampleIMG (with parameters GLenum, GLenum, GLenum, GLuint, GLint, GLsizei), but there is a declaration of some unrelated function type.