### PR TITLE
manually_instantiate_wasm

### DIFF
--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -110,6 +110,14 @@ Other methods
 
 	When compiled with ``PROXY_TO_WORKER = 1`` (see `settings.js <https://github.com/kripken/emscripten/blob/master/src/settings.js>`_), this callback (which should be implemented on both the client and worker's ``Module`` object) allows sending custom messages and data between the web worker and the main thread (using the ``postCustomMessage`` function defined in `proxyClient.js <https://github.com/kripken/emscripten/blob/master/src/proxyClient.js>`_ and `proxyWorker.js <https://github.com/kripken/emscripten/blob/master/src/proxyWorker.js>`_).
 
+.. js:function:: Module.instantiateWasm
+
+	When targeting WebAssembly, Module.instantiateWasm is an optional user-implemented callback function that the Emscripten runtime calls to perform the WebAssembly instantiation action. The callback function will be called with two parameters, ``imports`` and ``successCallback``. ``imports`` is a JS object which contains all the function imports that need to be passed to the WebAssembly Module when instantiating, and once instantiated, this callback function should call ``successCallback()`` with the generated WebAssembly Instance object.
+
+	The instantiation can be performed either synchronously or asynchronously. The return value of this function should contain the ``exports`` object of the instantiated WebAssembly Module, or an empty dictionary object ``{}`` if the instantiation is performed asynchronously, or ``false`` if instantiation failed.
+
+	Overriding the WebAssembly instantiation procedure via this function is useful when you have other custom asynchronous startup actions or downloads that can be performed in parallel to WebAssembly compilation. Implementing this callback allows performing all of these in parallel. See the file ``tests/manual_wasm_instantiate.html`` and the test ``browser.test_manual_wasm_instantiate`` for an example of how this construct works in action.
+
 .. js:function:: Module.getPreloadedPackage
 
 	If you want to manually manage the download of .data file packages for custom caching, progress reporting and error handling behavior, you can implement the ``Module.getPreloadedPackage = function(remotePackageName, remotePackageSize)`` callback to provide the contents of the data files back to the file loading scripts. The return value of this callback should be an Arraybuffer with the contents of the downloade file data. See file ``tests/manual_download_data.html`` and the test ``browser.test_preload_file_with_manual_data_download`` for an example.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2221,6 +2221,19 @@ function integrateWasmJS(Module) {
       Module['asm'] = exports;
       Module["usingWasm"] = true;
     }
+
+    // User shell pages can write their own Module.instantiateWasm = function(imports, successCallback) callback
+    // to manually instantiate the Wasm module themselves. This allows pages to run the instantiation parallel
+    // to any other async startup actions they are performing.
+    if (Module['instantiateWasm']) {
+      try {
+        return Module['instantiateWasm'](info, receiveInstance);
+      } catch(e) {
+        Module['printErr']('Module.instantiateWasm callback failed with error: ' + e);
+        return false;
+      }
+    }
+
 #if BINARYEN_ASYNC_COMPILATION
     Module['printErr']('asynchronously preparing wasm');
     addRunDependency('wasm-instantiate'); // we can't run yet

--- a/tests/manual_wasm_instantiate.cpp
+++ b/tests/manual_wasm_instantiate.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <emscripten/emscripten.h>
+
+int main()
+{
+	printf("OK\n");
+#ifdef REPORT_RESULT
+	int result = EM_ASM_INT_V({return Module.testWasmInstantiationSucceeded;});
+	REPORT_RESULT();
+#endif
+}

--- a/tests/manual_wasm_instantiate.html
+++ b/tests/manual_wasm_instantiate.html
@@ -168,7 +168,6 @@
       // should contain the exports object of the instantiated Module, or an empty dictionary object {} if the
       // instantiation is performed asynchronously, or false if instantiation failed.
       Module.instantiateWasm = function(imports, successCallback) {
-        addRunDependency('wasm-instantiate');
         console.log('instantiateWasm: instantiating asynchronously');
         wasm.then(function(wasmBinary) {
           console.log('wasm download finished, begin instantiating');
@@ -176,7 +175,6 @@
             console.log('wasm instantiation succeeded');
             Module.testWasmInstantiationSucceeded = 1;
             successCallback(output.instance);
-            removeRunDependency("wasm-instantiate");
           }).catch(function(e) {
             console.log('wasm instantiation failed! ' + e);
           });

--- a/tests/manual_wasm_instantiate.html
+++ b/tests/manual_wasm_instantiate.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      textarea.emscripten { font-family: monospace; width: 80%; }
+      div.emscripten { text-align: center; }
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; background-color: black; }
+
+      .spinner {
+        height: 50px;
+        width: 50px;
+        margin: 0px auto;
+        -webkit-animation: rotation .8s linear infinite;
+        -moz-animation: rotation .8s linear infinite;
+        -o-animation: rotation .8s linear infinite;
+        animation: rotation 0.8s linear infinite;
+        border-left: 10px solid rgb(0,150,240);
+        border-right: 10px solid rgb(0,150,240);
+        border-bottom: 10px solid rgb(0,150,240);
+        border-top: 10px solid rgb(100,0,200);
+        border-radius: 100%;
+        background-color: rgb(200,100,250);
+      }
+      @-webkit-keyframes rotation {
+        from {-webkit-transform: rotate(0deg);}
+        to {-webkit-transform: rotate(360deg);}
+      }
+      @-moz-keyframes rotation {
+        from {-moz-transform: rotate(0deg);}
+        to {-moz-transform: rotate(360deg);}
+      }
+      @-o-keyframes rotation {
+        from {-o-transform: rotate(0deg);}
+        to {-o-transform: rotate(360deg);}
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+    </style>
+  </head>
+  <body>
+    <hr/>
+    <figure style="overflow:visible;" id="spinner"><div class="spinner"></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
+    <div class="emscripten" id="status">Downloading...</div>
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>  
+    </div>
+    <div class="emscripten_border">
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <hr/>
+    <div class="emscripten">
+      <input type="checkbox" id="resize">Resize canvas
+      <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
+      &nbsp;&nbsp;&nbsp;
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
+                                                                                document.getElementById('resize').checked)">
+    </div>
+    
+    <hr/>
+    <textarea class="emscripten" id="output" rows="8"></textarea>
+    <hr>
+    <script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          if (0) { // XXX disabled for safety typeof dump == 'function') {
+            dump(text + '\n'); // fast, straight to the real console
+          } else {
+            console.error(text);
+          }
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Date.now() < 30) return; // if this is a progress update, skip it if too soon
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function() {
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) Module.printErr('[post-exception status] ' + text);
+        };
+      };
+
+      function downloadWasm(url) {
+        return new Promise(function(resolve, reject) {
+          var wasmXHR = new XMLHttpRequest();
+          wasmXHR.open('GET', url, true);
+          wasmXHR.responseType = 'arraybuffer';
+          wasmXHR.onload = function() { resolve(wasmXHR.response); }
+          wasmXHR.onerror = function() { reject('error '  + wasmXHR.status); }
+          wasmXHR.send(null);
+        });
+      }
+
+      var wasm = downloadWasm('manual_wasm_instantiate.wasm');
+
+      // Module.instantiateWasm is a user-implemented callback which the Emscripten runtime calls to perform
+      // the WebAssembly instantiation action. The callback function will be called with two parameters, imports
+      // and successCallback. imports is a JS object which contains all the function imports that need to be passed
+      // to the Module when instantiating, and once instantiated, the function should call successCallback() with
+      // the WebAssembly Instance object.
+      // The instantiation can be performed either synchronously or asynchronously. The return value of this function
+      // should contain the exports object of the instantiated Module, or an empty dictionary object {} if the
+      // instantiation is performed asynchronously, or false if instantiation failed.
+      Module.instantiateWasm = function(imports, successCallback) {
+        addRunDependency('wasm-instantiate');
+        console.log('instantiateWasm: instantiating asynchronously');
+        wasm.then(function(wasmBinary) {
+          console.log('wasm download finished, begin instantiating');
+          var wasmInstantiate = WebAssembly.instantiate(new Uint8Array(wasmBinary), imports).then(function(output) {
+            console.log('wasm instantiation succeeded');
+            Module.testWasmInstantiationSucceeded = 1;
+            successCallback(output.instance);
+            removeRunDependency("wasm-instantiate");
+          }).catch(function(e) {
+            console.log('wasm instantiation failed! ' + e);
+          });
+        });
+        return {}; // Compiling asynchronously, no exports.
+      }
+
+      var script = document.createElement('script');
+      script.src = "manual_wasm_instantiate.js";
+      document.body.appendChild(script);
+</script>
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3355,6 +3355,14 @@ window.close = function() {
       print opts, expect
       self.btest('binaryen_async.c', expected=str(expect), args=['-s', 'BINARYEN=1', '--shell-file', 'shell.html'] + opts)
 
+  # Test that implementing Module.instantiateWasm() callback works.
+  def test_manual_wasm_instantiate(self):
+    src = os.path.join(self.get_dir(), 'src.cpp')
+    open(src, 'w').write(self.with_report_result(open(os.path.join(path_from_root('tests/manual_wasm_instantiate.cpp'))).read()))
+    Popen([PYTHON, EMCC, 'src.cpp', '-o', 'manual_wasm_instantiate.js', '-s', 'BINARYEN=1']).communicate()
+    shutil.copyfile(path_from_root('tests', 'manual_wasm_instantiate.html'), os.path.join(self.get_dir(), 'manual_wasm_instantiate.html'))
+    self.run_browser('manual_wasm_instantiate.html', 'wasm instantiation succeeded', '/report_result?1')
+
   def test_binaryen_worker(self):
     self.do_test_worker(['-s', 'WASM=1'])
 


### PR DESCRIPTION
Implement a custom callback hook that users can override to manually perform WebAssembly Module instantiation.

This allows user shell html pages to manually perform the whole process of wasm download, cache, compile and instantiate actions and integrate tighter with custom IDB databases, progress indication and error handling, and parallelization with other startup tasks.

The http://mzl.la/webassemblydemo page uses this construct to take custom control over the WebAssembly module compilation.