### PR TITLE
Refactor emscripten py - method extraction

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -397,47 +397,20 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     in_table, debug_tables, function_tables_defs = make_function_tables_defs(
       implemented_functions, all_implemented, function_table_data, settings, metadata)
 
-    asm_setup = ''
+    exported_implemented_functions = get_exported_implemented_functions(
+      all_exported_functions, all_implemented, metadata, settings)
 
+    asm_setup = ''
     if settings['ASSERTIONS'] >= 2:
       for sig in function_table_data:
         asm_setup += '\nvar debug_table_' + sig + ' = ' + json.dumps(debug_tables[sig]) + ';'
-
-    basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
-    if settings['ABORTING_MALLOC']: basic_funcs += ['abortOnCannotGrowMemory']
-    if settings['STACK_OVERFLOW_CHECK']: basic_funcs += ['abortStackOverflow']
-
-    if settings['SAFE_HEAP']:
-      if asm_safe_heap(settings):
-        basic_funcs += ['segfault', 'alignfault', 'ftfault']
-      else:
-        basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
     if settings['ASSERTIONS']:
       for sig in function_table_sigs:
-        basic_funcs += ['nullFunc_' + sig]
         asm_setup += '\nfunction nullFunc_' + sig + '(x) { ' + get_function_pointer_error(sig, function_table_sigs, settings) + 'abort(x) }\n'
-
-    basic_vars = ['DYNAMICTOP_PTR', 'tempDoublePtr', 'ABORT']
-    if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
-      basic_vars += ['STACKTOP', 'STACK_MAX']
-
-    if metadata.get('preciseI64MathUsed'):
-      basic_vars += ['cttz_i8']
-    else:
-      if forwarded_json['Functions']['libraryFunctions'].get('_llvm_cttz_i32'):
-        basic_vars += ['cttz_i8']
-
     if settings['RELOCATABLE']:
-      if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
-        basic_vars += ['gb', 'fb']
-      else:
-        basic_vars += ['memoryBase', 'tableBase'] # wasm side modules have a specific convention for these
+      asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
       if not settings['SIDE_MODULE']:
         asm_setup += 'var gb = Runtime.GLOBAL_BASE, fb = 0;\n'
-
-      basic_funcs += ['setTempRet0', 'getTempRet0']
-      asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
-
     if settings['BINARYEN']:
       def table_size(table):
         table_contents = table[table.index('[') + 1: table.index(']')]
@@ -450,8 +423,36 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
       if not settings['EMULATED_FUNCTION_POINTERS']:
         asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size
 
-    exported_implemented_functions = get_exported_implemented_functions(
-      all_exported_functions, all_implemented, metadata, settings)
+
+    basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
+    if settings['ABORTING_MALLOC']:
+      basic_funcs += ['abortOnCannotGrowMemory']
+    if settings['STACK_OVERFLOW_CHECK']:
+      basic_funcs += ['abortStackOverflow']
+    if settings['SAFE_HEAP']:
+      if asm_safe_heap(settings):
+        basic_funcs += ['segfault', 'alignfault', 'ftfault']
+      else:
+        basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
+    if settings['ASSERTIONS']:
+      for sig in function_table_sigs:
+        basic_funcs += ['nullFunc_' + sig]
+    if settings['RELOCATABLE']:
+      basic_funcs += ['setTempRet0', 'getTempRet0']
+
+    basic_vars = ['DYNAMICTOP_PTR', 'tempDoublePtr', 'ABORT']
+    if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
+      basic_vars += ['STACKTOP', 'STACK_MAX']
+    if metadata.get('preciseI64MathUsed'):
+      basic_vars += ['cttz_i8']
+    else:
+      if forwarded_json['Functions']['libraryFunctions'].get('_llvm_cttz_i32'):
+        basic_vars += ['cttz_i8']
+    if settings['RELOCATABLE']:
+      if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
+        basic_vars += ['gb', 'fb']
+      else:
+        basic_vars += ['memoryBase', 'tableBase'] # wasm side modules have a specific convention for these
 
     # See if we need ASYNCIFY functions
     # We might not need them even if ASYNCIFY is enabled
