### PR TITLE
Fix outlining + growth + wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1926,7 +1926,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if opt_level >= 2:
           if debug_level < 2 and not use_closure_compiler == 2:
             JSOptimizer.queue += ['minifyNames']
-          if debug_level == 0:
+          # can minify whitespace when there is no debug level, but when
+          # building to wasm together with js opts, the opts must leave it
+          # properly formatted for the asm2wasm parser. (as this is a
+          # compromise build, not a fully optimized wasm-only one, this isn't
+          # too bad even if we keep the asm.js; if we don't, then it doesn't
+          # matter at all)
+          if debug_level == 0 and not (shared.Settings.BINARYEN and js_opts):
             JSOptimizer.minify_whitespace = True
 
         if use_closure_compiler == 1:

--- a/emcc.py
+++ b/emcc.py
@@ -1926,13 +1926,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if opt_level >= 2:
           if debug_level < 2 and not use_closure_compiler == 2:
             JSOptimizer.queue += ['minifyNames']
-          # can minify whitespace when there is no debug level, but when
-          # building to wasm together with js opts, the opts must leave it
-          # properly formatted for the asm2wasm parser. (as this is a
-          # compromise build, not a fully optimized wasm-only one, this isn't
-          # too bad even if we keep the asm.js; if we don't, then it doesn't
-          # matter at all)
-          if debug_level == 0 and not (shared.Settings.BINARYEN and js_opts):
+          if debug_level == 0:
             JSOptimizer.minify_whitespace = True
 
         if use_closure_compiler == 1:
@@ -1964,7 +1958,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if DEBUG: save_intermediate('eval-ctors', 'js')
 
       if js_opts:
-        if not shared.Settings.EMTERPRETIFY:
+        # some compilation modes require us to minify later or not at all
+        if not shared.Settings.EMTERPRETIFY and not shared.Settings.BINARYEN:
           do_minify()
 
         if opt_level >= 2:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7197,6 +7197,7 @@ int main() {
             (['-O2', '-s', 'EMTERPRETIFY=1'], True, False), # option forced
             (['-O2', '-s', 'EVAL_CTORS=1'], False, True), # ctor evaller turned off since only-wasm
             (['-O2', '-s', 'OUTLINING_LIMIT=1000'], True, False), # option forced
+            (['-O2', '-s', 'OUTLINING_LIMIT=1000', '-s', 'ALLOW_MEMORY_GROWTH=1'], True, False), # option forced, and also check growth does not interfere
             (['-O2', '-s', "BINARYEN_METHOD='interpret-s-expr,asmjs'"], True, False), # asmjs in methods means we need good asm.js
             (['-O3'], False, True),
             (['-Os'], False, True),
@@ -7207,7 +7208,9 @@ int main() {
             try_delete('a.out.wast')
             cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c'), '-s', option + '=1', '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
             print args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd)
-            output, err = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+            proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+            output, err = proc.communicate()
+            assert proc.returncode == 0
             assert expect_js_opts == ('applying js optimization passes:' in err), err
             assert expect_only_wasm == ('-emscripten-only-wasm' in err and '--wasm-only' in err), err # check both flag to fastcomp and to asm2wasm
             wast = open('a.out.wast').read()


### PR DESCRIPTION
Fixes #5014.

There just wasn't anything in the test suite that actually catches an asm2wasm parsing issue with minified JS. Anyhow, as mentioned in the comment in the commit, there is no downside to avoiding this issue by just not minifying JS in a wasm build that uses js opts (we used to do that in a bad hacky way that I removed recently, and that's when this regressed).