### PR TITLE
parallel_llvm_nm

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -36,7 +36,7 @@ class Cache:
 
   def acquire_cache_lock(self):
     if not self.EM_EXCLUSIVE_CACHE_ACCESS:
-      logging.debug('Cache: acquiring multiprocess file lock to Emscripten cache')
+      logging.debug('Cache: PID %s acquiring multiprocess file lock to Emscripten cache' % str(os.getpid()))
       try:
         self.filelock.acquire(60)
       except filelock.Timeout:
@@ -54,7 +54,7 @@ class Cache:
       if self.prev_EM_EXCLUSIVE_CACHE_ACCESS: os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = self.prev_EM_EXCLUSIVE_CACHE_ACCESS
       else: del os.environ['EM_EXCLUSIVE_CACHE_ACCESS']
       self.filelock.release()
-      logging.debug('Cache: released multiprocess file lock to Emscripten cache')
+      logging.debug('Cache: PID %s released multiprocess file lock to Emscripten cache' % str(os.getpid()))
 
   def ensure(self):
     self.acquire_cache_lock()

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -247,16 +247,8 @@ EMSCRIPTEN_FUNCS();
     if len(chunks) > 1 and cores >= 2:
       # We can parallelize
       if DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks, using %d cores  (total: %.2f MB)' % (len(chunks), cores, total_size/(1024*1024.))
-      pool = multiprocessing.Pool(processes=cores)
+      pool = shared.Building.get_multiprocessing_pool()
       filenames = pool.map(run_on_chunk, commands, chunksize=1)
-      try:
-        # Shut down the pool, since otherwise processes are left alive and would only be lazily terminated,
-        # and in other parts of the toolchain we also build up multiprocessing pools.
-        pool.terminate()
-        pool.join()
-      except Exception, e:
-        # On Windows we get occassional "Access is denied" errors when attempting to tear down the pool, ignore these.
-        logging.debug('Attempting to tear down multiprocessing pool failed with an exception: ' + str(e))
     else:
       # We can't parallize, but still break into chunks to avoid uglify/node memory issues
       if len(chunks) > 1 and DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks' % (len(chunks))

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -447,16 +447,9 @@ EMSCRIPTEN_FUNCS();
       if len(chunks) > 1 and cores >= 2:
         # We can parallelize
         if DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks, using %d cores  (total: %.2f MB)' % (len(chunks), cores, total_size/(1024*1024.))
-        pool = multiprocessing.Pool(processes=cores)
-        filenames = pool.map(run_on_chunk, commands, chunksize=1)
-        try:
-          # Shut down the pool, since otherwise processes are left alive and would only be lazily terminated,
-          # and in other parts of the toolchain we also build up multiprocessing pools.
-          pool.terminate()
-          pool.join()
-        except Exception, e:
-          # On Windows we get occassional "Access is denied" errors when attempting to tear down the pool, ignore these.
-          logging.debug('Attempting to tear down multiprocessing pool failed with an exception: ' + str(e))
+        with ToolchainProfiler.profile_block('optimizer_pool'):
+          pool = shared.Building.get_multiprocessing_pool()
+          filenames = pool.map(run_on_chunk, commands, chunksize=1)
       else:
         # We can't parallize, but still break into chunks to avoid uglify/node memory issues
         if len(chunks) > 1 and DEBUG: print >> sys.stderr, 'splitting up js optimization into %d chunks' % (len(chunks))

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -23,7 +23,7 @@ def run_commands(commands):
     for command in commands:
       call_process(command)
   else:
-    pool = multiprocessing.Pool(processes=cores)
+    pool = shared.Building.get_multiprocessing_pool()
     # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool, https://bugs.python.org/issue8296
     pool.map_async(call_process, commands, chunksize=1).get(maxint)
 
@@ -301,7 +301,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       add_back_deps(need) # recurse to get deps of deps
 
   # Scan symbols
-  symbolses = map(lambda temp_file: shared.Building.llvm_nm(temp_file), temp_files)
+  symbolses = shared.Building.parallel_llvm_nm(map(os.path.abspath, temp_files))
 
   if len(symbolses) == 0:
     class Dummy:


### PR DESCRIPTION
Centralize the use of multiple multiprocessing pools into one to speed up costly pool startup and teardown, and to avoid overallocating pools. Parallelize the reading of linker input files for faster link performance.

(will need testing on Windows before merge, because Windows multiprocessing spawn rules in Python are very different. This was authored on a Linux system)