### PR TITLE
First Canvas being leaked due to local variable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,3 +269,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vilibald Wanča <vilibald@wvi.cz>
 * Alex Hixon <alex@alexhixon.com>
 * Vladimir Davidovich <thy.ringo@gmail.com>
+* Joshua Lind <joshualind007@hotmail.com>

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -227,13 +227,13 @@ var LibraryBrowser = {
 
       // Canvas event setup
 
-      var canvas = Module['canvas'];
       function pointerLockChange() {
-        Browser.pointerLock = document['pointerLockElement'] === canvas ||
-                              document['mozPointerLockElement'] === canvas ||
-                              document['webkitPointerLockElement'] === canvas ||
-                              document['msPointerLockElement'] === canvas;
+        Browser.pointerLock = document['pointerLockElement'] === Module['canvas'] ||
+                              document['mozPointerLockElement'] === Module['canvas'] ||
+                              document['webkitPointerLockElement'] === Module['canvas'] ||
+                              document['msPointerLockElement'] === Module['canvas'];
       }
+      var canvas = Module['canvas'];
       if (canvas) {
         // forced aspect ratio can be enabled by defining 'forcedAspectRatio' on Module
         // Module['forcedAspectRatio'] = 4 / 3;
@@ -250,7 +250,6 @@ var LibraryBrowser = {
                                  function(){}; // no-op if function does not exist
         canvas.exitPointerLock = canvas.exitPointerLock.bind(document);
 
-
         document.addEventListener('pointerlockchange', pointerLockChange, false);
         document.addEventListener('mozpointerlockchange', pointerLockChange, false);
         document.addEventListener('webkitpointerlockchange', pointerLockChange, false);
@@ -258,8 +257,8 @@ var LibraryBrowser = {
 
         if (Module['elementPointerLock']) {
           canvas.addEventListener("click", function(ev) {
-            if (!Browser.pointerLock && canvas.requestPointerLock) {
-              canvas.requestPointerLock();
+            if (!Browser.pointerLock && Module['canvas'].requestPointerLock) {
+              Module['canvas'].requestPointerLock();
               ev.preventDefault();
             }
           }, false);


### PR DESCRIPTION
I am creating many canvases and destroying some and noticed I was always leaking the first canvas due to the pointerLockChange function and a click event added to the canvas that both use the local variable canvas forcing the browser to hold onto that specific canvas. With these changes it will use the active canvas to resolve the pointer, which as long as you set the canvas in the Browser it should work.