### PR TITLE
Multiprocessing pool cwd fix

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1238,7 +1238,7 @@ def g_llvm_nm_uncached(filename):
 def g_multiprocessing_initializer(*args):
   for item in args:
     (key, value) = item.split('=')
-    if key == 'CWD':
+    if key == 'EMCC_POOL_CWD':
       os.chdir(value)
     else:
       os.environ[key] = value
@@ -1274,11 +1274,11 @@ class Building:
         child_env = [
           # Multiprocessing pool children must have their current working directory set to a safe path that is guaranteed not to die in between of
           # executing commands, or otherwise the pool children will have trouble spawning subprocesses of their own.
-          'CWD='+configuration.TEMP_DIR,
+          'EMCC_POOL_CWD=' + path_from_root(),
           # Multiprocessing pool children need to avoid all calling check_vanilla() again and again,
           # otherwise the compiler can deadlock when building system libs, because the multiprocess parent can have the Emscripten cache directory locked for write
           # access, and the EMCC_WASM_BACKEND check also requires locked access to the cache, which the multiprocess children would not get.
-          'EMCC_WASM_BACKEND='+os.getenv('EMCC_WASM_BACKEND', '0'),
+          'EMCC_WASM_BACKEND=' + os.getenv('EMCC_WASM_BACKEND', '0'),
           'EMCC_CORES=1' # Multiprocessing pool children can't spawn their own linear number of children, that could cause a quadratic amount of spawned processes.
         ]
         Building.multiprocessing_pool = multiprocessing.Pool(processes=cores, initializer=g_multiprocessing_initializer, initargs=child_env)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1248,11 +1248,12 @@ class Building:
   @staticmethod
   def get_multiprocessing_pool():
     if not Building.multiprocessing_pool:
-      Building.multiprocessing_pool = Building.create_multiprocessing_pool()
+      pool = Building.get_new_multiprocessing_pool()
+      Building.multiprocessing_pool = pool
     return Building.multiprocessing_pool
 
   @staticmethod
-  def create_multiprocessing_pool():
+  def get_new_multiprocessing_pool():
     cores = int(os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
 
     # If running with one core only, create a mock instance of a pool that does not
@@ -1573,7 +1574,7 @@ class Building:
 
       # Archives contain objects, so process all archives first in parallel to obtain the object files in them.
       # new_pool is a workaround for https://github.com/kripken/emscripten/issues/4941 TODO: a better fix
-      pool = Building.create_multiprocessing_pool()
+      pool = Building.get_new_multiprocessing_pool()
       object_names_in_archives = pool.map(extract_archive_contents, archive_names)
 
       for n in range(len(archive_names)):


### PR DESCRIPTION
The issue with reusing the Multiprocessing pool in the test harness was that the pool was created to a CWD that was deleted in between tests, which would cause all later subprocess spawns from the pool workers to fail because the worker processes had CWD pointing to a nonexisting directory. To fix, root the pool subprocesses to a known safe directory (`EMSCRIPTEN_TEMP`) that is very unlikely to die throughout the main process run.

Reverts PR #4957 because that addressed a workaround only and had a bug that `close_multiprocessing_pool()` would not bind to closing the right pool each time if multiple ones had been created.

Also reverts PR #4958 because I don't think `TMP=.` is a feature we should support. Though tested that `TMP=. emcc tests/hello_world.c` does build fine without errors after this PR.