### PR TITLE
Fix emterpreter-async in binaryen mode

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -54,7 +54,7 @@ mergeInto(LibraryManager.library, {
 
   emscripten_sleep__deps: ['emscripten_async_resume', '$Browser'],
   emscripten_sleep: function(ms) {
-    asm.setAsync(); // tell the scheduler that we have a callback on hold
+    Module['asm'].setAsync(); // tell the scheduler that we have a callback on hold
     Browser.safeSetTimeout(_emscripten_async_resume, ms);
   },
 
@@ -196,7 +196,7 @@ mergeInto(LibraryManager.library, {
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
     _file = PATH.resolve(FS.cwd(), _file);
-    asm.setAsync();
+    Module['asm'].setAsync();
     Module['noExitRuntime'] = true;
     var destinationDirectory = PATH.dirname(_file);
     FS.createPreloadedFile(
@@ -255,15 +255,15 @@ mergeInto(LibraryManager.library, {
     setState: function(s) {
       this.ensureInit();
       this.state = s;
-      asm.setAsyncState(s);
+      Module['asm'].setAsyncState(s);
     },
     handle: function(doAsyncOp, yieldDuring) {
       Module['noExitRuntime'] = true;
       if (EmterpreterAsync.state === 0) {
         // save the stack we want to resume. this lets other code run in between
         // XXX this assumes that this stack top never ever leak! exceptions might violate that
-        var stack = new Int32Array(HEAP32.subarray(EMTSTACKTOP>>2, asm.emtStackSave()>>2));
-        var stacktop = asm.stackSave();
+        var stack = new Int32Array(HEAP32.subarray(EMTSTACKTOP>>2, Module['asm'].emtStackSave()>>2));
+        var stacktop = Module['asm'].stackSave();
 
         var resumedCallbacksForYield = false;
         function resumeCallbacksForYield() {
@@ -297,7 +297,7 @@ mergeInto(LibraryManager.library, {
           // copy the stack back in and resume
           HEAP32.set(stack, EMTSTACKTOP>>2);
 #if ASSERTIONS
-          assert(stacktop === asm.stackSave()); // nothing should have modified the stack meanwhile
+          assert(stacktop === Module['asm'].stackSave()); // nothing should have modified the stack meanwhile
 #endif
           EmterpreterAsync.setState(2);
           // Resume the main loop
@@ -306,7 +306,7 @@ mergeInto(LibraryManager.library, {
           }
           assert(!EmterpreterAsync.postAsync);
           EmterpreterAsync.postAsync = post || null;
-          asm.emterpret(stack[0]); // pc of the first function, from which we can reconstruct the rest, is at position 0 on the stack
+          Module['asm'].emterpret(stack[0]); // pc of the first function, from which we can reconstruct the rest, is at position 0 on the stack
           if (!yieldDuring && EmterpreterAsync.state === 0) {
             // if we did *not* do another async operation, then we know that nothing is conceptually on the stack now, and we can re-allow async callbacks as well as run the queued ones right now
             Browser.resumeAsyncCallbacks();

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -1,6 +1,8 @@
 
 // === Auto-generated postamble setup entry stuff ===
 
+Module['asm'] = asm;
+
 {{{ maybeExport('FS') }}}
 
 #if MEM_INIT_METHOD == 2
@@ -142,7 +144,7 @@ Module['callMain'] = Module.callMain = function callMain(args) {
   argv = allocate(argv, 'i32', ALLOC_NORMAL);
 
 #if EMTERPRETIFY_ASYNC
-  var initialEmtStackTop = asm.emtStackSave();
+  var initialEmtStackTop = Module['asm'].emtStackSave();
 #endif
 
   try {
@@ -169,7 +171,7 @@ Module['callMain'] = Module.callMain = function callMain(args) {
       Module['noExitRuntime'] = true;
 #if EMTERPRETIFY_ASYNC
       // an infinite loop keeps the C stack around, but the emterpreter stack must be unwound - we do not want to restore the call stack at infinite loop
-      asm.emtStackRestore(initialEmtStackTop);
+      Module['asm'].emtStackRestore(initialEmtStackTop);
 #endif
       return;
     } else {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2205,14 +2205,15 @@ function integrateWasmJS(Module) {
     function receiveInstance(instance) {
       exports = instance.exports;
       if (exports.memory) mergeMemory(exports.memory);
+      Module['asm'] = exports;
       Module["usingWasm"] = true;
     }
 #if BINARYEN_ASYNC_COMPILATION
     Module['printErr']('asynchronously preparing wasm');
     addRunDependency('wasm-instantiate'); // we can't run yet
     WebAssembly.instantiate(getBinary(), info).then(function(output) {
+      // receiveInstance() will swap in the exports (to Module.asm) so they can be called
       receiveInstance(output.instance);
-      Module['asm'] = exports; // swap in the exports so they can be called
       removeRunDependency('wasm-instantiate');
     });
     return {}; // no exports yet; we'll fill them in later

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -14,10 +14,11 @@ sys.path += [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.pat
 import shared
 
 # can add flags like --no-threads --ion-offthread-compile=off
-engine1 = eval('shared.' + sys.argv[1]) if len(sys.argv) > 1 else shared.JS_ENGINES[0]
-engine2 = shared.SPIDERMONKEY_ENGINE if os.path.exists(shared.SPIDERMONKEY_ENGINE[0]) else None
+engine = eval('shared.' + sys.argv[1]) if len(sys.argv) > 1 else shared.JS_ENGINES[0]
 
-print 'testing js engines', engine1, engine2
+print 'testing js engine', engine
+
+TEST_BINARYEN = 1
 
 CSMITH = os.environ.get('CSMITH') or find_executable('csmith')
 assert CSMITH, 'Could not find CSmith on your PATH. Please set the environment variable CSMITH.'
@@ -58,11 +59,6 @@ while 1:
   if random.random() < 0.5: extra_args += ['--max-funcs', str(random.randint(10, 30))]
   suffix = '.c'
   COMP = shared.CLANG_CC
-  if random.random() < 0.5:
-    extra_args += ['--lang-cpp']
-    suffix += 'pp'
-    COMP = shared.CLANG
-  print COMP, extra_args
   fullname = filename + suffix
   check_call([CSMITH, '--no-volatiles', '--no-packed-struct'] + extra_args,
                  #['--max-block-depth', '2', '--max-block-size', '2', '--max-expr-complexity', '2', '--max-funcs', '2'],
@@ -105,19 +101,9 @@ while 1:
   def try_js(args=[]):
     shared.try_delete(filename + '.js')
     js_args = [shared.PYTHON, shared.EMCC, fullname, '-o', filename + '.js'] + [opts] + llvm_opts + CSMITH_CFLAGS + args + ['-w']
-    if 0: # binaryen testing, off by default for now
+    if TEST_BINARYEN:
       js_args += ['-s', 'BINARYEN=1']
-      r = random.random()
-      if r < 0.45:
-        js_args += ['-s', 'BINARYEN_METHOD="interpret-s-expr"']
-      elif r < 0.90:
-        js_args += ['-s', 'BINARYEN_METHOD="interpret-binary"']
-      else:
-        if random.random() < 0.5:
-          js_args += ['-s', 'BINARYEN_METHOD="interpret-binary,asmjs"']
-        else:
-          js_args += ['-s', 'BINARYEN_METHOD="interpret-s-expr,asmjs"']
-      if random.random() < 0.5:
+      if random.random() < 0.1:
         if random.random() < 0.5:
           js_args += ['--js-opts', '0']
         else:
@@ -125,6 +111,7 @@ while 1:
       if random.random() < 0.5:
         # pick random passes
         BINARYEN_PASSES = [
+          "code-pushing",
           "duplicate-function-elimination",
           "dce",
           "remove-unused-brs",
@@ -132,11 +119,13 @@ while 1:
           "optimize-instructions",
           "precompute",
           "simplify-locals",
+          "simplify-locals-nostructure",
           "vacuum",
           "coalesce-locals",
           "reorder-locals",
           "merge-blocks",
-          "remove-unused-functions",
+          "remove-unused-module-elements",
+          "memory-packing",
         ]
         passes = []
         while 1:
@@ -150,7 +139,7 @@ while 1:
       js_args += ['-s', 'MAIN_MODULE=1']
     if random.random() < 0.25:
       js_args += ['-s', 'INLINING_LIMIT=1'] # inline nothing, for more call interaction
-    if random.random() < 0.333:
+    if random.random() < 0.1:
       js_args += ['-s', 'EMTERPRETIFY=1']
       if random.random() < 0.5:
         if random.random() < 0.5:
@@ -195,26 +184,7 @@ while 1:
   if not js_args:
     fail()
     continue
-  if not execute_js(engine1):
+  if not execute_js(engine):
     fail()
     continue
-  if engine2 and not execute_js(engine2):
-    fail()
-    continue
-
-  # This is ok. Try validation in secondary JS engine
-  if opts != '-O0' and 'ALLOW_MEMORY_GROWTH=1' not in js_args and engine2 and 'BINARYEN=1' not in js_args:
-    try:
-      js2 = shared.run_js(filename + '.js', stderr=PIPE, engine=engine2 + ['-w'], full_output=True, check_timeout=True, assert_returncode=None)
-    except:
-      print 'failed to run in secondary'
-      break
-
-    # asm.js testing
-    if 'warning: Successfully compiled asm.js code' not in js2:
-      print "ODIN VALIDATION BUG"
-      notes['embug'] += 1
-      fail()
-      continue
-    print '[asm.js validation ok in %s]' % str(engine2)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7135,8 +7135,16 @@ int main(int argc, char **argv) {
     return 0;
 }
 '''
-    Settings.ASYNCIFY = 1;
-    self.do_run(src, '*0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*');
+    Settings.ASYNCIFY = 1
+    self.do_run(src, '*0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
+
+  @no_emterpreter
+  def test_emterpretify(self):
+    Settings.EMTERPRETIFY = 1
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+    print 'async'
+    Settings.EMTERPRETIFY_ASYNC = 1
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
   def test_cxx_self_assign(self):
     # See https://github.com/kripken/emscripten/pull/2688 and http://llvm.org/bugs/show_bug.cgi?id=18735


### PR DESCRIPTION
By properly standardizing the setting of Module.asm, avoiding a hack where we relied on the global var 'asm' instead.

With that fixed, enable fuzzing of emterpreter and binaryen, and clean up fuzzing script for binaryen fuzzing.

Also add a test for emterpreter and emterpreter-async in core, so it's tested across all modes