### PR TITLE
Parallel test runner

### DIFF
--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -91,13 +91,16 @@ class ParallelTestSuite(unittest.BaseTestSuite):
 
   def create_test_queue(self):
     test_queue = multiprocessing.Queue()
+    for test in self.reversed_tests()
+      test_queue.put(test)
+    return test_queue
+
+  def reversed_tests(self):
     tests = []
     for test in self:
       tests.append(test)
     tests.sort(key=lambda test: str(test))
-    for test in tests[::-1]:
-      test_queue.put(test)
-    return test_queue
+    return tests[::-1]
 
   def init_processes(self, test_queue):
     self.processes = []

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -70,28 +70,28 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     print
     print 'DONE: combining results on main thread'
     print
-    for r in sorted(buffered_results, key=lambda res:str(res.result_test)):
+    for r in sorted(buffered_results, key=lambda res:str(res.test)):
       r.updateResult(result)
     return result
 
 
 class BufferedParallelTestResult(object):
   def __init__(self):
-    self.result_type = None
-    self.result_test = None
-    self.result_error = None
+    self.kind = None
+    self.test = None
+    self.error = None
 
   def updateResult(self, result):
-    result.startTest(self.result_test)
+    result.startTest(self.test)
 
-    if self.result_type == TestResultType.Success:
-      result.addSuccess(self.result_test)
-    elif self.result_type == TestResultType.Failure:
-      result.addFailure(self.result_test, self.result_error)
-    elif self.result_type == TestResultType.Error:
-      result.addError(self.result_test, self.result_error)
+    if self.kind == TestResultType.Success:
+      result.addSuccess(self.test)
+    elif self.kind == TestResultType.Failure:
+      result.addFailure(self.test, self.error)
+    elif self.kind == TestResultType.Error:
+      result.addError(self.test, self.error)
 
-    result.stopTest(self.result_test)
+    result.stopTest(self.test)
 
   def startTest(self, test):
     pass
@@ -100,26 +100,26 @@ class BufferedParallelTestResult(object):
 
   def addSuccess(self, test):
     print test, '... ok'
-    self.result_type = TestResultType.Success
-    self.result_test = test
+    self.kind = TestResultType.Success
+    self.test = test
 
   def addFailure(self, test, err):
     print test, '... FAIL:'
     print err
-    self.result_type = TestResultType.Failure
-    self.result_test = test
+    self.kind = TestResultType.Failure
+    self.test = test
     self._set_error(err)
 
   def addError(self, test, err):
     print test, '... ERROR:'
     print err
-    self.result_type = TestResultType.Error
-    self.result_test = test
+    self.kind = TestResultType.Error
+    self.test = test
     self._set_error(err)
 
   def _set_error(self, err):
     a, b, tb = err
-    self.result_error = (a, b, FakeTraceback(tb))
+    self.error = (a, b, FakeTraceback(tb))
 
 
 class TestResultType(enum.Enum):

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -15,125 +15,20 @@ class TestResultType(enum.Enum):
   Error = 3
 
 
-def can_pickle(item):
-  try:
-    pickle.dumps(item)
-    return True
-  except TypeError as e:
-    # print 'cannot pickle', item, 'because:', e
-    # traceback.print_tb(sys.exc_info()[2])
-    return False
-  except:
-    print "UNEXPECTED EXCEPTION FROM pickle.dumps"
+class FakeTraceback(object):
+  def __init__(self, tb):
+    self.tb_frame = FakeFrame(tb.tb_frame)
+    self.tb_lineno = tb.tb_lineno
+    self.tb_next = FakeTraceback(tb.tb_next) if tb.tb_next is not None else None
+class FakeFrame(object):
+  def __init__(self, f):
+    self.f_code = FakeCode(f.f_code)
+    self.f_globals = [] # f.f_globals
+class FakeCode(object):
+  def __init__(self, co):
+    self.co_filename = co.co_filename
+    self.co_name = co.co_name
 
