### PR TITLE
Search for .mem in same directory as Node script

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -41,6 +41,8 @@ if (memoryInitializer) {
     memoryInitializer = Module['locateFile'](memoryInitializer);
   } else if (Module['memoryInitializerPrefixURL']) {
     memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
+  } else if (ENVIRONMENT_IS_NODE) {
+    memoryInitializer = __dirname + '/' + memoryInitializer;
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
     var data = Module['readBinary'](memoryInitializer);


### PR DESCRIPTION
This seems to be a common source of issues when trying to run optimized code with separate .js.mem from Node.js, while not being in the same working directory (in particular, got hit by this nyself while implementing https://github.com/rust-lang/rust/pull/39490).

It was possible to workaround this and set search path using `Module.memoryInitializerPrefixURL` since 7e9e24, but I think it makes sense to have a nice default for 90% of cases too, which would be to search for `.js.mem` file in the same directory as `.js` itself.