### PR TITLE
Avoid using a temp file when separating asm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2060,10 +2060,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Separate out the asm.js code, if asked. Or, if necessary for another option
       if (separate_asm or shared.Settings.BINARYEN) and not shared.Settings.WASM_BACKEND:
         logging.debug('separating asm')
-        with misc_temp_files.get_file(suffix='.js') as temp_target:
-          subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), js_target, asm_target, temp_target])
-          generated_text_files_with_native_eols += [asm_target]
-          shutil.move(temp_target, js_target)
+        subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), js_target, asm_target, js_target])
+        generated_text_files_with_native_eols += [asm_target]
 
         # extra only-my-code logic
         if shared.Settings.ONLY_MY_CODE:


### PR DESCRIPTION
We don't need one anyhow, and if we use one then it can have the wrong permissions as seen in #4858.