### PR TITLE
Set 'use_cxx' flag based on the '-x' option instead input file suffix.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -760,7 +760,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       for i in range(0, len(newargs)):
         arg = newargs[i]
-        if not arg.startswith('-'):
+        if arg == '-xc':
+          use_cxx = False
+          break
+        elif arg == '-xc++':
+          use_cxx = True
+          break
+        elif not arg.startswith('-'):
           if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
             use_cxx = False
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -670,6 +670,12 @@ f.close()
       assert process.returncode is not 0, 'Trying to compile a nonexisting file should return with a nonzero error code!'
       assert os.path.exists('this_output_file_should_never_exist.js') == False, 'Emcc should not produce an output file when build fails!'
 
+  def test_use_cxx(self):
+    dash_xc = Popen([PYTHON, EMCC, '-v', '-xc', '/dev/null'], stdout=PIPE, stderr=PIPE).communicate()[1]
+    self.assertNotContained('-std=c++03', dash_xc)
+    dash_xcpp = Popen([PYTHON, EMCC, '-v', '-xc++', '/dev/null'], stdout=PIPE, stderr=PIPE).communicate()[1]
+    self.assertContained('-std=c++03', dash_xcpp)
+
   def test_cxx03(self):
     for compiler in [EMCC, EMXX]:
       process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_cxx03.cpp')], stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
This fix prevents the erroneous inclusion of '-std=c++03' compiler flag to Clang when the input file is explicitly requested to be treated as C language regardless of its file extension.