### PR TITLE
add a .then() method to the module-creating function in MODULARIZE

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -3,7 +3,6 @@
 
 Module['asm'] = asm;
 
-
 {{{ maybeExport('FS') }}}
 
 #if MEM_INIT_METHOD == 2

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -109,14 +109,17 @@ if (memoryInitializer) {
 // so you can use the output of .then(..)).
 Module['then'] = function(func) {
   // We may already be ready to run code at this time. if
-  // so, just queue a call to the callback. otherwise, add
-  // a preMain.
+  // so, just queue a call to the callback.
   if (Module['calledRun']) {
     func(Module);
   } else {
-    addOnPreMain(function() {
+    // we are not ready to call then() yet. we must call it
+    // at the same time we would call onRuntimeInitialized.
+    var old = Module['onRuntimeInitialized'];
+    Module['onRuntimeInitialized'] = function() {
       func(Module);
-    });
+      if (old) old();
+    };
   }
   return Module;
 };

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -117,8 +117,8 @@ Module['then'] = function(func) {
     // at the same time we would call onRuntimeInitialized.
     var old = Module['onRuntimeInitialized'];
     Module['onRuntimeInitialized'] = function() {
-      func(Module);
       if (old) old();
+      func(Module);
     };
   }
   return Module;

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -3,6 +3,7 @@
 
 Module['asm'] = asm;
 
+
 {{{ maybeExport('FS') }}}
 
 #if MEM_INIT_METHOD == 2
@@ -98,6 +99,28 @@ if (memoryInitializer) {
 
 #if CYBERDWARF
   Module['cyberdwarf'] = _cyberdwarf_Debugger(cyberDWARFFile);
+#endif
+
+#if MODULARIZE
+// Modularize mode returns a function, which can be called to
+// create instances. The instances provide a then() method,
+// must like a Promise, that receives a callback. The callback
+// is called when the module is ready to run, with the module
+// as a parameter. (Like a Promise, it also returns the module
+// so you can use the output of .then(..)).
+Module['then'] = function(func) {
+  // We may already be ready to run code at this time. if
+  // so, just queue a call to the callback. otherwise, add
+  // a preMain.
+  if (Module['calledRun']) {
+    func(Module);
+  } else {
+    addOnPreMain(function() {
+      func(Module);
+    });
+  }
+  return Module;
+};
 #endif
 
 function ExitStatus(status) {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2799,20 +2799,38 @@ window.close = function() {
     for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2'], ['-O2', '--closure', '1']]:
       for args, code in [
         ([], 'Module();'), # defaults
+        # use EXPORT_NAME
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           if (typeof Module !== "undefined") throw "what?!"; // do not pollute the global scope, we are modularized!
           HelloWorld.noInitialRun = true; // errorneous module capture will load this and cause timeout
           HelloWorld();
-        '''), # use EXPORT_NAME
+        '''),
+        # pass in a Module option (which prevents main(), which we then invoke ourselves)
         (['-s', 'EXPORT_NAME="HelloWorld"'], '''
           var hello = HelloWorld({ noInitialRun: true, onRuntimeInitialized: function() {
             setTimeout(function() { hello._main(); }); // must be async, because onRuntimeInitialized may be called synchronously, so |hello| is not yet set!
           } });
-        '''), # pass in a Module option (which prevents main(), which we then invoke ourselves)
+        '''),
+        # similar, but without a mem init file, everything is sync and simple
         (['-s', 'EXPORT_NAME="HelloWorld"', '--memory-init-file', '0'], '''
           var hello = HelloWorld({ noInitialRun: true});
           hello._main();
-        '''), # similar, but without a mem init file, everything is sync and simple
+        '''),
+        # use the then() API
+        (['-s', 'EXPORT_NAME="HelloWorld"'], '''
+          HelloWorld({ noInitialRun: true }).then(function(hello) {
+            hello._main();
+          });
+        '''),
+        # then() API, also note the returned value
+        (['-s', 'EXPORT_NAME="HelloWorld"'], '''
+          var helloOutside = HelloWorld({ noInitialRun: true }).then(function(hello) {
+            setTimeout(function() {
+              hello._main();
+              assert(hello === helloOutside); // as we are async, helloOutside must have been set
+            });
+          });
+        '''),
       ]:
         print 'test on', opts, args, code
         src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()


### PR DESCRIPTION
This lets it be used as a promise, and works in both sync and async mode (we need async for wasm).

In modularize mode, the entire output is a function `Module()` (or another name, set by EXPORT_NAME). This is useful for libraries, so they don't influence the global scope. Til now most libraries, like box2d.js and ammo.js, assumed synchronous startup, which was made possible by not having a mem init file (which was convenient anyhow as for libraries having extra files is less good). But for wasm it looks like we can't depend on sync compilation.

This PR adds a `then()` method, usable as
````
Module().then(function(Module) { .. });
````
Basically like a promise. The callback is called when the module is all compiled and ready to be used. It has the module as a parameter.

This is also perhaps a nicer API than the other methods for finding out when it is possible to call compiled code (e.g., onRuntimeInitialized), so in the long term, maybe we'd want to recommend people use modularize more, and this with it.

The [wasm branch of ammo.js](https://github.com/kripken/ammo.js/tree/wasm) uses this. Looks like it works ok.