### PR TITLE
Ban V8 from dylib tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2259,6 +2259,7 @@ The current type of b is: 9
   def can_dlfcn(self):
     if Settings.ALLOW_MEMORY_GROWTH == 1: return self.skip('no dlfcn with memory growth yet')
     if self.is_wasm_backend(): return self.skip('no shared modules in wasm backend')
+    self.banned_js_engines = [V8_ENGINE, NODE_JS] # V8 doesn't support mismatch between table import decl initial size and imported table runtime size
     return True
 
   def prep_dlfcn_lib(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2259,7 +2259,10 @@ The current type of b is: 9
   def can_dlfcn(self):
     if Settings.ALLOW_MEMORY_GROWTH == 1: return self.skip('no dlfcn with memory growth yet')
     if self.is_wasm_backend(): return self.skip('no shared modules in wasm backend')
-    self.banned_js_engines = [V8_ENGINE, NODE_JS] # V8 doesn't support mismatch between table import decl initial size and imported table runtime size
+    # V8 doesn't support mismatch between table import decl initial size and imported table runtime size.
+    # See https://bugs.chromium.org/p/v8/issues/detail?id=5795
+    if self.is_wasm():
+      self.banned_js_engines = [V8_ENGINE, NODE_JS]
     return True
 
   def prep_dlfcn_lib(self):


### PR DESCRIPTION
V8 currently doesn't support cases where the module's table import
declaration's initial size doesn't match the size of the actual imported
table at instantiation time. This is required for loading dynamic
libraries, so don't run those tests with V8 until it's
fixed. (Relatedly, v8 doesn't support grow_table yet either).