### PR TITLE
Add leading underscore to implemented functions in wasm_backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1503,7 +1503,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
     elif line.startswith('  (func '):
       parts = line.split()
       func_name = parts[1][1:]
-      metadata['implementedFunctions'].append(func_name)
+      metadata['implementedFunctions'].append('_' + func_name)
     elif line.startswith('  (export '):
       parts = line.split()
       export_name = parts[1][1:-1]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1495,7 +1495,6 @@ int main() {
 
     self.do_run_in_out_file_test('tests', 'core', 'test_set_align')
 
-  @no_wasm_backend('printf is incorrectly handling float values')
   def test_emscripten_api(self):
       check = '''
 def process(filename):
@@ -5258,7 +5257,6 @@ return malloc(size);
     return self.get_library('freetype',
                             os.path.join('objs', '.libs', 'libfreetype.a'))
 
-  @no_wasm_backend()
   def test_freetype(self):
     if WINDOWS: return self.skip('test_freetype uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
     assert 'asm2g' in test_modes
@@ -5402,7 +5400,6 @@ def process(filename):
         assert old.count('tempBigInt') > new.count('tempBigInt')
 
   @sync
-  @no_wasm_backend()
   def test_poppler(self):
     if WINDOWS: return self.skip('test_poppler depends on freetype, which uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
 


### PR DESCRIPTION
This caused a fun bug where if your C code used `lround`, then `lround` is implemented in terms of `round`, which is imported from JS. Because we were trimming the leading character that *wasn't* an underscore, we thought the module already implemented `round`, and didn't actually import it, which caused the module to fail to instantiate.

Depends on #4813 to fix the printf formatting for `test_emscripten_api`.