### PR TITLE
Allow embind to work with async wasm compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1299,20 +1299,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Building.is_wasm_only() and shared.Settings.EVAL_CTORS:
           logging.debug('disabling EVAL_CTORS, as in wasm-only mode it hurts more than it helps. TODO: a wasm version of it')
           shared.Settings.EVAL_CTORS = 0
-        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
-          if bind:
-            shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
-            if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
-              logging.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled since embind is not compatible with it yet')
-          elif shared.Building.is_wasm_only():
-            # async compilation requires a swappable module - we swap it in when it's ready
-            shared.Settings.SWAPPABLE_ASM_MODULE = 1
-          else:
-            # if not wasm-only, we can't do async compilation as the build can run in other
-            # modes than wasm (like asm.js) which may not support an async step
-            shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
-            if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
-              logging.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled since not in wasm-only mode')
+        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and shared.Building.is_wasm_only():
+          # async compilation requires a swappable module - we swap it in when it's ready
+          shared.Settings.SWAPPABLE_ASM_MODULE = 1
+        else:
+          # if not wasm-only, we can't do async compilation as the build can run in other
+          # modes than wasm (like asm.js) which may not support an async step
+          shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
+          if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
+            logging.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled since not in wasm-only mode')
 
       # wasm outputs are only possible with a side wasm
       if target.endswith(WASM_ENDINGS):

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -946,13 +946,13 @@ var LibraryEmbind = {
         // This has three main penalties:
         // - dynCall is another function call in the path from JavaScript to C++.
         // - JITs may not predict through the function table indirection at runtime.
-        var dc = asm['dynCall_' + signature];
+        var dc = Module["asm"]['dynCall_' + signature];
         if (dc === undefined) {
             // We will always enter this branch if the signature
             // contains 'f' and PRECISE_F32 is not enabled.
             //
             // Try again, replacing 'f' with 'd'.
-            dc = asm['dynCall_' + signature.replace(/f/g, 'd')];
+            dc = Module["asm"]['dynCall_' + signature.replace(/f/g, 'd')];
             if (dc === undefined) {
                 throwBindingError("No dynCall invoker for signature: " + signature);
             }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6268,10 +6268,13 @@ def process(filename):
     Settings.NO_EXIT_RUNTIME = 1 # we emit some post.js that we need to see
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
     open('post.js', 'w').write('''
-      Module.print('lerp ' + Module.lerp(100, 200, 66) + '.');
+      function printLerp() {
+          Module.print('lerp ' + Module.lerp(100, 200, 66) + '.');
+      }
     ''')
     src = r'''
       #include <stdio.h>
+      #include <emscripten.h>
       #include <emscripten/bind.h>
       using namespace emscripten;
       int lerp(int a, int b, int t) {
@@ -6281,6 +6284,7 @@ def process(filename):
           function("lerp", &lerp);
       }
       int main(int argc, char **argv) {
+          EM_ASM(printLerp());
           return 0;
       }
     '''


### PR DESCRIPTION
This PR fixes the embind references to the global `asm`.
It enables to use embind with `BINARYEN_ASYNC_COMPILATION`.

By the way, what is the difference between `asm` and `Module["asm"]` ?

Passed tests:
- binaryen2.test_embind*
- ALL.test_embind*
- other.test_embind*

I changed `binaryen2.test_embind_2` which did not work asynchronously (so was logically failing with an async initialization).

I have also tested that my own library (which heavily uses embind) works as expected after those commits, both in `asm.js` and `wasm`.