### PR TITLE
Fix closure externs for WebAssembly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -285,3 +285,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Tim Neumann <mail@timnn.me>
 * Ondrej Stava <ondrej.stava@gmail.com> (copyright owned by Google, Inc.
 * Jakub Jirutka <jakub@jirutka.cz>
+* Loo Rong Jie <loorongjie@gmail.com>

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -855,7 +855,6 @@ var GLctx = {};
  * @const
  */
 var WebAssembly = {};
-
 /**
  * @constructor
  * @param {!BufferSource} bytes
@@ -898,12 +897,12 @@ WebAssembly.LinkError = function() {};
 WebAssembly.RuntimeError = function() {};
 /**
  * Note: Closure compiler does not support function overloading, omit this overload for now.
- * {function(!BufferSource, Object=):!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
+ * {function(!WebAssembly.Module, Object=):!Promise<!WebAssembly.Instance>}
  */
 /**
- * @param {!WebAssembly.Module} moduleObject
+ * @param {!BufferSource} moduleObject
  * @param {Object=} importObject
- * @return {!Promise<!WebAssembly.Instance>}
+ * @return {!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
  */
 WebAssembly.instantiate = function(moduleObject, importObject) {};
 /**

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -852,12 +852,84 @@ SIMD.Bool64x2.xor = function() {};
 var GLctx = {};
 
 // WebAssembly
+var WebAssembly = {};
 
-var WebAssembly = {
-  Module: function() {},
-  Instance: function() {},
-  Memory: function() {},
-  Table: function() {},
-  instantiate: function() {},
-};
+/**
+ * @constructor
+ * @params {BufferSource} bytes
+ */
+WebAssembly.Module = function(bytes) {};
+/** 
+ * @constructor
+ * @params {WebAssembly.Module} moduleObject
+ * @params {object=} importObject
+ */
+WebAssembly.Instance = function(moduleObject, importObject) {};
+/**
+ * @constructor
+ * @params {object} memoryDescriptor
+ */
+WebAssembly.Memory = function(memoryDescriptor) {};
+/**
+ * @constructor
+ * @params {object} tableDescriptor
+ */
+WebAssembly.Table = function(tableDescriptor) {};
+/** @constructor */
+WebAssembly.CompileError = function() {};
+/** @constructor */
+WebAssembly.LinkError = function() {};
+/** @constructor */
+WebAssembly.RuntimeError = function() {};
 
+WebAssembly.instantiate = function(bytesOrModuleObject, importObject) {};
+/**
+ * @params {BufferSource} bytes
+ * @return {Promise<WebAssembly.Module>}
+ */
+WebAssembly.compile = function(bytes) {};
+/**
+ * @params {BufferSource} bytes
+ * @return {boolean}
+ */
+WebAssembly.validate = function(bytes) {};
+
+/** 
+ * @params {WebAssembly.Module} moduleObject
+ * @return {Array}
+ */
+WebAssembly.Module.exports = function(moduleObject) {};
+/** 
+ * @params {WebAssembly.Module} moduleObject
+ * @return {Array}
+ */
+WebAssembly.Module.imports = function(moduleObject) {};
+/** 
+ * @params {WebAssembly.Module} moduleObject
+ * @params {string} sectionName
+ * @return {Array}
+ */
+WebAssembly.Module.customSections = function(moduleObject, sectionName) {};
+/** 
+ * @params {number} delta
+ * @return {number}
+ */
+WebAssembly.Memory.prototype.grow = function(delta) {};
+/**
+ * @type {ArrayBuffer}
+ */
+WebAssembly.Memory.prototype.buffer;
+/** 
+ * @params {number} delta
+ * @return {number}
+ */
+WebAssembly.Table.prototype.grow = function(delta) {};
+/**
+ * @type {number}
+ */
+WebAssembly.Table.prototype.length;
+/** 
+ * @params {number} index
+ */
+WebAssembly.Table.prototype.get = function(index) {};
+WebAssembly.Table.prototype.set = function(index, value) {};

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -934,6 +934,8 @@ WebAssembly.Module.imports = function(moduleObject) {};
  * @return {Array}
  */
 WebAssembly.Module.customSections = function(moduleObject, sectionName) {};
+/** @dict */
+WebAssembly.Instance.prototype.exports;
 /** 
  * @param {number} delta
  * @return {number}

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -897,11 +897,9 @@ WebAssembly.LinkError = function() {};
  */
 WebAssembly.RuntimeError = function() {};
 /**
- * @param {!BufferSource} bytes
- * @param {Object=} importObject
- * @retrun {!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
+ * Note: Closure compiler does not support function overloading, omit this overload for now.
+ * {function(!BufferSource, Object=):!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
  */
-WebAssembly.instantiate = function(bytes, importObject) {};
 /**
  * @param {!WebAssembly.Module} moduleObject
  * @param {Object=} importObject

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -920,18 +920,18 @@ WebAssembly.compile = function(bytes) {};
 WebAssembly.validate = function(bytes) {};
 /**
  * @param {!WebAssembly.Module} moduleObject
- * @return {Array}
+ * @return {!Array<{name:string, kind:string}>}
  */
 WebAssembly.Module.exports = function(moduleObject) {};
 /** 
  * @param {!WebAssembly.Module} moduleObject
- * @return {Array}
+ * @return {!Array<{module:string, name:string, kind:string}>}
  */
 WebAssembly.Module.imports = function(moduleObject) {};
 /**
  * @param {!WebAssembly.Module} moduleObject
  * @param {string} sectionName
- * @return {Array}
+ * @return {!Array<!ArrayBuffer>}
  */
 WebAssembly.Module.customSections = function(moduleObject, sectionName) {};
 /** @dict */

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -851,76 +851,100 @@ SIMD.Bool64x2.xor = function() {};
 
 var GLctx = {};
 
-// WebAssembly
+/**
+ * @const
+ */
 var WebAssembly = {};
 
 /**
  * @constructor
- * @params {BufferSource} bytes
+ * @param {!BufferSource} bytes
  */
 WebAssembly.Module = function(bytes) {};
 /** 
  * @constructor
- * @params {WebAssembly.Module} moduleObject
- * @params {object=} importObject
+ * @param {!WebAssembly.Module} moduleObject
+ * @param {Object=} importObject
  */
 WebAssembly.Instance = function(moduleObject, importObject) {};
+/** @typedef {{initial:number, maximum:(number|undefined)}} */
+var MemoryDescriptor;
 /**
  * @constructor
- * @params {object} memoryDescriptor
+ * @param {MemoryDescriptor} memoryDescriptor
  */
 WebAssembly.Memory = function(memoryDescriptor) {};
+/** @typedef {{element:string, initial:number, maximum:(number|undefined)}} */
+var TableDescriptor;
 /**
  * @constructor
- * @params {object} tableDescriptor
+ * @param {TableDescriptor} tableDescriptor
  */
 WebAssembly.Table = function(tableDescriptor) {};
-/** @constructor */
-WebAssembly.CompileError = function() {};
-/** @constructor */
-WebAssembly.LinkError = function() {};
-/** @constructor */
-WebAssembly.RuntimeError = function() {};
-
-WebAssembly.instantiate = function(bytesOrModuleObject, importObject) {};
 /**
- * @params {BufferSource} bytes
- * @return {Promise<WebAssembly.Module>}
+ * @constructor
+ * @extends {Error}
+ */
+WebAssembly.CompileError = function() {};
+/**
+ * @constructor
+ * @extends {Error}
+ */
+WebAssembly.LinkError = function() {};
+/**
+ * @constructor
+ * @extends {Error}
+ */
+WebAssembly.RuntimeError = function() {};
+/**
+ * @param {!BufferSource} bytes
+ * @param {Object=} importObject
+ * @retrun {!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
+ */
+WebAssembly.instantiate = function(bytes, importObject) {};
+/**
+ * @param {!WebAssembly.Module} moduleObject
+ * @param {Object=} importObject
+ * @return {!Promise<!WebAssembly.Instance>}
+ */
+WebAssembly.instantiate = function(moduleObject, importObject) {};
+/**
+ * @param {!BufferSource} bytes
+ * @return {!Promise<!WebAssembly.Module>}
  */
 WebAssembly.compile = function(bytes) {};
 /**
- * @params {BufferSource} bytes
+ * @param {!BufferSource} bytes
  * @return {boolean}
  */
 WebAssembly.validate = function(bytes) {};
-
-/** 
- * @params {WebAssembly.Module} moduleObject
+/**
+ * @param {!WebAssembly.Module} moduleObject
  * @return {Array}
  */
 WebAssembly.Module.exports = function(moduleObject) {};
 /** 
- * @params {WebAssembly.Module} moduleObject
+ * @param {!WebAssembly.Module} moduleObject
  * @return {Array}
  */
 WebAssembly.Module.imports = function(moduleObject) {};
-/** 
- * @params {WebAssembly.Module} moduleObject
- * @params {string} sectionName
+/**
+ * @param {!WebAssembly.Module} moduleObject
+ * @param {string} sectionName
  * @return {Array}
  */
 WebAssembly.Module.customSections = function(moduleObject, sectionName) {};
 /** 
- * @params {number} delta
+ * @param {number} delta
  * @return {number}
  */
 WebAssembly.Memory.prototype.grow = function(delta) {};
 /**
- * @type {ArrayBuffer}
+ * @type {!ArrayBuffer}
  */
 WebAssembly.Memory.prototype.buffer;
-/** 
- * @params {number} delta
+/**
+ * @param {number} delta
  * @return {number}
  */
 WebAssembly.Table.prototype.grow = function(delta) {};
@@ -928,8 +952,13 @@ WebAssembly.Table.prototype.grow = function(delta) {};
  * @type {number}
  */
 WebAssembly.Table.prototype.length;
-/** 
- * @params {number} index
+/**
+ * @param {number} index
+ * @return {function(...)}
  */
 WebAssembly.Table.prototype.get = function(index) {};
+/**
+ * @param {number} index
+ * @param {?function(...)} value
+ */
 WebAssembly.Table.prototype.set = function(index, value) {};


### PR DESCRIPTION
`@constructor` must be used, otherwise `instanceOf WebAssembly.Module` etc will be converted to `WebAsssembly.blah`.

I run `emcc` without `--closure`, then pass the emitted load code with this updated externs to latest closure compiler in advanced mode. `Module` is renamed to something else so I have to rename it back manually, other than that I can run the code in `d8` just fine.

I didn't annotate all `WebAssembly` functions because I don't know how to define "Exported Function Exotic Object". `WebAssembly.instantiate` is also not annotated because it has two function signatures (4 if include async Web API).