-class FakeObject(object):
-  def __init__(self):
-    print 'initing', self
-    self.__real_attrs = {}
-
-  def __getstate__(self):
-    print 'getting state of', self
-    print 'state is', self.__real_attrs
-    return self.__real_attrs
-
-  def __setstate__(self, state):
-    print 'setting state of', self, state
-    self.__real_attrs = state
-
-  def __getattr__(self, key):
-    print 'getting attr of', self, key
-    if key in ('__getinitargs__', '__getnewargs__'):
-      raise AttributeError
-    if key in ('_FakeObject__real_attrs'):
-      print 'oh dear'
-      return self.__dict__[key]
-    print 'dict is', self.__real_attrs
-    return self.__real_attrs[key]
-
-  def __setattr__(self, key, value):
-    print 'setting attr of', self, key, value
-    if key in ('_FakeObject__real_attrs'):
-      self.__dict__[key] = value
-    else:
-      self.__real_attrs[key] = value
-
-class AutoFaker(object):
-  def __init__(self, wrapped):
-    print 'initing w/', wrapped
-    self.__wrapped = wrapped
-    self.__faked = {}
-    for method in dir(wrapped):
-      print 'considering', method
-      a = getattr(wrapped, method)
-      if callable(a) and method != '__class__':
-        print 'trying to set', method
-        def wrapped(s, *args, **kwargs):
-          a(s, *args, **kwargs)
-        setattr(self, method, wrapped)
-      print '  worked'
-    print 'done w/ init'
-
-  def __getattr__(self, key):
-    print 'autofake get:', key
-    if not self.__faked.get(key):
-      val = getattr(self.__wrapped, key)
-      if not can_pickle(val):
-        val = AutoFaker(val)
-      self.__faked[key] = val
-    return self.__faked[key]
-
-  # def __iter__(self):
-  #   print 'itering'
-  #   setattr(self.__faked, '__iter__', self.__wrapped.__iter__)
-  #   return self.__wrapped.__iter__()
-
-  # def next(self):
-  #   print 'nexting'
-  #   setattr(self.__faked, 'next', self.__wrapped.next)
-  #   return self.__wrapped.next()
-
-  def reify_fake_object(self):
-    print 'reifying'
-    result = FakeObject()
-    for k, v in self.__faked.iteritems():
-      if isinstance(v, AutoFaker):
-        setattr(result, k, v.reify_fake_object())
-    for method in dir(self.wrapped):
-      a = getattr(self.wrapped, method)
-      if callable(a):
-        setattr(result, method, a)
-    return result
-
-  def make_dict(self):
-    result = {}
-    for k, v in self.__faked.iteritems():
-      if isinstance(v, AutoFaker):
-        result[k] = v.make_dict()
-      else:
-        result[k] = v
-    return result
-    # return self.__faked
-
-def fake_for(item, funcs):
-  print 'faking:', item
-  fake = AutoFaker(item)
-  print 'trying'
-  try:
-    for f in funcs:
-      f(fake)
-    ret = fake.reify_fake_object()
-  except Exception as e:
-    print 'aw dang:', e
-    raise e
-  print 'fake:', ret
-  print ret.__dict__
-  print 'fakedict:', fake.make_dict()
-  print 'can pickle:', can_pickle(ret)
-  print 'pickled:', pickle.dumps(ret)
-  rounded = pickle.loads(pickle.dumps(ret))
-  print 'roundtripped:', rounded.__dict__
-  print 'wamp'
-  return ret
 
 class BufferedParallelTestResult(object):
   def __init__(self):
@@ -178,48 +73,8 @@ class BufferedParallelTestResult(object):
     self._set_error(err)
 
   def _set_error(self, err):
