### PR TITLE
Fix bug in extract_archive_contents when TMP=.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1203,7 +1203,6 @@ def extract_archive_contents(f):
       if dirname:
         safe_ensure_dirs(dirname)
     Popen([LLVM_AR, 'xo', f], stdout=PIPE).communicate() # if absolute paths, files will appear there. otherwise, in this directory
-    contents = map(lambda content: os.path.join(temp_dir, content), contents)
     contents = filter(os.path.exists, map(os.path.abspath, contents))
     contents = filter(Building.is_bitcode, contents)
     return {


### PR DESCRIPTION
Remove redundant call to os.path.join(temp_dir). This code
is running with CWD=temp_dir already.  In most cases this
is harmless since temp_dir is normally absolute and therefore
the resulting path is absolute.  However, setting TMP=. will
break this as python's gettempdir() will then return '.'.

To reproduce the problem simply run "TMP=. emcc hello.cc".
The effect is that all the libraries apprar to be empty and
you will get undefined symbols.