@@ -1078,6 +1079,7 @@ def asm_safe_heap(settings):
 
 def provide_fround(settings):
   return settings['PRECISE_F32'] or settings['SIMD']
+
 
 def create_exports(exported_implemented_functions, in_table, function_table_data, metadata, settings):
   quote = quoter(settings)

--- a/emscripten.py
+++ b/emscripten.py
@@ -420,7 +420,6 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     basic_vars = ['DYNAMICTOP_PTR', 'tempDoublePtr', 'ABORT']
     if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
       basic_vars += ['STACKTOP', 'STACK_MAX']
-    basic_float_vars = []
 
     if metadata.get('preciseI64MathUsed'):
       basic_vars += ['cttz_i8']
@@ -515,7 +514,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
       provide_fround, bg_funcs, bg_vars, access_quote, metadata, settings)
 
     the_global = create_the_global(metadata, settings)
-    sending_vars = basic_funcs + global_funcs + basic_vars + basic_float_vars + global_vars
+    sending_vars = basic_funcs + global_funcs + basic_vars + global_vars
     sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in sending_vars]) + ' }'
 
     receiving = create_receiving(function_table_data, function_tables, function_tables_defs,
@@ -1845,7 +1844,6 @@ return ASM_CONSTS[code](%s);
     return g if not g.startswith('Math_') else g.split('_')[1]
 
   basic_vars = ['STACKTOP', 'STACK_MAX', 'DYNAMICTOP_PTR', 'ABORT']
-  basic_float_vars = []
 
   # Asm.js-style exception handling: invoke wrapper generation
   invoke_wrappers = ''
@@ -1861,7 +1859,7 @@ return ASM_CONSTS[code](%s);
 
   # sent data
   the_global = '{}'
-  sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in basic_funcs + global_funcs + basic_vars + basic_float_vars + global_vars]) + ' }'
+  sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in basic_funcs + global_funcs + basic_vars + global_vars]) + ' }'
   # received
   receiving = ''
   if settings['ASSERTIONS']:

--- a/emscripten.py
+++ b/emscripten.py
@@ -403,7 +403,6 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
 
     shared.Settings.copy(settings)
 
-    basic_funcs += setup_basic_funcs(function_table_sigs, settings)
     funcs_js += setup_funcs_js(function_table_sigs, settings)
 
     exports = create_exports(exported_implemented_functions, in_table, function_table_data, metadata, settings)
