### PR TITLE
Add keys for EQUALS and MINUS for GLFW for other browsers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,3 +269,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vilibald Wanča <vilibald@wvi.cz>
 * Alex Hixon <alex@alexhixon.com>
 * Vladimir Davidovich <thy.ringo@gmail.com>
+* Brad Grantham <grantham@plunk.org>

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -135,10 +135,9 @@ var LibraryGLFW = {
         case 0xDE:return 39; // DOM_VK_QUOTE -> GLFW_KEY_APOSTROPHE
         case 0xBC:return 44; // DOM_VK_COMMA -> GLFW_KEY_COMMA
         case 0xAD:return 45; // DOM_VK_HYPHEN_MINUS -> GLFW_KEY_MINUS
+        case 0xBD:return 45; // DOM_VK_MINUS -> GLFW_KEY_MINUS
         case 0xBE:return 46; // DOM_VK_PERIOD -> GLFW_KEY_PERIOD
         case 0xBF:return 47; // DOM_VK_SLASH -> GLFW_KEY_SLASH
-        case 0xBD:return 45; // Opera, IE, Safari, Chrome DOM_VK_MINUS -> GLFW_KEY_MINUS
-        case 0xBB:return 61; // Opera, IE, Safari, Chrome DOM_VK_EQUALS -> GLFW_KEY_EQUAL
         case 0x30:return 48; // DOM_VK_0 -> GLFW_KEY_0
         case 0x31:return 49; // DOM_VK_1 -> GLFW_KEY_1
         case 0x32:return 50; // DOM_VK_2 -> GLFW_KEY_2
@@ -150,7 +149,8 @@ var LibraryGLFW = {
         case 0x38:return 56; // DOM_VK_8 -> GLFW_KEY_8
         case 0x39:return 57; // DOM_VK_9 -> GLFW_KEY_9
         case 0x3B:return 59; // DOM_VK_SEMICOLON -> GLFW_KEY_SEMICOLON
-        case 0x61:return 61; // DOM_VK_EQUALS -> GLFW_KEY_EQUAL
+        case 0x3D:return 61; // DOM_VK_EQUALS -> GLFW_KEY_EQUAL
+        case 0xBB:return 61; // DOM_VK_EQUALS -> GLFW_KEY_EQUAL
         case 0x41:return 65; // DOM_VK_A -> GLFW_KEY_A
         case 0x42:return 66; // DOM_VK_B -> GLFW_KEY_B
         case 0x43:return 67; // DOM_VK_C -> GLFW_KEY_C

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -137,6 +137,8 @@ var LibraryGLFW = {
         case 0xAD:return 45; // DOM_VK_HYPHEN_MINUS -> GLFW_KEY_MINUS
         case 0xBE:return 46; // DOM_VK_PERIOD -> GLFW_KEY_PERIOD
         case 0xBF:return 47; // DOM_VK_SLASH -> GLFW_KEY_SLASH
+        case 0xBD:return 45; // Opera, IE, Safari, Chrome DOM_VK_MINUS -> GLFW_KEY_MINUS
+        case 0xBB:return 61; // Opera, IE, Safari, Chrome DOM_VK_EQUALS -> GLFW_KEY_EQUAL
         case 0x30:return 48; // DOM_VK_0 -> GLFW_KEY_0
         case 0x31:return 49; // DOM_VK_1 -> GLFW_KEY_1
         case 0x32:return 50; // DOM_VK_2 -> GLFW_KEY_2


### PR DESCRIPTION
Fixes https://github.com/kripken/emscripten/issues/4843

Add two keycodes for MINUS and EQUALS on at least MacOS Chrome.  Reported by http://www.javascripter.net/faq/keycodes.htm to be the correct keycodes for Chrome, IE, and Opera.