### PR TITLE
WIP: Enable LLVM 4.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,6 +269,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vilibald Wanča <vilibald@wvi.cz>
 * Alex Hixon <alex@alexhixon.com>
 * Vladimir Davidovich <thy.ringo@gmail.com>
+* Dylan McKay <dylanmckay34@gmail.com>
 * Christophe Gragnic <cgragnic@netc.fr>
 * Murphy McCauley <murphy.mccauley@gmail.com>
 * Anatoly Trosinenko <anatoly.trosinenko@gmail.com>

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -320,7 +320,7 @@ EM_BUILD_VERBOSE_LEVEL = int(os.getenv('EM_BUILD_VERBOSE')) if os.getenv('EM_BUI
 
 # Expectations
 
-EXPECTED_LLVM_VERSION = (3, 9)
+EXPECTED_LLVM_VERSION = (4, 0)
 
 actual_clang_version = None
 


### PR DESCRIPTION
Part of a series of PRs

* kripken/emscripten-fastcomp#165
* kripken/emscripten-fastcomp-clang#13

Test suite still needs to be run locally.