-    if can_pickle(err):
-      self.result_error = err
-    else:
-      a, b, tb = err
-      self.result_error = (a, b, self.fake_traceback(tb))
-
-  @staticmethod
-  def fake_traceback(real_traceback):
-    # TODO: create a fake traceback object that mirrors the string info of the real one
-    '''
-    Need to mock:
-      tb_frame
-      tb_lineno
-      tb_next
-
-    In particular:
-      list = []
-      n = 0
-      while tb is not None and (limit is None or n < limit):
-          f = tb.tb_frame
-          lineno = tb.tb_lineno
-          co = f.f_code
-          filename = co.co_filename
-          name = co.co_name
-          linecache.checkcache(filename)
-          line = linecache.getline(filename, lineno, f.f_globals)
-          if line: line = line.strip()
-          else: line = None
-          list.append((filename, lineno, name, line))
-          tb = tb.tb_next
-          n = n+1
-      return list
-    '''
-    return fake_for(real_traceback, [
-      traceback.extract_tb,
-      lambda tb: 'foo' in tb.tb_frame.f_globals
-    ])
-    # try:
-    #   # We need to construct a traceback object and this is a hacky way to do that
-    #   1/0
-    # except Exception as e:
-    #   return sys.exc_info()[2]
+    a, b, tb = err
+    self.result_error = (a, b, FakeTraceback(tb))
 
 
 class ParallelTestSuite(unittest.BaseTestSuite):

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -1,0 +1,113 @@
+import enum
+import multiprocessing
+import os
+import unittest
+import time
+import sys
+
+
+class TestResultType(enum.Enum):
+  Success = 1
+  Failure = 2
+  Error = 3
+
+
+class ParallelTextTestResult(object):
+  def __init__(self):
+    self.resultType = None
+    self.resultTest = None
+    self.resultErr = None
+
+  def startTest(self, test):
+    pass
+  def stopTest(self, test):
+    pass
+
+  def addSuccess(self, test):
+    print 'Test', test, 'OK'
+    self.resultType = TestResultType.Success
+    self.resultTest = test
+
+  def addFailure(self, test, err):
+    print 'Test', test, 'FAIL with:', err
+    self.resultType = TestResultType.Failure
+    self.resultTest = test
+    self._setError(err)
+
+  def addError(self, test, err):
+    print 'Test', test, 'ERROR with:', err
+    self.resultType = TestResultType.Error
+    self.resultTest = test
+    self._setError(err)
+
+  def _setError(self, err):
+    a, b, _ = err
+    self.resultErr = (a, b, None)
+
+
+class ParallelTestSuite(unittest.BaseTestSuite):
+  def run(self, result):
+    import Queue
+    end_of_queue = 'STOP'
+    def worker(work_queue, result_queue):
+      for test in iter(work_queue.get, end_of_queue):
+        result = ParallelTextTestResult()
+        try:
+          test(result)
+        except Exception as e:
+          result.addError(test, e)
+        result_queue.put(result)
+
+    num_workers = ParallelTestSuite.num_cores()
+    processes = []
+    test_queue = multiprocessing.Queue()
+    result_queue = multiprocessing.Queue()
+    for test in self:
+      test_queue.put(test)
+    for i in xrange(num_workers):
+      p = multiprocessing.Process(target=worker, args=(test_queue, result_queue))
+      p.start()
+      processes.append(p)
+      test_queue.put(end_of_queue)
+
+    worker_status = {}
+    buffered_results = []
+    while len(processes) > 0:
+      try:
+        res = result_queue.get(True, 0.1)
+        buffered_results.append(res)
+      except Queue.Empty:
+        processes = filter(lambda p: p.is_alive(), processes)
+      except TypeError as e:
+        # Quirk of python 2.7 (marked WNF) : https://bugs.python.org/issue9400
+        print 'hopefully got a subprocess.CalledProcessError:', e
+
+    for r in buffered_results:
+      s = r.resultTest
+      result.startTest(s)
+      err = None
+      if r.resultErr is not None:
+        tb = None
+        try:
+          # We need to reconstruct some traceback and this is a hacky way to do that
+          1/0
+        except Exception as e:
+          tb = sys.exc_info()[2]
+        a, b, c = r.resultErr
+        err = (a, b, tb)
+      if r.resultType == TestResultType.Success:
+        result.addSuccess(s)
+      elif r.resultType == TestResultType.Failure:
+        result.addFailure(s, err)
+      elif r.resultType == TestResultType.Error:
+        result.addError(s, err)
+      result.stopTest(s)
+
+    return result
+
+  @staticmethod
+  def num_cores():
+    emcc_cores = os.environ.get('EMCC_CORES')
+    if emcc_cores:
+      return int(emcc_cores)
+    return multiprocessing.cpu_count()

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -16,7 +16,7 @@ class ParallelTextTestResult(object):
   def __init__(self):
     self.resultType = None
     self.resultTest = None
-    self.resultErr = None
+    self.resultError = None
 
   def startTest(self, test):
     pass
@@ -24,25 +24,27 @@ class ParallelTextTestResult(object):
     pass
 
   def addSuccess(self, test):
