### PR TITLE
update binaryen to version_28: 0x01, new type system

### DIFF
--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_27'
+TAG = 'version_28'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
This update brings us to what should hopefully emit proper wasm for the final wasm spec.