@@ -770,18 +769,6 @@ function jsCall_%s_%s(%s) {
   return function_tables_impls
 
 
-def setup_basic_funcs(function_table_sigs, settings):
-  basic_funcs = []
-  for sig in function_table_sigs:
-    basic_funcs.append('invoke_%s' % sig)
-    if settings.get('RESERVED_FUNCTION_POINTERS'):
-      basic_funcs.append('jsCall_%s' % sig)
-    if settings.get('EMULATED_FUNCTION_POINTERS'):
-      if not settings['BINARYEN']: # in wasm, emulated function pointers are just simple table calls
-        basic_funcs.append('ftCall_%s' % sig)
-  return basic_funcs
-
-
 def setup_funcs_js(function_table_sigs, settings):
   funcs_js = []
   for sig in function_table_sigs:
@@ -1083,6 +1070,14 @@ def create_basic_funcs(function_table_sigs, settings):
       basic_funcs += ['nullFunc_' + sig]
   if settings['RELOCATABLE']:
     basic_funcs += ['setTempRet0', 'getTempRet0']
+
+  for sig in function_table_sigs:
+    basic_funcs.append('invoke_%s' % sig)
+    if settings.get('RESERVED_FUNCTION_POINTERS'):
+      basic_funcs.append('jsCall_%s' % sig)
+    if settings.get('EMULATED_FUNCTION_POINTERS'):
+      if not settings['BINARYEN']: # in wasm, emulated function pointers are just simple table calls
+        basic_funcs.append('ftCall_%s' % sig)
   return basic_funcs
 
 def create_basic_vars(exported_implemented_functions, forwarded_json, metadata, settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -384,10 +384,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     else:
       pre_tables = ''
 
-    in_table = set()
-    debug_tables = {}
-
-    function_tables_defs = make_function_tables_defs(in_table, debug_tables, implemented_functions, all_implemented, forwarded_json, settings, metadata)
+    in_table, debug_tables, function_tables_defs = make_function_tables_defs(implemented_functions, all_implemented, forwarded_json, settings, metadata)
 
     asm_setup = ''
 
@@ -811,7 +808,10 @@ class Counter:
   j = 0
 
 
-def make_function_tables_defs(in_table, debug_tables, implemented_functions, all_implemented, forwarded_json, settings, metadata):
+def make_function_tables_defs(implemented_functions, all_implemented, forwarded_json, settings, metadata):
+  in_table = set()
+  debug_tables = {}
+
   def make_params(sig): return ','.join(['p%d' % p for p in range(len(sig)-1)])
   def make_coerced_params(sig): return ','.join([shared.JS.make_coercion('p%d', unfloat(sig[p+1]), settings) % p for p in range(len(sig)-1)])
   def make_coercions(sig): return ';'.join(['p%d = %s' % (p, shared.JS.make_coercion('p%d' % p, sig[p+1], settings)) for p in range(len(sig)-1)]) + ';'
@@ -936,7 +936,7 @@ def make_function_tables_defs(in_table, debug_tables, implemented_functions, all
   function_tables_defs = '\n'.join([info[0] for info in infos]) + '\n'
   function_tables_defs += '\n// EMSCRIPTEN_END_FUNCS\n'
   function_tables_defs += '\n'.join([info[1] for info in infos])
-  return function_tables_defs
+  return in_table, debug_tables, function_tables_defs
 
 
 def make_func(name, code, params, coercions):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1240,18 +1240,16 @@ for (var named in NAMED_GLOBALS) {
             'access': access,
             'coerced_access': coercer(access),
           }
-          getter = '''
+          return '''
 function get{name}(ptr) {{
   ptr = ptr | 0;
   return {coerced_access};
-}}'''.format(**format_data)
-          setter = '''
+}}
 function set{name}(ptr, value) {{
   ptr = ptr | 0;
   value = {coerced_value};
   {access} = value;
 }}'''.format(**format_data)
-          return getter + setter
         def int_coerce(s):
           return s + ' | 0'
         def float_coerce(s):

--- a/emscripten.py
+++ b/emscripten.py
@@ -734,36 +734,36 @@ def math_fix(g):
 
 
 def make_function_tables_impls(function_table_sigs, settings):
-    function_tables_impls = []
-    for sig in function_table_sigs:
-      args = ','.join(['a' + str(i) for i in range(1, len(sig))])
-      arg_coercions = ' '.join(['a' + str(i) + '=' + shared.JS.make_coercion('a' + str(i), sig[i], settings) + ';' for i in range(1, len(sig))])
-      coerced_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], settings) for i in range(1, len(sig))])
-      ret = ('return ' if sig[0] != 'v' else '') + shared.JS.make_coercion('FUNCTION_TABLE_%s[index&{{{ FTM_%s }}}](%s)' % (sig, sig, coerced_args), sig[0], settings)
-      if not settings['EMULATED_FUNCTION_POINTERS']:
-        function_tables_impls.append('''
+  function_tables_impls = []
+  for sig in function_table_sigs:
+    args = ','.join(['a' + str(i) for i in range(1, len(sig))])
+    arg_coercions = ' '.join(['a' + str(i) + '=' + shared.JS.make_coercion('a' + str(i), sig[i], settings) + ';' for i in range(1, len(sig))])
+    coerced_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], settings) for i in range(1, len(sig))])
+    ret = ('return ' if sig[0] != 'v' else '') + shared.JS.make_coercion('FUNCTION_TABLE_%s[index&{{{ FTM_%s }}}](%s)' % (sig, sig, coerced_args), sig[0], settings)
+    if not settings['EMULATED_FUNCTION_POINTERS']:
+      function_tables_impls.append('''
 function dynCall_%s(index%s%s) {
   index = index|0;
   %s
   %s;
 }
 ''' % (sig, ',' if len(sig) > 1 else '', args, arg_coercions, ret))