-    print 'Test', test, 'OK'
+    print test, '... ok'
     self.resultType = TestResultType.Success
     self.resultTest = test
 
   def addFailure(self, test, err):
-    print 'Test', test, 'FAIL with:', err
+    print test, '... FAIL:'
+    print err
     self.resultType = TestResultType.Failure
     self.resultTest = test
     self._setError(err)
 
   def addError(self, test, err):
-    print 'Test', test, 'ERROR with:', err
+    print test, '... ERROR:'
+    print err
     self.resultType = TestResultType.Error
     self.resultTest = test
     self._setError(err)
 
   def _setError(self, err):
     a, b, _ = err
-    self.resultErr = (a, b, None)
+    self.resultError = (a, b, None)
 
 
 class ParallelTestSuite(unittest.BaseTestSuite):
@@ -86,14 +88,14 @@ class ParallelTestSuite(unittest.BaseTestSuite):
       s = r.resultTest
       result.startTest(s)
       err = None
-      if r.resultErr is not None:
+      if r.resultError is not None:
         tb = None
         try:
           # We need to reconstruct some traceback and this is a hacky way to do that
           1/0
         except Exception as e:
           tb = sys.exc_info()[2]
-        a, b, c = r.resultErr
+        a, b, c = r.resultError
         err = (a, b, tb)
       if r.resultType == TestResultType.Success:
         result.addSuccess(s)

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -105,14 +105,12 @@ class BufferedParallelTestResult(object):
 
   def addFailure(self, test, err):
     print test, '... FAIL:'
-    print err
     self.kind = TestResultType.Failure
     self.test = test
     self._set_error(err)
 
   def addError(self, test, err):
     print test, '... ERROR:'
-    print err
     self.kind = TestResultType.Error
     self.test = test
     self._set_error(err)

--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -1,8 +1,11 @@
 import enum
 import multiprocessing
 import os
+import pickle
+import Queue
 import unittest
 import time
+import traceback
 import sys
 
 
@@ -11,6 +14,126 @@ class TestResultType(enum.Enum):
   Failure = 2
   Error = 3
 
+
+def can_pickle(item):
+  try:
+    pickle.dumps(item)
+    return True
+  except TypeError as e:
+    # print 'cannot pickle', item, 'because:', e
+    # traceback.print_tb(sys.exc_info()[2])
+    return False
+  except:
+    print "UNEXPECTED EXCEPTION FROM pickle.dumps"
+
+class FakeObject(object):
+  def __init__(self):
+    print 'initing', self
+    self.__real_attrs = {}
+
+  def __getstate__(self):
+    print 'getting state of', self
+    print 'state is', self.__real_attrs
+    return self.__real_attrs
+
+  def __setstate__(self, state):
+    print 'setting state of', self, state
+    self.__real_attrs = state
+
+  def __getattr__(self, key):
+    print 'getting attr of', self, key
+    if key in ('__getinitargs__', '__getnewargs__'):
+      raise AttributeError
+    if key in ('_FakeObject__real_attrs'):
+      print 'oh dear'
+      return self.__dict__[key]
+    print 'dict is', self.__real_attrs
+    return self.__real_attrs[key]
+
+  def __setattr__(self, key, value):
+    print 'setting attr of', self, key, value
+    if key in ('_FakeObject__real_attrs'):
+      self.__dict__[key] = value
+    else:
+      self.__real_attrs[key] = value
+
+class AutoFaker(object):
+  def __init__(self, wrapped):
+    print 'initing w/', wrapped
+    self.__wrapped = wrapped
+    self.__faked = {}
+    for method in dir(wrapped):
+      print 'considering', method
+      a = getattr(wrapped, method)
+      if callable(a) and method != '__class__':
+        print 'trying to set', method
+        def wrapped(s, *args, **kwargs):
+          a(s, *args, **kwargs)
+        setattr(self, method, wrapped)
+      print '  worked'
+    print 'done w/ init'
+
+  def __getattr__(self, key):
+    print 'autofake get:', key
+    if not self.__faked.get(key):
+      val = getattr(self.__wrapped, key)
+      if not can_pickle(val):
+        val = AutoFaker(val)
+      self.__faked[key] = val
+    return self.__faked[key]
+
+  # def __iter__(self):
+  #   print 'itering'
+  #   setattr(self.__faked, '__iter__', self.__wrapped.__iter__)
+  #   return self.__wrapped.__iter__()
+
+  # def next(self):
+  #   print 'nexting'
+  #   setattr(self.__faked, 'next', self.__wrapped.next)
+  #   return self.__wrapped.next()
+
+  def reify_fake_object(self):
+    print 'reifying'
+    result = FakeObject()
+    for k, v in self.__faked.iteritems():
+      if isinstance(v, AutoFaker):
+        setattr(result, k, v.reify_fake_object())
+    for method in dir(self.wrapped):
+      a = getattr(self.wrapped, method)
+      if callable(a):
+        setattr(result, method, a)
+    return result
+
+  def make_dict(self):
+    result = {}
+    for k, v in self.__faked.iteritems():
+      if isinstance(v, AutoFaker):
+        result[k] = v.make_dict()
+      else:
+        result[k] = v
+    return result
+    # return self.__faked
+
+def fake_for(item, funcs):
+  print 'faking:', item
+  fake = AutoFaker(item)
+  print 'trying'
+  try:
+    for f in funcs:
+      f(fake)
+    ret = fake.reify_fake_object()
+  except Exception as e:
+    print 'aw dang:', e
+    raise e
+  print 'fake:', ret
+  print ret.__dict__
+  print 'fakedict:', fake.make_dict()
+  print 'can pickle:', can_pickle(ret)
+  print 'pickled:', pickle.dumps(ret)
+  rounded = pickle.loads(pickle.dumps(ret))
+  print 'roundtripped:', rounded.__dict__
+  print 'wamp'
+  return ret
 
 class BufferedParallelTestResult(object):
   def __init__(self):
