### PR TITLE
Binaryen trap allow

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -690,14 +690,14 @@ var BINARYEN_IGNORE_IMPLICIT_TRAPS = 0; // Whether to ignore implicit traps when
                                         // is out of bounds, or div/rem of 0, etc. We can reorder them,
                                         // but we can't ignore that they have side effects, so turning on
                                         // this flag lets us do a little more to reduce code size.
-var BINARYEN_TRAP_MODE = "js"; // How we handle wasm operations that may trap, which includes integer
-                               // div/rem of 0 and float-to-int of values too large to fit in an int.
-                               //   js: do exactly what js does. this can be slower.
-                               //   clamp: avoid traps by clamping to a reasonable value. this can be
-                               //          faster than "js".
-                               //   allow: allow creating operations that can trap. this is the most
-                               //          compact, as we just emit a single wasm operation, with no
-                               //          guards to trapping values, and also often the fastest.
+var BINARYEN_TRAP_MODE = "allow"; // How we handle wasm operations that may trap, which includes integer
+                                  // div/rem of 0 and float-to-int of values too large to fit in an int.
+                                  //   js: do exactly what js does. this can be slower.
+                                  //   clamp: avoid traps by clamping to a reasonable value. this can be
+                                  //          faster than "js".
+                                  //   allow: allow creating operations that can trap. this is the most
+                                  //          compact, as we just emit a single wasm operation, with no
+                                  //          guards to trapping values, and also often the fastest.
 var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the binaryen optimizer,
                           // for example, "dce,precompute,vacuum".
                           // When set, this overrides the default passes we would normally run.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -132,16 +132,19 @@ process(sys.argv[1])
 # Benchmarkers
 try:
   benchmarkers_error = ''
-  benchmarkers = [NativeBenchmarker('clang', CLANG_CC, CLANG)]
+  benchmarkers = [
+    NativeBenchmarker('clang', CLANG_CC, CLANG),
+    NativeBenchmarker('gcc',   'gcc',    'g++')
+  ]
   if SPIDERMONKEY_ENGINE and Building.which(SPIDERMONKEY_ENGINE[0]):
     benchmarkers += [
       JSBenchmarker('sm-asmjs', SPIDERMONKEY_ENGINE, ['-s', 'PRECISE_F32=2']),
       JSBenchmarker('sm-simd',  SPIDERMONKEY_ENGINE, ['-s', 'SIMD=1']),
-      JSBenchmarker('sm-wasm',  SPIDERMONKEY_ENGINE, ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'BINARYEN_TRAP_MODE="allow"'])
+      JSBenchmarker('sm-wasm',  SPIDERMONKEY_ENGINE, ['-s', 'WASM=1']),
     ]
   if V8_ENGINE and Building.which(V8_ENGINE[0]):
     benchmarkers += [
-      JSBenchmarker('v8-wasm',  V8_ENGINE,           ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'BINARYEN_TRAP_MODE="allow"'])
+      JSBenchmarker('v8-wasm',  V8_ENGINE,           ['-s', 'WASM=1']),
     ]
 except Exception, e:
   benchmarkers_error = str(e)


### PR DESCRIPTION
Continuing #4625, we left open what default to use for the trap mode. We left it as 'js', for compatibility. But I've seen users get confused about this, seeing bad performance and not knowing what to do, despite our docs. And the tricky thing is bad performance is often unnoticed, whereas if we switch the default they'd get traps, which at least force them to figure things out.

So I'd like to suggest we switch the default to 'allow', which means we emit the simplest and most optimal wasm code, i.e., we allow wasm traps in all operations.