### PR TITLE
Fix the pwrite64 system call.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -271,3 +271,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vladimir Davidovich <thy.ringo@gmail.com>
 * Christophe Gragnic <cgragnic@netc.fr>
 * Murphy McCauley <murphy.mccauley@gmail.com>
+* Anatoly Trosinenko <anatoly.trosinenko@gmail.com>

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -838,11 +838,8 @@ var SyscallsLibrary = {
     return FS.read(stream, {{{ heapAndOffset('HEAP8', 'buf') }}}, count, offset);
   },
   __syscall181: function(which, varargs) { // pwrite64
-#if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
-#endif
     var stream = SYSCALLS.getStreamFromFD(), buf = SYSCALLS.get(), count = SYSCALLS.get(), zero = SYSCALLS.getZero(), offset = SYSCALLS.get64();
-    return FS.write(stream, {{{ heapAndOffset('HEAP8', 'buf') }}}, nbyte, offset);
+    return FS.write(stream, {{{ heapAndOffset('HEAP8', 'buf') }}}, count, offset);
   },
   __syscall183: function(which, varargs) { // getcwd
     var buf = SYSCALLS.get(), size = SYSCALLS.get();

--- a/tests/unistd/io.c
+++ b/tests/unistd/io.c
@@ -156,6 +156,16 @@ int main() {
   printf("errno: %d\n\n", errno);
   errno = 0;
 
+  printf("pwrite to the middle of file: %d\n", pwrite(f, writeBuffer + 2, 3, 17));
+  printf("errno: %d\n", errno);
+  printf("seek: %d\n\n", lseek(f, 0, SEEK_CUR));
+  errno = 0;
+
+  printf("pwrite past end of file: %d\n", pwrite(f, writeBuffer, 5, 32));
+  printf("errno: %d\n", errno);
+  printf("seek: %d\n\n", lseek(f, 0, SEEK_CUR));
+  errno = 0;
+
   int bytesRead;
   printf("seek: %d\n", lseek(f, 0, SEEK_SET));
   printf("read after write: %d\n", bytesRead = read(f, readBuffer, sizeof readBuffer));

--- a/tests/unistd/io.out
+++ b/tests/unistd/io.out
@@ -66,7 +66,15 @@ seek: 23
 write after end of file: 8
 errno: 0
 
-seek: 0
-read after write: 31
+pwrite to the middle of file: 3
 errno: 0
-final: wri4567890wri\0\0\0\0\0\0\0\0\0\0writeme\0
+seek: 31
+
+pwrite past end of file: 5
+errno: 0
+seek: 31
+
+seek: 0
+read after write: 37
+errno: 0
+final: wri4567890wri\0\0\0\0ite\0\0\0writeme\0\0write


### PR DESCRIPTION
Fixes #4837. An Emscripten implementation of the `pwrite64` system call is untested and references the wrong variable. This pull request fixes crash when this syscall is invoked and adds some tests.

The `test_unistd_io` passes.
There were 100 random tests run and all of them passed:
* asm1.test_simd7
* asm2f.test_pack
* asm3.test_cases
* asm2g.test_reinterpreted_ptrs
* asm3.test_bad_typeid
* asm2g.test_stdbool
* asm2i.test_sizeof
* asm2nn.test_simd_float64x2
* asm2f.test_stack_overflow
* asm2nn.test_sse4_1_full
* asm2.test_vprintf
* asm2nn.test_i64_cmp
* asm2i.test_sscanf_n
* asm2nn.test_asmjs_unknown_emscripten
* asm2nn.test_sscanf
* asm3.test_align64
* asm2f.test_mainenv
* asm3.test_sscanf_n
* asm3.test_mathfuncptr
* asm1.test_simd_int32x4
* asm2.test_i64_2
* asm2.test_em_asm_unused_arguments
* asm2nn.test_exceptions_uncaught_2
* asm2.test_dlfcn_mallocs
* asm2g.test_i64_llabs
* asm2g.test_dylink_printfs
* default.test_fs_mmap
* asm2nn.test_openjpeg
* asm2f.test_sscanf_3
* asm2f.test_isdigit_l
* asm3.test_errar
* asm1.test_embind_2
* asm2nn.test_iswdigit
* asm1.test_negative_zero
* asm1.test_exceptions_convert
* asm3.test_simd16
* asm2.test_strtoll_dec
* asm2f.test_structs
* asm2nn.test_llvm_used
* asm1.test_iswdigit
* asm2g.test_python
* asm2.test_printf_float
* asm2f.test_exceptions_libcxx
* asm2i.test_openjpeg
* asm2i.test_fgetc_unsigned
* asm2g.test_strtod
* default.test_ssr
* asm2g.test_getgep
* asm3.test_math
* asm2.test_phiundef
* asm2.test_funcptr
* asm2.test_exceptions
* asm2f.test_dlfcn_i64
* asm3.test_lua
* asm1.test_libcextra
* asm2nn.test_simd3
* default.test_isdigit_l
* default.test_em_asm_parameter_pack
* asm2f.test_newstruct
* asm2nn.test_isnan
* asm2i.test_closebitcasts
* asm2g.test_math_lgamma
* asm2nn.test_atomic_cxx
* asm2.test_mmap_file
* asm2g.test_pack
* asm2nn.test_assert
* asm1.test_sscanf_4
* asm2i.test_align64
* asm1.test_dylink_jslib
* asm2i.test_mmap
* asm1.test_alloca_stack
* asm2g.test_memmove3
* asm2f.test_intentional_fault
* asm3.test_raytrace
* asm2f.test_polymorph
* asm2g.test_exceptions_convert
* default.test_fs_base
* asm2.test_dlfcn_i64
* asm1.test_bad_typeid
* asm2f.test_exceptions_uncaught
* asm2f.test_zlib
* asm2i.test_uname
* default.test_sbrk
* default.test_literal_negative_zero
* default.test_dylink_global_init
* asm2nn.test_exit_status
* asm2f.test_stat
* asm2.test_unistd_dup
* asm3.test_bitfields
* asm2f.test_stdbool
* asm1.test_stack_overflow_check
* default.test_dylink_global_inits
* asm2nn.test_binaryen
* asm3.test_dead_functions
* asm3.test_dlfcn_longjmp
* asm3.test_strptime_reentrant
* asm2.test_double_i64_conversion
* asm2.test_emptyclass
* asm2f.test_statvfs
* asm2i.test_simd4