@@ -24,9 +147,9 @@ class BufferedParallelTestResult(object):
     if self.result_type == TestResultType.Success:
       result.addSuccess(self.result_test)
     elif self.result_type == TestResultType.Failure:
-      result.addFailure(self.result_test, self._get_error())
+      result.addFailure(self.result_test, self.result_error)
     elif self.result_type == TestResultType.Error:
-      result.addError(self.result_test, self._get_error())
+      result.addError(self.result_test, self.result_error)
 
     result.stopTest(self.result_test)
 
@@ -55,25 +178,48 @@ class BufferedParallelTestResult(object):
     self._set_error(err)
 
   def _set_error(self, err):
-    a, b, _ = err
-    self.result_error = (a, b, None)
-
-  def _get_error(self):
-    if self.result_error is None:
-      return None
-
-    a, b, tb = self.result_error
-    fake_tb = self.fake_traceback(tb)
-    return (a, b, fake_tb)
+    if can_pickle(err):
+      self.result_error = err
+    else:
+      a, b, tb = err
+      self.result_error = (a, b, self.fake_traceback(tb))
 
   @staticmethod
   def fake_traceback(real_traceback):
     # TODO: create a fake traceback object that mirrors the string info of the real one
-    try:
-      # We need to construct a traceback object and this is a hacky way to do that
-      1/0
-    except Exception as e:
-      return sys.exc_info()[2]
+    '''
+    Need to mock:
+      tb_frame
+      tb_lineno
+      tb_next
+
+    In particular:
+      list = []
+      n = 0
+      while tb is not None and (limit is None or n < limit):
+          f = tb.tb_frame
+          lineno = tb.tb_lineno
+          co = f.f_code
+          filename = co.co_filename
+          name = co.co_name
+          linecache.checkcache(filename)
+          line = linecache.getline(filename, lineno, f.f_globals)
+          if line: line = line.strip()
+          else: line = None
+          list.append((filename, lineno, name, line))
+          tb = tb.tb_next
+          n = n+1
+      return list
+    '''
+    return fake_for(real_traceback, [
+      traceback.extract_tb,
+      lambda tb: 'foo' in tb.tb_frame.f_globals
+    ])
+    # try:
+    #   # We need to construct a traceback object and this is a hacky way to do that
+    #   1/0
+    # except Exception as e:
+    #   return sys.exc_info()[2]
 
 
 class ParallelTestSuite(unittest.BaseTestSuite):
@@ -137,7 +283,6 @@ class ParallelTestSuite(unittest.BaseTestSuite):
 
 
 def get_from_queue(queue):
-  import Queue
   try:
     return queue.get(True, 0.1)
   except Queue.Empty:

