### PR TITLE
setTempRet0's return value is received in some cases, even though it …

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -132,6 +132,7 @@ var Runtime = {
   // word is placed in tempRet0. This provides an accessor for that value.
   setTempRet0: function(value) {
     tempRet0 = value;
+    return value;
   },
   getTempRet0: function() {
     return tempRet0;
@@ -565,6 +566,7 @@ if (MAIN_MODULE || SIDE_MODULE) {
   };
   Runtime.setTempRet0 = function(x) {
     Runtime.tempRet0 = x;
+    return x;
   };
 }
 


### PR DESCRIPTION
…is ignored. JS engines no longer accept an undefined as a valid value now, so we must return an int properly.

This fixes `binaryen0.test_dlfcn_i64` and some similar tests that broke recently. It wasn't due to a change we made - looks like both sm and v8 started to validate more carefully? Odd that they started to do so around the same time, I guess there was a bug noticed that got fixed in both around the same time.