### PR TITLE
Emterpreter: support float versions of binary operations, which is necessary as no…

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -6753,7 +6753,7 @@ function emterpretify(ast) {
         case '>>>': opcode = 'LSHR'; tryNumAsymmetrical(true); break;
         default: throw 'bad ' + node[1];
       }
-      if (!opcode) assert(0, JSON.stringify([node, type, sign]));
+      assert(opcode, 'failed to find the proper opcode in makeBinary: ' + JSON.stringify([node, type, sign]));
       var x, y, z;
       var usingNumValue = numValue !== null && ((!numValueUnsigned && ((numValue << 24 >> 24) === numValue)) ||
                                                 ( numValueUnsigned && ((numValue & 255) === numValue)));

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -6649,7 +6649,9 @@ function emterpretify(ast) {
             if (type === ASM_INT) {
               opcode = 'ADD';
               tryNumSymmetrical();
-            } else if (type === ASM_DOUBLE) opcode = 'ADDD';
+            } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+              opcode = 'ADDD';
+            }
             break;
           }
         }
@@ -6657,14 +6659,18 @@ function emterpretify(ast) {
           if (type === ASM_INT) {
             opcode = 'SUB';
             tryNumAsymmetrical();
-          } else if (type === ASM_DOUBLE) opcode = 'SUBD';
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'SUBD';
+          }
           break;
         }
         case '*': {
           if (type === ASM_INT) {
             opcode = 'MUL';
             tryNumSymmetrical();
-          } else if (type === ASM_DOUBLE) opcode = 'MULD';
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'MULD';
+          }
           break;
         }
         case '/': {
@@ -6673,8 +6679,9 @@ function emterpretify(ast) {
             if (sign === ASM_SIGNED) opcode = 'SDIV';
             else opcode = 'UDIV';
             tryNumAsymmetrical(sign === ASM_UNSIGNED);
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'DIVD';
           }
-          else if (type === ASM_DOUBLE) opcode = 'DIVD';
           break;
         }
         case '%': {
@@ -6683,8 +6690,9 @@ function emterpretify(ast) {
             if (sign === ASM_SIGNED) opcode = 'SMOD';
             else opcode = 'UMOD';
             tryNumAsymmetrical(sign === ASM_UNSIGNED);
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'MODD';
           }
-          else if (type === ASM_DOUBLE) opcode = 'MODD';
           break;
         }
         case '<': {
@@ -6693,8 +6701,9 @@ function emterpretify(ast) {
             if (sign === ASM_SIGNED) opcode = 'SLT';
             else opcode = 'ULT';
             tryNumAsymmetrical(sign === ASM_UNSIGNED);
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'LTD';
           }
-          else if (type === ASM_DOUBLE) opcode = 'LTD';
           break;
         }
         case '<=': {
@@ -6703,17 +6712,18 @@ function emterpretify(ast) {
             if (sign === ASM_SIGNED) opcode = 'SLE';
             else opcode = 'ULE';
             tryNumAsymmetrical(sign === ASM_UNSIGNED);
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'LED';
           }
-          else if (type === ASM_DOUBLE) opcode = 'LED';
           break;
         }
         case '>': {
-          assert(type === ASM_DOUBLE);
+          assert(type === ASM_DOUBLE || type === ASM_FLOAT);
           opcode = 'GTD';
           break;
         }
         case '>=': {
-          assert(type === ASM_DOUBLE);
+          assert(type === ASM_DOUBLE || type === ASM_FLOAT);
           opcode = 'GED';
           break;
         }
@@ -6721,14 +6731,18 @@ function emterpretify(ast) {
           if (type === ASM_INT) {
             opcode = 'EQ';
             tryNumSymmetrical();
-          } else if (type === ASM_DOUBLE) opcode = 'EQD';
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'EQD';
+          }
           break;
         }
         case '!=': {
           if (type === ASM_INT) {
             opcode = 'NE';
             tryNumSymmetrical();
-          } else if (type === ASM_DOUBLE) opcode = 'NED';
+          } else if (type === ASM_DOUBLE || type === ASM_FLOAT) {
+            opcode = 'NED';
+          }
           break;
         }
         case '&': opcode = 'AND'; tryNumSymmetrical(); break;


### PR DESCRIPTION
…w we detect f0 properly (since #5046), so we do notice float operations in more cases, which is why this went unnoticed before. we do all emterpreter math in doubles anyhow, so this just requires us to accept float ops and emit the same double ops

cc @aidanhs 