### PR TITLE
Minify JS in wasm mode too

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2207,11 +2207,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             shutil.move(js_target, final)
             if DEBUG: save_intermediate('preclean', 'js')
             if use_closure_compiler:
-              if DEBUG: print >> sys.stderr, 'running closure on shell code'
+              logging.debug('running closure on shell code')
               final = shared.Building.closure_compiler(final, pretty=not JSOptimizer.minify_whitespace)
             else:
               assert JSOptimizer.cleanup_shell
-              if DEBUG: print >> sys.stderr, 'running cleanup on shell code'
+              logging.debug('running cleanup on shell code')
               final = shared.Building.js_optimizer_no_asmjs(final, ['noPrintMetadata', 'JSDCE', 'last'] + (['minifyWhitespace'] if JSOptimizer.minify_whitespace else []))
             shutil.move(final, js_target)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7411,6 +7411,7 @@ int main() {
             (['-O2', '-g'],  True,  True,  False, True, False),
             (['-O2', '--closure', '1'],         False, False, True, False, True),
             (['-O2', '--closure', '1', '-g1'],  False, False, True, True,  True),
+            (['-O2', '--js-opts', '1'], False, False, True,  False, False),
           ]:
           print args, expect_dash_g, expect_emit_text
           try_delete('a.out.wast')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7399,16 +7399,18 @@ int main() {
       if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
       try:
         os.environ['EMCC_DEBUG'] = '1'
-        for args, expect_dash_g, expect_emit_text, expect_clean_js, expect_whitespace_js in [
-            (['-O0'], False, False, False, True),
-            (['-O0', '-g1'], False, False, False, True),
-            (['-O0', '-g2'], True, False, False, True), # in -g2+, we emit -g to asm2wasm so function names are saved
-            (['-O0', '-g'], True, True, False, True),
-            (['-O0', '--profiling-funcs'], True, False, False, True),
-            (['-O1'],        False, False, False, True),
-            (['-O2'],        False, False, True,  False),
-            (['-O2', '-g1'], False, False, True,  True),
-            (['-O2', '-g'],  True,  True,  False, True),
+        for args, expect_dash_g, expect_emit_text, expect_clean_js, expect_whitespace_js, expect_closured in [
+            (['-O0'], False, False, False, True, False),
+            (['-O0', '-g1'], False, False, False, True, False),
+            (['-O0', '-g2'], True, False, False, True, False), # in -g2+, we emit -g to asm2wasm so function names are saved
+            (['-O0', '-g'], True, True, False, True, False),
+            (['-O0', '--profiling-funcs'], True, False, False, True, False),
+            (['-O1'],        False, False, False, True, False),
+            (['-O2'],        False, False, True,  False, False),
+            (['-O2', '-g1'], False, False, True,  True, False),
+            (['-O2', '-g'],  True,  True,  False, True, False),
+            (['-O2', '--closure', '1'],         False, False, True, False, True),
+            (['-O2', '--closure', '1', '-g1'],  False, False, True, True,  True),
           ]:
           print args, expect_dash_g, expect_emit_text
           try_delete('a.out.wast')
@@ -7427,6 +7429,7 @@ int main() {
           js = open('a.out.js').read()
           assert expect_clean_js == ('// ' not in js), 'cleaned-up js must not have comments'
           assert expect_whitespace_js == ('{\n  ' in js), 'whitespace-minified js must not have excess spacing'
+          assert expect_closured == ('var a;' in js), 'closured js must have tiny variable names'
       finally:
         del os.environ['EMCC_DEBUG']
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7416,7 +7416,9 @@ int main() {
           try_delete('a.out.wast')
           cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'] + args
           print ' '.join(cmd)
-          output, err = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+          proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+          output, err = proc.communicate()
+          assert proc.returncode == 0
           asm2wasm_line = filter(lambda x: 'asm2wasm' in x, err.split('\n'))[0]
           asm2wasm_line = asm2wasm_line.strip() + ' ' # ensure it ends with a space, for simpler searches below
           print '|' + asm2wasm_line + '|'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2018,6 +2018,13 @@ class Building:
       ret = output_filename
     return ret
 
+  # run JS optimizer on some JS, ignoring asm.js contents if any - just run on it all
+  @staticmethod
+  def js_optimizer_no_asmjs(filename, passes):
+    next = filename + '.jso.js'
+    subprocess.check_call(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes, stdout=open(next, 'w'))
+    return next
+
   @staticmethod
   def eval_ctors(js_file, mem_init_file):
     subprocess.check_call([PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, mem_init_file, str(Settings.TOTAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE)])


### PR DESCRIPTION
In small projects, the JS side is significant so worth minifying when possible. That we didn't do this already was an oversight.