### PR TITLE
Add support for policies when calling val::as.

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -87,7 +87,7 @@ namespace emscripten {
             EM_VAL _emval_typeof(EM_VAL value);
         }
 
-        template<const char* address> 
+        template<const char* address>
         struct symbol_registrar {
             symbol_registrar() {
                 internal::_emval_register_symbol(address);
@@ -419,16 +419,17 @@ namespace emscripten {
             return MethodCaller<ReturnValue, Args...>::call(handle, name, std::forward<Args>(args)...);
         }
 
-        template<typename T>
-        T as() const {
+        template<typename T, typename ...Policies>
+        T as(Policies...) const {
             using namespace internal;
 
             typedef BindingType<T> BT;
+            typename WithPolicies<Policies...>::template ArgTypeList<T> targetType;
 
             EM_DESTRUCTORS destructors;
             EM_GENERIC_WIRE_TYPE result = _emval_as(
                 handle,
-                TypeID<T>::get(),
+                targetType.getTypes()[0],
                 &destructors);
             DestructorsRunner dr(destructors);
             return fromGenericWireType<T>(result);

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -478,6 +478,17 @@ module({
             assert.equal(3, cm.const_ref_adder(1, 2));
         });
 
+        test("get instance pointer as value", function() {
+            var v = cm.emval_test_instance_pointer();
+            assert.instanceof(v, cm.DummyForPointer);
+        });
+
+        test("cast value to instance pointer using as<T*>", function() {
+            var v = cm.emval_test_instance_pointer();
+            var p_value = cm.emval_test_value_from_instance_pointer(v);
+            assert.equal(42, p_value);
+        });
+
         test("passthrough", function() {
             var a = {foo: 'bar'};
             var b = cm.emval_test_passthrough(a);

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -39,6 +39,23 @@ val emval_test_new_object() {
     return rv;
 }
 
+struct DummyForPointer {
+    int value;
+    DummyForPointer(const int v) : value(v) {}
+};
+
+static DummyForPointer emval_pointer_dummy(42);
+
+val emval_test_instance_pointer() {
+    DummyForPointer* p = &emval_pointer_dummy;
+    return val(p);
+}
+
+int emval_test_value_from_instance_pointer(val v) {
+    DummyForPointer * p = v.as<DummyForPointer *>(allow_raw_pointers());
+    return p->value;
+}
+
 unsigned emval_test_passthrough_unsigned(unsigned v) {
     return v;
 }
@@ -1653,11 +1670,15 @@ EMSCRIPTEN_BINDINGS(tests) {
     register_vector<float>("FloatVector");
     register_vector<std::vector<int>>("IntegerVectorVector");
 
+    class_<DummyForPointer>("DummyForPointer");
+
     function("mallinfo", &emval_test_mallinfo);
     function("emval_test_new_integer", &emval_test_new_integer);
     function("emval_test_new_string", &emval_test_new_string);
     function("emval_test_get_string_from_val", &emval_test_get_string_from_val);
     function("emval_test_new_object", &emval_test_new_object);
+    function("emval_test_instance_pointer", &emval_test_instance_pointer);
+    function("emval_test_value_from_instance_pointer", &emval_test_value_from_instance_pointer);
     function("emval_test_passthrough_unsigned", &emval_test_passthrough_unsigned);
     function("emval_test_passthrough", &emval_test_passthrough);
     function("emval_test_return_void", &emval_test_return_void);


### PR DESCRIPTION
This allows to use allow_raw_pointers() with val::as to get a pointer.

Fixes #4863 

Tests from `other.test_embind` all pass.