-      else:
-        function_tables_impls.append('''
+    else:
+      function_tables_impls.append('''
 var dynCall_%s = ftCall_%s;
 ''' % (sig, sig))
 
-      ffi_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], settings, ffi_arg=True) for i in range(1, len(sig))])
-      for i in range(settings['RESERVED_FUNCTION_POINTERS']):
-        jsret = ('return ' if sig[0] != 'v' else '') + shared.JS.make_coercion('jsCall_%s(%d%s%s)' % (sig, i, ',' if ffi_args else '', ffi_args), sig[0], settings, ffi_result=True)
-        function_tables_impls.append('''
+    ffi_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], settings, ffi_arg=True) for i in range(1, len(sig))])
+    for i in range(settings['RESERVED_FUNCTION_POINTERS']):
+      jsret = ('return ' if sig[0] != 'v' else '') + shared.JS.make_coercion('jsCall_%s(%d%s%s)' % (sig, i, ',' if ffi_args else '', ffi_args), sig[0], settings, ffi_result=True)
+      function_tables_impls.append('''
 function jsCall_%s_%s(%s) {
   %s
   %s;
 }
 
 ''' % (sig, i, args, arg_coercions, jsret))
-    return function_tables_impls
+  return function_tables_impls
 
 
 def setup_function_pointers(function_table_sigs, settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -97,14 +97,14 @@ def emscript(infile, settings, outfile, libraries=None, compiler_engine=None,
       glue, forwarded_data = compiler_glue(metadata, settings, libraries, compiler_engine, temp_files, DEBUG)
 
     with ToolchainProfiler.profile_block('function_tables_and_exports'):
-      (post, funcs_js, sending, receiving, asm_setup, the_global,
-       asm_global_vars, asm_global_funcs, pre_tables, final_function_tables, exports, function_table_data,
+      (post, funcs_js, sending, receiving, asm_setup, the_global, asm_global_vars,
+       asm_global_funcs, pre_tables, final_function_tables, exports, function_table_data,
        forwarded_json) = function_tables_and_exports(funcs, metadata, mem_init, glue,
                                                      forwarded_data, settings, outfile, DEBUG)
     with ToolchainProfiler.profile_block('finalize_output'):
-      finalize_output(metadata, post, funcs_js, sending,
-                      receiving, asm_setup, the_global, asm_global_vars, asm_global_funcs, pre_tables,
-                      final_function_tables, exports, function_table_data, forwarded_json, settings, outfile, DEBUG)
+      finalize_output(metadata, post, funcs_js, sending, receiving, asm_setup, the_global,
+                      asm_global_vars, asm_global_funcs, pre_tables, final_function_tables,
+                      exports, function_table_data, forwarded_json, settings, outfile, DEBUG)
 
     success = True
 
@@ -1187,9 +1187,9 @@ return real_''' + s + '''.apply(null, arguments);
   return receiving
 
 
-def finalize_output(metadata, post, funcs_js, sending, receiving,
-  asm_setup, the_global, asm_global_vars, asm_global_funcs, pre_tables, final_function_tables, exports,
-  function_table_data, forwarded_json, settings, outfile, DEBUG):
+def finalize_output(metadata, post, funcs_js, sending, receiving, asm_setup, the_global,
+                    asm_global_vars, asm_global_funcs, pre_tables, final_function_tables, exports,
+                    function_table_data, forwarded_json, settings, outfile, DEBUG):
     if DEBUG:
       logging.debug('emscript: python processing: finalize')
       t = time.time()

--- a/emscripten.py
+++ b/emscripten.py
@@ -1237,68 +1237,68 @@ function get8(ptr) {
   ptr = ptr | 0;
   return HEAP8s[ptr >> SPLIT_MEMORY_BITS][ptr & SPLIT_MEMORY_MASK] | 0;
 }
-function get16(ptr) {
-  ptr = ptr | 0;
-  return HEAP16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] | 0;
-}
-function get32(ptr) {
-  ptr = ptr | 0;
-  return HEAP32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] | 0;
-}
-function getU8(ptr) {
-  ptr = ptr | 0;
-  return HEAPU8s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 0] | 0;
-}
-function getU16(ptr) {
-  ptr = ptr | 0;
-  return HEAPU16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] | 0;
-}
-function getU32(ptr) {
-  ptr = ptr | 0;
-  return HEAPU32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] | 0;
-}
-function getF32(ptr) {
-  ptr = ptr | 0;
-  return +HEAPF32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2]; // TODO: fround when present
-}
-function getF64(ptr) {
-  ptr = ptr | 0;
-  return +HEAPF64s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 3];
-}
 function set8(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAP8s[ptr >> SPLIT_MEMORY_BITS][ptr & SPLIT_MEMORY_MASK] = value;
+}
+function get16(ptr) {
+  ptr = ptr | 0;
+  return HEAP16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] | 0;
 }
 function set16(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAP16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] = value;
 }
