### PR TITLE
Fix bug in wasm table size calculation

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -710,8 +710,12 @@ function _emscripten_asm_const_%s(%s) {
 
     if settings['BINARYEN']:
       def table_size(table):
-        s = table.count(',')
-        return s + 1 if s > 0 else 0
+        t = table[table.index('[') + 1: table.index(']')].split(',')
+        size = len(t)
+        if size == 1:
+          # Could be empty or 1-element
+          return 0 if len(t[0]) == 0 else size
+        return size
       table_total_size = sum(map(table_size, last_forwarded_json['Functions']['tables'].values()))
       asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
       if not settings['EMULATED_FUNCTION_POINTERS']:

--- a/emscripten.py
+++ b/emscripten.py
@@ -710,12 +710,11 @@ function _emscripten_asm_const_%s(%s) {
 
     if settings['BINARYEN']:
       def table_size(table):
-        t = table[table.index('[') + 1: table.index(']')].split(',')
-        size = len(t)
-        if size == 1:
-          # Could be empty or 1-element
-          return 0 if len(t[0]) == 0 else size
-        return size
+        table_contents = table[table.index('[') + 1: table.index(']')]
+        if len(table_contents) == 0: # empty table
+          return 0
+        return table_contents.count(',') + 1
+
       table_total_size = sum(map(table_size, last_forwarded_json['Functions']['tables'].values()))
       asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
       if not settings['EMULATED_FUNCTION_POINTERS']:

--- a/emscripten.py
+++ b/emscripten.py
@@ -709,10 +709,13 @@ function _emscripten_asm_const_%s(%s) {
       asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
 
     if settings['BINARYEN']:
-      table_size = sum(map(lambda table: table.count(',') + 1, last_forwarded_json['Functions']['tables'].values()))
-      asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_size
+      def table_size(table):
+        s = table.count(',')
+        return s + 1 if s > 0 else 0
+      table_total_size = sum(map(table_size, last_forwarded_json['Functions']['tables'].values()))
+      asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
       if not settings['EMULATED_FUNCTION_POINTERS']:
-        asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_size
+        asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size
 
     # See if we need ASYNCIFY functions
     # We might not need them even if ASYNCIFY is enabled


### PR DESCRIPTION
When mapping split/homogenous tables to the single wasm table, the size
counting code didn't handle empty tables. These only occur with `-s
RELOCATABLE=1`, which results in an additional 'X' signature (which has
all the functions) and empty tables for the other signatures.

This resulted in `Module['wasmTableSize']` (which feeds into the size of
the `WebAssembly.Table` object) not matching the initial size of the table
import declaration in the wasm module. Currently V8 has a
limitation that it throws a LinkError in this case, while SM is happy
with it. In any case, since this mismatch is not intentional, it should
be fixed.