### PR TITLE
Always use async compile unless overridden

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1299,9 +1299,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Building.is_wasm_only() and shared.Settings.EVAL_CTORS:
           logging.debug('disabling EVAL_CTORS, as in wasm-only mode it hurts more than it helps. TODO: a wasm version of it')
           shared.Settings.EVAL_CTORS = 0
-        # enable async compilation if optimizing and not turned off manually
-        if opt_level > 0:
-          if 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
+        # enable async compilation if not turned off manually
+        if 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
             shared.Settings.BINARYEN_ASYNC_COMPILATION = 1
         if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
           if bind:

--- a/emcc.py
+++ b/emcc.py
@@ -1299,9 +1299,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Building.is_wasm_only() and shared.Settings.EVAL_CTORS:
           logging.debug('disabling EVAL_CTORS, as in wasm-only mode it hurts more than it helps. TODO: a wasm version of it')
           shared.Settings.EVAL_CTORS = 0
-        # enable async compilation if not turned off manually
-        if 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
-            shared.Settings.BINARYEN_ASYNC_COMPILATION = 1
         if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
           if bind:
             shared.Settings.BINARYEN_ASYNC_COMPILATION = 0

--- a/src/settings.js
+++ b/src/settings.js
@@ -698,9 +698,9 @@ var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the bina
 var BINARYEN_MEM_MAX = -1; // Set the maximum size of memory in the wasm module (in bytes).
                            // Without this, TOTAL_MEMORY is used (as it is used for the initial value),
                            // or if memory growth is enabled, no limit is set. This overrides both of those.
-var BINARYEN_ASYNC_COMPILATION = 0; // Whether to compile the wasm asynchronously, which is more
-                                    // efficient. This is off by default in unoptimized builds and
-                                    // on by default in optimized ones.
+var BINARYEN_ASYNC_COMPILATION = 1; // Whether to compile the wasm asynchronously, which is more
+                                    // efficient and does not block the main thread. This is currently
+                                    // required for all but the smallest modules to run in V8
 var BINARYEN_ROOT = ""; // Directory where we can find Binaryen. Will be automatically set for you,
                         // but you can set it to override if you are a Binaryen developer.
 
@@ -834,4 +834,3 @@ var ASMFS = 0; // If set to 1, uses the multithreaded filesystem that is impleme
 var WASM_TEXT_FILE = ''; // name of the file containing wasm text, if relevant
 var WASM_BINARY_FILE = ''; // name of the file containing wasm binary, if relevant
 var ASMJS_CODE_FILE = ''; // name of the file containing asm.js, if relevant
-

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3314,7 +3314,7 @@ window.close = function() {
 ''',
     ))
     for opts, expect in [
-      ([], 0),
+      ([], 1),
       (['-O1'], 1),
       (['-O2'], 1),
       (['-O3'], 1),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1628,7 +1628,6 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_parameter_pack')
 
   def test_runtime_stacksave(self):
-    Settings.BINARYEN_ASYNC_COMPILATION = 1
     self.do_run(r'''
 #include <emscripten.h>
 #include <assert.h>
@@ -7337,7 +7336,7 @@ asm2i = make_run("asm2i", compiler=CLANG, emcc_args=["-O2", '-s', 'EMTERPRETIFY=
 
 binaryen0 = make_run("binaryen0", compiler=CLANG, emcc_args=['-O0', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
 binaryen1 = make_run("binaryen1", compiler=CLANG, emcc_args=['-O1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
-binaryen2 = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'BINARYEN_ASYNC_COMPILATION=1'])
+binaryen2 = make_run("binaryen2", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
 binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'ASSERTIONS=1', "-s", "PRECISE_F32=1"])
 
 binaryen2jo = make_run("binaryen2jo", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'])


### PR DESCRIPTION
We should default to async compile/instantiation.
1. We want to avoid blocking the main thread whenever possible, even when debugging or not-optimizing.
2. Having different behavior here between optimization levels is really weird and surprising.
2. To enforce this preference to avoid blocking the main thread, Chrome will limit synchronous compiles to a pretty small module size; small enough that even emscripten's unoptimized hello world won't compile.