### PR TITLE
Fix for issue 4926

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -276,4 +276,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sam Clegg <sbc@chromium.org> (copyright owned by Google, Inc.)
 * Joshua Lind <joshualind007@hotmail.com>
 * Hiroaki GOTO as "GORRY" <gorry@hauN.org>
-
+* Mikhail Kremnyov <mkremnyov@gmail.com> (copyright owned by XCDS International)

--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
@@ -1,6 +1,7 @@
 // EMSCRIPTEN_START_ASM
 var asm = (function(global, env, buffer) {
  "use asm";
+ var tempDouble = 0.0;
  var e = 0;
  
 // EMSCRIPTEN_START_FUNCS

--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
@@ -1,6 +1,7 @@
 // EMSCRIPTEN_START_ASM
 var asm = (function(global, env, buffer) {
  "use asm";
+ var tempDouble = 0.0;
  var e = 0;
  
 // EMSCRIPTEN_START_FUNCS

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7051,7 +7051,7 @@ int main() {
 
       # Compare
       expected_file_contents = self.get_file_contents(path_from_root('tests', 'optimizer', 'test-function-eliminator-double-parsed-correctly-output.js'))
-      self.assertIdentical(output_file_contents, expected_file_contents)
+      self.assertIdentical(expected_file_contents, output_file_contents)
     finally:
       tools.tempfiles.try_delete(output_file)
 

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -18,7 +18,7 @@ import shared
 def validate_asmjs_jsfile(filename, muteOutput):
   cmd = shared.SPIDERMONKEY_ENGINE + ['-c', filename]
   if not shared.SPIDERMONKEY_ENGINE or cmd[0] == 'js-not-found' or len(cmd[0].strip()) == 0:
-    print >> sys.stderr, 'Could not find SpiderMonkey engine! Please set tis location to SPIDERMONKEY_ENGINE in your ' + shared.hint_config_file_location() + ' configuration file!'
+    print >> sys.stderr, 'Could not find SpiderMonkey engine! Please set its location to SPIDERMONKEY_ENGINE in your ' + shared.hint_config_file_location() + ' configuration file!'
     return False
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)


### PR DESCRIPTION
The originally suggested fix (replace the initial value of tempDouble) broke a lot of tests in "other.*binaryen*" (since asm2wasm expects those values to be zero), so I fixed the issue differently.

I ran the main and the 'other' test suites. The test 'other.test_crunch' failed because I don't have crunch; 'test_mmap' and 'test_unistd_sysconf' failed both with and without my changes. The rest of tests passed.