### PR TITLE
Remove noisy WebAssembly messages

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -225,7 +225,7 @@ function run(args) {
   if (preloadStartTime === null) preloadStartTime = Date.now();
 
   if (runDependencies > 0) {
-#if ASSERTIONS && !BINARYEN_ASYNC_COMPILATION
+#if RUNTIME_LOGGING
     Module.printErr('run() called, but dependencies remain, so not running');
 #endif
     return;

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -225,7 +225,7 @@ function run(args) {
   if (preloadStartTime === null) preloadStartTime = Date.now();
 
   if (runDependencies > 0) {
-#if ASSERTIONS
+#if ASSERTIONS && !BINARYEN_ASYNC_COMPILATION
     Module.printErr('run() called, but dependencies remain, so not running');
 #endif
     return;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2274,6 +2274,9 @@ function integrateWasmJS(Module) {
     }
 
 #if BINARYEN_ASYNC_COMPILATION
+#if RUNTIME_LOGGING
+    Module['printErr']('asynchronously preparing wasm');
+#endif
     getBinaryPromise().then(function(binary) {
       return WebAssembly.instantiate(binary, info)
     }).then(function(output) {
@@ -2437,6 +2440,10 @@ function integrateWasmJS(Module) {
     for (var i = 0; i < methods.length; i++) {
       var curr = methods[i];
 
+#if RUNTIME_LOGGING
+      Module['printErr']('trying binaryen method: ' + curr);
+#endif
+
       if (curr === 'native-wasm') {
         if (exports = doNativeWasm(global, env, providedBuffer)) break;
       } else if (curr === 'asmjs') {
@@ -2449,6 +2456,10 @@ function integrateWasmJS(Module) {
     }
 
     if (!exports) throw 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods';
+
+#if RUNTIME_LOGGING
+    Module['printErr']('binaryen method succeeded.');
+#endif
 
     return exports;
   };

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2274,7 +2274,6 @@ function integrateWasmJS(Module) {
     }
 
 #if BINARYEN_ASYNC_COMPILATION
-    Module['printErr']('asynchronously preparing wasm');
     getBinaryPromise().then(function(binary) {
       return WebAssembly.instantiate(binary, info)
     }).then(function(output) {
@@ -2438,8 +2437,6 @@ function integrateWasmJS(Module) {
     for (var i = 0; i < methods.length; i++) {
       var curr = methods[i];
 
-      Module['printErr']('trying binaryen method: ' + curr);
-
       if (curr === 'native-wasm') {
         if (exports = doNativeWasm(global, env, providedBuffer)) break;
       } else if (curr === 'asmjs') {
@@ -2452,8 +2449,6 @@ function integrateWasmJS(Module) {
     }
 
     if (!exports) throw 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods';
-
-    Module['printErr']('binaryen method succeeded.');
 
     return exports;
   };

--- a/src/settings.js
+++ b/src/settings.js
@@ -32,6 +32,8 @@ var ASSERTIONS = 1; // Whether we should add runtime assertions, for example to
                     // of positive size, etc., whether we should throw if we encounter a bad __label__, i.e.,
                     // if code flow runs into a fault
                     // ASSERTIONS == 2 gives even more runtime checks
+var RUNTIME_LOGGING = 0; // Whether extra logging should be enabled.
+                         // This logging isn't quite assertion-quality in that it isn't necessarily a symptom that something is wrong.
 var STACK_OVERFLOW_CHECK = 0; // Chooses what kind of stack smash checks to emit to generated code:
                               // 0: Stack overflows are not checked.
                               // 1: Adds a security cookie at the top of the stack, which is checked at end of each tick and at exit (practically zero performance overhead)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7339,14 +7339,6 @@ int main() {
     proc.communicate()
     assert proc.returncode != 0
 
-  def test_binaryen_default_method(self):
-    if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey')
-    subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'])
-    # might or might not fail, we don't care, just check which method is tried
-    out = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE, full_output=True, stderr=PIPE, assert_returncode=None)
-    self.assertContained('trying binaryen method: native-wasm', out) # native is the default
-    assert out.count('trying binaryen method') == 1, 'must not try any other method'
-
   def test_binaryen_asmjs_outputs(self):
     # Test that an .asm.js file is outputted exactly when it is requested.
     for args, output_asmjs in [


### PR DESCRIPTION
These messages were getting printing to the console's error log even though they're not errors.