+function get32(ptr) {
+  ptr = ptr | 0;
+  return HEAP32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] | 0;
+}
 function set32(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAP32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] = value;
+}
+function getU8(ptr) {
+  ptr = ptr | 0;
+  return HEAPU8s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 0] | 0;
 }
 function setU8(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAPU8s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 0] = value;
 }
+function getU16(ptr) {
+  ptr = ptr | 0;
+  return HEAPU16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] | 0;
+}
 function setU16(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAPU16s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 1] = value;
+}
+function getU32(ptr) {
+  ptr = ptr | 0;
+  return HEAPU32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] | 0;
 }
 function setU32(ptr, value) {
   ptr = ptr | 0;
   value = value | 0;
   HEAPU32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] = value;
 }
+function getF32(ptr) {
+  ptr = ptr | 0;
+  return +HEAPF32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2]; // TODO: fround when present
+}
 function setF32(ptr, value) {
   ptr = ptr | 0;
   value = +value;
   HEAPF32s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 2] = value;
+}
+function getF64(ptr) {
+  ptr = ptr | 0;
+  return +HEAPF64s[ptr >> SPLIT_MEMORY_BITS][(ptr & SPLIT_MEMORY_MASK) >> 3];
 }
 function setF64(ptr, value) {
   ptr = ptr | 0;

--- a/emscripten.py
+++ b/emscripten.py
@@ -451,9 +451,9 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
         len(exports), len(the_global), len(sending), len(receiving)]))
       logging.debug('  emscript: python processing: function tables and exports took %s seconds' % (time.time() - t))
 
