### PR TITLE
force absolute paths in Building.llvm_nm to maximize cache usage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -278,3 +278,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Hiroaki GOTO as "GORRY" <gorry@hauN.org>
 * Mikhail Kremnyov <mkremnyov@gmail.com> (copyright owned by XCDS International)
 * Tasuku SUENAGA a.k.a. gunyarakun <tasuku-s-github@titech.ac>
+* Evan Wallace <evan.exe@gmail.com>

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1911,6 +1911,9 @@ class Building:
 
   @staticmethod
   def llvm_nm(filename, stdout=PIPE, stderr=PIPE, include_internal=False):
+    # Always use absolute paths to maximize cache usage
+    filename = os.path.abspath(filename)
+
     if include_internal and filename in Building.internal_nm_cache:
       return Building.internal_nm_cache[filename]
     elif not include_internal and filename in Building.uninternal_nm_cache:


### PR DESCRIPTION
I noticed that emscripten always loads all object files twice, once with the relative path and once with the absolute path. Always using the absolute path results in a 4.5s speedup on our codebase.