### PR TITLE
fix binaryen setup: if we don't find binaryen on the local system, se…

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -226,7 +226,7 @@ else:
     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
     llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
-    binaryen_root = os.path.dirname(find_executable('asm2wasm') or '/usr/bin/asm2wasm')
+    binaryen_root = os.path.dirname(find_executable('asm2wasm') or '') # if we don't find it, we'll use the port
     config_file = config_file.replace('\'{{{ BINARYEN_ROOT }}}\'', repr(binaryen_root))
 
     node = find_executable('nodejs') or find_executable('node') or 'node'


### PR DESCRIPTION
…t it to nothing, so that we use the port automatically. fixes regression from 0c77c773.

I suspect this went unnoticed til now because it only happens when not using the SDK (which provides binaryen).