### PR TITLE
Wasm async compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1287,6 +1287,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Building.is_wasm_only() and shared.Settings.EVAL_CTORS:
           logging.debug('disabling EVAL_CTORS, as in wasm-only mode it hurts more than it helps. TODO: a wasm version of it')
           shared.Settings.EVAL_CTORS = 0
+        # enable async compilation if optimizing and not turned off manually
+        if opt_level > 0:
+          if 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
+            shared.Settings.BINARYEN_ASYNC_COMPILATION = 1
+        # async compilation requires a swappable module - we swap it in when it's ready
+        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
+          shared.Settings.SWAPPABLE_ASM_MODULE = 1
 
       # wasm outputs are only possible with a side wasm
       if target.endswith(WASM_ENDINGS):

--- a/emcc.py
+++ b/emcc.py
@@ -1291,9 +1291,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if opt_level > 0:
           if 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
             shared.Settings.BINARYEN_ASYNC_COMPILATION = 1
-        # async compilation requires a swappable module - we swap it in when it's ready
         if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
-          shared.Settings.SWAPPABLE_ASM_MODULE = 1
+          if shared.Building.is_wasm_only():
+            # async compilation requires a swappable module - we swap it in when it's ready
+            shared.Settings.SWAPPABLE_ASM_MODULE = 1
+          else:
+            # if not wasm-only, we can't do async compilation as the build can run in other
+            # modes than wasm (like asm.js) which may not support an async step
+            shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
+            if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
+              logging.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled since not in wasm-only mode')
 
       # wasm outputs are only possible with a side wasm
       if target.endswith(WASM_ENDINGS):

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2200,6 +2200,21 @@ function integrateWasmJS(Module) {
     };
     info['global.Math'] = global.Math;
     info['env'] = env;
+    function receiveInstance(instance) {
+      exports = instance.exports;
+      if (exports.memory) mergeMemory(exports.memory);
+      Module["usingWasm"] = true;
+    }
+#if BINARYEN_ASYNC_COMPILATION
+    Module['printErr']('asynchronously preparing wasm');
+    addRunDependency('wasm-instantiate');
+    WebAssembly.instantiate(getBinary(), info).then(function(output) {
+      receiveInstance(output.instance);
+      Module['asm'] = exports;
+      removeRunDependency('wasm-instantiate');
+    });
+    return {}; // no exports yet; we'll fill them in later
+#endif
     var instance;
     try {
       instance = new WebAssembly.Instance(new WebAssembly.Module(getBinary()), info)
@@ -2210,11 +2225,7 @@ function integrateWasmJS(Module) {
       }
       return false;
     }
-    exports = instance.exports;
-    if (exports.memory) mergeMemory(exports.memory);
-
-    Module["usingWasm"] = true;
-
+    receiveInstance(instance);
     return exports;
   }
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2200,6 +2200,8 @@ function integrateWasmJS(Module) {
     };
     info['global.Math'] = global.Math;
     info['env'] = env;
+    // handle a generated wasm instance, receiving its exports and
+    // performing other necessary setup
     function receiveInstance(instance) {
       exports = instance.exports;
       if (exports.memory) mergeMemory(exports.memory);
@@ -2207,10 +2209,10 @@ function integrateWasmJS(Module) {
     }
 #if BINARYEN_ASYNC_COMPILATION
     Module['printErr']('asynchronously preparing wasm');
-    addRunDependency('wasm-instantiate');
+    addRunDependency('wasm-instantiate'); // we can't run yet
     WebAssembly.instantiate(getBinary(), info).then(function(output) {
       receiveInstance(output.instance);
-      Module['asm'] = exports;
+      Module['asm'] = exports; // swap in the exports so they can be called
       removeRunDependency('wasm-instantiate');
     });
     return {}; // no exports yet; we'll fill them in later

--- a/src/settings.js
+++ b/src/settings.js
@@ -687,6 +687,9 @@ var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the bina
 var BINARYEN_MEM_MAX = -1; // Set the maximum size of memory in the wasm module (in bytes).
                            // Without this, TOTAL_MEMORY is used (as it is used for the initial value),
                            // or if memory growth is enabled, no limit is set. This overrides both of those.
+var BINARYEN_ASYNC_COMPILATION = 0; // Whether to compile the wasm asynchronously, which is more
+                                    // efficient. This is off by default in unoptimized builds and
+                                    // on by default in optimized ones.
 var BINARYEN_ROOT = ""; // Directory where we can find Binaryen. Will be automatically set for you,
                         // but you can set it to override if you are a Binaryen developer.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -582,10 +582,11 @@ var FINALIZE_ASM_JS = 1; // If 1, will finalize the final emitted code, includin
                          // that prevent later js optimizer passes from running, like
                          // converting +5 into 5.0 (the js optimizer sees 5.0 as just 5).
 
-var SWAPPABLE_ASM_MODULE = 0; // If 1, then all exports from the asm.js module will be accessed
-                              // indirectly, which allow the asm module to be swapped later.
-                              // Note: It is very important to build the two modules that
-                              // are to be swapped with the same optimizations and so forth,
+var SWAPPABLE_ASM_MODULE = 0; // If 1, then all exports from the asm/wasm module will be accessed
+                              // indirectly, which allow the module to be swapped later,
+                              // simply by replacing Module['asm'].
+                              // Note: It is very important that the replacement module be
+                              // built with the same optimizations and so forth,
                               // as we depend on them being a drop-in replacement for each
                               // other (same globals on the heap at the same locations, etc.)
 

--- a/tests/binaryen_async.c
+++ b/tests/binaryen_async.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+#include <emscripten.h>
+
+int main() {
+  printf("hello, world!\n");
+  int result = EM_ASM_INT_V({
+    return Module.sawAsyncCompilation | 0;
+  });
+  REPORT_RESULT();
+  return 0;
+}
+

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3307,6 +3307,7 @@ window.close = function() {
       (['-O3'], 1),
       (['-s', 'BINARYEN_ASYNC_COMPILATION=1'], 1), # force it on
       (['-O1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'], 0), # force it off
+      (['-s', 'BINARYEN_ASYNC_COMPILATION=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'], 0), # try to force it on, but have it disabled
     ]:
       print opts, expect
       self.btest('binaryen_async.c', expected=str(expect), args=['-s', 'BINARYEN=1', '--shell-file', 'shell.html'] + opts)


### PR DESCRIPTION
This builds on #4859 (and must wait for it to land) to implement async compilation using `WebAssembly.instantiate`. As discussed in [the design repo](https://github.com/WebAssembly/design/issues/838), this is enabled by default in all recommended compilation modes (everything but `-O0`, and it can be manually flipped off but no one should do that).

As also discussed in the design repo, this works around the problems with doing async compilation (see details there) by wrapping the exports in an indirection layer. We already had one lying around, `SWAPPABLE_ASM_MODULE`, so this PR reuses that. Basically, all calls to exports call `Module.asm.*`, so that the `asm` part can be replaced. Here we start with nothing, and replace it with the compiled module when it arrives. This adds overhead when calling exports, but the hope is that it isn't too bad.

@juj, the tests here require that bots have wasm enabled in the browser test suite, let me know if that's ok.