### PR TITLE
Fix glfw character callback typing keyboard shortcuts. Closes GH-5121

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -343,6 +343,7 @@ var LibraryGLFW = {
 
     onKeyPress: function(event) {
       if (!GLFW.active || !GLFW.active.charFunc) return;
+      if (event.ctrlKey || event.metaKey) return;
 
       // correct unicode charCode is only available with onKeyPress event
       var charCode = event.charCode;

--- a/tests/glfw_events.c
+++ b/tests/glfw_events.c
@@ -18,6 +18,7 @@
         int button;
         int action;
         int modify;
+        int character;
     } test_args_t;
 
     typedef struct {
@@ -54,9 +55,17 @@
         #if USE_GLFW == 2
             { "Module.injectKeyEvent('keydown', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESC, GLFW_PRESS, -1 } },
             { "Module.injectKeyEvent('keyup', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESC, GLFW_RELEASE, -1 } },
+
+            { "Module.injectKeyEvent('keydown', 65)", { 0, 0.0, 0.0, 'A', GLFW_PRESS, -1, 'A' } },
+            { "Module.injectKeyEvent('keypress', 65, {charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, 'A' } },
+            { "Module.injectKeyEvent('keyup', 65)", { 0, 0.0, 0.0, 'A', GLFW_RELEASE, -1, 'A' } },
         #else
             { "Module.injectKeyEvent('keydown', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESCAPE, GLFW_PRESS, -1 } },
             { "Module.injectKeyEvent('keyup', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESCAPE, GLFW_RELEASE, -1 } },
+
+            { "Module.injectKeyEvent('keydown', 65)", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_PRESS, -1 } },
+            { "Module.injectKeyEvent('keypress', 65, {charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, 'A' } },
+            { "Module.injectKeyEvent('keyup', 65)", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_RELEASE, -1 } },
         #endif
     };
 
@@ -115,6 +124,24 @@
         }
     }
 
+    #if USE_GLFW == 2
+        static void on_char_callback(int character, int action)
+    #else
+        static void on_char_callback(GLFWwindow* window, unsigned int character)
+    #endif
+    {
+        test_args_t args = g_tests[g_test_actual].args;
+        if (args.character == character)
+        {
+            g_state |= 1 << g_test_actual;
+        }
+        else
+        {
+            printf("Test %d: FAIL\n", g_test_actual);
+        }
+
+    }
+
     #if USE_GLFW == 3
         static void on_mouse_wheel(GLFWwindow* window, double x, double y)
         {
@@ -161,10 +188,8 @@
                 //canvas.dispatchEvent(event);
             };
 
-            Module.injectKeyEvent = function(type, keyCode) {
-                var keyboardEvent = document.createEvent("KeyboardEvent");
-                var initMethod = typeof keyboardEvent.initKeyboardEvent !== 'undefined' ? "initKeyboardEvent" : "initKeyEvent";
-                keyboardEvent[initMethod](type, true, true, window, false, false, false, false, keyCode, 0);
+            Module.injectKeyEvent = function(type, keyCode, options) {
+                var keyboardEvent = new KeyboardEvent(type, Object.assign({ keyCode: keyCode}, options));
                 canvas.dispatchEvent(keyboardEvent);
             };
         ));
@@ -175,7 +200,7 @@
             glfwOpenWindow(WIDTH, HEIGHT, 5, 6, 5, 0, 0, 0, GLFW_WINDOW); // != GL_TRUE)
             
             glfwSetMousePosCallback(on_mouse_move);
-            //glfwSetCharCallback(...);
+            glfwSetCharCallback(on_char_callback);
         #else
             glfwSetErrorCallback(on_error);
             printf("%s\n", glfwGetVersionString());
@@ -187,7 +212,7 @@
 
             glfwSetCursorPosCallback(_mainWindow, on_mouse_move);
             glfwSetScrollCallback(_mainWindow, on_mouse_wheel);
-            //glfwSetCharCallback(_mainWindow, ...);
+            glfwSetCharCallback(_mainWindow, on_char_callback);
         #endif
 
         for (int p = 0; p < 2 && result; ++p) // 2 passes, with and without callbacks.
@@ -222,9 +247,9 @@
                 } else {
                     // Keyboard.
                 #if USE_GLFW == 2
-                    if (glfwGetKey(test.args.button) != test.args.action)
+                    if (test.args.action != -1 && glfwGetKey(test.args.button) != test.args.action)
                 #else
-                    if (glfwGetKey(_mainWindow, test.args.button) != test.args.action)
+                    if (test.args.action != -1 && glfwGetKey(_mainWindow, test.args.button) != test.args.action)
                 #endif
                     {
                         printf("Test %d: FAIL\n", g_test_actual);

--- a/tests/glfw_events.c
+++ b/tests/glfw_events.c
@@ -197,7 +197,14 @@
             };
 
             Module.injectKeyEvent = function(type, keyCode, options) {
-                var keyboardEvent = new KeyboardEvent(type, Object.assign({ keyCode: keyCode}, options));
+                // KeyboardEvent constructor always returns 0 keyCode on Chrome, so use generic events
+                //var keyboardEvent = new KeyboardEvent(type, Object.assign({ keyCode: keyCode}, options));
+                var keyboardEvent = document.createEventObject ?
+                        document.createEventObject() : document.createEvent('Events');
+                keyboardEvent.initEvent(type, true, true);
+                keyboardEvent.keyCode = keyCode;
+                keyboardEvent = Object.assign(keyboardEvent,  options);
+
                 canvas.dispatchEvent(keyboardEvent);
             };
         ));

