### PR TITLE
Fix embinding functions for wasm backend

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1116,12 +1116,13 @@ namespace emscripten {
 
         EMSCRIPTEN_ALWAYS_INLINE explicit class_(const char* name) {
             using namespace internal;
+            typedef void (*VoidFunctionPtr)(void);
 
             BaseSpecifier::template verify<ClassType>();
 
             auto _getActualType = &getActualType<ClassType>;
-            void (*upcast)(void) = (void (*)(void))BaseSpecifier::template getUpcaster<ClassType>();
-            void (*downcast)(void) = (void (*)(void))BaseSpecifier::template getDowncaster<ClassType>();
+            VoidFunctionPtr upcast   = (VoidFunctionPtr)BaseSpecifier::template getUpcaster<ClassType>();
+            VoidFunctionPtr downcast = (VoidFunctionPtr)BaseSpecifier::template getDowncaster<ClassType>();
             auto destructor = &raw_destructor<ClassType>;
 
             _embind_register_class(

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -24,7 +24,7 @@ namespace emscripten {
     namespace internal {
         typedef long GenericEnumValue;
 
-        typedef void (*GenericFunction)();
+        typedef void* GenericFunction;
 
         // Implemented in JavaScript.  Don't call these directly.
         extern "C" {
@@ -1120,8 +1120,8 @@ namespace emscripten {
             BaseSpecifier::template verify<ClassType>();
 
             auto _getActualType = &getActualType<ClassType>;
-            auto upcast = BaseSpecifier::template getUpcaster<ClassType>();
-            auto downcast = BaseSpecifier::template getDowncaster<ClassType>();
+            void (*upcast)(void) = (void (*)(void))BaseSpecifier::template getUpcaster<ClassType>();
+            void (*downcast)(void) = (void (*)(void))BaseSpecifier::template getDowncaster<ClassType>();
             auto destructor = &raw_destructor<ClassType>;
 
             _embind_register_class(

--- a/tests/core/test_embind_5.cpp
+++ b/tests/core/test_embind_5.cpp
@@ -1,0 +1,30 @@
+#include <emscripten.h>
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+class MyFoo {
+public:
+    MyFoo() {
+        EM_ASM({print("constructing my foo");});
+    }
+    void doit() {
+        EM_ASM({print("doing it");});
+    }
+};
+EMSCRIPTEN_BINDINGS(my_module) {
+    class_<MyFoo>("MyFoo")
+      .constructor<>()
+      .function("doit", &MyFoo::doit)
+      ;
+}
+int main(int argc, char **argv) {
+    EM_ASM(
+      try {
+        var foo = new Module.MyFoo();
+        foo.doit();
+      } catch(e) {
+        Module.print(e);
+      }
+    );
+    return 0;
+}

--- a/tests/core/test_embind_5.out
+++ b/tests/core/test_embind_5.out
@@ -1,0 +1,2 @@
+constructing my foo
+doing it

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6289,6 +6289,10 @@ def process(filename):
     '''
     self.do_run(src, '107')
 
+  def test_embind_5(self):
+    Building.COMPILER_TEST_OPTS += ['--bind']
+    self.do_run_in_out_file_test('tests', 'core', 'test_embind_5')
+
   @sync
   @no_wasm_backend()
   def test_scriptaclass(self):


### PR DESCRIPTION
Embinding functions for wasm backend doesn't always work because of missing `dynCall_` signatures. This is because the wasm backend doesn't support function pointer bitcasting, and has a pass that generates bitcast thunks to wrap the type signatures. s2wasm knows which `dynCall_` functions to generate based on the symbols it can find - specifically as relocations in `wasm-linker`.

The problem is fundamentally that by bitcasting function types we're hiding the type information. So, let's just not bitcast.

The solution I have here is to use `void*` instead of `void (*)(void)` as the interchange type between JS and C++. This is fine because JS has its own notion of what types mean, the actual bits of the function pointer that crosses the JS-wasm boundary are the same. `void*` says on the C++ side that we don't care about the type of the pointer, which is closer to how JS sees it.

Tested with `default`, `asm2`, and `binaryen2` (using both asm2wasm and s2wasm). Tried testing `other.test_embind` but that's broken on `incoming`