### PR TITLE
Implement getting glfw input cursor mode from Pointer Lock. Closes GH-5120

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -288,3 +288,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Loo Rong Jie <loorongjie@gmail.com>
 * Jean-François Geyelin <jfgeyelin@gmail.com>
 * Matthew Collins <thethinkofdeath@gmail.com>
+* Satoshi N. M <snmatsutake@yahoo.co.jp>

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1230,6 +1230,17 @@ var LibraryGLFW = {
   glfwGetInputMode: function(winid, mode) {
     var win = GLFW.WindowFromId(winid);
     if (!win) return;
+
+    switch (mode) {
+      case 0x00033001: { // GLFW_CURSOR
+        if (Browser.pointerLock) {
+          win.inputModes[mode] = 0x00034003; // GLFW_CURSOR_DISABLED
+        } else {
+          win.inputModes[mode] = 0x00034001; // GLFW_CURSOR_NORMAL
+        }
+      }
+    }
+
     return win.inputModes[mode];
   },
 

--- a/tests/test_glfw_cursor_disabled.c
+++ b/tests/test_glfw_cursor_disabled.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <GLFW/glfw3.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#endif
+
+GLFWwindow *window;
+
+int last_cursor_disabled = -1;
+int pointerlock_isActive = 0;
+int result = 0;
+void render() {
+    glClearColor(0.5f, 0.5f, 0.5f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    int cursor_disabled = glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED;
+
+    if (cursor_disabled != last_cursor_disabled) {
+        last_cursor_disabled = cursor_disabled;
+
+        printf("GLFW_CURSOR_DISABLED? %d\n", cursor_disabled);
+
+        static int step = 2;
+        if (cursor_disabled == pointerlock_isActive) {
+            printf("Pass %d: glfwGetInputMode GLFW_CURSOR matches pointerlockchange event\n\n", step++);
+
+            if (step == 5) {
+                printf("All tests passed.\n");
+                result = 1;
+                REPORT_RESULT();
+                exit(0);
+            }
+
+            if (cursor_disabled) printf("Press escape to exit Pointer Lock\n");
+            else printf("Click again to enable Pointer Lock\n");
+        } else {
+            printf("FAIL: cursor_disabled(%d) != pointerlock_isActive(%d)\n", cursor_disabled, pointerlock_isActive);
+            REPORT_RESULT();
+            exit(1);
+        }
+    }
+}
+
+
+#ifdef __EMSCRIPTEN__
+EM_BOOL on_pointerlockchange(int eventType, const EmscriptenPointerlockChangeEvent *event, void *userData) {
+    printf("pointerlockchange, isActive=%d\n", event->isActive);
+    pointerlock_isActive = event->isActive;
+    return 0;
+}
+#endif
+
+int main() {
+    if (!glfwInit()) {
+        return -1;
+    }
+
+    window = glfwCreateWindow(640, 480, "test_glfw_cursor_disabled", NULL, NULL);
+    if (!window) {
+        glfwTerminate();
+        return -1;
+    }
+
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+
+    if (glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED) {
+        // Browsers do not allow disabling the cursor (Pointer Lock) without a gesture.
+        printf("FAIL: glfwGetInputMode returned GLFW_CURSOR_DISABLED prematurely\n");
+        REPORT_RESULT();
+        exit(1);
+    }
+    printf("Pass 1: glfwGetInputMode not prematurely returning cursor disabled\n");
+    printf("Click within the canvas to activate Pointer Lock\n");
+
+#ifdef __EMSCRIPTEN__
+    emscripten_set_pointerlockchange_callback(NULL, NULL, 0, on_pointerlockchange);
+    emscripten_set_main_loop(render, 0, 1);
+#else
+    while (!glfwWindowShouldClose(window)) {
+        glfwPollEvents();
+    }
+#endif
+
+    glfwTerminate();
+    return 0;
+}

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -131,6 +131,9 @@ class interactive(BrowserCore):
   def test_vr(self):
     self.btest(path_from_root('tests', 'test_vr.c'), expected='0')
 
+  def test_glfw_cursor_disabled(self):
+    self.btest('test_glfw_cursor_disabled.c', expected='1', args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'])
+
   def test_glfw_fullscreen(self):
     self.btest('test_glfw_fullscreen.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
 


### PR DESCRIPTION
Emscripten's glfw supports enabling Pointer Lock with glfwSetInputMode(), but getting the input mode with glfwGetInputMode() on GLFW_CURSOR would return the last value set, even if it was not successful. 

This pull request enhances/fixes glfwGetInputMode(GLFW_CURSOR) to return the actual live state of Pointer Lock: GLFW_CURSOR_DISABLED if it is actually enabled, GLFW_CURSOR_NORMAL otherwise. Therefore fixing apps getting confused into believing the pointer is disabled (i.e., they have exclusive control over the mouse pointer for mouse look / free look).

Fixes https://github.com/kripken/emscripten/issues/5120 and the example app therein.

---

Removes the need for this emscripten-specific workaround when porting native glfw games:

```c
#ifdef __EMSCRIPTEN__
EM_BOOL on_pointerlockchange(int eventType, const EmscriptenPointerlockChangeEvent *event, void *userData) {
    if (!pointerlockChangeEvent->isActive) {
        glfwSetInputMode(g->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
    }
    return 0;
}

...

    emscripten_set_pointerlockchange_callback(NULL, NULL, 0, on_pointerlockchange);

#endif
```