### PR TITLE
no_dyncall_garbage

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -478,7 +478,7 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #if FETCH_DEBUG
     console.log('fetch: operation success. e: ' + e);
 #endif
-    if (onsuccess && Runtime.dynCall) Runtime.dynCall('vi', onsuccess, [fetch]);
+    if (onsuccess && Runtime.dynCall) Module['dynCall_vi'](onsuccess, fetch);
     else if (successcb) successcb(fetch);
   };
 
@@ -497,12 +497,12 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #endif
     };
     __emscripten_fetch_cache_data(Fetch.dbInstance, fetch, xhr.response, storeSuccess, storeError);
-    if (onsuccess && Runtime.dynCall) Runtime.dynCall('vi', onsuccess, [fetch]);
+    if (onsuccess && Runtime.dynCall) Module['dynCall_vi'](onsuccess, fetch);
     else if (successcb) successcb(fetch);
   };
 
   var reportProgress = function(fetch, xhr, e) {
-    if (onprogress && Runtime.dynCall) Runtime.dynCall('vi', onprogress, [fetch]);      
+    if (onprogress && Runtime.dynCall) Module['dynCall_vi'](onprogress, fetch);
     else if (progresscb) progresscb(fetch);
   };
 
@@ -510,7 +510,7 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #if FETCH_DEBUG
     console.error('fetch: operation failed: ' + e);
 #endif
-    if (onerror && Runtime.dynCall) Runtime.dynCall('vi', onerror, [fetch]);
+    if (onerror && Runtime.dynCall) Module['dynCall_vi'](onerror, fetch);
     else if (errorcb) errorcb(fetch);
   };
 

--- a/src/library.js
+++ b/src/library.js
@@ -1092,10 +1092,10 @@ LibraryManager.library = {
       if (info.refcount === 0 && !info.rethrown) {
         if (info.destructor) {
 #if WASM_BACKEND == 0
-          Runtime.dynCall('vi', info.destructor, [ptr]);
+          Module['dynCall_vi'](info.destructor, ptr);
 #else
           // In Wasm, destructors return 'this' as in ARM
-          Runtime.dynCall('ii', info.destructor, [ptr]);
+          Module['dynCall_ii'](info.destructor, ptr);
 #endif
         }
         delete EXCEPTIONS.infos[ptr];
@@ -4192,7 +4192,7 @@ LibraryManager.library = {
     var trace = _emscripten_get_callstack_js();
     var parts = trace.split('\n');
     for (var i = 0; i < parts.length; i++) {
-      var ret = Runtime.dynCall('iii', [0, arg]);
+      var ret = Module['dynCall_iii'](func, 0, arg);
       if (ret !== 0) return;
     }
   },

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -746,7 +746,7 @@ var LibraryBrowser = {
     function doCallback(callback) {
       if (callback) {
         var stack = Runtime.stackSave();
-        Runtime.dynCall('vi', callback, [allocate(intArrayFromString(_file), 'i8', ALLOC_STACK)]);
+        Module['dynCall_vi'](callback, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK));
         Runtime.stackRestore(stack);
       }
     }
@@ -778,10 +778,10 @@ var LibraryBrowser = {
     Browser.asyncLoad(Pointer_stringify(url), function(byteArray) {
       var buffer = _malloc(byteArray.length);
       HEAPU8.set(byteArray, buffer);
-      Runtime.dynCall('viii', onload, [arg, buffer, byteArray.length]);
+      Module['dynCall_viii'](onload, arg, buffer, byteArray.length);
       _free(buffer);
     }, function() {
-      if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+      if (onerror) Module['dynCall_vi'](onerror, arg);
     }, true /* no need for run dependency, this is async but will not do any prepare etc. step */ );
   },
 
@@ -816,11 +816,11 @@ var LibraryBrowser = {
         FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(http.response), true, true, false);
         if (onload) {
           var stack = Runtime.stackSave();
-          Runtime.dynCall('viii', onload, [handle, arg, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK)]);
+          Module['dynCall_viii'](onload, handle, arg, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK));
           Runtime.stackRestore(stack);
         }
       } else {
-        if (onerror) Runtime.dynCall('viii', onerror, [handle, arg, http.status]);
+        if (onerror) Module['dynCall_viii'](onerror, handle, arg, http.status);
       }
 
       delete Browser.wgetRequests[handle];