--- a/tests/glfw_events.c
+++ b/tests/glfw_events.c
@@ -59,6 +59,10 @@
             { "Module.injectKeyEvent('keydown', 65)", { 0, 0.0, 0.0, 'A', GLFW_PRESS, -1, 'A' } },
             { "Module.injectKeyEvent('keypress', 65, {charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, 'A' } },
             { "Module.injectKeyEvent('keyup', 65)", { 0, 0.0, 0.0, 'A', GLFW_RELEASE, -1, 'A' } },
+
+            { "Module.injectKeyEvent('keydown', 65, {ctrlKey: true})", { 0, 0.0, 0.0, 'A', GLFW_PRESS, -1, 'A' } },
+            { "Module.injectKeyEvent('keypress', 65, {ctrlKey: true, charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, -1 } },
+            { "Module.injectKeyEvent('keyup', 65, {ctrlKey: true})", { 0, 0.0, 0.0, 'A', GLFW_RELEASE, -1, 'A' } },
         #else
             { "Module.injectKeyEvent('keydown', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESCAPE, GLFW_PRESS, -1 } },
             { "Module.injectKeyEvent('keyup', 27)", { 0, 0.0, 0.0, GLFW_KEY_ESCAPE, GLFW_RELEASE, -1 } },
@@ -66,6 +70,10 @@
             { "Module.injectKeyEvent('keydown', 65)", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_PRESS, -1 } },
             { "Module.injectKeyEvent('keypress', 65, {charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, 'A' } },
             { "Module.injectKeyEvent('keyup', 65)", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_RELEASE, -1 } },
+
+            { "Module.injectKeyEvent('keydown', 65, {ctrlKey: true})", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_PRESS, -1, 'A' } },
+            { "Module.injectKeyEvent('keypress', 65, {ctrlKey: true, charCode: 65})", { 0, 0.0, 0.0, -1, -1, -1, -1 } },
+            { "Module.injectKeyEvent('keyup', 65, {ctrlKey: true})", { 0, 0.0, 0.0, GLFW_KEY_A, GLFW_RELEASE, -1, 'A' } },
         #endif
     };
 
@@ -131,7 +139,7 @@
     #endif
     {
         test_args_t args = g_tests[g_test_actual].args;
-        if (args.character == character)
+        if (args.character != -1 && args.character == character)
         {
             g_state |= 1 << g_test_actual;
         }
@@ -232,6 +240,11 @@
             {
                 g_test_actual = i;
                 test_t test = g_tests[g_test_actual];
+
+                if (test.args.character == -1) {
+                     g_state |= 1 << g_test_actual;
+                }
+
                 emscripten_run_script(test.cmd);
 
                 if (test.args.mouse) {


### PR DESCRIPTION
Fixes text input appearing in `glfwSetCharCallback()` when pressing keyboard shortcuts.

Adds a check to not call the callback if ctrlKey (control) or metaKey (super/command) is set (*), matching the native glfw behavior and documentation at http://www.glfw.org/docs/latest/input.html#input_char which says this callback is for "text input" (note, not checking shiftKey and altKey since those can be used to type alternative characters).

Fixes https://github.com/kripken/emscripten/issues/5121 and the example there. Tested on Firefox 55.0a1 (2017-04-22), this change fixes Cmd-A and Ctrl-A both typing "a", as well as  Safari Technology Preview 28, fixes Cmd-A typing "a". 