### PR TITLE
Refactor emscripten py pt3 - emscript_wasm_backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -15,6 +15,7 @@ if __name__ == '__main__':
 
 import difflib
 import os, sys, json, optparse, subprocess, re, time, logging
+import shutil
 
 from tools import shared
 from tools import jsrun, cache as cache_module, tempfiles
@@ -1669,7 +1670,6 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
     if DEBUG:
       logging.debug('  emscript: llvm wasm backend took %s seconds' % (time.time() - t))
       t = time.time()
-      import shutil
       shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
 
     assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
@@ -1690,7 +1690,6 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
   if DEBUG:
     logging.debug('  emscript: binaryen s2wasm took %s seconds' % (time.time() - t))
     t = time.time()
-    import shutil
     shutil.copyfile(wast, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-s2wasm-output.wast'))
   return wast
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -1570,39 +1570,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
 
   if libraries is None: libraries = []
 
-  with temp_files.get_file('.wb.s') as temp_s:
-    backend_args = create_backend_args_wasm(infile, temp_s, settings)
-
-    if DEBUG:
-      logging.debug('emscript: llvm wasm backend: ' + ' '.join(backend_args))
-      t = time.time()
-    shared.check_call(backend_args)
-    if DEBUG:
-      logging.debug('  emscript: llvm wasm backend took %s seconds' % (time.time() - t))
-      t = time.time()
-      import shutil
-      shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
-
-    assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
-    basename = outfile.name[:-3]
-    wast = basename + '.wast'
-    s2wasm_args = create_s2wasm_args(temp_s)
-    if DEBUG:
-      logging.debug('emscript: binaryen s2wasm: ' + ' '.join(s2wasm_args))
-      t = time.time()
-      #s2wasm_args += ['--debug']
-    shared.check_call(s2wasm_args, stdout=open(wast, 'w'))
-    # Also convert wasm text to binary
-    wasm_as_args = [os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-as'),
-                    wast, '-o', basename + '.wasm']
-    logging.debug('  emscript: binaryen wasm-as: ' + ' '.join(wasm_as_args))
-    shared.check_call(wasm_as_args)
-
-  if DEBUG:
-    logging.debug('  emscript: binaryen s2wasm took %s seconds' % (time.time() - t))
-    t = time.time()
-    import shutil
-    shutil.copyfile(wast, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-s2wasm-output.wast'))
+  wast = build_wasm(temp_files, infile, outfile, settings, DEBUG)
 
   # js compiler
 
@@ -1893,6 +1861,42 @@ Runtime.getTempRet0 = Module['getTempRet0'];
   outfile.write(post)
 
   outfile.close()
+
+
+def build_wasm(temp_files, infile, outfile, settings, DEBUG):
+  with temp_files.get_file('.wb.s') as temp_s:
+    backend_args = create_backend_args_wasm(infile, temp_s, settings)
+    if DEBUG:
+      logging.debug('emscript: llvm wasm backend: ' + ' '.join(backend_args))
+      t = time.time()
+    shared.check_call(backend_args)
+    if DEBUG:
+      logging.debug('  emscript: llvm wasm backend took %s seconds' % (time.time() - t))
+      t = time.time()
+      import shutil
+      shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
+
+    assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
+    basename = outfile.name[:-3]
+    wast = basename + '.wast'
+    s2wasm_args = create_s2wasm_args(temp_s)
+    if DEBUG:
+      logging.debug('emscript: binaryen s2wasm: ' + ' '.join(s2wasm_args))
+      t = time.time()
+      #s2wasm_args += ['--debug']
+    shared.check_call(s2wasm_args, stdout=open(wast, 'w'))
+    # Also convert wasm text to binary
+    wasm_as_args = [os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-as'),
+                    wast, '-o', basename + '.wasm']
+    logging.debug('  emscript: binaryen wasm-as: ' + ' '.join(wasm_as_args))
+    shared.check_call(wasm_as_args)
+
+  if DEBUG:
+    logging.debug('  emscript: binaryen s2wasm took %s seconds' % (time.time() - t))
+    t = time.time()
+    import shutil
+    shutil.copyfile(wast, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-s2wasm-output.wast'))
+  return wast
 
 
 def create_backend_args_wasm(infile, temp_s, settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1674,19 +1674,17 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
 
   invoke_funcs = read_wast_invoke_imports(wast)
 
-  # calculate globals
   try:
     del forwarded_json['Variables']['globals']['_llvm_global_ctors'] # not a true variable
   except:
     pass
 
   # sent data
-  the_global = '{}'
   sending = create_sending_wasm(invoke_funcs, forwarded_json, metadata, settings)
   receiving = create_receiving_wasm(exported_implemented_functions, settings)
 
   # finalize
-  module = create_module_wasm(the_global, sending, receiving, invoke_funcs, settings)
+  module = create_module_wasm(sending, receiving, invoke_funcs, settings)
 
   for i in range(len(module)): # do this loop carefully to save memory
     if WINDOWS: module[i] = module[i].replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
@@ -1824,9 +1822,11 @@ return real_''' + asmjs_mangle(s) + '''.apply(null, arguments);
   return receiving
 
 
-def create_module_wasm(the_global, sending, receiving, invoke_funcs, settings):
+def create_module_wasm(sending, receiving, invoke_funcs, settings):
   access_quote = access_quoter(settings)
   invoke_wrappers = create_invoke_wrappers(invoke_funcs)
+
+  the_global = '{}'
 
   if settings['USE_PTHREADS']:
     shared_array_buffer = "if (typeof SharedArrayBuffer !== 'undefined') Module.asmGlobalArg['Atomics'] = Atomics;"

--- a/emscripten.py
+++ b/emscripten.py
@@ -1783,13 +1783,12 @@ def create_metadata_wasm(metadata_raw, wast):
 
 def read_wast_invoke_imports(wast):
   invoke_funcs = []
-  with open(wast) as f:
-    for line in f:
-      if line.strip().startswith('(import '):
-        parts = line.split()
-        func_name = parts[2][1:-1]
-        if func_name.startswith('invoke_'):
-          invoke_funcs.append(func_name)
+  for line in open(wast).readlines():
+    if line.strip().startswith('(import '):
+      parts = line.split()
+      func_name = parts[2][1:-1]
+      if func_name.startswith('invoke_'):
+        invoke_funcs.append(func_name)
   return invoke_funcs
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -1604,14 +1604,6 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   for k, v in metadata_json.iteritems():
     metadata[k] = v
 
-  def asmjs_mangle(name):
-    # Mangle a name the way asm.js/JSBackend globals are mangled (i.e. prepend
-    # '_' and replace non-alphanumerics with '_')
-    library_functions_in_module = ('setThrew', 'setTempRet0', 'getTempRet0')
-    if name.startswith('dynCall_'): return name
-    if name in library_functions_in_module: return name
-    return '_' + ''.join(['_' if not c.isalnum() else c for c in name])
-
   # Initializers call the global var version of the export, so they get the mangled name.
   metadata['initializers'] = [asmjs_mangle(i) for i in metadata['initializers']]
 
@@ -1933,6 +1925,18 @@ def create_s2wasm_args(temp_s):
   args += ['--allow-memory-growth'] if shared.Settings.ALLOW_MEMORY_GROWTH else []
   args += ['-l', compiler_rt_lib]
   return args
+
+
+def asmjs_mangle(name):
+  """Mangle a name the way asm.js/JSBackend globals are mangled.
+
+  Prepends '_' and replaces non-alphanumerics with '_'.
+  Used by wasm backend for JS library consistency with asm.js.
+  """
+  library_functions_in_module = ('setThrew', 'setTempRet0', 'getTempRet0')
+  if name.startswith('dynCall_'): return name
+  if name in library_functions_in_module: return name
+  return '_' + ''.join(['_' if not c.isalnum() else c for c in name])
 
 
 if os.environ.get('EMCC_FAST_COMPILER') == '0':

--- a/emscripten.py
+++ b/emscripten.py
@@ -312,15 +312,10 @@ def update_settings_glue(settings, metadata):
   if settings['SIDE_MODULE']:
     settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] = [] # we don't need any JS library contents in side modules
 
-  if metadata['cantValidate'] and settings['ASM_JS'] != 2:
+  if metadata.get('cantValidate') and settings['ASM_JS'] != 2:
     logging.warning('disabling asm.js validation due to use of non-supported features: ' + metadata['cantValidate'])
     settings['ASM_JS'] = 2
 
-  update_settings_common(settings, metadata)
-
-
-def update_settings_common(settings, metadata):
-  """Update settings shared between asm.js and wasm backends."""
   settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] = list(
     set(settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] + map(shared.JS.to_nice_ident, metadata['declares'])).difference(
       map(lambda x: x[1:], metadata['implementedFunctions'])
@@ -1597,7 +1592,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   metadata = create_metadata_wasm(metadata_raw, wast)
   if DEBUG: logging.debug(repr(metadata))
 
-  update_settings_common(settings, metadata)
+  update_settings_glue(settings, metadata)
 
   if DEBUG: t = time.time()
   glue, forwarded_data = compile_settings(compiler_engine, settings, libraries, temp_files)


### PR DESCRIPTION
Final refactoring pass for now - did a bunch of function extraction in `emscript_wasm_backend`. Reused a few pieces from previous refactorings (yay!). Built this on top of part 2 (https://github.com/kripken/emscripten/pull/5150), but surprisingly to me the reuse I did happened to already be in part 1, so this is committable separately.

Tested with `default`, `asm2`, `binaryen0` and `binaryen2` with both backends. Skipped `other` and `browser` because these changes are pretty well localized to the `emscript_wasm_backend` path.