### PR TITLE
Add stub function for pthread_setcancelstate

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -104,6 +104,8 @@ var LibraryPThreadStub = {
     return 0;
   },
 
+  pthread_setcancelstate: function() { return 0; },
+
   pthread_once: function(ptr, func) {
     if (!_pthread_once.seen) _pthread_once.seen = {};
     if (ptr in _pthread_once.seen) return;


### PR DESCRIPTION
We already have a `__pthread_setcancelstate` in `library.js`, but that's for internal libc uses that directly call the `__`-prefixed form. musl aliases the prefixes away for user code, and so non-threaded user code that happens to call `pthread_setcancelstate` doesn't get the alias and has an unresolved symbol warning. This silences that.