### PR TITLE
Fix wasm + emterpreter file

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2269,14 +2269,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # We need to load the emterpreter file before anything else, it has to be synchronously ready
           un_src()
           script_inline = '''
-          var xhr = new XMLHttpRequest();
-          xhr.open('GET', '%s', true);
-          xhr.responseType = 'arraybuffer';
-          xhr.onload = function() {
-            Module.emterpreterFile = xhr.response;
+          var emterpretXHR = new XMLHttpRequest();
+          emterpretXHR.open('GET', '%s', true);
+          emterpretXHR.responseType = 'arraybuffer';
+          emterpretXHR.onload = function() {
+            Module.emterpreterFile = emterpretXHR.response;
 %s
           };
-          xhr.send(null);
+          emterpretXHR.send(null);
 ''' % (shared.Settings.EMTERPRETIFY_FILE, script_inline)
 
         if memory_init_file:
@@ -2290,10 +2290,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             } else if (Module['memoryInitializerPrefixURL']) {
               memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
             }
-            var xhr = Module['memoryInitializerRequest'] = new XMLHttpRequest();
-            xhr.open('GET', memoryInitializer, true);
-            xhr.responseType = 'arraybuffer';
-            xhr.send(null);
+            var meminitXHR = Module['memoryInitializerRequest'] = new XMLHttpRequest();
+            meminitXHR.open('GET', memoryInitializer, true);
+            meminitXHR.responseType = 'arraybuffer';
+            meminitXHR.send(null);
           })();
 ''' % os.path.basename(memfile)) + script_inline
 
@@ -2343,14 +2343,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # We need to load the wasm file before anything else, it has to be synchronously ready TODO: optimize
           un_src()
           script_inline = '''
-          var xhr = new XMLHttpRequest();
-          xhr.open('GET', '%s', true);
-          xhr.responseType = 'arraybuffer';
-          xhr.onload = function() {
-            Module.wasmBinary = xhr.response;
+          var wasmXHR = new XMLHttpRequest();
+          wasmXHR.open('GET', '%s', true);
+          wasmXHR.responseType = 'arraybuffer';
+          wasmXHR.onload = function() {
+            Module.wasmBinary = wasmXHR.response;
 %s
           };
-          xhr.send(null);
+          wasmXHR.send(null);
 ''' % (os.path.basename(wasm_binary_target), script_inline)
 
         html = open(target, 'wb')


### PR DESCRIPTION
Consider the case where you use wasm and also an emterpret file. You get a `<script>` tag that looks like this:
```
var xhr = new XMLHttpRequest();
xhr.open('GET', 'module.wasm', true);
xhr.responseType = 'arraybuffer';
xhr.onload = function() {
    Module.wasmBinary = xhr.response; // <<<< ERROR
    var xhr = new XMLHttpRequest();
    xhr.open('GET', 'emterpret.file', true);
    xhr.responseType = 'arraybuffer';
    xhr.onload = function() {
        Module.emterpreterFile = xhr.response;
        var script = document.createElement('script');
        script.src = "module.js";
        document.body.appendChild(script);
    };
    xhr.send(null);
};
xhr.send(null);
```
This will error on the indicated line with `Uncaught TypeError: Cannot read property 'response' of undefined`. Can you see the issue? The name of the branch is a hint (as is the commit itself). It took me longer to track this down than I'd like to admit, though it's been a while since I've written JS.

<details><summary>Click to see answer</summary><p>
`var xhr` in the onload closure is hoisted to the top and shadows the outer one, so `xhr` is undefined when it comes to do `xhr.response`

The meminit xhr renaming isn't strictly necessary, but keeps things consistent.
</p></details>