### PR TITLE
Fix suffix() and unsuffix() to use python builtins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -273,4 +273,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Murphy McCauley <murphy.mccauley@gmail.com>
 * Anatoly Trosinenko <anatoly.trosinenko@gmail.com>
 * Brad Grantham <grantham@plunk.org>
+* Sam Clegg <sbc@chromium.org> (copyright owned by Google, Inc.)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2336,14 +2336,10 @@ def check_call(cmd, *args, **kw):
     raise
 
 def suffix(name):
-  parts = name.split('.')
-  if len(parts) > 1:
-    return parts[-1]
-  else:
-    return None
+  return os.path.splitext(name)[1]
 
 def unsuffixed(name):
-  return '.'.join(name.split('.')[:-1])
+  return os.path.splitext(name)[0]
 
 def unsuffixed_basename(name):
   return os.path.basename(unsuffixed(name))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2336,7 +2336,8 @@ def check_call(cmd, *args, **kw):
     raise
 
 def suffix(name):
-  return os.path.splitext(name)[1]
+  """Return the file extension *not* including the '.'."""
+  return os.path.splitext(name)[1][1:]
 
 def unsuffixed(name):
   return os.path.splitext(name)[0]


### PR DESCRIPTION
I ran into a strange behaviour with the existing custom
implementation:
 unsuffix("foo.txt") -> "foo"
 unsuffix("foo") -> ""

The python builtins to a seemingly more reasonable thing:
 unsuffix("foo.txt") -> "foo"
 unsuffix("foo") -> "foo"