### PR TITLE
Fix emscripten_get_mouse_status

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -287,3 +287,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jakub Jirutka <jakub@jirutka.cz>
 * Loo Rong Jie <loorongjie@gmail.com>
 * Jean-François Geyelin <jfgeyelin@gmail.com>
+* Matthew Collins <thethinkofdeath@gmail.com>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1124,7 +1124,7 @@ var LibraryJSEvents = {
     // HTML5 does not really have a polling API for mouse events, so implement one manually by
     // returning the data from the most recently received event. This requires that user has registered
     // at least some no-op function as an event handler to any of the mouse function.
-    HEAP32.set(HEAP32.subarray(JSEvents.mouseEvent, {{{ C_STRUCTS.EmscriptenMouseEvent.__size__ }}}), mouseState);
+    HEAP8.set(HEAP8.subarray(JSEvents.mouseEvent, JSEvents.mouseEvent + {{{ C_STRUCTS.EmscriptenMouseEvent.__size__ }}}), mouseState);
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 

--- a/tests/test_html5_mouse.c
+++ b/tests/test_html5_mouse.c
@@ -130,8 +130,21 @@ int main()
       for(var d in data) event[d] = data[d];
       window.dispatchEvent(event);
     }
-    sendEvent('click', { screenX: 1, screenY: 1, clientX: 1, clientY: 1, button: 0, buttons: 1 });
+    sendEvent('click', { screenX: 123, screenY: 456, clientX: 123, clientY: 456, button: 0, buttons: 1 });
   );
+
+  // get_mouse_status should contain the results of the last event
+  EmscriptenMouseEvent mouseEvent;
+  ret = emscripten_get_mouse_status(&mouseEvent);
+  TEST_RESULT(emscripten_get_mouse_status);
+
+  if (mouseEvent.screenX != 123 || mouseEvent.screenY != 456
+    || mouseEvent.clientX != 123 || mouseEvent.clientY != 456)
+  {
+    printf("ERROR! Incorrect mouse status\n");
+    report_result(1);
+  }
+
   // Test that unregistering a callback works. Clicks should no longer be received.
   ret = emscripten_set_click_callback(0, 0, 1, 0);
   TEST_RESULT(emscripten_set_click_callback);


### PR DESCRIPTION
Fixes two issues:
* `subarray`'s last argument is the [end index not the length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray).
* Used HEAP32 without shifting the pointer, changed to HEAP8 to simplify as well.