@@ -828,7 +828,7 @@ var LibraryBrowser = {
 
     // ERROR
     http.onerror = function http_onerror(e) {
-      if (onerror) Runtime.dynCall('viii', onerror, [handle, arg, http.status]);
+      if (onerror) Module['dynCall_viii'](onerror, handle, arg, http.status);
       delete Browser.wgetRequests[handle];
     };
 
@@ -836,7 +836,7 @@ var LibraryBrowser = {
     http.onprogress = function http_onprogress(e) {
       if (e.lengthComputable || (e.lengthComputable === undefined && e.total != 0)) {
         var percentComplete = (e.loaded / e.total)*100;
-        if (onprogress) Runtime.dynCall('viii', onprogress, [handle, arg, percentComplete]);
+        if (onprogress) Module['dynCall_viii'](onprogress, handle, arg, percentComplete);
       }
     };
 
@@ -881,10 +881,10 @@ var LibraryBrowser = {
         var byteArray = new Uint8Array(http.response);
         var buffer = _malloc(byteArray.length);
         HEAPU8.set(byteArray, buffer);
-        if (onload) Runtime.dynCall('viiii', onload, [handle, arg, buffer, byteArray.length]);
+        if (onload) Module['dynCall_viiii'](onload, handle, arg, buffer, byteArray.length);
         if (free) _free(buffer);
       } else {
-        if (onerror) Runtime.dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
+        if (onerror) Module['dynCall_viiii'](onerror, handle, arg, http.status, http.statusText);
       }
       delete Browser.wgetRequests[handle];
     };
@@ -892,14 +892,14 @@ var LibraryBrowser = {
     // ERROR
     http.onerror = function http_onerror(e) {
       if (onerror) {
-        Runtime.dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
+        Module['dynCall_viiii'](onerror, handle, arg, http.status, http.statusText);
       }
       delete Browser.wgetRequests[handle];
     };
 
     // PROGRESS
     http.onprogress = function http_onprogress(e) {
-      if (onprogress) Runtime.dynCall('viiii', onprogress, [handle, arg, e.loaded, e.lengthComputable || e.lengthComputable === undefined ? e.total : 0]);
+      if (onprogress) Module['dynCall_viiii'](onprogress, handle, arg, e.loaded, e.lengthComputable || e.lengthComputable === undefined ? e.total : 0);
     };
 
     // ABORT
@@ -945,10 +945,10 @@ var LibraryBrowser = {
       PATH.basename(_file),
       new Uint8Array(data.object.contents), true, true,
       function() {
-        if (onload) Runtime.dynCall('vi', onload, [file]);
+        if (onload) Module['dynCall_vi'](onload, file);
       },
       function() {
-        if (onerror) Runtime.dynCall('vi', onerror, [file]);
+        if (onerror) Module['dynCall_vi'](onerror, file);
       },
       true // don'tCreateFile - it's already there
     );
@@ -970,10 +970,10 @@ var LibraryBrowser = {
       {{{ makeHEAPView('U8', 'data', 'data + size') }}},
       true, true,
       function() {
-        if (onload) Runtime.dynCall('vii', onload, [arg, cname]);
+        if (onload) Module['dynCall_vii'](onload, arg, cname);
       },
       function() {
-        if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+        if (onerror) Module['dynCall_vi'](onerror, arg);
       },
       true // don'tCreateFile - it's already there
     );
@@ -1076,13 +1076,12 @@ var LibraryBrowser = {
 
     var browserIterationFunc;
     if (typeof arg !== 'undefined') {
-      var argArray = [arg];
       browserIterationFunc = function() {
-        Runtime.dynCall('vi', func, argArray);
+        Module['dynCall_vi'](func, arg);
       };
     } else {
       browserIterationFunc = function() {
-        Runtime.dynCall('v', func);
+        Module['dynCall_v'](func);
       };
     }
 
@@ -1197,14 +1196,14 @@ var LibraryBrowser = {
 
   _emscripten_push_main_loop_blocker: function(func, arg, name) {
     Browser.mainLoop.queue.push({ func: function() {
-      Runtime.dynCall('vi', func, [arg]);
+      Module['dynCall_vi'](func, arg);
     }, name: Pointer_stringify(name), counted: true });
     Browser.mainLoop.updateStatus();
   },
 
   _emscripten_push_uncounted_main_loop_blocker: function(func, arg, name) {
     Browser.mainLoop.queue.push({ func: function() {
-      Runtime.dynCall('vi', func, [arg]);
+      Module['dynCall_vi'](func, arg);
     }, name: Pointer_stringify(name), counted: false });
     Browser.mainLoop.updateStatus();
   },

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -349,11 +349,11 @@ var LibraryGLFW = {
       if (charCode == 0 || (charCode >= 0x00 && charCode <= 0x1F)) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.charFunc, [charCode, 1]);
+      Module['dynCall_vii'](GLFW.active.charFunc, charCode, 1);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('vii', GLFW.active.charFunc, [GLFW.active.id, charCode]);
+      Module['dynCall_vii'](GLFW.active.charFunc, GLFW.active.id, charCode);
 #endif
     },
 
@@ -370,12 +370,12 @@ var LibraryGLFW = {
       if (!GLFW.active.keyFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.keyFunc, [key, status]);
+      Module['dynCall_vii'](GLFW.active.keyFunc, key, status);
 #endif
 
 #if USE_GLFW == 3
       if (repeat) status = 2; // GLFW_REPEAT
-      Runtime.dynCall('viiiii', GLFW.active.keyFunc, [GLFW.active.id, key, event.keyCode, status, GLFW.getModBits(GLFW.active)]);
+      Module['dynCall_viiiii'](GLFW.active.keyFunc, GLFW.active.id, key, event.keyCode, status, GLFW.getModBits(GLFW.active));
 #endif
     },
 
@@ -402,11 +402,11 @@ var LibraryGLFW = {
       if (event.target != Module["canvas"] || !GLFW.active.cursorPosFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.cursorPosFunc, [Browser.mouseX, Browser.mouseY]);
+      Module['dynCall_vii'](GLFW.active.cursorPosFunc, Browser.mouseX, Browser.mouseY);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('vidd', GLFW.active.cursorPosFunc, [GLFW.active.id, Browser.mouseX, Browser.mouseY]);
+      Module['dynCall_vidd'](GLFW.active.cursorPosFunc, GLFW.active.id, Browser.mouseX, Browser.mouseY);
 #endif
     },
 
@@ -430,7 +430,7 @@ var LibraryGLFW = {
       if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
 
 #if USE_GLFW == 3
-      Runtime.dynCall('vii', GLFW.active.cursorEnterFunc, [GLFW.active.id, 1]);
+      Module['dynCall_vii'](GLFW.active.cursorEnterFunc, GLFW.active.id, 1);
 #endif
     },
 
@@ -440,7 +440,7 @@ var LibraryGLFW = {
       if (event.target != Module["canvas"] || !GLFW.active.cursorEnterFunc) return;
 
 #if USE_GLFW == 3
-      Runtime.dynCall('vii', GLFW.active.cursorEnterFunc, [GLFW.active.id, 0]);
+      Module['dynCall_vii'](GLFW.active.cursorEnterFunc, GLFW.active.id, 0);
 #endif
     },
 
@@ -465,11 +465,11 @@ var LibraryGLFW = {
       if (!GLFW.active.mouseButtonFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.mouseButtonFunc, [eventButton, status]);
+      Module['dynCall_vii'](GLFW.active.mouseButtonFunc, eventButton, status);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viiii', GLFW.active.mouseButtonFunc, [GLFW.active.id, eventButton, status, GLFW.getModBits(GLFW.active)]);
+      Module['dynCall_viiii'](GLFW.active.mouseButtonFunc, GLFW.active.id, eventButton, status, GLFW.getModBits(GLFW.active));
 #endif
     },
 
@@ -492,7 +492,7 @@ var LibraryGLFW = {
       if (!GLFW.active || !GLFW.active.scrollFunc || event.target != Module['canvas']) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vi', GLFW.active.scrollFunc, [GLFW.wheelPos]);
+      Module['dynCall_vi'](GLFW.active.scrollFunc, GLFW.wheelPos);
 #endif
 
 #if USE_GLFW == 3
@@ -506,7 +506,7 @@ var LibraryGLFW = {
         sy = event.deltaY;
       }
 
-      Runtime.dynCall('vidd', GLFW.active.scrollFunc, [GLFW.active.id, sx, sy]);
+      Module['dynCall_vidd'](GLFW.active.scrollFunc, GLFW.active.id, sx, sy);
 #endif
 
       event.preventDefault();
@@ -561,11 +561,11 @@ var LibraryGLFW = {
       if (!GLFW.active.windowSizeFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', GLFW.active.windowSizeFunc, [GLFW.active.width, GLFW.active.height]);
+      Module['dynCall_vii'](GLFW.active.windowSizeFunc, GLFW.active.width, GLFW.active.height);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viii', GLFW.active.windowSizeFunc, [GLFW.active.id, GLFW.active.width, GLFW.active.height]);
+      Module['dynCall_viii'](GLFW.active.windowSizeFunc, GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
     },
 
@@ -575,7 +575,7 @@ var LibraryGLFW = {
       if (!GLFW.active.framebufferSizeFunc) return;
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viii', GLFW.active.framebufferSizeFunc, [GLFW.active.id, GLFW.active.width, GLFW.active.height]);
+      Module['dynCall_viii'](GLFW.active.framebufferSizeFunc, GLFW.active.id, GLFW.active.width, GLFW.active.height);
 #endif
     },
 
@@ -669,7 +669,7 @@ var LibraryGLFW = {
       // function returns.
       // GLFW3 on the over hand doesn't have this behavior (https://github.com/glfw/glfw/issues/62).
       if (!win.windowSizeFunc) return;
-      Runtime.dynCall('vii', win.windowSizeFunc, [win.width, win.height]);
+      Module['dynCall_vii'](win.windowSizeFunc, win.width, win.height);
 #endif
     },
 
@@ -815,11 +815,11 @@ var LibraryGLFW = {
       if (!win.windowSizeFunc) return;
 
 #if USE_GLFW == 2
-      Runtime.dynCall('vii', win.windowSizeFunc, [width, height]);
+      Module['dynCall_vii'](win.windowSizeFunc, width, height);
 #endif
 
 #if USE_GLFW == 3
-      Runtime.dynCall('viii', win.windowSizeFunc, [win.id, width, height]);
+      Module['dynCall_viii'](win.windowSizeFunc, win.id, width, height);
 #endif
     },
 
@@ -875,7 +875,7 @@ var LibraryGLFW = {
 
 #if USE_GLFW == 3
       if (win.windowCloseFunc)
-        Runtime.dynCall('vi', win.windowCloseFunc, [win.id]);
+        Module['dynCall_vi'](win.windowCloseFunc, win.id);
 #endif
 
       GLFW.windows[win.id - 1] = null;

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -50,11 +50,11 @@ var LibraryGLUT = {
       if (GLUT.buttons == 0 && event.target == Module["canvas"] && GLUT.passiveMotionFunc) {
         event.preventDefault();
         GLUT.saveModifiers(event);
-        Runtime.dynCall('vii', GLUT.passiveMotionFunc, [lastX, lastY]);
+        Module['dynCall_vii'](GLUT.passiveMotionFunc, lastX, lastY);
       } else if (GLUT.buttons != 0 && GLUT.motionFunc) {
         event.preventDefault();
         GLUT.saveModifiers(event);
-        Runtime.dynCall('vii', GLUT.motionFunc, [lastX, lastY]);
+        Module['dynCall_vii'](GLUT.motionFunc, lastX, lastY);
       }
     },
 
@@ -162,7 +162,7 @@ var LibraryGLUT = {
           if( GLUT.specialFunc ) {
             event.preventDefault();
             GLUT.saveModifiers(event);
-            Runtime.dynCall('viii', GLUT.specialFunc, [key, Browser.mouseX, Browser.mouseY]);
+            Module['dynCall_viii'](GLUT.specialFunc, key, Browser.mouseX, Browser.mouseY);
           }
         }
         else
@@ -171,7 +171,7 @@ var LibraryGLUT = {
           if( key !== null && GLUT.keyboardFunc ) {
             event.preventDefault();
             GLUT.saveModifiers(event);
-            Runtime.dynCall('viii', GLUT.keyboardFunc, [key, Browser.mouseX, Browser.mouseY]);
+            Module['dynCall_viii'](GLUT.keyboardFunc, key, Browser.mouseX, Browser.mouseY);
           }
         }
       }
@@ -184,7 +184,7 @@ var LibraryGLUT = {
           if(GLUT.specialUpFunc) {
             event.preventDefault ();
             GLUT.saveModifiers(event);
-            Runtime.dynCall('viii', GLUT.specialUpFunc, [key, Browser.mouseX, Browser.mouseY]);
+            Module['dynCall_viii'](GLUT.specialUpFunc, key, Browser.mouseX, Browser.mouseY);
           }
         }
         else
@@ -193,7 +193,7 @@ var LibraryGLUT = {
           if( key !== null && GLUT.keyboardUpFunc ) {
             event.preventDefault ();
             GLUT.saveModifiers(event);
-            Runtime.dynCall('viii', GLUT.keyboardUpFunc, [key, Browser.mouseX, Browser.mouseY]);
+            Module['dynCall_viii'](GLUT.keyboardUpFunc, key, Browser.mouseX, Browser.mouseY);
           }
         }
       }
@@ -236,7 +236,7 @@ var LibraryGLUT = {
         } catch (e) {}
         event.preventDefault();
         GLUT.saveModifiers(event);
-        Runtime.dynCall('viiii', GLUT.mouseFunc, [event['button'], 0/*GLUT_DOWN*/, Browser.mouseX, Browser.mouseY]);
+        Module['dynCall_viiii'](GLUT.mouseFunc, event['button'], 0/*GLUT_DOWN*/, Browser.mouseX, Browser.mouseY);
       }
     },
 
@@ -248,7 +248,7 @@ var LibraryGLUT = {
       if (GLUT.mouseFunc) {
         event.preventDefault();
         GLUT.saveModifiers(event);
-        Runtime.dynCall('viiii', GLUT.mouseFunc, [event['button'], 1/*GLUT_UP*/, Browser.mouseX, Browser.mouseY]);
+        Module['dynCall_viiii'](GLUT.mouseFunc, event['button'], 1/*GLUT_UP*/, Browser.mouseX, Browser.mouseY);
       }
     },
 
@@ -269,7 +269,7 @@ var LibraryGLUT = {
       if (GLUT.mouseFunc) {
         event.preventDefault();
         GLUT.saveModifiers(event);
-        Runtime.dynCall('viiii', GLUT.mouseFunc, [button, 0/*GLUT_DOWN*/, Browser.mouseX, Browser.mouseY]);
+        Module['dynCall_viiii'](GLUT.mouseFunc, button, 0/*GLUT_DOWN*/, Browser.mouseX, Browser.mouseY);
       }
     },
 
@@ -293,7 +293,7 @@ var LibraryGLUT = {
       /* Can't call _glutReshapeWindow as that requests cancelling fullscreen. */
       if (GLUT.reshapeFunc) {
         // console.log("GLUT.reshapeFunc (from FS): " + width + ", " + height);
-        Runtime.dynCall('vii', GLUT.reshapeFunc, [width, height]);
+        Module['dynCall_vii'](GLUT.reshapeFunc, width, height);
       }
       _glutPostRedisplay();
     },
@@ -363,7 +363,7 @@ var LibraryGLUT = {
 
     Browser.resizeListeners.push(function(width, height) {
       if (GLUT.reshapeFunc) {
-      	Runtime.dynCall('vii', GLUT.reshapeFunc, [width, height]);
+        Module['dynCall_vii'](GLUT.reshapeFunc, width, height);
       }
     });
 
@@ -431,7 +431,7 @@ var LibraryGLUT = {
   glutIdleFunc: function(func) {
     function callback() {
       if (GLUT.idleFunc) {
-        Runtime.dynCall('v', GLUT.idleFunc);
+        Module['dynCall_v'](GLUT.idleFunc);
         Browser.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
       }
     }
@@ -442,7 +442,7 @@ var LibraryGLUT = {
   },
 
   glutTimerFunc: function(msec, func, value) {
-    Browser.safeSetTimeout(function() { Runtime.dynCall('vi', func, [value]); }, msec);
+    Browser.safeSetTimeout(function() { Module['dynCall_vi'](func, value); }, msec);
   },
 
   glutDisplayFunc: function(func) {
@@ -579,7 +579,7 @@ var LibraryGLUT = {
     GLUT.exitFullscreen();
     Browser.setCanvasSize(width, height);
     if (GLUT.reshapeFunc) {
-      Runtime.dynCall('vii', GLUT.reshapeFunc, [width, height]);
+      Module['dynCall_vii'](GLUT.reshapeFunc, width, height);
     }
     _glutPostRedisplay();
   },
@@ -615,7 +615,7 @@ var LibraryGLUT = {
       Browser.requestAnimationFrame(function() {
         GLUT.requestedAnimationFrame = false;
         Browser.mainLoop.runIter(function() {
-          Runtime.dynCall('v', GLUT.displayFunc);
+          Module['dynCall_v'](GLUT.displayFunc);
         });
       });
     }

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -197,7 +197,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.keyEvent', C_STRUCTS.EmscriptenKeyboardEvent.charCode, 'e.charCode', 'i32') }}};
         {{{ makeSetValue('JSEvents.keyEvent', C_STRUCTS.EmscriptenKeyboardEvent.keyCode, 'e.keyCode', 'i32') }}};
         {{{ makeSetValue('JSEvents.keyEvent', C_STRUCTS.EmscriptenKeyboardEvent.which, 'e.which', 'i32') }}};
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.keyEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.keyEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -265,7 +265,7 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
         JSEvents.fillMouseEventData(JSEvents.mouseEvent, e, target);
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.mouseEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.mouseEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -297,7 +297,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaY, 'e["deltaY"]', 'double') }}};
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaZ, 'e["deltaZ"]', 'double') }}};
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaMode, 'e["deltaMode"]', 'i32') }}};
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.wheelEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.wheelEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -310,7 +310,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaY, '-(e["wheelDeltaY"] ? e["wheelDeltaY"] : e["wheelDelta"]) /* 1. Invert to unify direction with the DOM Level 3 wheel event. 2. MSIE does not provide wheelDeltaY, so wheelDelta is used as a fallback. */', 'double') }}};
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaZ, '0 /* Not available */', 'double') }}};
         {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaMode, '0 /* DOM_DELTA_PIXEL */', 'i32') }}};
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.wheelEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.wheelEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -367,7 +367,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.uiEvent', C_STRUCTS.EmscriptenUiEvent.windowOuterHeight, 'window.outerHeight', 'i32') }}};
         {{{ makeSetValue('JSEvents.uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollTop, 'scrollPos[0]', 'i32') }}};
         {{{ makeSetValue('JSEvents.uiEvent', C_STRUCTS.EmscriptenUiEvent.scrollLeft, 'scrollPos[1]', 'i32') }}};
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.uiEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.uiEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -402,7 +402,7 @@ var LibraryJSEvents = {
         var id = e.target.id ? e.target.id : '';
         stringToUTF8(nodeName, JSEvents.focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.nodeName }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
         stringToUTF8(id, JSEvents.focusEvent + {{{ C_STRUCTS.EmscriptenFocusEvent.id }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.focusEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.focusEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -437,7 +437,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.deviceOrientationEvent', C_STRUCTS.EmscriptenDeviceOrientationEvent.gamma, 'e.gamma', 'double') }}};
         {{{ makeSetValue('JSEvents.deviceOrientationEvent', C_STRUCTS.EmscriptenDeviceOrientationEvent.absolute, 'e.absolute', 'i32') }}};
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.deviceOrientationEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.deviceOrientationEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -472,7 +472,7 @@ var LibraryJSEvents = {
         {{{ makeSetValue('JSEvents.deviceMotionEvent', C_STRUCTS.EmscriptenDeviceMotionEvent.rotationRateBeta, 'e.rotationRate.beta', 'double') }}};
         {{{ makeSetValue('JSEvents.deviceMotionEvent', C_STRUCTS.EmscriptenDeviceMotionEvent.rotationRateGamma, 'e.rotationRate.gamma', 'double') }}};
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.deviceMotionEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.deviceMotionEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -524,7 +524,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillOrientationChangeEventData(JSEvents.orientationChangeEvent, e);
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.orientationChangeEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.orientationChangeEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -586,7 +586,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillFullscreenChangeEventData(JSEvents.fullscreenChangeEvent, e);
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.fullscreenChangeEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.fullscreenChangeEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -683,7 +683,7 @@ var LibraryJSEvents = {
       }
 
       if (strategy.canvasResizedCallback) {
-        Runtime.dynCall('iiii', strategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData]);
+        Module['dynCall_iiii'](strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
       }
 
       return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
@@ -715,7 +715,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillPointerlockChangeEventData(JSEvents.pointerlockChangeEvent, e);
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.pointerlockChangeEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.pointerlockChangeEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -742,7 +742,7 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, 0, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -804,7 +804,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillVisibilityChangeEventData(JSEvents.visibilityChangeEvent, e);
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.visibilityChangeEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.visibilityChangeEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -884,7 +884,7 @@ var LibraryJSEvents = {
         }
         {{{ makeSetValue('JSEvents.touchEvent', C_STRUCTS.EmscriptenTouchEvent.numTouches, 'numTouches', 'i32') }}};
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.touchEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.touchEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -940,7 +940,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillGamepadEventData(JSEvents.gamepadEvent, e.gamepad);
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.gamepadEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.gamepadEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -961,7 +961,7 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
 
-        var confirmationMessage = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);
+        var confirmationMessage = Module['dynCall_iiii'](callbackfunc, eventTypeId, 0, userData);
         
         if (confirmationMessage) {
           confirmationMessage = Pointer_stringify(confirmationMessage);
@@ -1003,7 +1003,7 @@ var LibraryJSEvents = {
 
         JSEvents.fillBatteryEventData(JSEvents.batteryEvent, JSEvents.battery());
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.batteryEvent, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, JSEvents.batteryEvent, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -1027,7 +1027,7 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
 
-        var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);
+        var shouldCancel = Module['dynCall_iiii'](callbackfunc, eventTypeId, 0, userData);
         if (shouldCancel) {
           e.preventDefault();
         }
@@ -1311,7 +1311,7 @@ var LibraryJSEvents = {
         if (canvas.GLctxObject) canvas.GLctxObject.GLctx.viewport(0, 0, oldWidth, oldHeight);
 
         if (__currentFullscreenStrategy.canvasResizedCallback) {
-          Runtime.dynCall('iiii', __currentFullscreenStrategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData]);
+          Module['dynCall_iiii'](__currentFullscreenStrategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData);
         }
       }
     }
@@ -1422,7 +1422,7 @@ var LibraryJSEvents = {
     }
 
     if (!inCenteredWithoutScalingFullscreenMode && __currentFullscreenStrategy.canvasResizedCallback) {
-      Runtime.dynCall('iiii', __currentFullscreenStrategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData]);
+      Module['dynCall_iiii'](__currentFullscreenStrategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData);
     }
   },
 
@@ -1508,7 +1508,7 @@ var LibraryJSEvents = {
       __restoreHiddenElements(hiddenElements);
       window.removeEventListener('resize', __softFullscreenResizeWebGLRenderTarget);
       if (strategy.canvasResizedCallback) {
-        Runtime.dynCall('iiii', strategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData]);
+        Module['dynCall_iiii'](strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
       }
     }
     __restoreOldWindowedStyle = restoreWindowedState;
@@ -1517,7 +1517,7 @@ var LibraryJSEvents = {
 
     // Inform the caller that the canvas size has changed.
     if (strategy.canvasResizedCallback) {
-      Runtime.dynCall('iiii', strategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData]);
+      Module['dynCall_iiii'](strategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, strategy.canvasResizedCallbackUserData);
     }
 
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
@@ -1550,7 +1550,7 @@ var LibraryJSEvents = {
     }
 
     if (__currentFullscreenStrategy.canvasResizedCallback) {
-      Runtime.dynCall('iiii', __currentFullscreenStrategy.canvasResizedCallback, [{{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData]);
+      Module['dynCall_iiii'](__currentFullscreenStrategy.canvasResizedCallback, {{{ cDefine('EMSCRIPTEN_EVENT_CANVASRESIZED') }}}, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData);
     }
 
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};

--- a/src/library_idbstore.js
+++ b/src/library_idbstore.js
@@ -11,12 +11,12 @@ var LibraryIDBStore = {
   emscripten_idb_async_load: function(db, id, arg, onload, onerror) {
     IDBStore.getFile(Pointer_stringify(db), Pointer_stringify(id), function(error, byteArray) {
       if (error) {
-        if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+        if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
       }
       var buffer = _malloc(byteArray.length);
       HEAPU8.set(byteArray, buffer);
-      Runtime.dynCall('viii', onload, [arg, buffer, byteArray.length]);
+      Module['dynCall_viii'](onload, arg, buffer, byteArray.length);
       _free(buffer);
     });
   },
@@ -24,28 +24,28 @@ var LibraryIDBStore = {
     // note that we copy the data here, as these are async operatins - changes to HEAPU8 meanwhile should not affect us!
     IDBStore.setFile(Pointer_stringify(db), Pointer_stringify(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), function(error) {
       if (error) {
-        if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+        if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
       }
-      if (onstore) Runtime.dynCall('vi', onstore, [arg]);
+      if (onstore) Module['dynCall_vi'](onstore, arg);
     });
   },
   emscripten_idb_async_delete: function(db, id, arg, ondelete, onerror) {
     IDBStore.deleteFile(Pointer_stringify(db), Pointer_stringify(id), function(error) {
       if (error) {
-        if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+        if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
       }
-      if (ondelete) Runtime.dynCall('vi', ondelete, [arg]);
+      if (ondelete) Module['dynCall_vi'](ondelete, arg);
     });
   },
   emscripten_idb_async_exists: function(db, id, arg, oncheck, onerror) {
     IDBStore.existsFile(Pointer_stringify(db), Pointer_stringify(id), function(error, exists) {
       if (error) {
-        if (onerror) Runtime.dynCall('vi', onerror, [arg]);
+        if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
       }
-      if (oncheck) Runtime.dynCall('vii', oncheck, [arg, exists]);
+      if (oncheck) Module['dynCall_vii'](oncheck, arg, exists);
     });
   },
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -868,7 +868,7 @@ var LibraryPThread = {
         __ATEXIT__.push(function() { PThread.runExitHandlers(); });
       }
     }
-    PThread.exitHandlers.push(function() { Runtime.dynCall('vi', routine, [arg]) });
+    PThread.exitHandlers.push(function() { Module['dynCall_vi'](routine, arg) });
   },
 
   pthread_cleanup_pop: function(execute) {

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -113,7 +113,7 @@ var LibraryPThreadStub = {
   pthread_once: function(ptr, func) {
     if (!_pthread_once.seen) _pthread_once.seen = {};
     if (ptr in _pthread_once.seen) return;
-    Runtime.dynCall('v', func);
+    Module['dynCall_v'](func);
     _pthread_once.seen[ptr] = 1;
   },
 
@@ -155,7 +155,7 @@ var LibraryPThreadStub = {
   },
 
   pthread_cleanup_push: function(routine, arg) {
-    __ATEXIT__.push(function() { Runtime.dynCall('vi', routine, [arg]) })
+    __ATEXIT__.push(function() { Module['dynCall_vi'](routine, arg) })
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -850,7 +850,7 @@ var LibrarySDL = {
       if (!SDL.eventHandler) return;
 
       while (SDL.pollEvent(SDL.eventHandlerTemp)) {
-        Runtime.dynCall('iii', SDL.eventHandler, [SDL.eventHandlerContext, SDL.eventHandlerTemp]);
+        Module['dynCall_iii'](SDL.eventHandler, SDL.eventHandlerContext, SDL.eventHandlerTemp);
       }
     },
 
@@ -2338,7 +2338,7 @@ var LibrarySDL = {
           if (secsUntilNextPlayStart >= SDL.audio.bufferingDelay + SDL.audio.bufferDurationSecs*SDL.audio.numSimultaneouslyQueuedBuffers) return;
 
           // Ask SDL audio data from the user code.
-          Runtime.dynCall('viii', SDL.audio.callback, [SDL.audio.userdata, SDL.audio.buffer, SDL.audio.bufferSize]);
+          Module['dynCall_viii'](SDL.audio.callback, SDL.audio.userdata, SDL.audio.buffer, SDL.audio.bufferSize);
           // And queue it to be played after the currently playing audio stream.
           SDL.audio.pushAudio(SDL.audio.buffer, SDL.audio.bufferSize);
         }
@@ -2875,7 +2875,7 @@ var LibrarySDL = {
     }
     SDL.music.audio = null;
     if (SDL.hookMusicFinished) {
-      Runtime.dynCall('v', SDL.hookMusicFinished);
+      Module['dynCall_v'](SDL.hookMusicFinished);
     }
     return 0;
   },
@@ -3412,7 +3412,7 @@ var LibrarySDL = {
 
   SDL_AddTimer: function(interval, callback, param) {
     return window.setTimeout(function() {
-      Runtime.dynCall('iii', callback, [interval, param]);
+      Module['dynCall_iii'](callback, interval, param);
     }, interval);
   },
   SDL_RemoveTimer: function(id) {

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -100,7 +100,7 @@ var funs = {
   alarm__deps: ['_sigalrm_handler'],
   alarm: function(seconds) {
     setTimeout(function() {
-      if (__sigalrm_handler) Runtime.dynCall('vi', __sigalrm_handler, [0]);
+      if (__sigalrm_handler) Module['dynCall_vi'](__sigalrm_handler, 0);
     }, seconds*1000);
   },
   ualarm: function() {

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -699,10 +699,10 @@ mergeInto(LibraryManager.library, {
         if (event === 'error') {
           var sp = Runtime.stackSave();
           var msg = allocate(intArrayFromString(data[2]), 'i8', ALLOC_STACK);
-          Runtime.dynCall('viiii', callback, [data[0], data[1], msg, userData]);
+          Module['dynCall_viiii'](callback, data[0], data[1], msg, userData);
           Runtime.stackRestore(sp);
         } else {
-          Runtime.dynCall('vii', callback, [data, userData]);
+          Module['dynCall_vii'](callback, data, userData);
         }
       } catch (e) {
         if (e instanceof ExitStatus) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1552,9 +1552,9 @@ function callRuntimeCallbacks(callbacks) {
     var func = callback.func;
     if (typeof func === 'number') {
       if (callback.arg === undefined) {
-        Runtime.dynCall('v', func);
+        Module['dynCall_v'](func);
       } else {
-        Runtime.dynCall('vi', func, [callback.arg]);
+        Module['dynCall_vi'](func, callback.arg);
       }
     } else {
       func(callback.arg === undefined ? null : callback.arg);


### PR DESCRIPTION
Fix function pointer call in _Unwind_Backtrace(). Remove use of Runtime.dynCall('signatureString', func, [args]) in favor of the static form Runtime.dynCall_signature(func, args) which is faster and produces no garbage.