### PR TITLE
no_unconnected_gamepad_garbage

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -1698,6 +1698,12 @@ Functions
 	
 	.. note:: A gamepad does not show up as connected until a button on it is pressed.
 
+	.. note:: Gamepad API uses an array of gamepad state objects to return the state of each device. The devices are identified via the index they are present in in
+	this array. Because of that, if one first connects gamepad A, then gamepad B, and then disconnects gamepad A, the gamepad B shall not take the place of gamepad A,
+	so in this scenario, this function will still keep returning two for the count of connected gamepads, even though gamepad A is no longer present. To find the actual
+	number of connected gamepads, listen for the gamepadconnected and gamepaddisconnected events.
+	Consider the return value of this function as the largest value (-1) that can be passed to the function emscripten_get_gamepad_status().
+
 	:returns: :c:data:`EMSCRIPTEN_RESULT_SUCCESS`, or one of the other result values.
 	:rtype: int
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1,4 +1,5 @@
 var LibraryJSEvents = {
+  $JSEvents__postset: 'JSEvents.staticInit();',
   $JSEvents: {
     // pointers to structs malloc()ed to Emscripten HEAP for JS->C interop.
     keyEvent: 0,
@@ -19,6 +20,7 @@ var LibraryJSEvents = {
     // state.
     lastGamepadState: null,
     lastGamepadStateFrame: null, // The integer value of Browser.mainLoop.currentFrameNumber of when the last gamepad state was produced.
+    numGamepadsConnected: 0, // Keep track of how many gamepads are connected, to optimize to not poll gamepads when none are connected.
 
     // When we transition from fullscreen to windowed mode, we remember here the element that was just in fullscreen mode
     // so that we can report information about that element in the event message.
@@ -32,6 +34,11 @@ var LibraryJSEvents = {
     // When the C runtime exits via exit(), we unregister all event handlers added by this library to be nice and clean.
     // Track in this field whether we have yet registered that __ATEXIT__ handler.
     removeEventListenersRegistered: false, 
+
+    staticInit: function() {
+      window.addEventListener("gamepadconnected", function() { ++JSEvents.numGamepadsConnected; });
+      window.addEventListener("gamepaddisconnected", function() { --JSEvents.numGamepadsConnected; });
+    },
 
     registerRemoveEventListeners: function() {
       if (!JSEvents.removeEventListenersRegistered) {
@@ -1703,6 +1710,9 @@ var LibraryJSEvents = {
  },
   
   _emscripten_sample_gamepad_data: function() {
+    // Polling gamepads generates garbage, so don't do it when we know there are no gamepads connected.
+    if (!JSEvents.numGamepadsConnected) return;
+
     // Produce a new Gamepad API sample if we are ticking a new game frame, or if not using emscripten_set_main_loop() at all to drive animation.
     if (Browser.mainLoop.currentFrameNumber !== JSEvents.lastGamepadStateFrame || !Browser.mainLoop.currentFrameNumber) {
       JSEvents.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : null);
@@ -1712,6 +1722,9 @@ var LibraryJSEvents = {
 
   emscripten_get_num_gamepads__deps: ['_emscripten_sample_gamepad_data'],
   emscripten_get_num_gamepads: function() {
+    // Polling gamepads generates garbage, so don't do it when we know there are no gamepads connected.
+    if (!JSEvents.numGamepadsConnected) return 0;
+
     __emscripten_sample_gamepad_data();
     if (!JSEvents.lastGamepadState) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     return JSEvents.lastGamepadState.length;


### PR DESCRIPTION
Optimize to avoid generating temporary garbage in Gamepad API when no gamepads are connected.