--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -10,6 +10,7 @@ You may want to run this with unbuffered output, python -u ...
 
 import os, sys, subprocess, multiprocessing, threading, time
 from runner import test_modes, PYTHON, path_from_root
+import parallel_runner
 
 assert not os.environ.get('EM_SAVE_DIR'), 'Need separate directories to avoid the parallel tests clashing'
 
@@ -97,7 +98,7 @@ def main():
   watcher.start()
 
   # run all modes
-  cores = int(os.environ.get('PARALLEL_SUITE_EMCC_CORES') or os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
+  cores = parallel_runner.num_cores()
   pool = multiprocessing.Pool(processes=cores)
   args = [[x] + sys.argv[1:] for x in optimal_order]
   num_failures = pool.map(run_mode, args, chunksize=1)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1196,7 +1196,8 @@ def skip_requested_tests(args, modules):
 
 def suite_for_module(module):
   import parallel_runner
-  if module.__name__ == 'test_core':
+  has_multiple_cores = parallel_runner.num_cores() > 1
+  if module.__name__ == 'test_core' and has_multiple_cores:
     return parallel_runner.ParallelTestSuite()
   return unittest.TestSuite()
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -12,6 +12,9 @@ from subprocess import Popen, PIPE, STDOUT
 import os, unittest, tempfile, shutil, time, inspect, sys, math, glob, re, difflib
 import webbrowser, hashlib, threading, platform, BaseHTTPServer, SimpleHTTPServer
 import multiprocessing, functools, stat, string, random, fnmatch, httplib
+import atexit
+import operator
+import parallel_runner
 from urllib import unquote
 
 # Setup
@@ -1187,7 +1190,6 @@ def print_random_test_statistics(num_tests):
          % (num_tests, expected))
   print
 
-  import atexit
   def show():
     print ('if all tests passed then there is a greater than 95%% chance that at least '
            '%.2f%% of the test suite will pass'
@@ -1195,7 +1197,6 @@ def print_random_test_statistics(num_tests):
   atexit.register(show)
 
 def load_test_suites(args, modules):
-  import operator
   loader = unittest.TestLoader()
   unmatched_test_names = set(args[1:])
   suites = []
@@ -1225,7 +1226,6 @@ def flattened_tests(loaded_tests):
   return tests
 
 def suite_for_module(module, tests):
-  import parallel_runner
   suite_supported = module.__name__ == 'test_core'
   has_multiple_tests = len(tests) > 1
   has_multiple_cores = parallel_runner.num_cores() > 1

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1209,7 +1209,12 @@ def load_test_suites(args, modules):
       except AttributeError:
         pass
     if len(names_in_module) > 0:
-      suites.append((m.__name__, loader.loadTestsFromNames(sorted(names_in_module), m)))
+      tests = loader.loadTestsFromNames(sorted(names_in_module), m)
+      suite = unittest.TestSuite()
+      for subsuite in tests:
+        for test in subsuite:
+          suite.addTest(test)
+      suites.append((m.__name__, suite))
   return suites, unmatched_test_names
 
 def run_tests(suites, unmatched_test_names):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1194,8 +1194,14 @@ def skip_requested_tests(args, modules):
       args[i] = None
   return filter(lambda arg: arg is not None, args)
 
+def suite_for_module(module):
+  import parallel_runner
+  if module.__name__ == 'test_core':
+    return parallel_runner.ParallelTestSuite()
+  return unittest.TestSuite()
+
 def load_test_suites(args, modules):
-  import operator, parallel_runner
+  import operator
   loader = unittest.TestLoader()
   unmatched_test_names = set(args[1:])
   suites = []
@@ -1210,8 +1216,7 @@ def load_test_suites(args, modules):
         pass
     if len(names_in_module) > 0:
       tests = loader.loadTestsFromNames(sorted(names_in_module), m)
-      module_name = m.__name__
-      suite = parallel_runner.ParallelTestSuite() if module_name == 'test_core' else unittest.TestSuite()
+      suite = suite_for_module(m)
       for subsuite in tests:
         for test in subsuite:
           suite.addTest(test)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1169,149 +1169,6 @@ def print_random_test_statistics(num_tests):
            % (expected))
   atexit.register(show)
 
