### PR TITLE
Make anonymous mmap return page-aligned addresses

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -10,7 +10,7 @@
   "realloc": ["malloc", "free"],
   "getlogin": ["malloc"],
   "tmpnam": ["malloc"],
-  "mmap": ["malloc"],
+  "mmap": ["memalign"],
   "realpath": ["malloc"],
   "strerror": ["malloc"],
   "__ctype_b_loc": ["malloc"],

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -866,7 +866,7 @@ var SyscallsLibrary = {
     var ptr;
     var allocated = false;
     if (fd === -1) {
-      ptr = _memalign(4096, len);
+      ptr = _memalign(PAGE_SIZE, len);
       if (!ptr) return -ERRNO_CODES.ENOMEM;
       _memset(ptr, 0, len);
       allocated = true;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -866,7 +866,7 @@ var SyscallsLibrary = {
     var ptr;
     var allocated = false;
     if (fd === -1) {
-      ptr = _malloc(len);
+      ptr = _memalign(4096, len);
       if (!ptr) return -ERRNO_CODES.ENOMEM;
       _memset(ptr, 0, len);
       allocated = true;

--- a/tests/core/test_mmap.c
+++ b/tests/core/test_mmap.c
@@ -1,14 +1,19 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <assert.h>
+#include <unistd.h>
 
 int main(int argc, char* argv[]) {
+  // Alignment check for mmap below should be consistent with the reported page size
+  // For now, just require it to be 4096
+  assert(getpagesize() == 4096);
+  assert(sysconf(_SC_PAGESIZE) == 4096);
+
   for (int i = 0; i < 10; i++) {
     int* map = (int*)mmap(0, 5000, PROT_READ | PROT_WRITE,
                           MAP_SHARED | MAP_ANON, -1, 0);
-    /* TODO: Should we align to 4k?
+    assert(map != MAP_FAILED);
     assert(((int)map) % 4096 == 0); // aligned
-    */
     assert(munmap(map, 5000) == 0);
   }
 


### PR DESCRIPTION
Fixes #4835.

An obsolete `memalign` function was used instead of `posix_memalign`,
since it passes pointer to the allocated memory as a return value and
do not require us to pass `void **ptr` from the JS library code.

In theory, pointers returned by `memalign` (but not `posix_memalign`)
may be non `free()`-able, but particular implementation from dlmalloc
is documented as having minor differences from `posix_memalign` and there
is already a test that mmaps some memory and then unmaps it.

This patch was tested by `./tests/runner.py random500`.