### PR TITLE
Crash fix for "for .. in + third party framework" bug

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -766,7 +766,7 @@ var LibraryGL = {
       case 0x1F03 /* GL_EXTENSIONS */:
         var exts = GLctx.getSupportedExtensions();
         var gl_exts = [];
-        for (var i in exts) {
+        for (var i = 0; i < exts.length; ++i) {
           gl_exts.push(exts[i]);
           gl_exts.push("GL_" + exts[i]);
         }
@@ -968,7 +968,7 @@ var LibraryGL = {
         var exts = GLctx.getSupportedExtensions();
         var gl_exts = [];
         // each extension is duplicated, first in unprefixed WebGL form, and then a second time with "GL_" prefix.
-        for (var i in exts) {
+        for (var i = 0; i < exts.length; ++i) {
           gl_exts.push(allocate(intArrayFromString(exts[i]), 'i8', ALLOC_NORMAL));
           gl_exts.push(allocate(intArrayFromString("GL_" + exts[i]), 'i8', ALLOC_NORMAL));
         }

--- a/tests/webgl2.cpp
+++ b/tests/webgl2.cpp
@@ -10,6 +10,12 @@ EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
 
 int main()
 {
+  EM_ASM({
+    Array.prototype.someExtensionFromThirdParty = {};
+    Array.prototype.someExtensionFromThirdParty.length = 42;
+    Array.prototype.someExtensionFromThirdParty.something = function() { return "Surprise!"; };
+  });
+
   EmscriptenWebGLContextAttributes attrs;
   emscripten_webgl_init_context_attributes(&attrs);
   attrs.majorVersion = 2;


### PR DESCRIPTION
I replaced for..in only in library_gl but emscripten codebase is full of for..in's. Any idea how to handle this?