-    return (post, funcs_js, sending, receiving,
-            asm_setup, the_global, asm_global_vars, asm_global_funcs, pre_tables, final_function_tables,
-            exports, function_table_data, forwarded_json)
+    return (post, funcs_js, sending, receiving, asm_setup, the_global, asm_global_vars,
+            asm_global_funcs, pre_tables, final_function_tables, exports,
+            function_table_data, forwarded_json)
 
 
 def memory_and_global_initializers(pre, metadata, mem_init, settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -403,10 +403,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
       for sig in function_table_data:
         asm_setup += '\nvar debug_table_' + sig + ' = ' + json.dumps(debug_tables[sig]) + ';'
 
-    math_envs = []
-
-
-    basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory'] + [m.replace('.', '_') for m in math_envs]
+    basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
     if settings['ABORTING_MALLOC']: basic_funcs += ['abortOnCannotGrowMemory']
     if settings['STACK_OVERFLOW_CHECK']: basic_funcs += ['abortStackOverflow']
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -360,7 +360,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     pre = memory_and_global_initializers(pre, metadata, mem_init, settings)
     pre, funcs_js = get_js_funcs(pre, funcs)
     exported_implemented_functions, all_implemented = get_exported_implemented_functions(metadata, forwarded_json, settings)
-    implemented_functions = get_implemented_functions(pre, metadata, forwarded_json, settings, all_implemented)
+    implemented_functions = get_implemented_functions(pre, metadata, settings, all_implemented)
     if settings['BINARYEN'] and settings['SIDE_MODULE']:
       assert len(metadata['asmConsts']) == 0, 'EM_ASM is not yet supported in shared wasm module (it cannot be stored in the wasm itself, need some solution)'
     pre = include_asm_consts(pre, metadata, forwarded_json)
@@ -683,7 +683,7 @@ def get_exported_implemented_functions(metadata, forwarded_json, settings):
   return exported_implemented_functions, all_implemented
 
 
-def get_implemented_functions(pre, metadata, forwarded_json, settings, all_implemented):
+def get_implemented_functions(pre, metadata, settings, all_implemented):
   implemented_functions = set(metadata['implementedFunctions'])
   if settings['ASSERTIONS'] and settings.get('ORIGINAL_EXPORTED_FUNCTIONS'):
     original_exports = settings['ORIGINAL_EXPORTED_FUNCTIONS']

--- a/emscripten.py
+++ b/emscripten.py
@@ -485,7 +485,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
         exported_implemented_functions += ['setThrew']
     exported_implemented_functions = list(set(exported_implemented_functions))
 
-    exports = create_exports(exported_implemented_functions, in_table, function_tables, settings)
+    exports = create_exports(exported_implemented_functions, in_table, function_tables, metadata, settings)
     # calculate globals
     try:
       del forwarded_json['Variables']['globals']['_llvm_global_ctors'] # not a true variable
@@ -1074,7 +1074,7 @@ def need_asyncify(exported_implemented_functions):
   return '_emscripten_alloc_async_context' in exported_implemented_functions
 
 
-def create_exports(exported_implemented_functions, in_table, function_tables, settings):
+def create_exports(exported_implemented_functions, in_table, function_tables, metadata, settings):
   quote = quoter(settings)
   asm_runtime_funcs = create_asm_runtime_funcs(settings)
   if need_asyncify(exported_implemented_functions):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1075,7 +1075,7 @@ def need_asyncify(exported_implemented_functions):
 
 def asm_safe_heap(settings):
   """optimized safe heap in asm, when we can"""
-  settings['SAFE_HEAP'] and not settings['SAFE_HEAP_LOG'] and not settings['RELOCATABLE']
+  return settings['SAFE_HEAP'] and not settings['SAFE_HEAP_LOG'] and not settings['RELOCATABLE']
 
 
 def create_exports(exported_implemented_functions, in_table, function_table_data, metadata, settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -401,7 +401,8 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     basic_funcs = create_basic_funcs(function_table_sigs, settings)
     basic_vars = create_basic_vars(exported_implemented_functions, forwarded_json, metadata, settings)
 
-    function_tables_impls = make_function_tables_impls(function_table_sigs, settings)
+    shared.Settings.copy(settings)
+
     asm_setup += setup_function_pointers(function_table_sigs, settings)
     basic_funcs += setup_basic_funcs(function_table_sigs, settings)
     funcs_js += setup_funcs_js(function_table_sigs, settings)
@@ -434,6 +435,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     receiving = create_receiving(function_table_data, function_tables_defs,
                                  exported_implemented_functions, settings)
 
+    function_tables_impls = make_function_tables_impls(function_table_sigs, settings)
     final_function_tables = '\n'.join(function_tables_impls) + '\n' + function_tables_defs
     if settings.get('EMULATED_FUNCTION_POINTERS'):
       asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'

--- a/emscripten.py
+++ b/emscripten.py
@@ -1153,7 +1153,7 @@ return real_''' + s + '''.apply(null, arguments);
   if not settings['SWAPPABLE_ASM_MODULE']:
     receiving += ';\n'.join(['var ' + s + ' = Module["' + s + '"] = asm["' + s + '"]' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
   else:
-    receiving += 'Module["asm"] = asm;\n' + ';\n'.join(['var ' + s + ' = Module["' + s + '"] = function() { return Module["asm"]["' + s + '"].apply(null, arguments) }' for s in exported_implemented_functions + function_tables])
+    receiving += 'Module["asm"] = asm;\n' + ';\n'.join(['var ' + s + ' = Module["' + s + '"] = function() { return Module["asm"]["' + s + '"].apply(null, arguments) }' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
   receiving += ';\n'
 
   if settings['EXPORT_FUNCTION_TABLES'] and not settings['BINARYEN']:


### PR DESCRIPTION
Still working on this, but wanted to post what I've got so far.

Goal: Make emscripten.py easier to understand.

At the moment I've been mainly decomposing the four big sub-functions that make up `emscript` into smaller functions with more explicit input/output. Haven't touched yet but am planning to: `finalize_output` and `emscript_wasm_backend`. `function_tables_and_exports` still needs work too.

Looking for feedback on:
* general direction
* obvious things I'm missing
* style

in roughly that order.

Been testing by running the core tests.