### PR TITLE
webgl2_backwards_compatibility_emulation

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -3440,6 +3440,7 @@ var LibraryGL = {
       // the corresponding vertex shader, we would not know if that needed to
       // be compiled with or without the patch, so we must patch all shaders.
       if (source.indexOf('#version 100') != -1) {
+        source = source.replace(/#extension GL_OES_standard_derivatives : enable/g, "");
         source = source.replace(/#extension GL_EXT_shader_texture_lod : enable/g, '');
         var prelude = '';
         if (source.indexOf('gl_FragColor') != -1) {

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1299,7 +1299,26 @@ var LibraryGL = {
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
 #if USE_WEBGL2
-    if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
+
+    if (GL.currentContext.version >= 2) {
+#if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
+      // WebGL 1 unsized texture internalFormats are no longer supported in WebGL 2, so patch those format
+      // enums to the ones that are present in WebGL 2.
+      if (format == 0x1902/*GL_DEPTH_COMPONENT*/ && internalFormat == 0x1902/*GL_DEPTH_COMPONENT*/ && type == 0x1405/*GL_UNSIGNED_INT*/) {
+        internalFormat = 0x81A6 /*GL_DEPTH_COMPONENT24*/;
+      }
+      if (type == 0x8d61/*GL_HALF_FLOAT_OES*/) {
+        type = 0x140B /*GL_HALF_FLOAT*/;
+        if (format == 0x1908/*GL_RGBA*/ && internalFormat == 0x1908/*GL_RGBA*/) {
+          internalFormat = 0x881A/*GL_RGBA16F*/;
+        }
+      }
+      if (internalFormat == 0x84f9 /*GL_DEPTH_STENCIL*/) {
+        internalFormat = 0x88F0 /*GL_DEPTH24_STENCIL8*/;
+      }
+#endif
+
+      // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels != 0) {
@@ -1324,7 +1343,16 @@ var LibraryGL = {
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
 #if USE_WEBGL2
-    if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
+
+    if (GL.currentContext.version >= 2) {
+#if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
+      // In WebGL 1 to do half float textures, one uses the type enum GL_HALF_FLOAT_OES, but in
+      // WebGL 2 when half float textures were adopted to the core spec, the enum changed value
+      // which breaks backwards compatibility. Route old enum number to the new one.
+      if (type == 0x8d61/*GL_HALF_FLOAT_OES*/) type = 0x140B /*GL_HALF_FLOAT*/;
+#endif
+
+      // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texSubImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels != 0) {
@@ -3395,6 +3423,48 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.shaders, shader, 'glShaderSource', 'shader');
 #endif
     var source = GL.getSource(shader, count, string, length);
+
+#if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
+    if (GL.currentContext.version >= 2) {
+      // If a WebGL 1 shader happens to use GL_EXT_shader_texture_lod extension,
+      // it will not compile on WebGL 2, because WebGL 2 no longer supports that
+      // extension for WebGL 1 shaders. Therefore upgrade shaders to WebGL 2
+      // by doing a bunch of dirty hacks. Not guaranteed to work on all shaders.
+      // One might consider doing this for only the shaders that actually use
+      // the GL_EXT_shader_texture_lod extension, but the problem is that
+      // vertex and fragment shader versions need to match, and when compiling
+      // the corresponding vertex shader, we would not know if that needed to
+      // be compiled with or without the patch, so we must patch all shaders.
+      if (source.indexOf('#version 100') != -1) {
+        source = source.replace(/#extension GL_EXT_shader_texture_lod : enable/g, '');
+        var prelude = '';
+        if (source.indexOf('gl_FragColor') != -1) {
+          prelude += 'out mediump vec4 GL_FragColor;\n';
+          source = source.replace(/gl_FragColor/g, 'GL_FragColor');
+        }
+        if (source.indexOf('attribute') != -1) {
+          source = source.replace(/attribute/g, 'in');
+          source = source.replace(/varying/g, 'out');
+        } else {
+          source = source.replace(/varying/g, 'in');
+        }
+
+        source = source.replace(/textureCubeLodEXT/g, 'textureCubeLod');
+        source = source.replace(/texture2DLodEXT/g, 'texture2DLod');
+        source = source.replace(/texture2DProjLodEXT/g, 'texture2DProjLod');
+        source = source.replace(/texture2DGradEXT/g, 'texture2DGrad');
+        source = source.replace(/texture2DProjGradEXT/g, 'texture2DProjGrad');
+        source = source.replace(/textureCubeGradEXT/g, 'textureCubeGrad');
+
+        source = source.replace(/textureCube/g, 'texture');
+        source = source.replace(/texture1D/g, 'texture');
+        source = source.replace(/texture2D/g, 'texture');
+        source = source.replace(/texture3D/g, 'texture');
+        source = source.replace(/#version 100/g, '#version 300 es\n' + prelude);
+      }
+    }
+#endif
+
     GLctx.shaderSource(GL.shaders[shader], source);
   },
 

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -415,7 +415,11 @@ var LibraryGL = {
     createContext: function(canvas, webGLContextAttributes) {
       if (typeof webGLContextAttributes['majorVersion'] === 'undefined' && typeof webGLContextAttributes['minorVersion'] === 'undefined') {
 #if USE_WEBGL2
-        webGLContextAttributes['majorVersion'] = 2;
+        // If caller did not specify a context, initialize the best one that is possibly available.
+        // To explicitly create a WebGL 1 or a WebGL 2 context, call this function with a specific
+        // majorVersion set.
+        if (typeof WebGL2RenderingContext !== 'undefined') webGLContextAttributes['majorVersion'] = 2;
+        else webGLContextAttributes['majorVersion'] = 1;
 #else
         webGLContextAttributes['majorVersion'] = 1;
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -264,6 +264,11 @@ var GL_UNSAFE_OPTS = 1; // Enables some potentially-unsafe optimizations in GL e
 var FULL_ES2 = 0;   // Forces support for all GLES2 features, not just the WebGL-friendly subset.
 var USE_WEBGL2 = 0; // Enables WebGL2 native functions. This mode will also create a WebGL2
                     // context by default if no version is specified.
+var WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION = 0; // If true, emulates some WebGL 1 features on WebGL 2 contexts, meaning that applications that
+                                                  // use WebGL 1/GLES 2 can initialize a WebGL 2/GLES3 context, but still keep using WebGL1/GLES 2
+                                                  // functionality that no longer is supported in WebGL2/GLES3. Currently this emulates
+                                                  // GL_EXT_shader_texture_lod extension in GLSLES 1.00 shaders, support for unsized internal
+                                                  // texture formats, and the GL_HALF_FLOAT_OES != GL_HALF_FLOAT mixup.
 var FULL_ES3 = 0;   // Forces support for all GLES3 features, not just the WebGL2-friendly subset.
 var LEGACY_GL_EMULATION = 0; // Includes code to emulate various desktop GL features. Incomplete but useful
                              // in some cases, see http://kripken.github.io/emscripten-site/docs/porting/multimedia_and_graphics/OpenGL-support.html

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2191,6 +2191,9 @@ Module["preRun"].push(function () {
     self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1'], expected='1')
     self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), expected='1')
 
+  def test_webgl2_backwards_compatibility_emulation(self):
+    self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'USE_WEBGL2=1', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
+
   def test_webgl_with_closure(self):
     self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
 

--- a/tests/webgl2_backwards_compatibility_emulation.cpp
+++ b/tests/webgl2_backwards_compatibility_emulation.cpp
@@ -1,0 +1,37 @@
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = 2;
+  attrs.minorVersion = 0;
+
+  int result = 0;
+
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context(0, &attrs);
+  assert(context);
+  EMSCRIPTEN_RESULT res = emscripten_webgl_make_context_current(context);
+  assert(res == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(emscripten_webgl_get_current_context() == context);
+  GLuint tex;
+  glGenTextures(1, &tex);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA, GL_HALF_FLOAT_OES, 0);
+  assert(glGetError() == 0);
+  emscripten_webgl_destroy_context(context);
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT();
+#endif
+  return 0;
+}


### PR DESCRIPTION
A number of engines find it useful to co-target both WebGL 1 and WebGL 2 at the same time, however there is no backwards compatibility provided between the specs mostly due to silly spec reasons that are relatively simple to emulate. This PR adds a new linker flag which allows codebases to opt in to compatibility between WebGL context versions easier. This flag is not by far complete at this point, but enough to run a few large codebases.