-
-import enum
-class TestResultType(enum.Enum):
-  Success = 1
-  Failure = 2
-  Error = 3
-
-
-# class ParallelTextTestResult(unittest.TestResult):
-class ParallelTextTestResult(object):
-  def __init__(self):
-    self.resultType = None
-    self.resultTest = None
-    self.resultErr = None
-
-  def startTest(self, test):
-    pass
-  def stopTest(self, test):
-    pass
-
-  def addSuccess(self, test):
-    self.resultType = TestResultType.Success
-    self.resultTest = test
-
-  def addFailure(self, test, err):
-    print 'adding failure:', err
-    self.resultType = TestResultType.Failure
-    self.resultTest = test
-    a, b, c = err
-    print 'c =', str(c)
-    self.resultErr = (a, b, str(c))
-
-  def addError(self, test, err):
-    print 'adding error:', err
-    self.resultType = TestResultType.Error
-    self.resultTest = test
-    a, b, c = err
-    print 'c =', str(c)
-    self.resultErr = (a, b, str(c))
-
-
-class ParallelTestSuite(unittest.BaseTestSuite):
-  def run(self, result):
-    import Queue
-    end_of_queue = 'STOP'
-    def worker(worker_id, work_queue, result_queue, execution_queue):
-      for test in iter(work_queue.get, end_of_queue):
-        execution_queue.put((worker_id, test, 'START'))
-        result = ParallelTextTestResult()
-        started = time.time()
-        try:
-          test(result)
-        except Exception as e:
-          print 'hold up wait', e
-          result.addError(test, "wo dang something went fucky")
-        elapsed = time.time() - started
-        if elapsed > 30:
-          print 'SLOW TEST:', test, '; t=', elapsed
-        result_queue.put(result)
-        execution_queue.put((worker_id, test, 'END'))
-      print "finishing thread", worker_id
-
-    num_workers = int(os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
-    processes = []
-    test_queue = multiprocessing.Queue()
-    result_queue = multiprocessing.Queue()
-    execution_queue = multiprocessing.Queue()
-    print 'tests to run:'
-    for test in self:
-      print "  '" + str(test) + "'"
-      test_queue.put(test)
-    for worker_id in xrange(num_workers):
-      p = multiprocessing.Process(target=worker, args=(worker_id, test_queue, result_queue, execution_queue))
-      p.start()
-      processes.append(p)
-      test_queue.put(end_of_queue)
-
-    worker_status = {}
-    started = time.time()
-    num_started = 0
-    num_ended = 0
-    def elapsed():
-      return time.time() - started
-    def print_status():
-      print 'Worker state at t =', elapsed(), ':'
-      print '   tests started:', num_started
-      print '   tests ended:', num_ended
-      for i in xrange(num_workers):
-        print '  ', i, ': ', worker_status.get(i)
-    buffered_results = []
-    while len(processes) > 0:
-      try:
-        res = result_queue.get(True, 0.1)
-        buffered_results.append(res)
-      except Queue.Empty:
-        processes = filter(lambda p: p.is_alive(), processes)
-      except TypeError as e:
-        print 'oh damn got a s.CPE A', e
-      try:
-        res = execution_queue.get(True, 0.1)
-        w, t, s = res
-        status = str(t) + ': ' + s
-        print 'got event: #', w, ':', status
-        worker_status[w] = status
-        if s == 'START': num_started += 1
-        if s == 'END': num_ended += 1
-        print_status()
-      except Queue.Empty:
-        pass
-      except TypeError as e:
-        print 'oh damn got a s.CPE B', e
-    print 'trying to join threads'
-    sys.stdout.flush()
-    # for p in processes:
-    #   p.join()
-    # print 'actually joined threads!'
-    # sys.stdout.flush()
-
-    # result_queue.put(end_of_queue)
-    # for r in iter(result_queue.get, end_of_queue):
-    for r in buffered_results:
-      s = r.resultTest
-      result.startTest(s)
-      err = None
-      if r.resultErr is not None:
-        tb = None
-        try:
-          1/0
-        except Exception as e:
-          tb = sys.exc_info()[2]
-        a, b, c = r.resultErr
-        err = (a, b, tb)
-      if r.resultType == TestResultType.Success:
-        result.addSuccess(s)
-      elif r.resultType == TestResultType.Failure:
-        result.addFailure(s, err)
-      elif r.resultType == TestResultType.Error:
-        result.addError(s, err)
-      result.stopTest(s)
-
-
-    return result
-
 def skip_requested_tests(args, modules):
   for i in range(len(args)):
     arg = args[i]
@@ -1338,7 +1195,7 @@ def skip_requested_tests(args, modules):
   return filter(lambda arg: arg is not None, args)
 
 def load_test_suites(args, modules):
-  import operator
+  import operator, parallel_runner
   loader = unittest.TestLoader()
   unmatched_test_names = set(args[1:])
   suites = []
@@ -1354,7 +1211,7 @@ def load_test_suites(args, modules):
     if len(names_in_module) > 0:
       tests = loader.loadTestsFromNames(sorted(names_in_module), m)
       module_name = m.__name__
-      suite = ParallelTestSuite() if module_name == 'test_core' else unittest.TestSuite()
+      suite = parallel_runner.ParallelTestSuite() if module_name == 'test_core' else unittest.TestSuite()
       for subsuite in tests:
         for test in subsuite:
           suite.addTest(test)

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -34,9 +34,10 @@ class Cache:
         dirname = os.path.join(dirname, 'asmjs')
     self.dirname = dirname
     self.debug = debug
+    self.acquired_count = 0
 
   def acquire_cache_lock(self):
-    if not self.EM_EXCLUSIVE_CACHE_ACCESS:
+    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 0:
       logging.debug('Cache: PID %s acquiring multiprocess file lock to Emscripten cache' % str(os.getpid()))
       try:
         self.filelock.acquire(60)
@@ -49,13 +50,15 @@ class Cache:
       self.prev_EM_EXCLUSIVE_CACHE_ACCESS = os.environ.get('EM_EXCLUSIVE_CACHE_ACCESS')
       os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = '1'
       logging.debug('Cache: done')
+    self.acquired_count += 1
 
   def release_cache_lock(self):
-    if not self.EM_EXCLUSIVE_CACHE_ACCESS:
+    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 1:
       if self.prev_EM_EXCLUSIVE_CACHE_ACCESS: os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = self.prev_EM_EXCLUSIVE_CACHE_ACCESS
       else: del os.environ['EM_EXCLUSIVE_CACHE_ACCESS']
       self.filelock.release()
       logging.debug('Cache: PID %s released multiprocess file lock to Emscripten cache' % str(os.getpid()))
+    self.acquired_count = max(self.acquired_count - 1, 0)
 
   def ensure(self):
     self.acquire_cache_lock()

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -53,13 +53,13 @@ class Cache:
     self.acquired_count += 1
 
   def release_cache_lock(self):
-    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 1:
+    self.acquired_count -= 1
+    assert self.acquired_count >= 0, "Called release more times than acquire"
+    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 0:
       if self.prev_EM_EXCLUSIVE_CACHE_ACCESS: os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = self.prev_EM_EXCLUSIVE_CACHE_ACCESS
       else: del os.environ['EM_EXCLUSIVE_CACHE_ACCESS']
       self.filelock.release()
       logging.debug('Cache: PID %s released multiprocess file lock to Emscripten cache' % str(os.getpid()))
-    self.acquired_count -= 1
-    assert self.acquired_count >= 0, "Called release more times than acquire"
 
   def ensure(self):
     self.acquire_cache_lock()

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -58,7 +58,8 @@ class Cache:
       else: del os.environ['EM_EXCLUSIVE_CACHE_ACCESS']
       self.filelock.release()
       logging.debug('Cache: PID %s released multiprocess file lock to Emscripten cache' % str(os.getpid()))
-    self.acquired_count = max(self.acquired_count - 1, 0)
+    self.acquired_count -= 1
+    assert self.acquired_count >= 0, "Called release more times than acquire"
 
   def ensure(self):
     self.acquire_cache_lock()


### PR DESCRIPTION
This runs a set of tests in parallel with finer granularity than the existing `parallel_test_core`, allowing for fuller utilization of machines with many cores, running less than a full suite of tests in parallel, etc.

Ideally this happens automatically by just calling `runner.py` as normal. Number of cores used can be limited with the general `EMCC_CORES` environment variable, or the testing-only `PARALLEL_SUITE_EMCC_CORES` environment variable.