### PR TITLE
Check for LLVM env to set llvm_root on initial startup

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -224,7 +224,7 @@ else:
     config_file = '\n'.join(config_file)
     # autodetect some default paths
     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
-    llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
+    llvm_root = os.environ.get('LLVM') or os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
     binaryen_root = os.path.dirname(find_executable('asm2wasm') or '/usr/bin/asm2wasm')
     config_file = config_file.replace('\'{{{ BINARYEN_ROOT }}}\'', repr(binaryen_root))


### PR DESCRIPTION
Set `LLVM` in the env and the `.emscripten` creation will set `LLVM_ROOT` to that. The other alternative was to set `PATH` to point to the emscripten fastcomp, and since `LLVM` is already used as an override I found it was the obvious choice.

This is one of the issue that rose from my attempt to package emscripten for Fedora in Copr:
https://copr.fedorainfracloud.org/coprs/hub/emscripten/

Thanks !