### PR TITLE
Search for .mem in same directory as Node script

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -43,6 +43,8 @@ if (memoryInitializer) {
     memoryInitializer = Module['locateFile'](memoryInitializer);
   } else if (Module['memoryInitializerPrefixURL']) {
     memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
+  } else if (ENVIRONMENT_IS_NODE) {
+    memoryInitializer = __dirname + '/' + memoryInitializer;
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
     var data = Module['readBinary'](memoryInitializer);

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -44,6 +44,7 @@ if (memoryInitializer) {
   } else if (Module['memoryInitializerPrefixURL']) {
     memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
   } else if (ENVIRONMENT_IS_NODE) {
+    // Look for .mem file in the same folder as script by default
     memoryInitializer = __dirname + '/' + memoryInitializer;
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1240,6 +1240,18 @@ int f() {
                   output_filename='a.out.js')
     _test()
 
+  def test_memory_file_not_in_cwd(self):
+    # Test that even if JS is executed in different working directory, then it should still find .js.mem file in the same folder as script itself
+    filename = path_from_root('a.out.js')
+    Building.emcc(path_from_root('tests', 'hello_world.c'), ['--memory-init-file', '1'], output_filename=filename)
+    cwd = path_from_root('tests')
+    print
+    print 'Filename: %s' % filename
+    print 'Working dir: %s' % cwd
+    for engine in JS_ENGINES:
+      print engine
+      run_js(filename, cwd=cwd)
+
   def test_ungetc_fscanf(self):
     open('main.cpp', 'w').write(r'''
       #include <stdio.h>


### PR DESCRIPTION
This seems to be a common source of issues when trying to run optimised code with separate `.js.mem` from Node.js, while not being in the same working directory as script itself.

It was possible to workaround this and set search path using `memoryInitializerPrefixURL` since 7e9e24, but I think it makes sense to have a nice default too, which would be to search for `.js.mem` file in the same directory as `.js` itself when running using Node.js.

Added regression test for this behaviour, which also revealed that SpiderMonkey / V8 shells already got this right, so this PR aligns Node.js behaviour to others.

(Note: this is reopening of #4936, cc @juj)