### PR TITLE
Re-add missing SIGSTKSZ defines from musl 1.1.15

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/signal.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/signal.h
@@ -1,6 +1,11 @@
 #if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#define MINSIGSTKSZ 2048
+#define SIGSTKSZ 8192
+#endif
+
 #ifdef _GNU_SOURCE
 #define REG_GS          0
 #define REG_FS          1


### PR DESCRIPTION
Fixes https://github.com/kripken/emscripten/issues/5146