### PR TITLE
use Runtime.GLOBAL_BASE at runtime, so we use the adjusted (for align…

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -296,7 +296,7 @@ function JSify(data, functionsOnly) {
         Variables.generatedGlobalBase = true;
         // Globals are done, here is the rest of static memory
         if (!SIDE_MODULE) {
-          print('STATIC_BASE = ' + Runtime.GLOBAL_BASE + ';\n');
+          print('STATIC_BASE = Runtime.GLOBAL_BASE;\n');
           print('STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
         } else {
           print('gb = Runtime.alignMemory(getMemory({{{ STATIC_BUMP }}}, ' + MAX_GLOBAL_ALIGN + ' || 1));\n');

--- a/tests/core/test_main_module_static_align.c
+++ b/tests/core/test_main_module_static_align.c
@@ -1,0 +1,13 @@
+#include <emscripten.h>
+
+__attribute__((aligned(16))) volatile char aligned;
+
+int main() {
+  emscripten_log(EM_LOG_WARN, "16-byte aligned char: %d.", int(&aligned));
+  EM_ASM({
+    // whether the char was properly aligned affects tempDoublePtr, which is after the static aligns
+    Module['print']('tempDoublePtr: ' + tempDoublePtr + '.');
+    Module['print']('tempDoublePtr alignment: ' + (tempDoublePtr % 16) + '.');
+  });
+}
+

--- a/tests/core/test_main_module_static_align.txt
+++ b/tests/core/test_main_module_static_align.txt
@@ -1,0 +1,1 @@
+tempDoublePtr alignment: 0.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4623,6 +4623,12 @@ PORT: 3979
     expected = open(path_from_root('tests', 'netinet', 'in.out'), 'r').read()
     self.do_run(src, expected)
 
+  @no_wasm_backend()
+  def test_main_module_static_align(self):
+    if Settings.ALLOW_MEMORY_GROWTH: return self.skip('no shared modules with memory growth')
+    Settings.MAIN_MODULE = 1
+    self.do_run_in_out_file_test('tests', 'core', 'test_main_module_static_align')
+
   # libc++ tests
 
   def test_iostream_and_determinism(self):


### PR DESCRIPTION
…ment) address. without that, in main modules STATIC_BASE could be out of sync.

Without linking, we determine all this in a simple way, but for the linking case, we used the old value instead of the aligned one. Really, we should use `Runtime.GLOBAL_BASE` everywhere, which we do, except for this one bug.