### PR TITLE
embuilder: if EMCC_WASM_BACKEND, omit tasks using pthreads from ALL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -284,3 +284,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Henning Pohl <henning@still-hidden.de>
 * Tim Neumann <mail@timnn.me>
 * Ondrej Stava <ondrej.stava@gmail.com> (copyright owned by Google, Inc.
+* Jakub Jirutka <jakub@jirutka.cz>

--- a/embuilder.py
+++ b/embuilder.py
@@ -85,6 +85,10 @@ if operation == 'build':
   tasks = sys.argv[2:]
   if 'ALL' in tasks:
     tasks = ['libc', 'libc-mt', 'dlmalloc', 'dlmalloc_threadsafe', 'pthreads', 'libcxx', 'libcxx_noexcept', 'libcxxabi', 'gl', 'binaryen', 'bullet', 'freetype', 'libpng', 'ogg', 'sdl2', 'sdl2-image', 'sdl2-ttf', 'sdl2-net', 'vorbis', 'zlib']
+    if os.environ.get('EMCC_WASM_BACKEND') == '1':
+      skip_tasks = {'libc-mt', 'dlmalloc_threadsafe', 'pthreads'}
+      print('Skipping building of %s, because WebAssembly does not support pthreads.' % ', '.join(skip_tasks))
+      tasks = [x for x in tasks if x not in skip_tasks]
     if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER'):
       print 'Skipping building of native-optimizer since environment variable EMSCRIPTEN_NATIVE_OPTIMIZER is present and set to point to a prebuilt native optimizer path.'
     elif hasattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER'):


### PR DESCRIPTION
Fixes the following error:

    $ EMCC_WASM_BACKEND=1 ./embuild build ALL
    Traceback (most recent call last):
      File "emscripten/src/emscripten-1.37.9/emcc", line 13, in <module>
        emcc.run()
      File "emscripten/src/emscripten-1.37.9/emcc.py", line 1278, in run
        assert not shared.Settings.USE_PTHREADS, 'WebAssembly does not support pthreads'
    AssertionError: WebAssembly does not support pthreads