### PR TITLE
robust_is_bitcode_check

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1940,7 +1940,7 @@ class Building:
     try:
       if Building._is_ar_cache.get(filename):
         return Building._is_ar_cache[filename]
-      b = open(filename, 'r').read(8)
+      b = open(filename, 'rb').read(8)
       sigcheck = b[0] == '!' and b[1] == '<' and \
                  b[2] == 'a' and b[3] == 'r' and \
                  b[4] == 'c' and b[5] == 'h' and \
@@ -1954,7 +1954,8 @@ class Building:
   @staticmethod
   def is_bitcode(filename):
     # look for magic signature
-    b = open(filename, 'r').read(4)
+    b = open(filename, 'rb').read(4)
+    if len(b) < 4: return False
     if b[0] == 'B' and b[1] == 'C':
       return True
     # look for ar signature
@@ -1962,7 +1963,7 @@ class Building:
       return True
     # on OS X, there is a 20-byte prefix
     elif ord(b[0]) == 222 and ord(b[1]) == 192 and ord(b[2]) == 23 and ord(b[3]) == 11:
-      b = open(filename, 'r').read(24)
+      b = open(filename, 'rb').read(24)
       return b[20] == 'B' and b[21] == 'C'
 
     return False


### PR DESCRIPTION
For good form, open archive and object files in binary mode, and be sure to return false if is_bitcode() is run on zero length files.