### PR TITLE
Update glfw3 library to version 3.2.1

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1027,7 +1027,7 @@ var LibraryGLFW = {
 #if USE_GLFW == 3
   glfwGetVersionString: function() {
     if (!GLFW.versionString) {
-      GLFW.versionString = allocate(intArrayFromString("3.0.0 JS WebGL Emscripten"), 'i8', ALLOC_NORMAL);
+      GLFW.versionString = allocate(intArrayFromString("3.2.1 JS WebGL Emscripten"), 'i8', ALLOC_NORMAL);
     }
     return GLFW.versionString;
   },

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1036,6 +1036,10 @@ var LibraryGLFW = {
     GLFW.errorFunc = cbfun;
   },
 
+  glfwWaitEventsTimeout: function(timeout) {},
+
+  glfwPostEmptyEvent: function() {},
+
   glfwGetMonitors: function(count) {
     setValue(count, 1, 'i32');
     if (!GLFW.monitors) {
@@ -1221,6 +1225,28 @@ var LibraryGLFW = {
     win.windowIconifyFunc = cbfun;
   },
 
+  glfwSetWindowIcon: function(winid, count, images) {},
+
+  glfwSetWindowSizeLimits: function(winid, minwidth, minheight, maxwidth, maxheight) {},
+
+  glfwSetWindowAspectRatio: function(winid, numer, denom) {},
+
+  glfwGetWindowFrameSize: function(winid, left, top, right, bottom) { throw "glfwGetWindowFrameSize not implemented."; },
+
+  glfwMaximizeWindow: function(winid) {},
+
+  glfwFocusWindow: function(winid) {},
+
+  glfwSetWindowMonitor: function(winid, monitor, xpos, ypos, width, height, refreshRate) { throw "glfwSetWindowMonitor not implemented."; },
+
+  glfwCreateCursor: function(image, xhot, yhot) {},
+
+  glfwCreateStandardCursor: function(shape) {},
+
+  glfwDestroyCursor: function(cursor) {},
+
+  glfwSetCursor: function(winid, cursor) {},
+
   glfwSetFramebufferSizeCallback: function(winid, cbfun) {
     var win = GLFW.WindowFromId(winid);
     if (!win) return;
@@ -1252,6 +1278,8 @@ var LibraryGLFW = {
     return GLFW.getKey(winid, key);
   },
 
+  glfwGetKeyName: function(key, scancode) { throw "glfwGetKeyName not implemented."; },
+
   glfwGetMouseButton: function(winid, button) {
     return GLFW.getMouseButton(winid, button);
   },
@@ -1273,6 +1301,8 @@ var LibraryGLFW = {
     GLFW.setCharCallback(winid, cbfun);
   },
 
+  glfwSetCharModsCallback: function(winid, cbfun) { throw "glfwSetCharModsCallback not implemented."; },
+
   glfwSetMouseButtonCallback: function(winid, cbfun) {
     GLFW.setMouseButtonCallback(winid, cbfun);
   },
@@ -1290,6 +1320,26 @@ var LibraryGLFW = {
   glfwSetScrollCallback: function(winid, cbfun) {
     GLFW.setScrollCallback(winid, cbfun);
   },
+
+  glfwVulkanSupported: function() {
+    return 0;
+  },
+
+  glfwSetDropCallback: function(winid, cbfun) { throw "glfwSetDropCallback is not implemented."; },
+
+  glfwGetTimerValue: function() { throw "glfwGetTimerValue is not implemented."; },
+
+  glfwGetTimerFrequency: function() { throw "glfwGetTimerFrequency is not implemented."; },
+
+  glfwGetRequiredInstanceExtensions: function(count) { throw "glfwGetRequiredInstanceExtensions is not implemented."; },
+
+  glfwGetInstanceProcAddress: function(instance, procname) { throw "glfwGetInstanceProcAddress is not implemented."; },
+
+  glfwGetPhysicalDevicePresentationSupport: function(instance, device, queuefamily) { throw "glfwGetPhysicalDevicePresentationSupport is not implemented"; },
+
+  glfwCreateWindowSurface: function(instance, winid, allocator, surface) { throw "glfwCreateWindowSurface is not implemented."; },
+
+  glfwSetJoystickCallback: function(cbfun) { throw "glfwSetJoystickCallback is not implemented."; },
 
   glfwJoystickPresent: function(joy) { throw "glfwJoystickPresent is not implemented."; },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -983,8 +983,8 @@ var LibraryGLFW = {
 
 #if USE_GLFW == 3
     setValue(major, 3, 'i32');
-    setValue(minor, 0, 'i32');
-    setValue(rev, 0, 'i32');
+    setValue(minor, 2, 'i32');
+    setValue(rev, 1, 'i32');
 #endif
   },
 

--- a/system/include/GLFW/glfw3.h
+++ b/system/include/GLFW/glfw3.h
@@ -1,9 +1,9 @@
 /*************************************************************************
- * GLFW 3.0 - www.glfw.org
+ * GLFW 3.2 - www.glfw.org
  * A library for OpenGL, window and input
  *------------------------------------------------------------------------
  * Copyright (c) 2002-2006 Marcus Geelnard
- * Copyright (c) 2006-2010 Camilla Berglund <elmindreda@elmindreda.org>
+ * Copyright (c) 2006-2016 Camilla Berglund <elmindreda@glfw.org>
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -38,54 +38,60 @@ extern "C" {
  * Doxygen documentation
  *************************************************************************/
 
-/*! @defgroup clipboard Clipboard support
+/*! @file glfw3.h
+ *  @brief The header of the GLFW 3 API.
+ *
+ *  This is the header file of the GLFW 3 API.  It defines all its types and
+ *  declares all its functions.
+ *
+ *  For more information about how to use this file, see @ref build_include.
  */
-/*! @defgroup context Context handling
+/*! @defgroup context Context reference
+ *
+ *  This is the reference documentation for OpenGL and OpenGL ES context related
+ *  functions.  For more task-oriented information, see the @ref context_guide.
  */
-/*! @defgroup error Error handling
+/*! @defgroup vulkan Vulkan reference
+ *
+ *  This is the reference documentation for Vulkan related functions and types.
+ *  For more task-oriented information, see the @ref vulkan_guide.
  */
-/*! @defgroup init Initialization and version information
+/*! @defgroup init Initialization, version and error reference
+ *
+ *  This is the reference documentation for initialization and termination of
+ *  the library, version management and error handling.  For more task-oriented
+ *  information, see the @ref intro_guide.
  */
-/*! @defgroup input Input handling
+/*! @defgroup input Input reference
+ *
+ *  This is the reference documentation for input related functions and types.
+ *  For more task-oriented information, see the @ref input_guide.
  */
-/*! @defgroup monitor Monitor handling
+/*! @defgroup monitor Monitor reference
  *
  *  This is the reference documentation for monitor related functions and types.
- *  For more information, see the @ref monitor.
+ *  For more task-oriented information, see the @ref monitor_guide.
  */
-/*! @defgroup time Time input
- */
-/*! @defgroup window Window handling
+/*! @defgroup window Window reference
  *
  *  This is the reference documentation for window related functions and types,
- *  including creation, deletion and event polling.  For more information, see
- *  the @ref window.
+ *  including creation, deletion and event polling.  For more task-oriented
+ *  information, see the @ref window_guide.
  */
 
 
 /*************************************************************************
- * Global definitions
+ * Compiler- and platform-specific preprocessor work
  *************************************************************************/
 
-/* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
-
-/* Please report any problems that you find with your compiler, which may
- * be solved in this section! There are several compilers that I have not
- * been able to test this file with yet.
- *
- * First: If we are we on Windows, we want a single define for it (_WIN32)
- * (Note: For Cygwin the compiler flag -mwin32 should be used, but to
- * make sure that things run smoothly for Cygwin users, we add __CYGWIN__
- * to the list of "valid Win32 identifiers", which removes the need for
- * -mwin32)
+/* If we are we on Windows, we want a single define for it.
  */
-#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__))
+#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
  #define _WIN32
 #endif /* _WIN32 */
 
-/* In order for extension support to be portable, we need to define an
- * OpenGL function call method. We use the keyword APIENTRY, which is
- * defined for Win32. (Note: Windows also needs this for <GL/gl.h>)
+/* It is customary to use APIENTRY for OpenGL function pointer declarations on
+ * all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
  */
 #ifndef APIENTRY
  #ifdef _WIN32
@@ -95,111 +101,107 @@ extern "C" {
  #endif
 #endif /* APIENTRY */
 
-/* The following three defines are here solely to make some Windows-based
- * <GL/gl.h> files happy. Theoretically we could include <windows.h>, but
- * it has the major drawback of severely polluting our namespace.
+/* Some Windows OpenGL headers need this.
  */
-
-/* Under Windows, we need WINGDIAPI defined */
 #if !defined(WINGDIAPI) && defined(_WIN32)
- #if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__POCC__)
-  /* Microsoft Visual C++, Borland C++ Builder and Pelles C */
-  #define WINGDIAPI __declspec(dllimport)
- #elif defined(__LCC__)
-  /* LCC-Win32 */
-  #define WINGDIAPI __stdcall
- #else
-  /* Others (e.g. MinGW, Cygwin) */
-  #define WINGDIAPI extern
- #endif
+ #define WINGDIAPI __declspec(dllimport)
  #define GLFW_WINGDIAPI_DEFINED
 #endif /* WINGDIAPI */
 
-/* Some <GL/glu.h> files also need CALLBACK defined */
+/* Some Windows GLU headers need this.
+ */
 #if !defined(CALLBACK) && defined(_WIN32)
- #if defined(_MSC_VER)
-  /* Microsoft Visual C++ */
-  #if (defined(_M_MRX000) || defined(_M_IX86) || defined(_M_ALPHA) || defined(_M_PPC)) && !defined(MIDL_PASS)
-   #define CALLBACK __stdcall
-  #else
-   #define CALLBACK
-  #endif
- #else
-  /* Other Windows compilers */
-  #define CALLBACK __stdcall
- #endif
+ #define CALLBACK __stdcall
  #define GLFW_CALLBACK_DEFINED
 #endif /* CALLBACK */
 
-/* Most GL/glu.h variants on Windows need wchar_t
- * OpenGL/gl.h blocks the definition of ptrdiff_t by glext.h on OS X */
-#if !defined(GLFW_INCLUDE_NONE)
- #include <stddef.h>
-#endif
+/* Include because most Windows GLU headers need wchar_t and
+ * the OS X OpenGL header blocks the definition of ptrdiff_t by glext.h.
+ * Include it unconditionally to avoid surprising side-effects.
+ */
+#include <stddef.h>
+
+/* Include because it is needed by Vulkan and related functions.
+ */
+#include <stdint.h>
 
 /* Include the chosen client API headers.
  */
-#if defined(__APPLE_CC__)
-  #if defined(GLFW_INCLUDE_GLCOREARB)
-    #include <OpenGL/gl3.h>
-  #elif !defined(GLFW_INCLUDE_NONE)
-    #define GL_GLEXT_LEGACY
-    #include <OpenGL/gl.h>
+#if defined(__APPLE__)
+ #if defined(GLFW_INCLUDE_GLCOREARB)
+  #include <OpenGL/gl3.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <OpenGL/gl3ext.h>
   #endif
-  #if defined(GLFW_INCLUDE_GLU)
-    #include <OpenGL/glu.h>
+ #elif !defined(GLFW_INCLUDE_NONE)
+  #if !defined(GLFW_INCLUDE_GLEXT)
+   #define GL_GLEXT_LEGACY
   #endif
+  #include <OpenGL/gl.h>
+ #endif
+ #if defined(GLFW_INCLUDE_GLU)
+  #include <OpenGL/glu.h>
+ #endif
 #else
-  #if defined(GLFW_INCLUDE_GLCOREARB)
-    #include <GL/glcorearb.h>
-  #elif defined(GLFW_INCLUDE_ES1)
-    #include <GLES/gl.h>
-  #elif defined(GLFW_INCLUDE_ES2)
-    #include <GLES2/gl2.h>
-  #elif defined(GLFW_INCLUDE_ES3)
-    #include <GLES3/gl3.h>
-  #elif !defined(GLFW_INCLUDE_NONE)
-    #include <GL/gl.h>
+ #if defined(GLFW_INCLUDE_GLCOREARB)
+  #include <GL/glcorearb.h>
+ #elif defined(GLFW_INCLUDE_ES1)
+  #include <GLES/gl.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GLES/glext.h>
   #endif
-  #if defined(GLFW_INCLUDE_GLU)
-    #include <GL/glu.h>
+ #elif defined(GLFW_INCLUDE_ES2)
+  #include <GLES2/gl2.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GLES2/gl2ext.h>
   #endif
+ #elif defined(GLFW_INCLUDE_ES3)
+  #include <GLES3/gl3.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GLES2/gl2ext.h>
+  #endif
+ #elif defined(GLFW_INCLUDE_ES31)
+  #include <GLES3/gl31.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GLES2/gl2ext.h>
+  #endif
+ #elif defined(GLFW_INCLUDE_VULKAN)
+  #include <vulkan/vulkan.h>
+ #elif !defined(GLFW_INCLUDE_NONE)
+  #include <GL/gl.h>
+  #if defined(GLFW_INCLUDE_GLEXT)
+   #include <GL/glext.h>
+  #endif
+ #endif
+ #if defined(GLFW_INCLUDE_GLU)
+  #include <GL/glu.h>
+ #endif
 #endif
 
 #if defined(GLFW_DLL) && defined(_GLFW_BUILD_DLL)
- /* GLFW_DLL is defined by users of GLFW when compiling programs that will link
-  * to the DLL version of the GLFW library.  _GLFW_BUILD_DLL is defined by the
-  * GLFW configuration header when compiling the DLL version of the library.
+ /* GLFW_DLL must be defined by applications that are linking against the DLL
+  * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
+  * configuration header when compiling the DLL version of the library.
   */
  #error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
 #endif
 
+/* GLFWAPI is used to declare public API functions for export
+ * from the DLL / shared library / dynamic library.
+ */
 #if defined(_WIN32) && defined(_GLFW_BUILD_DLL)
-
- /* We are building a Win32 DLL */
+ /* We are building GLFW as a Win32 DLL */
  #define GLFWAPI __declspec(dllexport)
-
 #elif defined(_WIN32) && defined(GLFW_DLL)
-
- /* We are calling a Win32 DLL */
- #if defined(__LCC__)
-  #define GLFWAPI extern
- #else
-  #define GLFWAPI __declspec(dllimport)
- #endif
-
+ /* We are calling GLFW as a Win32 DLL */
+ #define GLFWAPI __declspec(dllimport)
 #elif defined(__GNUC__) && defined(_GLFW_BUILD_DLL)
-
+ /* We are building GLFW as a shared / dynamic library */
  #define GLFWAPI __attribute__((visibility("default")))
-
 #else
-
- /* We are either building/calling a static lib or we are non-win32 */
+ /* We are building or calling GLFW as a static library */
  #define GLFWAPI
-
 #endif
-
-/* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
 
 
 /*************************************************************************
@@ -220,27 +222,54 @@ extern "C" {
  *  backward-compatible.
  *  @ingroup init
  */
-#define GLFW_VERSION_MINOR          0
+#define GLFW_VERSION_MINOR          2
 /*! @brief The revision number of the GLFW library.
  *
  *  This is incremented when a bug fix release is made that does not contain any
  *  API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION       3
+#define GLFW_VERSION_REVISION       1
+/*! @} */
+
+/*! @name Boolean values
+ *  @{ */
+/*! @brief One.
+ *
+ *  One.  Seriously.  You don't _need_ to use this symbol in your code.  It's
+ *  just semantic sugar for the number 1.  You can use `1` or `true` or `_True`
+ *  or `GL_TRUE` or whatever you want.
+ */
+#define GLFW_TRUE                   1
+/*! @brief Zero.
+ *
+ *  Zero.  Seriously.  You don't _need_ to use this symbol in your code.  It's
+ *  just just semantic sugar for the number 0.  You can use `0` or `false` or
+ *  `_False` or `GL_FALSE` or whatever you want.
+ */
+#define GLFW_FALSE                  0
 /*! @} */
 
 /*! @name Key and button actions
  *  @{ */
-/*! @brief The key or button was released.
+/*! @brief The key or mouse button was released.
+ *
+ *  The key or mouse button was released.
+ *
  *  @ingroup input
  */
 #define GLFW_RELEASE                0
-/*! @brief The key or button was pressed.
+/*! @brief The key or mouse button was pressed.
+ *
+ *  The key or mouse button was pressed.
+ *
  *  @ingroup input
  */
 #define GLFW_PRESS                  1
 /*! @brief The key was held down until it repeated.
+ *
+ *  The key was held down until it repeated.
+ *
  *  @ingroup input
  */
 #define GLFW_REPEAT                 2
@@ -248,20 +277,22 @@ extern "C" {
 
 /*! @defgroup keys Keyboard keys
  *
- * These key codes are inspired by the *USB HID Usage Tables v1.12* (p. 53-60),
- * but re-arranged to map to 7-bit ASCII for printable keys (function keys are
- * put in the 256+ range).
+ *  See [key input](@ref input_key) for how these are used.
  *
- * The naming of the key codes follow these rules:
- *  - The US keyboard layout is used
- *  - Names of printable alpha-numeric characters are used (e.g. "A", "R",
- *    "3", etc.)
- *  - For non-alphanumeric characters, Unicode:ish names are used (e.g.
- *    "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not
- *    correspond to the Unicode standard (usually for brevity)
- *  - Keys that lack a clear US mapping are named "WORLD_x"
- *  - For non-printable keys, custom names are used (e.g. "F4",
- *    "BACKSPACE", etc.)
+ *  These key codes are inspired by the _USB HID Usage Tables v1.12_ (p. 53-60),
+ *  but re-arranged to map to 7-bit ASCII for printable keys (function keys are
+ *  put in the 256+ range).
+ *
+ *  The naming of the key codes follow these rules:
+ *   - The US keyboard layout is used
+ *   - Names of printable alpha-numeric characters are used (e.g. "A", "R",
+ *     "3", etc.)
+ *   - For non-alphanumeric characters, Unicode:ish names are used (e.g.
+ *     "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not
+ *     correspond to the Unicode standard (usually for brevity)
+ *   - Keys that lack a clear US mapping are named "WORLD_x"
+ *   - For non-printable keys, custom names are used (e.g. "F4",
+ *     "BACKSPACE", etc.)
  *
  *  @ingroup input
  *  @{
@@ -393,11 +424,15 @@ extern "C" {
 #define GLFW_KEY_RIGHT_ALT          346
 #define GLFW_KEY_RIGHT_SUPER        347
 #define GLFW_KEY_MENU               348
+
 #define GLFW_KEY_LAST               GLFW_KEY_MENU
 
 /*! @} */
 
 /*! @defgroup mods Modifier key flags
+ *
+ *  See [key input](@ref input_key) for how these are used.
+ *
  *  @ingroup input
  *  @{ */
 
@@ -417,6 +452,9 @@ extern "C" {
 /*! @} */
 
 /*! @defgroup buttons Mouse buttons
+ *
+ *  See [mouse button input](@ref input_mouse_button) for how these are used.
+ *
  *  @ingroup input
  *  @{ */
 #define GLFW_MOUSE_BUTTON_1         0
@@ -434,6 +472,9 @@ extern "C" {
 /*! @} */
 
 /*! @defgroup joysticks Joysticks
+ *
+ *  See [joystick input](@ref joystick) for how these are used.
+ *
  *  @ingroup input
  *  @{ */
 #define GLFW_JOYSTICK_1             0
@@ -456,38 +497,129 @@ extern "C" {
 /*! @} */
 
 /*! @defgroup errors Error codes
- *  @ingroup error
+ *
+ *  See [error handling](@ref error_handling) for how these are used.
+ *
+ *  @ingroup init
  *  @{ */
 /*! @brief GLFW has not been initialized.
+ *
+ *  This occurs if a GLFW function was called that must not be called unless the
+ *  library is [initialized](@ref intro_init).
+ *
+ *  @analysis Application programmer error.  Initialize GLFW before calling any
+ *  function that requires initialization.
  */
 #define GLFW_NOT_INITIALIZED        0x00010001
 /*! @brief No context is current for this thread.
+ *
+ *  This occurs if a GLFW function was called that needs and operates on the
+ *  current OpenGL or OpenGL ES context but no context is current on the calling
+ *  thread.  One such function is @ref glfwSwapInterval.
+ *
+ *  @analysis Application programmer error.  Ensure a context is current before
+ *  calling functions that require a current context.
  */
 #define GLFW_NO_CURRENT_CONTEXT     0x00010002
-/*! @brief One of the enum parameters for the function was given an invalid
- *  enum.
+/*! @brief One of the arguments to the function was an invalid enum value.
+ *
+ *  One of the arguments to the function was an invalid enum value, for example
+ *  requesting [GLFW_RED_BITS](@ref window_hints_fb) with @ref
+ *  glfwGetWindowAttrib.
+ *
+ *  @analysis Application programmer error.  Fix the offending call.
  */
 #define GLFW_INVALID_ENUM           0x00010003
-/*! @brief One of the parameters for the function was given an invalid value.
+/*! @brief One of the arguments to the function was an invalid value.
+ *
+ *  One of the arguments to the function was an invalid value, for example
+ *  requesting a non-existent OpenGL or OpenGL ES version like 2.7.
+ *
+ *  Requesting a valid but unavailable OpenGL or OpenGL ES version will instead
+ *  result in a @ref GLFW_VERSION_UNAVAILABLE error.
+ *
+ *  @analysis Application programmer error.  Fix the offending call.
  */
 #define GLFW_INVALID_VALUE          0x00010004
 /*! @brief A memory allocation failed.
+ *
+ *  A memory allocation failed.
+ *
+ *  @analysis A bug in GLFW or the underlying operating system.  Report the bug
+ *  to our [issue tracker](https://github.com/glfw/glfw/issues).
  */
 #define GLFW_OUT_OF_MEMORY          0x00010005
-/*! @brief GLFW could not find support for the requested client API on the
- *  system.
+/*! @brief GLFW could not find support for the requested API on the system.
+ *
+ *  GLFW could not find support for the requested API on the system.
+ *
+ *  @analysis The installed graphics driver does not support the requested
+ *  API, or does not support it via the chosen context creation backend.
+ *  Below are a few examples.
+ *
+ *  @par
+ *  Some pre-installed Windows graphics drivers do not support OpenGL.  AMD only
+ *  supports OpenGL ES via EGL, while Nvidia and Intel only support it via
+ *  a WGL or GLX extension.  OS X does not provide OpenGL ES at all.  The Mesa
+ *  EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
+ *  driver.  Older graphics drivers do not support Vulkan.
  */
 #define GLFW_API_UNAVAILABLE        0x00010006
-/*! @brief The requested client API version is not available.
+/*! @brief The requested OpenGL or OpenGL ES version is not available.
+ *
+ *  The requested OpenGL or OpenGL ES version (including any requested context
+ *  or framebuffer hints) is not available on this machine.
+ *
+ *  @analysis The machine does not support your requirements.  If your
+ *  application is sufficiently flexible, downgrade your requirements and try
+ *  again.  Otherwise, inform the user that their machine does not match your
+ *  requirements.
+ *
+ *  @par
+ *  Future invalid OpenGL and OpenGL ES versions, for example OpenGL 4.8 if 5.0
+ *  comes out before the 4.x series gets that far, also fail with this error and
+ *  not @ref GLFW_INVALID_VALUE, because GLFW cannot know what future versions
+ *  will exist.
  */
 #define GLFW_VERSION_UNAVAILABLE    0x00010007
 /*! @brief A platform-specific error occurred that does not match any of the
  *  more specific categories.
+ *
+ *  A platform-specific error occurred that does not match any of the more
+ *  specific categories.
+ *
+ *  @analysis A bug or configuration error in GLFW, the underlying operating
+ *  system or its drivers, or a lack of required resources.  Report the issue to
+ *  our [issue tracker](https://github.com/glfw/glfw/issues).
  */
 #define GLFW_PLATFORM_ERROR         0x00010008
-/*! @brief The clipboard did not contain data in the requested format.
+/*! @brief The requested format is not supported or available.
+ *
+ *  If emitted during window creation, the requested pixel format is not
+ *  supported.
+ *
+ *  If emitted when querying the clipboard, the contents of the clipboard could
+ *  not be converted to the requested format.
+ *
+ *  @analysis If emitted during window creation, one or more
+ *  [hard constraints](@ref window_hints_hard) did not match any of the
+ *  available pixel formats.  If your application is sufficiently flexible,
+ *  downgrade your requirements and try again.  Otherwise, inform the user that
+ *  their machine does not match your requirements.
+ *
+ *  @par
+ *  If emitted when querying the clipboard, ignore the error or report it to
+ *  the user, as appropriate.
  */
 #define GLFW_FORMAT_UNAVAILABLE     0x00010009
+/*! @brief The specified window does not have an OpenGL or OpenGL ES context.
+ *
+ *  A window that does not have an OpenGL or OpenGL ES context was passed to
+ *  a function that requires it to have one.
+ *
+ *  @analysis Application programmer error.  Fix the offending call.
+ */
+#define GLFW_NO_WINDOW_CONTEXT      0x0001000A
 /*! @} */
 
 #define GLFW_FOCUSED                0x00020001
@@ -495,6 +627,9 @@ extern "C" {
 #define GLFW_RESIZABLE              0x00020003
 #define GLFW_VISIBLE                0x00020004
 #define GLFW_DECORATED              0x00020005
+#define GLFW_AUTO_ICONIFY           0x00020006
+#define GLFW_FLOATING               0x00020007
+#define GLFW_MAXIMIZED              0x00020008
 
 #define GLFW_RED_BITS               0x00021001
 #define GLFW_GREEN_BITS             0x00021002
@@ -511,6 +646,7 @@ extern "C" {
 #define GLFW_SAMPLES                0x0002100D
 #define GLFW_SRGB_CAPABLE           0x0002100E
 #define GLFW_REFRESH_RATE           0x0002100F
+#define GLFW_DOUBLEBUFFER           0x00021010
 
 #define GLFW_CLIENT_API             0x00022001
 #define GLFW_CONTEXT_VERSION_MAJOR  0x00022002
@@ -520,7 +656,11 @@ extern "C" {
 #define GLFW_OPENGL_FORWARD_COMPAT  0x00022006
 #define GLFW_OPENGL_DEBUG_CONTEXT   0x00022007
 #define GLFW_OPENGL_PROFILE         0x00022008
+#define GLFW_CONTEXT_RELEASE_BEHAVIOR 0x00022009
+#define GLFW_CONTEXT_NO_ERROR       0x0002200A
+#define GLFW_CONTEXT_CREATION_API   0x0002200B
 
+#define GLFW_NO_API                          0
 #define GLFW_OPENGL_API             0x00030001
 #define GLFW_OPENGL_ES_API          0x00030002
 
@@ -540,8 +680,56 @@ extern "C" {
 #define GLFW_CURSOR_HIDDEN          0x00034002
 #define GLFW_CURSOR_DISABLED        0x00034003
 
+#define GLFW_ANY_RELEASE_BEHAVIOR            0
+#define GLFW_RELEASE_BEHAVIOR_FLUSH 0x00035001
+#define GLFW_RELEASE_BEHAVIOR_NONE  0x00035002
+
+#define GLFW_NATIVE_CONTEXT_API     0x00036001
+#define GLFW_EGL_CONTEXT_API        0x00036002
+
+/*! @defgroup shapes Standard cursor shapes
+ *
+ *  See [standard cursor creation](@ref cursor_standard) for how these are used.
+ *
+ *  @ingroup input
+ *  @{ */
+
+/*! @brief The regular arrow cursor shape.
+ *
+ *  The regular arrow cursor.
+ */
+#define GLFW_ARROW_CURSOR           0x00036001
+/*! @brief The text input I-beam cursor shape.
+ *
+ *  The text input I-beam cursor shape.
+ */
+#define GLFW_IBEAM_CURSOR           0x00036002
+/*! @brief The crosshair shape.
+ *
+ *  The crosshair shape.
+ */
+#define GLFW_CROSSHAIR_CURSOR       0x00036003
+/*! @brief The hand shape.
+ *
+ *  The hand shape.
+ */
+#define GLFW_HAND_CURSOR            0x00036004
+/*! @brief The horizontal resize arrow shape.
+ *
+ *  The horizontal resize arrow shape.
+ */
+#define GLFW_HRESIZE_CURSOR         0x00036005
+/*! @brief The vertical resize arrow shape.
+ *
+ *  The vertical resize arrow shape.
+ */
+#define GLFW_VRESIZE_CURSOR         0x00036006
+/*! @} */
+
 #define GLFW_CONNECTED              0x00040001
 #define GLFW_DISCONNECTED           0x00040002
+
+#define GLFW_DONT_CARE              -1
 
 
 /*************************************************************************
@@ -553,13 +741,36 @@ extern "C" {
  *  Generic function pointer used for returning client API function pointers
  *  without forcing a cast from a regular pointer.
  *
+ *  @sa @ref context_glext
+ *  @sa glfwGetProcAddress
+ *
+ *  @since Added in version 3.0.
+ 
  *  @ingroup context
  */
 typedef void (*GLFWglproc)(void);
 
+/*! @brief Vulkan API function pointer type.
+ *
+ *  Generic function pointer used for returning Vulkan API function pointers
+ *  without forcing a cast from a regular pointer.
+ *
+ *  @sa @ref vulkan_proc
+ *  @sa glfwGetInstanceProcAddress
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+typedef void (*GLFWvkproc)(void);
+
 /*! @brief Opaque monitor object.
  *
  *  Opaque monitor object.
+ *
+ *  @see @ref monitor_object
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -569,9 +780,25 @@ typedef struct GLFWmonitor GLFWmonitor;
  *
  *  Opaque window object.
  *
+ *  @see @ref window_object
+ *
+ *  @since Added in version 3.0.
+ *
  *  @ingroup window
  */
 typedef struct GLFWwindow GLFWwindow;
+
+/*! @brief Opaque cursor object.
+ *
+ *  Opaque cursor object.
+ *
+ *  @see @ref cursor_object
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup cursor
+ */
+typedef struct GLFWcursor GLFWcursor;
 
 /*! @brief The function signature for error callbacks.
  *
@@ -580,9 +807,12 @@ typedef struct GLFWwindow GLFWwindow;
  *  @param[in] error An [error code](@ref errors).
  *  @param[in] description A UTF-8 encoded string describing the error.
  *
+ *  @sa @ref error_handling
  *  @sa glfwSetErrorCallback
  *
- *  @ingroup error
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup init
  */
 typedef void (* GLFWerrorfun)(int,const char*);
 
@@ -590,13 +820,16 @@ typedef void (* GLFWerrorfun)(int,const char*);
  *
  *  This is the function signature for window position callback functions.
  *
- *  @param[in] window The window that the user moved.
+ *  @param[in] window The window that was moved.
  *  @param[in] xpos The new x-coordinate, in screen coordinates, of the
  *  upper-left corner of the client area of the window.
  *  @param[in] ypos The new y-coordinate, in screen coordinates, of the
  *  upper-left corner of the client area of the window.
  *
+ *  @sa @ref window_pos
  *  @sa glfwSetWindowPosCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -606,11 +839,15 @@ typedef void (* GLFWwindowposfun)(GLFWwindow*,int,int);
  *
  *  This is the function signature for window size callback functions.
  *
- *  @param[in] window The window that the user resized.
+ *  @param[in] window The window that was resized.
  *  @param[in] width The new width, in screen coordinates, of the window.
  *  @param[in] height The new height, in screen coordinates, of the window.
  *
+ *  @sa @ref window_size
  *  @sa glfwSetWindowSizeCallback
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -622,7 +859,11 @@ typedef void (* GLFWwindowsizefun)(GLFWwindow*,int,int);
  *
  *  @param[in] window The window that the user attempted to close.
  *
+ *  @sa @ref window_close
  *  @sa glfwSetWindowCloseCallback
+ *
+ *  @since Added in version 2.5.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -634,7 +875,11 @@ typedef void (* GLFWwindowclosefun)(GLFWwindow*);
  *
  *  @param[in] window The window whose content needs to be refreshed.
  *
+ *  @sa @ref window_refresh
  *  @sa glfwSetWindowRefreshCallback
+ *
+ *  @since Added in version 2.5.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -644,11 +889,14 @@ typedef void (* GLFWwindowrefreshfun)(GLFWwindow*);
  *
  *  This is the function signature for window focus callback functions.
  *
- *  @param[in] window The window that was focused or defocused.
- *  @param[in] focused `GL_TRUE` if the window was focused, or `GL_FALSE` if
- *  it was defocused.
+ *  @param[in] window The window that gained or lost input focus.
+ *  @param[in] focused `GLFW_TRUE` if the window was given input focus, or
+ *  `GLFW_FALSE` if it lost it.
  *
+ *  @sa @ref window_focus
  *  @sa glfwSetWindowFocusCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -660,10 +908,13 @@ typedef void (* GLFWwindowfocusfun)(GLFWwindow*,int);
  *  functions.
  *
  *  @param[in] window The window that was iconified or restored.
- *  @param[in] iconified `GL_TRUE` if the window was iconified, or `GL_FALSE`
- *  if it was restored.
+ *  @param[in] iconified `GLFW_TRUE` if the window was iconified, or
+ *  `GLFW_FALSE` if it was restored.
  *
+ *  @sa @ref window_iconify
  *  @sa glfwSetWindowIconifyCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -678,7 +929,10 @@ typedef void (* GLFWwindowiconifyfun)(GLFWwindow*,int);
  *  @param[in] width The new width, in pixels, of the framebuffer.
  *  @param[in] height The new height, in pixels, of the framebuffer.
  *
+ *  @sa @ref window_fbsize
  *  @sa glfwSetFramebufferSizeCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -695,7 +949,11 @@ typedef void (* GLFWframebuffersizefun)(GLFWwindow*,int,int);
  *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
  *  held down.
  *
+ *  @sa @ref input_mouse_button
  *  @sa glfwSetMouseButtonCallback
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle and modifier mask parameters.
  *
  *  @ingroup input
  */
@@ -706,10 +964,15 @@ typedef void (* GLFWmousebuttonfun)(GLFWwindow*,int,int,int);
  *  This is the function signature for cursor position callback functions.
  *
  *  @param[in] window The window that received the event.
- *  @param[in] xpos The new x-coordinate of the cursor.
- *  @param[in] ypos The new y-coordinate of the cursor.
+ *  @param[in] xpos The new cursor x-coordinate, relative to the left edge of
+ *  the client area.
+ *  @param[in] ypos The new cursor y-coordinate, relative to the top edge of the
+ *  client area.
  *
+ *  @sa @ref cursor_pos
  *  @sa glfwSetCursorPosCallback
+ *
+ *  @since Added in version 3.0.  Replaces `GLFWmouseposfun`.
  *
  *  @ingroup input
  */
@@ -720,10 +983,13 @@ typedef void (* GLFWcursorposfun)(GLFWwindow*,double,double);
  *  This is the function signature for cursor enter/leave callback functions.
  *
  *  @param[in] window The window that received the event.
- *  @param[in] entered `GL_TRUE` if the cursor entered the window's client
- *  area, or `GL_FALSE` if it left it.
+ *  @param[in] entered `GLFW_TRUE` if the cursor entered the window's client
+ *  area, or `GLFW_FALSE` if it left it.
  *
+ *  @sa @ref cursor_enter
  *  @sa glfwSetCursorEnterCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup input
  */
@@ -737,7 +1003,10 @@ typedef void (* GLFWcursorenterfun)(GLFWwindow*,int);
  *  @param[in] xoffset The scroll offset along the x-axis.
  *  @param[in] yoffset The scroll offset along the y-axis.
  *
+ *  @sa @ref scrolling
  *  @sa glfwSetScrollCallback
+ *
+ *  @since Added in version 3.0.  Replaces `GLFWmousewheelfun`.
  *
  *  @ingroup input
  */
@@ -750,11 +1019,15 @@ typedef void (* GLFWscrollfun)(GLFWwindow*,double,double);
  *  @param[in] window The window that received the event.
  *  @param[in] key The [keyboard key](@ref keys) that was pressed or released.
  *  @param[in] scancode The system-specific scancode of the key.
- *  @param[in] action @ref GLFW_PRESS, @ref GLFW_RELEASE or @ref GLFW_REPEAT.
+ *  @param[in] action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.
  *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
  *  held down.
  *
+ *  @sa @ref input_key
  *  @sa glfwSetKeyCallback
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle, scancode and modifier mask parameters.
  *
  *  @ingroup input
  */
@@ -765,13 +1038,55 @@ typedef void (* GLFWkeyfun)(GLFWwindow*,int,int,int,int);
  *  This is the function signature for Unicode character callback functions.
  *
  *  @param[in] window The window that received the event.
- *  @param[in] character The Unicode code point of the character.
+ *  @param[in] codepoint The Unicode code point of the character.
  *
+ *  @sa @ref input_char
  *  @sa glfwSetCharCallback
+ *
+ *  @since Added in version 2.4.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup input
  */
 typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int);
+
+/*! @brief The function signature for Unicode character with modifiers
+ *  callbacks.
+ *
+ *  This is the function signature for Unicode character with modifiers callback
+ *  functions.  It is called for each input character, regardless of what
+ *  modifier keys are held down.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] codepoint The Unicode code point of the character.
+ *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+ *  held down.
+ *
+ *  @sa @ref input_char
+ *  @sa glfwSetCharModsCallback
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWcharmodsfun)(GLFWwindow*,unsigned int,int);
+
+/*! @brief The function signature for file drop callbacks.
+ *
+ *  This is the function signature for file drop callbacks.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] count The number of dropped files.
+ *  @param[in] paths The UTF-8 encoded file and/or directory path names.
+ *
+ *  @sa @ref path_drop
+ *  @sa glfwSetDropCallback
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWdropfun)(GLFWwindow*,int,const char**);
 
 /*! @brief The function signature for monitor configuration callbacks.
  *
@@ -780,15 +1095,41 @@ typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int);
  *  @param[in] monitor The monitor that was connected or disconnected.
  *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.
  *
+ *  @sa @ref monitor_event
  *  @sa glfwSetMonitorCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
 typedef void (* GLFWmonitorfun)(GLFWmonitor*,int);
 
+/*! @brief The function signature for joystick configuration callbacks.
+ *
+ *  This is the function signature for joystick configuration callback
+ *  functions.
+ *
+ *  @param[in] joy The joystick that was connected or disconnected.
+ *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.
+ *
+ *  @sa @ref joystick_event
+ *  @sa glfwSetJoystickCallback
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWjoystickfun)(int,int);
+
 /*! @brief Video mode type.
  *
  *  This describes a single video mode.
+ *
+ *  @sa @ref monitor_modes
+ *  @sa glfwGetVideoMode glfwGetVideoModes
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added refresh rate member.
  *
  *  @ingroup monitor
  */
@@ -818,7 +1159,10 @@ typedef struct GLFWvidmode
  *
  *  This describes the gamma ramp for a monitor.
  *
+ *  @sa @ref monitor_gamma
  *  @sa glfwGetGammaRamp glfwSetGammaRamp
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -838,6 +1182,27 @@ typedef struct GLFWgammaramp
     unsigned int size;
 } GLFWgammaramp;
 
+/*! @brief Image data.
+ *
+ *  @sa @ref cursor_custom
+ *  @sa @ref window_icon
+ *
+ *  @since Added in version 2.1.
+ *  @glfw3 Removed format and bytes-per-pixel members.
+ */
+typedef struct GLFWimage
+{
+    /*! The width, in pixels, of this image.
+     */
+    int width;
+    /*! The height, in pixels, of this image.
+     */
+    int height;
+    /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
+     */
+    unsigned char* pixels;
+} GLFWimage;
+
 
 /*************************************************************************
  * GLFW API functions
@@ -846,31 +1211,32 @@ typedef struct GLFWgammaramp
 /*! @brief Initializes the GLFW library.
  *
  *  This function initializes the GLFW library.  Before most GLFW functions can
- *  be used, GLFW must be initialized, and before a program terminates GLFW
+ *  be used, GLFW must be initialized, and before an application terminates GLFW
  *  should be terminated in order to free any resources allocated during or
  *  after initialization.
  *
  *  If this function fails, it calls @ref glfwTerminate before returning.  If it
- *  succeeds, you should call @ref glfwTerminate before the program exits.
+ *  succeeds, you should call @ref glfwTerminate before the application exits.
  *
  *  Additional calls to this function after successful initialization but before
- *  termination will succeed but will do nothing.
+ *  termination will return `GLFW_TRUE` immediately.
  *
- *  @return `GL_TRUE` if successful, or `GL_FALSE` if an error occurred.
+ *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @par New in GLFW 3
- *  This function no longer registers @ref glfwTerminate with `atexit`.
+ *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
  *
- *  @note This function may only be called from the main thread.
- *
- *  @note This function may take several seconds to complete on some systems,
- *  while on other systems it may take only a fraction of a second to complete.
- *
- *  @note **Mac OS X:** This function will change the current directory of the
+ *  @remark @osx This function will change the current directory of the
  *  application to the `Contents/Resources` subdirectory of the application's
- *  bundle, if present.
+ *  bundle, if present.  This can be disabled with a
+ *  [compile-time option](@ref compile_options_osx).
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref intro_init
  *  @sa glfwTerminate
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup init
  */
@@ -878,23 +1244,31 @@ GLFWAPI int glfwInit(void);
 
 /*! @brief Terminates the GLFW library.
  *
- *  This function destroys all remaining windows, frees any allocated resources
- *  and sets the library to an uninitialized state.  Once this is called, you
- *  must again call @ref glfwInit successfully before you will be able to use
- *  most GLFW functions.
+ *  This function destroys all remaining windows and cursors, restores any
+ *  modified gamma ramps and frees any other allocated resources.  Once this
+ *  function is called, you must again call @ref glfwInit successfully before
+ *  you will be able to use most GLFW functions.
  *
  *  If GLFW has been successfully initialized, this function should be called
- *  before the program exits.  If initialization fails, there is no need to call
- *  this function, as it is called by @ref glfwInit before it returns failure.
+ *  before the application exits.  If initialization fails, there is no need to
+ *  call this function, as it is called by @ref glfwInit before it returns
+ *  failure.
  *
- *  @remarks This function may be called before @ref glfwInit.
+ *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
  *
- *  @note This function may only be called from the main thread.
+ *  @remark This function may be called before @ref glfwInit.
  *
- *  @warning No window's context may be current on another thread when this
- *  function is called.
+ *  @warning The contexts of any remaining windows must not be current on any
+ *  other thread when this function is called.
  *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref intro_init
  *  @sa glfwInit
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup init
  */
@@ -906,15 +1280,22 @@ GLFWAPI void glfwTerminate(void);
  *  library.  It is intended for when you are using GLFW as a shared library and
  *  want to ensure that you are using the minimum required version.
  *
+ *  Any or all of the version arguments may be `NULL`.
+ *
  *  @param[out] major Where to store the major version number, or `NULL`.
  *  @param[out] minor Where to store the minor version number, or `NULL`.
  *  @param[out] rev Where to store the revision number, or `NULL`.
  *
- *  @remarks This function may be called before @ref glfwInit.
+ *  @errors None.
  *
- *  @remarks This function may be called from any thread.
+ *  @remark This function may be called before @ref glfwInit.
  *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref intro_version
  *  @sa glfwGetVersionString
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup init
  */
@@ -922,29 +1303,30 @@ GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
 
 /*! @brief Returns a string describing the compile-time configuration.
  *
- *  This function returns a static string generated at compile-time according to
- *  which configuration macros were defined.  This is intended for use when
- *  submitting bug reports, to allow developers to see which code paths are
- *  enabled in a binary.
+ *  This function returns the compile-time generated
+ *  [version string](@ref intro_version_string) of the GLFW library binary.  It
+ *  describes the version, platform, compiler and any platform-specific
+ *  compile-time options.  It should not be confused with the OpenGL or OpenGL
+ *  ES version string, queried with `glGetString`.
  *
- *  The format of the string is as follows:
- *  - The version of GLFW
- *  - The name of the window system API
- *  - The name of the context creation API
- *  - Any additional options or APIs
+ *  __Do not use the version string__ to parse the GLFW library version.  The
+ *  @ref glfwGetVersion function provides the version of the running library
+ *  binary in numerical format.
  *
- *  For example, when compiling GLFW 3.0 with MinGW using the Win32 and WGL
- *  back ends, the version string may look something like this:
+ *  @return The ASCII encoded GLFW version string.
  *
- *      3.0.0 Win32 WGL MinGW
+ *  @errors None.
  *
- *  @return The GLFW version string.
+ *  @remark This function may be called before @ref glfwInit.
  *
- *  @remarks This function may be called before @ref glfwInit.
+ *  @pointer_lifetime The returned string is static and compile-time generated.
  *
- *  @remarks This function may be called from any thread.
+ *  @thread_safety This function may be called from any thread.
  *
+ *  @sa @ref intro_version
  *  @sa glfwGetVersion
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup init
  */
@@ -955,43 +1337,59 @@ GLFWAPI const char* glfwGetVersionString(void);
  *  This function sets the error callback, which is called with an error code
  *  and a human-readable description each time a GLFW error occurs.
  *
+ *  The error callback is called on the thread where the error occurred.  If you
+ *  are using GLFW from multiple threads, your error callback needs to be
+ *  written accordingly.
+ *
+ *  Because the description string may have been generated specifically for that
+ *  error, it is not guaranteed to be valid after the callback has returned.  If
+ *  you wish to use it after the callback returns, you need to make a copy.
+ *
+ *  Once set, the error callback remains set even after the library has been
+ *  terminated.
+ *
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set.
  *
- *  @remarks This function may be called before @ref glfwInit.
+ *  @errors None.
  *
- *  @note The error callback is called by the thread where the error was
- *  generated.  If you are using GLFW from multiple threads, your error callback
- *  needs to be written accordingly.
+ *  @remark This function may be called before @ref glfwInit.
  *
- *  @note Because the description string provided to the callback may have been
- *  generated specifically for that error, it is not guaranteed to be valid
- *  after the callback has returned.  If you wish to use it after that, you need
- *  to make your own copy of it before returning.
+ *  @thread_safety This function must only be called from the main thread.
  *
- *  @ingroup error
+ *  @sa @ref error_handling
+ *
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup init
  */
 GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun cbfun);
 
 /*! @brief Returns the currently connected monitors.
  *
  *  This function returns an array of handles for all currently connected
- *  monitors.
+ *  monitors.  The primary monitor is always first in the returned array.  If no
+ *  monitors were found, this function returns `NULL`.
  *
- *  @param[out] count Where to store the size of the returned array.  This is
- *  set to zero if an error occurred.
- *  @return An array of monitor handles, or `NULL` if an error occurred.
+ *  @param[out] count Where to store the number of monitors in the returned
+ *  array.  This is set to zero if an error occurred.
+ *  @return An array of monitor handles, or `NULL` if no monitors were found or
+ *  if an [error](@ref error_handling) occurred.
  *
- *  @note The returned array is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
- *  @note The returned array is valid only until the monitor configuration
- *  changes.  See @ref glfwSetMonitorCallback to receive notifications of
- *  configuration changes.
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is guaranteed to be valid only until the
+ *  monitor configuration changes or the library is terminated.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_monitors
+ *  @sa @ref monitor_event
  *  @sa glfwGetPrimaryMonitor
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1000,11 +1398,22 @@ GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
 /*! @brief Returns the primary monitor.
  *
  *  This function returns the primary monitor.  This is usually the monitor
- *  where elements like the Windows task bar or the OS X menu bar is located.
+ *  where elements like the task bar or global menu bar are located.
  *
- *  @return The primary monitor, or `NULL` if an error occurred.
+ *  @return The primary monitor, or `NULL` if no monitors were found or if an
+ *  [error](@ref error_handling) occurred.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @remark The primary monitor is always first in the array returned by @ref
+ *  glfwGetMonitors.
+ *
+ *  @sa @ref monitor_monitors
  *  @sa glfwGetMonitors
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1015,9 +1424,21 @@ GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
  *  This function returns the position, in screen coordinates, of the upper-left
  *  corner of the specified monitor.
  *
+ *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` position arguments will be set to zero.
+ *
  *  @param[in] monitor The monitor to query.
  *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
  *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_properties
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1028,31 +1449,56 @@ GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
  *  This function returns the size, in millimetres, of the display area of the
  *  specified monitor.
  *
- *  @param[in] monitor The monitor to query.
- *  @param[out] width Where to store the width, in mm, of the monitor's display
- *  area, or `NULL`.
- *  @param[out] height Where to store the height, in mm, of the monitor's
- *  display area, or `NULL`.
+ *  Some systems do not provide accurate monitor size information, either
+ *  because the monitor
+ *  [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data)
+ *  data is incorrect or because the driver does not report it accurately.
  *
- *  @note Some operating systems do not provide accurate information, either
- *  because the monitor's EDID data is incorrect, or because the driver does not
- *  report it accurately.
+ *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` size arguments will be set to zero.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @param[out] widthMM Where to store the width, in millimetres, of the
+ *  monitor's display area, or `NULL`.
+ *  @param[out] heightMM Where to store the height, in millimetres, of the
+ *  monitor's display area, or `NULL`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @remark @win32 calculates the returned physical size from the
+ *  current resolution and system DPI instead of querying the monitor EDID data.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_properties
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
-GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* width, int* height);
+GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
 
 /*! @brief Returns the name of the specified monitor.
  *
  *  This function returns a human-readable name, encoded as UTF-8, of the
- *  specified monitor.
+ *  specified monitor.  The name typically reflects the make and model of the
+ *  monitor and is not guaranteed to be unique among the connected monitors.
  *
  *  @param[in] monitor The monitor to query.
- *  @return The UTF-8 encoded name of the monitor, or `NULL` if an error
- *  occurred.
+ *  @return The UTF-8 encoded name of the monitor, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @note The returned string is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified monitor is
+ *  disconnected or the library is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_properties
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1066,11 +1512,16 @@ GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
  *
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
  *
- *  @bug **X11:** This callback is not yet called on monitor configuration
- *  changes.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_event
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1086,15 +1537,24 @@ GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun cbfun);
  *  @param[in] monitor The monitor to query.
  *  @param[out] count Where to store the number of video modes in the returned
  *  array.  This is set to zero if an error occurred.
- *  @return An array of video modes, or `NULL` if an error occurred.
+ *  @return An array of video modes, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @note The returned array is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @note The returned array is valid only until this function is called again
- *  for the specified monitor.
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified monitor is
+ *  disconnected, this function is called again for that monitor or the library
+ *  is terminated.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_modes
  *  @sa glfwGetVideoMode
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Changed to return an array of modes for a specific monitor.
  *
  *  @ingroup monitor
  */
@@ -1103,16 +1563,26 @@ GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
 /*! @brief Returns the current mode of the specified monitor.
  *
  *  This function returns the current video mode of the specified monitor.  If
- *  you are using a full screen window, the return value will therefore depend
- *  on whether it is focused.
+ *  you have created a full screen window for that monitor, the return value
+ *  will depend on whether that window is iconified.
  *
  *  @param[in] monitor The monitor to query.
- *  @return The current mode of the monitor, or `NULL` if an error occurred.
+ *  @return The current mode of the monitor, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @note The returned struct is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified monitor is
+ *  disconnected or the library is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_modes
  *  @sa glfwGetVideoModes
+ *
+ *  @since Added in version 3.0.  Replaces `glfwGetDesktopMode`.
  *
  *  @ingroup monitor
  */
@@ -1121,24 +1591,46 @@ GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
 /*! @brief Generates a gamma ramp and sets it for the specified monitor.
  *
  *  This function generates a 256-element gamma ramp from the specified exponent
- *  and then calls @ref glfwSetGammaRamp with it.
+ *  and then calls @ref glfwSetGammaRamp with it.  The value must be a finite
+ *  number greater than zero.
  *
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] gamma The desired exponent.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_gamma
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
 GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
 
-/*! @brief Retrieves the current gamma ramp for the specified monitor.
+/*! @brief Returns the current gamma ramp for the specified monitor.
  *
- *  This function retrieves the current gamma ramp of the specified monitor.
+ *  This function returns the current gamma ramp of the specified monitor.
  *
  *  @param[in] monitor The monitor to query.
- *  @return The current gamma ramp, or `NULL` if an error occurred.
+ *  @return The current gamma ramp, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @note The value arrays of the returned ramp are allocated and freed by GLFW.
- *  You should not free them yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The returned structure and its arrays are allocated and
+ *  freed by GLFW.  You should not free them yourself.  They are valid until the
+ *  specified monitor is disconnected, this function is called again for that
+ *  monitor or the library is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_gamma
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1146,12 +1638,29 @@ GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
 
 /*! @brief Sets the current gamma ramp for the specified monitor.
  *
- *  This function sets the current gamma ramp for the specified monitor.
+ *  This function sets the current gamma ramp for the specified monitor.  The
+ *  original gamma ramp for that monitor is saved by GLFW the first time this
+ *  function is called and is restored by @ref glfwTerminate.
  *
  *  @param[in] monitor The monitor whose gamma ramp to set.
  *  @param[in] ramp The gamma ramp to use.
  *
- *  @note Gamma ramp sizes other than 256 are not supported by all hardware.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @remark Gamma ramp sizes other than 256 are not supported by all platforms
+ *  or graphics hardware.
+ *
+ *  @remark @win32 The gamma ramp size must be 256.
+ *
+ *  @pointer_lifetime The specified gamma ramp is copied before this function
+ *  returns.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref monitor_gamma
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup monitor
  */
@@ -1162,9 +1671,14 @@ GLFWAPI void glfwSetGammaRamp(GLFWmonitor* monitor, const GLFWgammaramp* ramp);
  *  This function resets all window hints to their
  *  [default values](@ref window_hints_values).
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_hints
  *  @sa glfwWindowHint
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1175,77 +1689,145 @@ GLFWAPI void glfwDefaultWindowHints(void);
  *  This function sets hints for the next call to @ref glfwCreateWindow.  The
  *  hints, once set, retain their values until changed by a call to @ref
  *  glfwWindowHint or @ref glfwDefaultWindowHints, or until the library is
- *  terminated with @ref glfwTerminate.
+ *  terminated.
  *
- *  @param[in] target The [window hint](@ref window_hints) to set.
- *  @param[in] hint The new value of the window hint.
+ *  This function does not check whether the specified hint values are valid.
+ *  If you set hints to invalid values this will instead be reported by the next
+ *  call to @ref glfwCreateWindow.
  *
- *  @par New in GLFW 3
- *  Hints are no longer reset to their default values on window creation.  To
- *  set default hint values, use @ref glfwDefaultWindowHints.
+ *  @param[in] hint The [window hint](@ref window_hints) to set.
+ *  @param[in] value The new value of the window hint.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_ENUM.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_hints
  *  @sa glfwDefaultWindowHints
+ *
+ *  @since Added in version 3.0.  Replaces `glfwOpenWindowHint`.
  *
  *  @ingroup window
  */
-GLFWAPI void glfwWindowHint(int target, int hint);
+GLFWAPI void glfwWindowHint(int hint, int value);
 
 /*! @brief Creates a window and its associated context.
  *
- *  This function creates a window and its associated context.  Most of the
- *  options controlling how the window and its context should be created are
- *  specified through @ref glfwWindowHint.
+ *  This function creates a window and its associated OpenGL or OpenGL ES
+ *  context.  Most of the options controlling how the window and its context
+ *  should be created are specified with [window hints](@ref window_hints).
  *
  *  Successful creation does not change which context is current.  Before you
- *  can use the newly created context, you need to make it current using @ref
- *  glfwMakeContextCurrent.
+ *  can use the newly created context, you need to
+ *  [make it current](@ref context_current).  For information about the `share`
+ *  parameter, see @ref context_sharing.
  *
- *  Note that the created window and context may differ from what you requested,
- *  as not all parameters and hints are
+ *  The created window, framebuffer and context may differ from what you
+ *  requested, as not all parameters and hints are
  *  [hard constraints](@ref window_hints_hard).  This includes the size of the
- *  window, especially for full screen windows.  To retrieve the actual
- *  attributes of the created window and context, use queries like @ref
- *  glfwGetWindowAttrib and @ref glfwGetWindowSize.
+ *  window, especially for full screen windows.  To query the actual attributes
+ *  of the created window, framebuffer and context, see @ref
+ *  glfwGetWindowAttrib, @ref glfwGetWindowSize and @ref glfwGetFramebufferSize.
  *
- *  To create a full screen window, you need to specify the monitor to use.  If
- *  no monitor is specified, windowed mode will be used.  Unless you have a way
- *  for the user to choose a specific monitor, it is recommended that you pick
- *  the primary monitor.  For more information on how to retrieve monitors, see
- *  @ref monitor_monitors.
+ *  To create a full screen window, you need to specify the monitor the window
+ *  will cover.  If no monitor is specified, the window will be windowed mode.
+ *  Unless you have a way for the user to choose a specific monitor, it is
+ *  recommended that you pick the primary monitor.  For more information on how
+ *  to query connected monitors, see @ref monitor_monitors.
  *
- *  To create the window at a specific position, make it initially invisible
- *  using the `GLFW_VISIBLE` window hint, set its position and then show it.
+ *  For full screen windows, the specified size becomes the resolution of the
+ *  window's _desired video mode_.  As long as a full screen window is not
+ *  iconified, the supported video mode most closely matching the desired video
+ *  mode is set for the specified monitor.  For more information about full
+ *  screen windows, including the creation of so called _windowed full screen_
+ *  or _borderless full screen_ windows, see @ref window_windowed_full_screen.
  *
- *  If a full screen window is active, the screensaver is prohibited from
- *  starting.
+ *  Once you have created the window, you can switch it between windowed and
+ *  full screen mode with @ref glfwSetWindowMonitor.  If the window has an
+ *  OpenGL or OpenGL ES context, it will be unaffected.
+ *
+ *  By default, newly created windows use the placement recommended by the
+ *  window system.  To create the window at a specific position, make it
+ *  initially invisible using the [GLFW_VISIBLE](@ref window_hints_wnd) window
+ *  hint, set its [position](@ref window_pos) and then [show](@ref window_hide)
+ *  it.
+ *
+ *  As long as at least one full screen window is not iconified, the screensaver
+ *  is prohibited from starting.
+ *
+ *  Window systems put limits on window sizes.  Very large or very small window
+ *  dimensions may be overridden by the window system on creation.  Check the
+ *  actual [size](@ref window_size) after creation.
+ *
+ *  The [swap interval](@ref buffer_swap) is not set during window creation and
+ *  the initial value may vary depending on driver settings and defaults.
  *
  *  @param[in] width The desired width, in screen coordinates, of the window.
  *  This must be greater than zero.
  *  @param[in] height The desired height, in screen coordinates, of the window.
  *  This must be greater than zero.
  *  @param[in] title The initial, UTF-8 encoded window title.
- *  @param[in] monitor The monitor to use for full screen mode, or `NULL` to use
+ *  @param[in] monitor The monitor to use for full screen mode, or `NULL` for
  *  windowed mode.
  *  @param[in] share The window whose context to share resources with, or `NULL`
  *  to not share resources.
- *  @return The handle of the created window, or `NULL` if an error occurred.
+ *  @return The handle of the created window, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @remarks **Windows:** If the executable has an icon resource named
- *  `GLFW_ICON,` it will be set as the icon for the window.  If no such icon is
- *  present, the `IDI_WINLOGO` icon will be used instead.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_API_UNAVAILABLE, @ref
+ *  GLFW_VERSION_UNAVAILABLE, @ref GLFW_FORMAT_UNAVAILABLE and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @remarks **Mac OS X:** The GLFW window has no icon, as it is not a document
+ *  @remark @win32 Window creation will fail if the Microsoft GDI software
+ *  OpenGL implementation is the only one available.
+ *
+ *  @remark @win32 If the executable has an icon resource named `GLFW_ICON,` it
+ *  will be set as the initial icon for the window.  If no such icon is present,
+ *  the `IDI_WINLOGO` icon will be used instead.  To set a different icon, see
+ *  @ref glfwSetWindowIcon.
+ *
+ *  @remark @win32 The context to share resources with must not be current on
+ *  any other thread.
+ *
+ *  @remark @osx The GLFW window has no icon, as it is not a document
  *  window, but the dock icon will be the same as the application bundle's icon.
- *  Also, the first time a window is opened the menu bar is populated with
- *  common commands like Hide, Quit and About.  The (minimal) about dialog uses
- *  information from the application's bundle.  For more information on bundles,
- *  see the Bundle Programming Guide provided by Apple.
+ *  For more information on bundles, see the
+ *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
+ *  in the Mac Developer Library.
  *
- *  @note This function may only be called from the main thread.
+ *  @remark @osx The first time a window is created the menu bar is populated
+ *  with common commands like Hide, Quit and About.  The About entry opens
+ *  a minimal about dialog with information from the application's bundle.  The
+ *  menu bar can be disabled with a
+ *  [compile-time option](@ref compile_options_osx).
  *
+ *  @remark @osx On OS X 10.10 and later the window frame will not be rendered
+ *  at full resolution on Retina displays unless the `NSHighResolutionCapable`
+ *  key is enabled in the application bundle's `Info.plist`.  For more
+ *  information, see
+ *  [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html)
+ *  in the Mac Developer Library.  The GLFW test and example programs use
+ *  a custom `Info.plist` template for this, which can be found as
+ *  `CMake/MacOSXBundleInfo.plist.in` in the source tree.
+ *
+ *  @remark @x11 Some window managers will not respect the placement of
+ *  initially hidden windows.
+ *
+ *  @remark @x11 Due to the asynchronous nature of X11, it may take a moment for
+ *  a window to reach its requested state.  This means you may not be able to
+ *  query the final size, position or other attributes directly after window
+ *  creation.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_creation
  *  @sa glfwDestroyWindow
+ *
+ *  @since Added in version 3.0.  Replaces `glfwOpenWindow`.
  *
  *  @ingroup window
  */
@@ -1256,18 +1838,25 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, G
  *  This function destroys the specified window and its context.  On calling
  *  this function, no further callbacks will be called for that window.
  *
- *  @param[in] window The window to destroy.
- *
- *  @note This function may only be called from the main thread.
- *
- *  @note This function may not be called from a callback.
- *
- *  @note If the window's context is current on the main thread, it is
+ *  If the context of the specified window is current on the main thread, it is
  *  detached before being destroyed.
  *
- *  @warning The window's context must not be current on any other thread.
+ *  @param[in] window The window to destroy.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @note The context of the specified window must not be current on any other
+ *  thread when this function is called.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_creation
  *  @sa glfwCreateWindow
+ *
+ *  @since Added in version 3.0.  Replaces `glfwCloseWindow`.
  *
  *  @ingroup window
  */
@@ -1280,7 +1869,14 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
  *  @param[in] window The window to query.
  *  @return The value of the close flag.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @sa @ref window_close
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1295,7 +1891,14 @@ GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
  *  @param[in] window The window whose flag to change.
  *  @param[in] value The new value.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @sa @ref window_close
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1309,16 +1912,69 @@ GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
  *  @param[in] window The window whose title to change.
  *  @param[in] title The UTF-8 encoded window title.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @remark @osx The window title will not be updated until the next time you
+ *  process events.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_title
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
 
+/*! @brief Sets the icon for the specified window.
+ *
+ *  This function sets the icon of the specified window.  If passed an array of
+ *  candidate images, those of or closest to the sizes desired by the system are
+ *  selected.  If no images are specified, the window reverts to its default
+ *  icon.
+ *
+ *  The desired image sizes varies depending on platform and system settings.
+ *  The selected images will be rescaled as needed.  Good sizes include 16x16,
+ *  32x32 and 48x48.
+ *
+ *  @param[in] window The window whose icon to set.
+ *  @param[in] count The number of images in the specified array, or zero to
+ *  revert to the default window icon.
+ *  @param[in] images The images to create the icon from.  This is ignored if
+ *  count is zero.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The specified image data is copied before this function
+ *  returns.
+ *
+ *  @remark @osx The GLFW window has no icon, as it is not a document
+ *  window, so this function does nothing.  The dock icon will be the same as
+ *  the application bundle's icon.  For more information on bundles, see the
+ *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
+ *  in the Mac Developer Library.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_icon
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowIcon(GLFWwindow* window, int count, const GLFWimage* images);
+
 /*! @brief Retrieves the position of the client area of the specified window.
  *
  *  This function retrieves the position, in screen coordinates, of the
  *  upper-left corner of the client area of the specified window.
+ *
+ *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` position arguments will be set to zero.
  *
  *  @param[in] window The window to query.
  *  @param[out] xpos Where to store the x-coordinate of the upper-left corner of
@@ -1326,7 +1982,15 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
  *  @param[out] ypos Where to store the y-coordinate of the upper-left corner of
  *  the client area, or `NULL`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_pos
  *  @sa glfwSetWindowPos
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1335,30 +1999,29 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
 /*! @brief Sets the position of the client area of the specified window.
  *
  *  This function sets the position, in screen coordinates, of the upper-left
- *  corner of the client area of the window.
+ *  corner of the client area of the specified windowed mode window.  If the
+ *  window is a full screen window, this function does nothing.
  *
- *  If the specified window is a full screen window, this function does nothing.
+ *  __Do not use this function__ to move an already visible window unless you
+ *  have very good reasons for doing so, as it will confuse and annoy the user.
  *
- *  If you wish to set an initial window position you should create a hidden
- *  window (using @ref glfwWindowHint and `GLFW_VISIBLE`), set its position and
- *  then show it.
+ *  The window manager may put limits on what positions are allowed.  GLFW
+ *  cannot and should not override these limits.
  *
  *  @param[in] window The window to query.
  *  @param[in] xpos The x-coordinate of the upper-left corner of the client area.
  *  @param[in] ypos The y-coordinate of the upper-left corner of the client area.
  *
- *  @note It is very rarely a good idea to move an already visible window, as it
- *  will confuse and annoy the user.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @note This function may only be called from the main thread.
+ *  @thread_safety This function must only be called from the main thread.
  *
- *  @note The window manager may put limits on what positions are allowed.
- *
- *  @bug **X11:** Some window managers ignore the set position of hidden (i.e.
- *  unmapped) windows, instead placing them where it thinks is appropriate once
- *  they are shown.
- *
+ *  @sa @ref window_pos
  *  @sa glfwGetWindowPos
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -1367,7 +2030,11 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
 /*! @brief Retrieves the size of the client area of the specified window.
  *
  *  This function retrieves the size, in screen coordinates, of the client area
- *  of the specified window.
+ *  of the specified window.  If you wish to retrieve the size of the
+ *  framebuffer of the window in pixels, see @ref glfwGetFramebufferSize.
+ *
+ *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` size arguments will be set to zero.
  *
  *  @param[in] window The window whose size to retrieve.
  *  @param[out] width Where to store the width, in screen coordinates, of the
@@ -1375,31 +2042,134 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
  *  @param[out] height Where to store the height, in screen coordinates, of the
  *  client area, or `NULL`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_size
  *  @sa glfwSetWindowSize
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
+
+/*! @brief Sets the size limits of the specified window.
+ *
+ *  This function sets the size limits of the client area of the specified
+ *  window.  If the window is full screen, the size limits only take effect
+ *  once it is made windowed.  If the window is not resizable, this function
+ *  does nothing.
+ *
+ *  The size limits are applied immediately to a windowed mode window and may
+ *  cause it to be resized.
+ *
+ *  The maximum dimensions must be greater than or equal to the minimum
+ *  dimensions and all must be greater than or equal to zero.
+ *
+ *  @param[in] window The window to set limits for.
+ *  @param[in] minwidth The minimum width, in screen coordinates, of the client
+ *  area, or `GLFW_DONT_CARE`.
+ *  @param[in] minheight The minimum height, in screen coordinates, of the
+ *  client area, or `GLFW_DONT_CARE`.
+ *  @param[in] maxwidth The maximum width, in screen coordinates, of the client
+ *  area, or `GLFW_DONT_CARE`.
+ *  @param[in] maxheight The maximum height, in screen coordinates, of the
+ *  client area, or `GLFW_DONT_CARE`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remark If you set size limits and an aspect ratio that conflict, the
+ *  results are undefined.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_sizelimits
+ *  @sa glfwSetWindowAspectRatio
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minheight, int maxwidth, int maxheight);
+
+/*! @brief Sets the aspect ratio of the specified window.
+ *
+ *  This function sets the required aspect ratio of the client area of the
+ *  specified window.  If the window is full screen, the aspect ratio only takes
+ *  effect once it is made windowed.  If the window is not resizable, this
+ *  function does nothing.
+ *
+ *  The aspect ratio is specified as a numerator and a denominator and both
+ *  values must be greater than zero.  For example, the common 16:9 aspect ratio
+ *  is specified as 16 and 9, respectively.
+ *
+ *  If the numerator and denominator is set to `GLFW_DONT_CARE` then the aspect
+ *  ratio limit is disabled.
+ *
+ *  The aspect ratio is applied immediately to a windowed mode window and may
+ *  cause it to be resized.
+ *
+ *  @param[in] window The window to set limits for.
+ *  @param[in] numer The numerator of the desired aspect ratio, or
+ *  `GLFW_DONT_CARE`.
+ *  @param[in] denom The denominator of the desired aspect ratio, or
+ *  `GLFW_DONT_CARE`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remark If you set size limits and an aspect ratio that conflict, the
+ *  results are undefined.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_sizelimits
+ *  @sa glfwSetWindowSizeLimits
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* window, int numer, int denom);
 
 /*! @brief Sets the size of the client area of the specified window.
  *
  *  This function sets the size, in screen coordinates, of the client area of
  *  the specified window.
  *
- *  For full screen windows, this function selects and switches to the resolution
- *  closest to the specified size, without affecting the window's context.  As
- *  the context is unaffected, the bit depths of the framebuffer remain
- *  unchanged.
+ *  For full screen windows, this function updates the resolution of its desired
+ *  video mode and switches to the video mode closest to it, without affecting
+ *  the window's context.  As the context is unaffected, the bit depths of the
+ *  framebuffer remain unchanged.
+ *
+ *  If you wish to update the refresh rate of the desired video mode in addition
+ *  to its resolution, see @ref glfwSetWindowMonitor.
+ *
+ *  The window manager may put limits on what sizes are allowed.  GLFW cannot
+ *  and should not override these limits.
  *
  *  @param[in] window The window to resize.
- *  @param[in] width The desired width of the specified window.
- *  @param[in] height The desired height of the specified window.
+ *  @param[in] width The desired width, in screen coordinates, of the window
+ *  client area.
+ *  @param[in] height The desired height, in screen coordinates, of the window
+ *  client area.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @note The window manager may put limits on what window sizes are allowed.
+ *  @thread_safety This function must only be called from the main thread.
  *
+ *  @sa @ref window_size
  *  @sa glfwGetWindowSize
+ *  @sa glfwSetWindowMonitor
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -1408,7 +2178,11 @@ GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
 /*! @brief Retrieves the size of the framebuffer of the specified window.
  *
  *  This function retrieves the size, in pixels, of the framebuffer of the
- *  specified window.
+ *  specified window.  If you wish to retrieve the size of the window in screen
+ *  coordinates, see @ref glfwGetWindowSize.
+ *
+ *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` size arguments will be set to zero.
  *
  *  @param[in] window The window whose framebuffer to query.
  *  @param[out] width Where to store the width, in pixels, of the framebuffer,
@@ -1416,24 +2190,79 @@ GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
  *  @param[out] height Where to store the height, in pixels, of the framebuffer,
  *  or `NULL`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_fbsize
  *  @sa glfwSetFramebufferSizeCallback
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height);
 
+/*! @brief Retrieves the size of the frame of the window.
+ *
+ *  This function retrieves the size, in screen coordinates, of each edge of the
+ *  frame of the specified window.  This size includes the title bar, if the
+ *  window has one.  The size of the frame may vary depending on the
+ *  [window-related hints](@ref window_hints_wnd) used to create it.
+ *
+ *  Because this function retrieves the size of each window frame edge and not
+ *  the offset along a particular coordinate axis, the retrieved values will
+ *  always be zero or positive.
+ *
+ *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` size arguments will be set to zero.
+ *
+ *  @param[in] window The window whose frame size to query.
+ *  @param[out] left Where to store the size, in screen coordinates, of the left
+ *  edge of the window frame, or `NULL`.
+ *  @param[out] top Where to store the size, in screen coordinates, of the top
+ *  edge of the window frame, or `NULL`.
+ *  @param[out] right Where to store the size, in screen coordinates, of the
+ *  right edge of the window frame, or `NULL`.
+ *  @param[out] bottom Where to store the size, in screen coordinates, of the
+ *  bottom edge of the window frame, or `NULL`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_size
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* window, int* left, int* top, int* right, int* bottom);
+
 /*! @brief Iconifies the specified window.
  *
- *  This function iconifies/minimizes the specified window, if it was previously
- *  restored.  If it is a full screen window, the original monitor resolution is
- *  restored until the window is restored.  If the window is already iconified,
- *  this function does nothing.
+ *  This function iconifies (minimizes) the specified window if it was
+ *  previously restored.  If the window is already iconified, this function does
+ *  nothing.
+ *
+ *  If the specified window is a full screen window, the original monitor
+ *  resolution is restored until the window is restored.
  *
  *  @param[in] window The window to iconify.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_iconify
  *  @sa glfwRestoreWindow
+ *  @sa glfwMaximizeWindow
+ *
+ *  @since Added in version 2.1.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
@@ -1441,32 +2270,73 @@ GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
 
 /*! @brief Restores the specified window.
  *
- *  This function restores the specified window, if it was previously
- *  iconified/minimized.  If it is a full screen window, the resolution chosen
- *  for the window is restored on the selected monitor.  If the window is
- *  already restored, this function does nothing.
+ *  This function restores the specified window if it was previously iconified
+ *  (minimized) or maximized.  If the window is already restored, this function
+ *  does nothing.
+ *
+ *  If the specified window is a full screen window, the resolution chosen for
+ *  the window is restored on the selected monitor.
  *
  *  @param[in] window The window to restore.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_iconify
  *  @sa glfwIconifyWindow
+ *  @sa glfwMaximizeWindow
+ *
+ *  @since Added in version 2.1.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
 
+/*! @brief Maximizes the specified window.
+ *
+ *  This function maximizes the specified window if it was previously not
+ *  maximized.  If the window is already maximized, this function does nothing.
+ *
+ *  If the specified window is a full screen window, this function does nothing.
+ *
+ *  @param[in] window The window to maximize.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @par Thread Safety
+ *  This function may only be called from the main thread.
+ *
+ *  @sa @ref window_iconify
+ *  @sa glfwIconifyWindow
+ *  @sa glfwRestoreWindow
+ *
+ *  @since Added in GLFW 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
+
 /*! @brief Makes the specified window visible.
  *
- *  This function makes the specified window visible, if it was previously
+ *  This function makes the specified window visible if it was previously
  *  hidden.  If the window is already visible or is in full screen mode, this
  *  function does nothing.
  *
  *  @param[in] window The window to make visible.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_hide
  *  @sa glfwHideWindow
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1474,19 +2344,53 @@ GLFWAPI void glfwShowWindow(GLFWwindow* window);
 
 /*! @brief Hides the specified window.
  *
- *  This function hides the specified window, if it was previously visible.  If
+ *  This function hides the specified window if it was previously visible.  If
  *  the window is already hidden or is in full screen mode, this function does
  *  nothing.
  *
  *  @param[in] window The window to hide.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_hide
  *  @sa glfwShowWindow
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwHideWindow(GLFWwindow* window);
+
+/*! @brief Brings the specified window to front and sets input focus.
+ *
+ *  This function brings the specified window to front and sets input focus.
+ *  The window should already be visible and not iconified.
+ *
+ *  By default, both windowed and full screen mode windows are focused when
+ *  initially created.  Set the [GLFW_FOCUSED](@ref window_hints_wnd) to disable
+ *  this behavior.
+ *
+ *  __Do not use this function__ to steal focus from other applications unless
+ *  you are certain that is what the user wants.  Focus stealing can be
+ *  extremely disruptive.
+ *
+ *  @param[in] window The window to give input focus.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_focus
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwFocusWindow(GLFWwindow* window);
 
 /*! @brief Returns the monitor that the window uses for full screen mode.
  *
@@ -1494,21 +2398,99 @@ GLFWAPI void glfwHideWindow(GLFWwindow* window);
  *  in full screen on.
  *
  *  @param[in] window The window to query.
- *  @return The monitor, or `NULL` if the window is in windowed mode.
+ *  @return The monitor, or `NULL` if the window is in windowed mode or an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_monitor
+ *  @sa glfwSetWindowMonitor
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
 GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
 
+/*! @brief Sets the mode, monitor, video mode and placement of a window.
+ *
+ *  This function sets the monitor that the window uses for full screen mode or,
+ *  if the monitor is `NULL`, makes it windowed mode.
+ *
+ *  When setting a monitor, this function updates the width, height and refresh
+ *  rate of the desired video mode and switches to the video mode closest to it.
+ *  The window position is ignored when setting a monitor.
+ *
+ *  When the monitor is `NULL`, the position, width and height are used to
+ *  place the window client area.  The refresh rate is ignored when no monitor
+ *  is specified.
+ *
+ *  If you only wish to update the resolution of a full screen window or the
+ *  size of a windowed mode window, see @ref glfwSetWindowSize.
+ *
+ *  When a window transitions from full screen to windowed mode, this function
+ *  restores any previous window settings such as whether it is decorated,
+ *  floating, resizable, has size or aspect ratio limits, etc..
+ *
+ *  @param[in] window The window whose monitor, size or video mode to set.
+ *  @param[in] monitor The desired monitor, or `NULL` to set windowed mode.
+ *  @param[in] xpos The desired x-coordinate of the upper-left corner of the
+ *  client area.
+ *  @param[in] ypos The desired y-coordinate of the upper-left corner of the
+ *  client area.
+ *  @param[in] width The desired with, in screen coordinates, of the client area
+ *  or video mode.
+ *  @param[in] height The desired height, in screen coordinates, of the client
+ *  area or video mode.
+ *  @param[in] refreshRate The desired refresh rate, in Hz, of the video mode,
+ *  or `GLFW_DONT_CARE`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_monitor
+ *  @sa @ref window_full_screen
+ *  @sa glfwGetWindowMonitor
+ *  @sa glfwSetWindowSize
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
+
 /*! @brief Returns an attribute of the specified window.
  *
- *  This function returns an attribute of the specified window.  There are many
- *  attributes, some related to the window and others to its context.
+ *  This function returns the value of an attribute of the specified window or
+ *  its OpenGL or OpenGL ES context.
  *
  *  @param[in] window The window to query.
  *  @param[in] attrib The [window attribute](@ref window_attribs) whose value to
  *  return.
- *  @return The value of the attribute, or zero if an error occurred.
+ *  @return The value of the attribute, or zero if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remark Framebuffer related hints are not window attributes.  See @ref
+ *  window_attribs_fb for more information.
+ *
+ *  @remark Zero is a valid value for many window and context related
+ *  attributes so you cannot use a return value of zero as an indication of
+ *  errors.  However, this function should not fail as long as it is passed
+ *  valid arguments and the library has been [initialized](@ref intro_init).
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_attribs
+ *
+ *  @since Added in version 3.0.  Replaces `glfwGetWindowParam` and
+ *  `glfwGetGLVersion`.
  *
  *  @ingroup window
  */
@@ -1523,7 +2505,15 @@ GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
  *  @param[in] window The window whose pointer to set.
  *  @param[in] pointer The new value.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @sa @ref window_userptr
  *  @sa glfwGetWindowUserPointer
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1536,7 +2526,15 @@ GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
  *
  *  @param[in] window The window whose pointer to return.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @sa @ref window_userptr
  *  @sa glfwSetWindowUserPointer
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1551,8 +2549,16 @@ GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_pos
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1567,8 +2573,17 @@ GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindow
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_size
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter and return value.
  *
  *  @ingroup window
  */
@@ -1588,11 +2603,20 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwind
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
  *
- *  @remarks **Mac OS X:** Selecting Quit from the application menu will
- *  trigger the close callback for all windows.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @remark @osx Selecting Quit from the application menu will trigger the close
+ *  callback for all windows.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_close
+ *
+ *  @since Added in version 2.5.
+ *  @glfw3 Added window handle parameter and return value.
  *
  *  @ingroup window
  */
@@ -1611,12 +2635,17 @@ GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwi
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
  *
- *  @note On compositing window systems such as Aero, Compiz or Aqua, where the
- *  window contents are saved off-screen, this callback may be called only very
- *  infrequently or never at all.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_refresh
+ *
+ *  @since Added in version 2.5.
+ *  @glfw3 Added window handle parameter and return value.
  *
  *  @ingroup window
  */
@@ -1625,18 +2654,26 @@ GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GL
 /*! @brief Sets the focus callback for the specified window.
  *
  *  This function sets the focus callback of the specified window, which is
- *  called when the window gains or loses focus.
+ *  called when the window gains or loses input focus.
  *
- *  After the focus callback is called for a window that lost focus, synthetic
- *  key and mouse button release events will be generated for all such that had
- *  been pressed.  For more information, see @ref glfwSetKeyCallback and @ref
- *  glfwSetMouseButtonCallback.
+ *  After the focus callback is called for a window that lost input focus,
+ *  synthetic key and mouse button release events will be generated for all such
+ *  that had been pressed.  For more information, see @ref glfwSetKeyCallback
+ *  and @ref glfwSetMouseButtonCallback.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_focus
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1650,8 +2687,16 @@ GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwi
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_iconify
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1665,8 +2710,16 @@ GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GL
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref window_fbsize
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup window
  */
@@ -1674,124 +2727,317 @@ GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window
 
 /*! @brief Processes all pending events.
  *
- *  This function processes only those events that have already been received
- *  and then returns immediately.  Processing events will cause the window and
- *  input callbacks associated with those events to be called.
+ *  This function processes only those events that are already in the event
+ *  queue and then returns immediately.  Processing events will cause the window
+ *  and input callbacks associated with those events to be called.
  *
- *  This function is not required for joystick input to work.
+ *  On some platforms, a window move, resize or menu operation will cause event
+ *  processing to block.  This is due to how event processing is designed on
+ *  those platforms.  You can use the
+ *  [window refresh callback](@ref window_refresh) to redraw the contents of
+ *  your window when necessary during such operations.
  *
- *  @par New in GLFW 3
- *  This function is no longer called by @ref glfwSwapBuffers.  You need to call
- *  it or @ref glfwWaitEvents yourself.
+ *  On some platforms, certain events are sent directly to the application
+ *  without going through the event queue, causing callbacks to be called
+ *  outside of a call to one of the event processing functions.
  *
- *  @note This function may only be called from the main thread.
+ *  Event processing is not required for joystick input to work.
  *
- *  @note This function may not be called from a callback.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @note On some platforms, certain callbacks may be called outside of a call
- *  to one of the event processing functions.
+ *  @reentrancy This function must not be called from a callback.
  *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref events
  *  @sa glfwWaitEvents
+ *  @sa glfwWaitEventsTimeout
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwPollEvents(void);
 
-/*! @brief Waits until events are pending and processes them.
+/*! @brief Waits until events are queued and processes them.
  *
- *  This function puts the calling thread to sleep until at least one event has
- *  been received.  Once one or more events have been received, it behaves as if
- *  @ref glfwPollEvents was called, i.e. the events are processed and the
- *  function then returns immediately.  Processing events will cause the window
- *  and input callbacks associated with those events to be called.
+ *  This function puts the calling thread to sleep until at least one event is
+ *  available in the event queue.  Once one or more events are available,
+ *  it behaves exactly like @ref glfwPollEvents, i.e. the events in the queue
+ *  are processed and the function then returns immediately.  Processing events
+ *  will cause the window and input callbacks associated with those events to be
+ *  called.
  *
  *  Since not all events are associated with callbacks, this function may return
  *  without a callback having been called even if you are monitoring all
  *  callbacks.
  *
- *  This function is not required for joystick input to work.
+ *  On some platforms, a window move, resize or menu operation will cause event
+ *  processing to block.  This is due to how event processing is designed on
+ *  those platforms.  You can use the
+ *  [window refresh callback](@ref window_refresh) to redraw the contents of
+ *  your window when necessary during such operations.
  *
- *  @note This function may only be called from the main thread.
+ *  On some platforms, certain callbacks may be called outside of a call to one
+ *  of the event processing functions.
  *
- *  @note This function may not be called from a callback.
+ *  If no windows exist, this function returns immediately.  For synchronization
+ *  of threads in applications that do not create windows, use your threading
+ *  library of choice.
  *
- *  @note On some platforms, certain callbacks may be called outside of a call
- *  to one of the event processing functions.
+ *  Event processing is not required for joystick input to work.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref events
  *  @sa glfwPollEvents
+ *  @sa glfwWaitEventsTimeout
+ *
+ *  @since Added in version 2.5.
  *
  *  @ingroup window
  */
 GLFWAPI void glfwWaitEvents(void);
 
+/*! @brief Waits with timeout until events are queued and processes them.
+ *
+ *  This function puts the calling thread to sleep until at least one event is
+ *  available in the event queue, or until the specified timeout is reached.  If
+ *  one or more events are available, it behaves exactly like @ref
+ *  glfwPollEvents, i.e. the events in the queue are processed and the function
+ *  then returns immediately.  Processing events will cause the window and input
+ *  callbacks associated with those events to be called.
+ *
+ *  The timeout value must be a positive finite number.
+ *
+ *  Since not all events are associated with callbacks, this function may return
+ *  without a callback having been called even if you are monitoring all
+ *  callbacks.
+ *
+ *  On some platforms, a window move, resize or menu operation will cause event
+ *  processing to block.  This is due to how event processing is designed on
+ *  those platforms.  You can use the
+ *  [window refresh callback](@ref window_refresh) to redraw the contents of
+ *  your window when necessary during such operations.
+ *
+ *  On some platforms, certain callbacks may be called outside of a call to one
+ *  of the event processing functions.
+ *
+ *  If no windows exist, this function returns immediately.  For synchronization
+ *  of threads in applications that do not create windows, use your threading
+ *  library of choice.
+ *
+ *  Event processing is not required for joystick input to work.
+ *
+ *  @param[in] timeout The maximum amount of time, in seconds, to wait.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref events
+ *  @sa glfwPollEvents
+ *  @sa glfwWaitEvents
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwWaitEventsTimeout(double timeout);
+
+/*! @brief Posts an empty event to the event queue.
+ *
+ *  This function posts an empty event from the current thread to the event
+ *  queue, causing @ref glfwWaitEvents or @ref glfwWaitEventsTimeout to return.
+ *
+ *  If no windows exist, this function returns immediately.  For synchronization
+ *  of threads in applications that do not create windows, use your threading
+ *  library of choice.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref events
+ *  @sa glfwWaitEvents
+ *  @sa glfwWaitEventsTimeout
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwPostEmptyEvent(void);
+
 /*! @brief Returns the value of an input option for the specified window.
+ *
+ *  This function returns the value of an input option for the specified window.
+ *  The mode must be one of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
+ *  `GLFW_STICKY_MOUSE_BUTTONS`.
  *
  *  @param[in] window The window to query.
  *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
  *  `GLFW_STICKY_MOUSE_BUTTONS`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_ENUM.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
  *  @sa glfwSetInputMode
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup input
  */
 GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
 
 /*! @brief Sets an input option for the specified window.
+ *
+ *  This function sets an input mode option for the specified window.  The mode
+ *  must be one of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
+ *  `GLFW_STICKY_MOUSE_BUTTONS`.
+ *
+ *  If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
+ *  modes:
+ *  - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
+ *  - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the client
+ *    area of the window but does not restrict the cursor from leaving.
+ *  - `GLFW_CURSOR_DISABLED` hides and grabs the cursor, providing virtual
+ *    and unlimited cursor movement.  This is useful for implementing for
+ *    example 3D camera controls.
+ *
+ *  If the mode is `GLFW_STICKY_KEYS`, the value must be either `GLFW_TRUE` to
+ *  enable sticky keys, or `GLFW_FALSE` to disable it.  If sticky keys are
+ *  enabled, a key press will ensure that @ref glfwGetKey returns `GLFW_PRESS`
+ *  the next time it is called even if the key had been released before the
+ *  call.  This is useful when you are only interested in whether keys have been
+ *  pressed but not when or in which order.
+ *
+ *  If the mode is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either
+ *  `GLFW_TRUE` to enable sticky mouse buttons, or `GLFW_FALSE` to disable it.
+ *  If sticky mouse buttons are enabled, a mouse button press will ensure that
+ *  @ref glfwGetMouseButton returns `GLFW_PRESS` the next time it is called even
+ *  if the mouse button had been released before the call.  This is useful when
+ *  you are only interested in whether mouse buttons have been pressed but not
+ *  when or in which order.
+ *
  *  @param[in] window The window whose input mode to set.
  *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
  *  `GLFW_STICKY_MOUSE_BUTTONS`.
  *  @param[in] value The new value of the specified input mode.
  *
- *  If `mode` is `GLFW_CURSOR`, the value must be one of the supported input
- *  modes:
- *  - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
- *  - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the client
- *    area of the window.
- *  - `GLFW_CURSOR_DISABLED` disables the cursor and removes any limitations on
- *    cursor movement.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
  *
- *  If `mode` is `GLFW_STICKY_KEYS`, the value must be either `GL_TRUE` to
- *  enable sticky keys, or `GL_FALSE` to disable it.  If sticky keys are
- *  enabled, a key press will ensure that @ref glfwGetKey returns @ref
- *  GLFW_PRESS the next time it is called even if the key had been released
- *  before the call.  This is useful when you are only interested in whether
- *  keys have been pressed but not when or in which order.
- *
- *  If `mode` is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either `GL_TRUE`
- *  to enable sticky mouse buttons, or `GL_FALSE` to disable it.  If sticky
- *  mouse buttons are enabled, a mouse button press will ensure that @ref
- *  glfwGetMouseButton returns @ref GLFW_PRESS the next time it is called even
- *  if the mouse button had been released before the call.  This is useful when
- *  you are only interested in whether mouse buttons have been pressed but not
- *  when or in which order.
+ *  @thread_safety This function must only be called from the main thread.
  *
  *  @sa glfwGetInputMode
+ *
+ *  @since Added in version 3.0.  Replaces `glfwEnable` and `glfwDisable`.
  *
  *  @ingroup input
  */
 GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
+
+/*! @brief Returns the localized name of the specified printable key.
+ *
+ *  This function returns the localized name of the specified printable key.
+ *  This is intended for displaying key bindings to the user.
+ *
+ *  If the key is `GLFW_KEY_UNKNOWN`, the scancode is used instead, otherwise
+ *  the scancode is ignored.  If a non-printable key or (if the key is
+ *  `GLFW_KEY_UNKNOWN`) a scancode that maps to a non-printable key is
+ *  specified, this function returns `NULL`.          
+ *
+ *  This behavior allows you to pass in the arguments passed to the
+ *  [key callback](@ref input_key) without modification.
+ *
+ *  The printable keys are:
+ *  - `GLFW_KEY_APOSTROPHE`
+ *  - `GLFW_KEY_COMMA`
+ *  - `GLFW_KEY_MINUS`
+ *  - `GLFW_KEY_PERIOD`
+ *  - `GLFW_KEY_SLASH`
+ *  - `GLFW_KEY_SEMICOLON`
+ *  - `GLFW_KEY_EQUAL`
+ *  - `GLFW_KEY_LEFT_BRACKET`
+ *  - `GLFW_KEY_RIGHT_BRACKET`
+ *  - `GLFW_KEY_BACKSLASH`
+ *  - `GLFW_KEY_WORLD_1`
+ *  - `GLFW_KEY_WORLD_2`
+ *  - `GLFW_KEY_0` to `GLFW_KEY_9`
+ *  - `GLFW_KEY_A` to `GLFW_KEY_Z`
+ *  - `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
+ *  - `GLFW_KEY_KP_DECIMAL`
+ *  - `GLFW_KEY_KP_DIVIDE`
+ *  - `GLFW_KEY_KP_MULTIPLY`
+ *  - `GLFW_KEY_KP_SUBTRACT`
+ *  - `GLFW_KEY_KP_ADD`
+ *  - `GLFW_KEY_KP_EQUAL`
+ *
+ *  @param[in] key The key to query, or `GLFW_KEY_UNKNOWN`.
+ *  @param[in] scancode The scancode of the key to query.
+ *  @return The localized name of the key, or `NULL`.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the next call to @ref
+ *  glfwGetKeyName, or until the library is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_key_name
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const char* glfwGetKeyName(int key, int scancode);
 
 /*! @brief Returns the last reported state of a keyboard key for the specified
  *  window.
  *
  *  This function returns the last state reported for the specified key to the
  *  specified window.  The returned state is one of `GLFW_PRESS` or
- *  `GLFW_RELEASE`.  The higher-level state `GLFW_REPEAT` is only reported to
+ *  `GLFW_RELEASE`.  The higher-level action `GLFW_REPEAT` is only reported to
  *  the key callback.
  *
  *  If the `GLFW_STICKY_KEYS` input mode is enabled, this function returns
- *  `GLFW_PRESS` the first time you call this function after a key has been
- *  pressed, even if the key has already been released.
+ *  `GLFW_PRESS` the first time you call it for a key that was pressed, even if
+ *  that key has already been released.
  *
  *  The key functions deal with physical keys, with [key tokens](@ref keys)
  *  named after their use on the standard US keyboard layout.  If you want to
  *  input text, use the Unicode character callback instead.
  *
+ *  The [modifier key bit masks](@ref mods) are not key tokens and cannot be
+ *  used with this function.
+ *
+ *  __Do not use this function__ to implement [text input](@ref input_char).
+ *
  *  @param[in] window The desired window.
- *  @param[in] key The desired [keyboard key](@ref keys).
+ *  @param[in] key The desired [keyboard key](@ref keys).  `GLFW_KEY_UNKNOWN` is
+ *  not a valid key for this function.
  *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
  *
- *  @note `GLFW_KEY_UNKNOWN` is not a valid key for this function.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_ENUM.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_key
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
  *
  *  @ingroup input
  */
@@ -1801,25 +3047,37 @@ GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
  *  window.
  *
  *  This function returns the last state reported for the specified mouse button
- *  to the specified window.
+ *  to the specified window.  The returned state is one of `GLFW_PRESS` or
+ *  `GLFW_RELEASE`.
  *
  *  If the `GLFW_STICKY_MOUSE_BUTTONS` input mode is enabled, this function
- *  returns `GLFW_PRESS` the first time you call this function after a mouse
- *  button has been pressed, even if the mouse button has already been released.
+ *  `GLFW_PRESS` the first time you call it for a mouse button that was pressed,
+ *  even if that mouse button has already been released.
  *
  *  @param[in] window The desired window.
  *  @param[in] button The desired [mouse button](@ref buttons).
  *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_ENUM.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_mouse_button
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
+ *
  *  @ingroup input
  */
 GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
 
-/*! @brief Retrieves the last reported cursor position, relative to the client
- *  area of the window.
+/*! @brief Retrieves the position of the cursor relative to the client area of
+ *  the window.
  *
- *  This function returns the last reported position of the cursor to the
- *  specified window.
+ *  This function returns the position of the cursor, in screen coordinates,
+ *  relative to the upper-left corner of the client area of the specified
+ *  window.
  *
  *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
  *  position is unbounded and limited only by the minimum and maximum values of
@@ -1829,26 +3087,44 @@ GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
  *  `floor` function.  Casting directly to an integer type works for positive
  *  coordinates, but fails for negative ones.
  *
+ *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+ *  non-`NULL` position arguments will be set to zero.
+ *
  *  @param[in] window The desired window.
  *  @param[out] xpos Where to store the cursor x-coordinate, relative to the
  *  left edge of the client area, or `NULL`.
  *  @param[out] ypos Where to store the cursor y-coordinate, relative to the to
  *  top edge of the client area, or `NULL`.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_pos
  *  @sa glfwSetCursorPos
+ *
+ *  @since Added in version 3.0.  Replaces `glfwGetMousePos`.
  *
  *  @ingroup input
  */
 GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
 
-/*! @brief Sets the position of the cursor, relative to the client area of the window.
+/*! @brief Sets the position of the cursor, relative to the client area of the
+ *  window.
  *
- *  This function sets the position of the cursor.  The specified window must be
- *  focused.  If the window does not have focus when this function is called, it
- *  fails silently.
+ *  This function sets the position, in screen coordinates, of the cursor
+ *  relative to the upper-left corner of the client area of the specified
+ *  window.  The window must have input focus.  If the window does not have
+ *  input focus when this function is called, it fails silently.
  *
- *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
- *  position is unbounded and limited only by the minimum and maximum values of
+ *  __Do not use this function__ to implement things like camera controls.  GLFW
+ *  already provides the `GLFW_CURSOR_DISABLED` cursor mode that hides the
+ *  cursor, transparently re-centers it and provides unconstrained cursor
+ *  motion.  See @ref glfwSetInputMode for more information.
+ *
+ *  If the cursor mode is `GLFW_CURSOR_DISABLED` then the cursor position is
+ *  unconstrained and limited only by the minimum and maximum values of
  *  a `double`.
  *
  *  @param[in] window The desired window.
@@ -1857,15 +3133,139 @@ GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
  *  @param[in] ypos The desired y-coordinate, relative to the top edge of the
  *  client area.
  *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_pos
  *  @sa glfwGetCursorPos
+ *
+ *  @since Added in version 3.0.  Replaces `glfwSetMousePos`.
  *
  *  @ingroup input
  */
 GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
 
+/*! @brief Creates a custom cursor.
+ *
+ *  Creates a new custom cursor image that can be set for a window with @ref
+ *  glfwSetCursor.  The cursor can be destroyed with @ref glfwDestroyCursor.
+ *  Any remaining cursors are destroyed by @ref glfwTerminate.
+ *
+ *  The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+ *  bits per channel.  They are arranged canonically as packed sequential rows,
+ *  starting from the top-left corner.
+ *
+ *  The cursor hotspot is specified in pixels, relative to the upper-left corner
+ *  of the cursor image.  Like all other coordinate systems in GLFW, the X-axis
+ *  points to the right and the Y-axis points down.
+ *
+ *  @param[in] image The desired cursor image.
+ *  @param[in] xhot The desired x-coordinate, in pixels, of the cursor hotspot.
+ *  @param[in] yhot The desired y-coordinate, in pixels, of the cursor hotspot.
+ *  @return The handle of the created cursor, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The specified image data is copied before this function
+ *  returns.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_object
+ *  @sa glfwDestroyCursor
+ *  @sa glfwCreateStandardCursor
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot);
+
+/*! @brief Creates a cursor with a standard shape.
+ *
+ *  Returns a cursor with a [standard shape](@ref shapes), that can be set for
+ *  a window with @ref glfwSetCursor.
+ *
+ *  @param[in] shape One of the [standard shapes](@ref shapes).
+ *  @return A new cursor ready to use or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_object
+ *  @sa glfwCreateCursor
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape);
+
+/*! @brief Destroys a cursor.
+ *
+ *  This function destroys a cursor previously created with @ref
+ *  glfwCreateCursor.  Any remaining cursors will be destroyed by @ref
+ *  glfwTerminate.
+ *
+ *  @param[in] cursor The cursor object to destroy.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @reentrancy This function must not be called from a callback.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_object
+ *  @sa glfwCreateCursor
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
+
+/*! @brief Sets the cursor for the window.
+ *
+ *  This function sets the cursor image to be used when the cursor is over the
+ *  client area of the specified window.  The set cursor will only be visible
+ *  when the [cursor mode](@ref cursor_mode) of the window is
+ *  `GLFW_CURSOR_NORMAL`.
+ *
+ *  On some platforms, the set cursor may not be visible unless the window also
+ *  has input focus.
+ *
+ *  @param[in] window The window to set the cursor for.
+ *  @param[in] cursor The cursor to set, or `NULL` to switch back to the default
+ *  arrow cursor.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_object
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
+
 /*! @brief Sets the key callback.
  *
- *  This function sets the key callback of the specific window, which is called
+ *  This function sets the key callback of the specified window, which is called
  *  when a key is pressed, repeated or released.
  *
  *  The key functions deal with physical keys, with layout independent
@@ -1873,16 +3273,16 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
  *  layout.  If you want to input text, use the
  *  [character callback](@ref glfwSetCharCallback) instead.
  *
- *  When a window loses focus, it will generate synthetic key release events
- *  for all pressed keys.  You can tell these events from user-generated events
- *  by the fact that the synthetic ones are generated after the window has lost
- *  focus, i.e. `GLFW_FOCUSED` will be false and the focus callback will have
- *  already been called.
+ *  When a window loses input focus, it will generate synthetic key release
+ *  events for all pressed keys.  You can tell these events from user-generated
+ *  events by the fact that the synthetic ones are generated after the focus
+ *  loss event has been processed, i.e. after the
+ *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
  *
  *  The scancode of a key is specific to that platform or sometimes even to that
  *  machine.  Scancodes are intended to allow users to bind keys that don't have
  *  a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
- *  state is not saved and so it cannot be retrieved with @ref glfwGetKey.
+ *  state is not saved and so it cannot be queried with @ref glfwGetKey.
  *
  *  Sometimes GLFW needs to generate synthetic key events, in which case the
  *  scancode may be zero.
@@ -1890,8 +3290,17 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new key callback, or `NULL` to remove the currently
  *  set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_key
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter and return value.
  *
  *  @ingroup input
  */
@@ -1899,39 +3308,100 @@ GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun cbfun);
 
 /*! @brief Sets the Unicode character callback.
  *
- *  This function sets the character callback of the specific window, which is
+ *  This function sets the character callback of the specified window, which is
  *  called when a Unicode character is input.
  *
- *  The character callback is intended for text input.  If you want to know
- *  whether a specific key was pressed or released, use the
+ *  The character callback is intended for Unicode text input.  As it deals with
+ *  characters, it is keyboard layout dependent, whereas the
+ *  [key callback](@ref glfwSetKeyCallback) is not.  Characters do not map 1:1
+ *  to physical keys, as a key may produce zero, one or more characters.  If you
+ *  want to know whether a specific physical key was pressed or released, see
+ *  the key callback instead.
+ *
+ *  The character callback behaves as system text input normally does and will
+ *  not be called if modifier keys are held down that would prevent normal text
+ *  input on that platform, for example a Super (Command) key on OS X or Alt key
+ *  on Windows.  There is a
+ *  [character with modifiers callback](@ref glfwSetCharModsCallback) that
+ *  receives these events.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in version 2.4.
+ *  @glfw3 Added window handle parameter and return value.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun cbfun);
+
+/*! @brief Sets the Unicode character with modifiers callback.
+ *
+ *  This function sets the character with modifiers callback of the specified
+ *  window, which is called when a Unicode character is input regardless of what
+ *  modifier keys are used.
+ *
+ *  The character with modifiers callback is intended for implementing custom
+ *  Unicode character input.  For regular Unicode text input, see the
+ *  [character callback](@ref glfwSetCharCallback).  Like the character
+ *  callback, the character with modifiers callback deals with characters and is
+ *  keyboard layout dependent.  Characters do not map 1:1 to physical keys, as
+ *  a key may produce zero, one or more characters.  If you want to know whether
+ *  a specific physical key was pressed or released, see the
  *  [key callback](@ref glfwSetKeyCallback) instead.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
  *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_char
+ *
+ *  @since Added in version 3.1.
  *
  *  @ingroup input
  */
-GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun cbfun);
+GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun cbfun);
 
 /*! @brief Sets the mouse button callback.
  *
  *  This function sets the mouse button callback of the specified window, which
  *  is called when a mouse button is pressed or released.
  *
- *  When a window loses focus, it will generate synthetic mouse button release
- *  events for all pressed mouse buttons.  You can tell these events from
- *  user-generated events by the fact that the synthetic ones are generated
- *  after the window has lost focus, i.e. `GLFW_FOCUSED` will be false and the
- *  focus callback will have already been called.
+ *  When a window loses input focus, it will generate synthetic mouse button
+ *  release events for all pressed mouse buttons.  You can tell these events
+ *  from user-generated events by the fact that the synthetic ones are generated
+ *  after the focus loss event has been processed, i.e. after the
+ *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref input_mouse_button
+ *
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter and return value.
  *
  *  @ingroup input
  */
@@ -1941,13 +3411,22 @@ GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmo
  *
  *  This function sets the cursor position callback of the specified window,
  *  which is called when the cursor is moved.  The callback is provided with the
- *  position relative to the upper-left corner of the client area of the window.
+ *  position, in screen coordinates, relative to the upper-left corner of the
+ *  client area of the window.
  *
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_pos
+ *
+ *  @since Added in version 3.0.  Replaces `glfwSetMousePosCallback`.
  *
  *  @ingroup input
  */
@@ -1962,8 +3441,16 @@ GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursor
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
  *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref cursor_enter
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup input
  */
@@ -1981,19 +3468,64 @@ GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcu
  *  @param[in] window The window whose callback to set.
  *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
  *  set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  error occurred.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref scrolling
+ *
+ *  @since Added in version 3.0.  Replaces `glfwSetMouseWheelCallback`.
  *
  *  @ingroup input
  */
 GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun cbfun);
 
+/*! @brief Sets the file drop callback.
+ *
+ *  This function sets the file drop callback of the specified window, which is
+ *  called when one or more dragged files are dropped on the window.
+ *
+ *  Because the path array and its strings may have been generated specifically
+ *  for that event, they are not guaranteed to be valid after the callback has
+ *  returned.  If you wish to use them after the callback returns, you need to
+ *  make a deep copy.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new file drop callback, or `NULL` to remove the
+ *  currently set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref path_drop
+ *
+ *  @since Added in version 3.1.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun cbfun);
+
 /*! @brief Returns whether the specified joystick is present.
  *
  *  This function returns whether the specified joystick is present.
  *
- *  @param[in] joy The joystick to query.
- *  @return `GL_TRUE` if the joystick is present, or `GL_FALSE` otherwise.
+ *  @param[in] joy The [joystick](@ref joysticks) to query.
+ *  @return `GLFW_TRUE` if the joystick is present, or `GLFW_FALSE` otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick
+ *
+ *  @since Added in version 3.0.  Replaces `glfwGetJoystickParam`.
  *
  *  @ingroup input
  */
@@ -2002,17 +3534,32 @@ GLFWAPI int glfwJoystickPresent(int joy);
 /*! @brief Returns the values of all axes of the specified joystick.
  *
  *  This function returns the values of all axes of the specified joystick.
+ *  Each element in the array is a value between -1.0 and 1.0.
  *
- *  @param[in] joy The joystick to query.
- *  @param[out] count Where to store the size of the returned array.  This is
- *  set to zero if an error occurred.
- *  @return An array of axis values, or `NULL` if the joystick is not present.
+ *  Querying a joystick slot with no device present is not an error, but will
+ *  cause this function to return `NULL`.  Call @ref glfwJoystickPresent to
+ *  check device presence.
  *
- *  @note The returned array is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @param[in] joy The [joystick](@ref joysticks) to query.
+ *  @param[out] count Where to store the number of axis values in the returned
+ *  array.  This is set to zero if the joystick is not present or an error
+ *  occurred.
+ *  @return An array of axis values, or `NULL` if the joystick is not present or
+ *  an [error](@ref error_handling) occurred.
  *
- *  @note The returned array is valid only until the next call to @ref
- *  glfwGetJoystickAxes for that joystick.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified joystick is
+ *  disconnected, this function is called again for that joystick or the library
+ *  is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_axis
+ *
+ *  @since Added in version 3.0.  Replaces `glfwGetJoystickPos`.
  *
  *  @ingroup input
  */
@@ -2021,17 +3568,33 @@ GLFWAPI const float* glfwGetJoystickAxes(int joy, int* count);
 /*! @brief Returns the state of all buttons of the specified joystick.
  *
  *  This function returns the state of all buttons of the specified joystick.
+ *  Each element in the array is either `GLFW_PRESS` or `GLFW_RELEASE`.
  *
- *  @param[in] joy The joystick to query.
- *  @param[out] count Where to store the size of the returned array.  This is
- *  set to zero if an error occurred.
- *  @return An array of button states, or `NULL` if the joystick is not present.
+ *  Querying a joystick slot with no device present is not an error, but will
+ *  cause this function to return `NULL`.  Call @ref glfwJoystickPresent to
+ *  check device presence.
  *
- *  @note The returned array is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @param[in] joy The [joystick](@ref joysticks) to query.
+ *  @param[out] count Where to store the number of button states in the returned
+ *  array.  This is set to zero if the joystick is not present or an error
+ *  occurred.
+ *  @return An array of button states, or `NULL` if the joystick is not present
+ *  or an [error](@ref error_handling) occurred.
  *
- *  @note The returned array is valid only until the next call to @ref
- *  glfwGetJoystickButtons for that joystick.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified joystick is
+ *  disconnected, this function is called again for that joystick or the library
+ *  is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_button
+ *
+ *  @since Added in version 2.2.
+ *  @glfw3 Changed to return a dynamic array.
  *
  *  @ingroup input
  */
@@ -2040,58 +3603,110 @@ GLFWAPI const unsigned char* glfwGetJoystickButtons(int joy, int* count);
 /*! @brief Returns the name of the specified joystick.
  *
  *  This function returns the name, encoded as UTF-8, of the specified joystick.
+ *  The returned string is allocated and freed by GLFW.  You should not free it
+ *  yourself.
  *
- *  @param[in] joy The joystick to query.
+ *  Querying a joystick slot with no device present is not an error, but will
+ *  cause this function to return `NULL`.  Call @ref glfwJoystickPresent to
+ *  check device presence.
+ *
+ *  @param[in] joy The [joystick](@ref joysticks) to query.
  *  @return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
- *  is not present.
+ *  is not present or an [error](@ref error_handling) occurred.
  *
- *  @note The returned string is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
  *
- *  @note The returned string is valid only until the next call to @ref
- *  glfwGetJoystickName for that joystick.
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the specified joystick is
+ *  disconnected, this function is called again for that joystick or the library
+ *  is terminated.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_name
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup input
  */
 GLFWAPI const char* glfwGetJoystickName(int joy);
 
+/*! @brief Sets the joystick configuration callback.
+ *
+ *  This function sets the joystick configuration callback, or removes the
+ *  currently set callback.  This is called when a joystick is connected to or
+ *  disconnected from the system.
+ *
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or the
+ *  library had not been [initialized](@ref intro_init).
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref joystick_event
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun cbfun);
+
 /*! @brief Sets the clipboard to the specified string.
  *
  *  This function sets the system clipboard to the specified, UTF-8 encoded
- *  string.  The string is copied before returning, so you don't have to retain
- *  it afterwards.
+ *  string.
  *
  *  @param[in] window The window that will own the clipboard contents.
  *  @param[in] string A UTF-8 encoded string.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
+ *  @pointer_lifetime The specified string is copied before this function
+ *  returns.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @sa @ref clipboard
  *  @sa glfwGetClipboardString
  *
- *  @ingroup clipboard
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup input
  */
 GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
 
-/*! @brief Retrieves the contents of the clipboard as a string.
+/*! @brief Returns the contents of the clipboard as a string.
  *
  *  This function returns the contents of the system clipboard, if it contains
- *  or is convertible to a UTF-8 encoded string.
+ *  or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
+ *  if its contents cannot be converted, `NULL` is returned and a @ref
+ *  GLFW_FORMAT_UNAVAILABLE error is generated.
  *
  *  @param[in] window The window that will request the clipboard contents.
  *  @return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
- *  if an error occurred.
+ *  if an [error](@ref error_handling) occurred.
  *
- *  @note This function may only be called from the main thread.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
  *
- *  @note The returned string is allocated and freed by GLFW.  You should not
- *  free it yourself.
+ *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is valid until the next call to @ref
+ *  glfwGetClipboardString or @ref glfwSetClipboardString, or until the library
+ *  is terminated.
  *
- *  @note The returned string is valid only until the next call to @ref
- *  glfwGetClipboardString or @ref glfwSetClipboardString.
+ *  @thread_safety This function must only be called from the main thread.
  *
+ *  @sa @ref clipboard
  *  @sa glfwSetClipboardString
  *
- *  @ingroup clipboard
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup input
  */
 GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
 
@@ -2101,46 +3716,125 @@ GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
  *  been set using @ref glfwSetTime, the timer measures time elapsed since GLFW
  *  was initialized.
  *
- *  @return The current value, in seconds, or zero if an error occurred.
+ *  The resolution of the timer is system dependent, but is usually on the order
+ *  of a few micro- or nanoseconds.  It uses the highest-resolution monotonic
+ *  time source on each supported platform.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @return The current value, in seconds, or zero if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @note The resolution of the timer is system dependent, but is usually on the
- *  order of a few micro- or nanoseconds.  It uses the highest-resolution
- *  monotonic time source on each supported platform.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
- *  @ingroup time
+ *  @thread_safety This function may be called from any thread.  Reading and
+ *  writing of the internal timer offset is not atomic, so it needs to be
+ *  externally synchronized with calls to @ref glfwSetTime.
+ *
+ *  @sa @ref time
+ *
+ *  @since Added in version 1.0.
+ *
+ *  @ingroup input
  */
 GLFWAPI double glfwGetTime(void);
 
 /*! @brief Sets the GLFW timer.
  *
  *  This function sets the value of the GLFW timer.  It then continues to count
- *  up from that value.
+ *  up from that value.  The value must be a positive finite number less than
+ *  or equal to 18446744073.0, which is approximately 584.5 years.
  *
  *  @param[in] time The new value, in seconds.
  *
- *  @note The resolution of the timer is system dependent, but is usually on the
- *  order of a few micro- or nanoseconds.  It uses the highest-resolution
- *  monotonic time source on each supported platform.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_INVALID_VALUE.
  *
- *  @ingroup time
+ *  @remark The upper limit of the timer is calculated as
+ *  floor((2<sup>64</sup> - 1) / 10<sup>9</sup>) and is due to implementations
+ *  storing nanoseconds in 64 bits.  The limit may be increased in the future.
+ *
+ *  @thread_safety This function may be called from any thread.  Reading and
+ *  writing of the internal timer offset is not atomic, so it needs to be
+ *  externally synchronized with calls to @ref glfwGetTime.
+ *
+ *  @sa @ref time
+ *
+ *  @since Added in version 2.2.
+ *
+ *  @ingroup input
  */
 GLFWAPI void glfwSetTime(double time);
+
+/*! @brief Returns the current value of the raw timer.
+ *
+ *  This function returns the current value of the raw timer, measured in
+ *  1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call @ref
+ *  glfwGetTimerFrequency.
+ *
+ *  @return The value of the timer, or zero if an 
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref time
+ *  @sa glfwGetTimerFrequency
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI uint64_t glfwGetTimerValue(void);
+
+/*! @brief Returns the frequency, in Hz, of the raw timer.
+ *
+ *  This function returns the frequency, in Hz, of the raw timer.
+ *
+ *  @return The frequency of the timer, in Hz, or zero if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref time
+ *  @sa glfwGetTimerValue
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup input
+ */
+GLFWAPI uint64_t glfwGetTimerFrequency(void);
 
 /*! @brief Makes the context of the specified window current for the calling
  *  thread.
  *
- *  This function makes the context of the specified window current on the
- *  calling thread.  A context can only be made current on a single thread at
- *  a time and each thread can have only a single current context at a time.
+ *  This function makes the OpenGL or OpenGL ES context of the specified window
+ *  current on the calling thread.  A context can only be made current on
+ *  a single thread at a time and each thread can have only a single current
+ *  context at a time.
+ *
+ *  By default, making a context non-current implicitly forces a pipeline flush.
+ *  On machines that support `GL_KHR_context_flush_control`, you can control
+ *  whether a context performs this flush by setting the
+ *  [GLFW_CONTEXT_RELEASE_BEHAVIOR](@ref window_hints_ctx) window hint.
+ *
+ *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
+ *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
+ *  error.
  *
  *  @param[in] window The window whose context to make current, or `NULL` to
  *  detach the current context.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
  *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref context_current
  *  @sa glfwGetCurrentContext
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup context
  */
@@ -2148,15 +3842,20 @@ GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
 
 /*! @brief Returns the window whose context is current on the calling thread.
  *
- *  This function returns the window whose context is current on the calling
- *  thread.
+ *  This function returns the window whose OpenGL or OpenGL ES context is
+ *  current on the calling thread.
  *
  *  @return The window whose context is current, or `NULL` if no window's
  *  context is current.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
  *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref context_current
  *  @sa glfwMakeContextCurrent
+ *
+ *  @since Added in version 3.0.
  *
  *  @ingroup context
  */
@@ -2164,30 +3863,45 @@ GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
 
 /*! @brief Swaps the front and back buffers of the specified window.
  *
- *  This function swaps the front and back buffers of the specified window.  If
- *  the swap interval is greater than zero, the GPU driver waits the specified
- *  number of screen updates before swapping the buffers.
+ *  This function swaps the front and back buffers of the specified window when
+ *  rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
+ *  zero, the GPU driver waits the specified number of screen updates before
+ *  swapping the buffers.
+ *
+ *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
+ *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
+ *  error.
+ *
+ *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+ *  see `vkQueuePresentKHR` instead.
  *
  *  @param[in] window The window whose buffers to swap.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
  *
- *  @par New in GLFW 3
- *  This function no longer calls @ref glfwPollEvents.  You need to call it or
- *  @ref glfwWaitEvents yourself.
+ *  @remark __EGL:__ The context of the specified window must be current on the
+ *  calling thread.
  *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref buffer_swap
  *  @sa glfwSwapInterval
  *
- *  @ingroup context
+ *  @since Added in version 1.0.
+ *  @glfw3 Added window handle parameter.
+ *
+ *  @ingroup window
  */
 GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
 
 /*! @brief Sets the swap interval for the current context.
  *
- *  This function sets the swap interval for the current context, i.e. the
- *  number of screen updates to wait before swapping the buffers of a window and
- *  returning from @ref glfwSwapBuffers.  This is sometimes called 'vertical
- *  synchronization', 'vertical retrace synchronization' or 'vsync'.
+ *  This function sets the swap interval for the current OpenGL or OpenGL ES
+ *  context, i.e. the number of screen updates to wait from the time @ref
+ *  glfwSwapBuffers was called before swapping the buffers and returning.  This
+ *  is sometimes called _vertical synchronization_, _vertical retrace
+ *  synchronization_ or just _vsync_.
  *
  *  Contexts that support either of the `WGL_EXT_swap_control_tear` and
  *  `GLX_EXT_swap_control_tear` extensions also accept negative swap intervals,
@@ -2196,16 +3910,33 @@ GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
  *  glfwExtensionSupported.  For more information about swap tearing, see the
  *  extension specifications.
  *
+ *  A context must be current on the calling thread.  Calling this function
+ *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+ *
+ *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+ *  see the present mode of your swapchain instead.
+ *
  *  @param[in] interval The minimum number of screen updates to wait for
  *  until the buffers are swapped by @ref glfwSwapBuffers.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
  *
- *  @note Some GPU drivers do not honor the requested swap interval, either
- *  because of user settings that override the request or due to bugs in the
- *  driver.
+ *  @remark This function is not called during context creation, leaving the
+ *  swap interval set to whatever is the default on that platform.  This is done
+ *  because some swap interval extensions used by GLFW do not allow the swap
+ *  interval to be reset to zero once it has been set to a non-zero value.
  *
+ *  @remark Some GPU drivers do not honor the requested swap interval, either
+ *  because of a user setting that overrides the application's request or due to
+ *  bugs in the driver.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref buffer_swap
  *  @sa glfwSwapBuffers
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup context
  */
@@ -2214,19 +3945,36 @@ GLFWAPI void glfwSwapInterval(int interval);
 /*! @brief Returns whether the specified extension is available.
  *
  *  This function returns whether the specified
- *  [OpenGL or context creation API extension](@ref context_glext) is supported
- *  by the current context.  For example, on Windows both the OpenGL and WGL
- *  extension strings are checked.
+ *  [API extension](@ref context_glext) is supported by the current OpenGL or
+ *  OpenGL ES context.  It searches both for client API extension and context
+ *  creation API extensions.
  *
- *  @param[in] extension The ASCII encoded name of the extension.
- *  @return `GL_TRUE` if the extension is available, or `GL_FALSE` otherwise.
+ *  A context must be current on the calling thread.  Calling this function
+ *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
  *
- *  @remarks This function may be called from secondary threads.
- *
- *  @note As this functions searches one or more extension strings on each call,
- *  it is recommended that you cache its results if it's going to be used
+ *  As this functions retrieves and searches one or more extension strings each
+ *  call, it is recommended that you cache its results if it is going to be used
  *  frequently.  The extension strings will not change during the lifetime of
  *  a context, so there is no danger in doing this.
+ *
+ *  This function does not apply to Vulkan.  If you are using Vulkan, see @ref
+ *  glfwGetRequiredInstanceExtensions, `vkEnumerateInstanceExtensionProperties`
+ *  and `vkEnumerateDeviceExtensionProperties` instead.
+ *
+ *  @param[in] extension The ASCII encoded name of the extension.
+ *  @return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
+ *  otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_CURRENT_CONTEXT, @ref GLFW_INVALID_VALUE and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref context_glext
+ *  @sa glfwGetProcAddress
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup context
  */
@@ -2235,23 +3983,242 @@ GLFWAPI int glfwExtensionSupported(const char* extension);
 /*! @brief Returns the address of the specified function for the current
  *  context.
  *
- *  This function returns the address of the specified
- *  [client API or extension function](@ref context_glext), if it is supported
+ *  This function returns the address of the specified OpenGL or OpenGL ES
+ *  [core or extension function](@ref context_glext), if it is supported
  *  by the current context.
  *
+ *  A context must be current on the calling thread.  Calling this function
+ *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+ *
+ *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+ *  see @ref glfwGetInstanceProcAddress, `vkGetInstanceProcAddr` and
+ *  `vkGetDeviceProcAddr` instead.
+ *
  *  @param[in] procname The ASCII encoded name of the function.
- *  @return The address of the function, or `NULL` if the function is
- *  unavailable.
+ *  @return The address of the function, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
  *
- *  @remarks This function may be called from secondary threads.
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
  *
- *  @note The addresses of these functions are not guaranteed to be the same for
- *  all contexts, especially if they use different client APIs or even different
- *  context creation hints.
+ *  @remark The address of a given function is not guaranteed to be the same
+ *  between contexts.
+ *
+ *  @remark This function may return a non-`NULL` address despite the
+ *  associated version or extension not being available.  Always check the
+ *  context version or extension string first.
+ *
+ *  @pointer_lifetime The returned function pointer is valid until the context
+ *  is destroyed or the library is terminated.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref context_glext
+ *  @sa glfwExtensionSupported
+ *
+ *  @since Added in version 1.0.
  *
  *  @ingroup context
  */
 GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
+
+/*! @brief Returns whether the Vulkan loader has been found.
+ *
+ *  This function returns whether the Vulkan loader has been found.  This check
+ *  is performed by @ref glfwInit.
+ *
+ *  The availability of a Vulkan loader does not by itself guarantee that window
+ *  surface creation or even device creation is possible.  Call @ref
+ *  glfwGetRequiredInstanceExtensions to check whether the extensions necessary
+ *  for Vulkan surface creation are available and @ref
+ *  glfwGetPhysicalDevicePresentationSupport to check whether a queue family of
+ *  a physical device supports image presentation.
+ *
+ *  @return `GLFW_TRUE` if Vulkan is available, or `GLFW_FALSE` otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref vulkan_support
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI int glfwVulkanSupported(void);
+
+/*! @brief Returns the Vulkan instance extensions required by GLFW.
+ *
+ *  This function returns an array of names of Vulkan instance extensions required
+ *  by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
+ *  list will always contains `VK_KHR_surface`, so if you don't require any
+ *  additional extensions you can pass this list directly to the
+ *  `VkInstanceCreateInfo` struct.
+ *
+ *  If Vulkan is not available on the machine, this function returns `NULL` and
+ *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+ *  to check whether Vulkan is available.
+ *
+ *  If Vulkan is available but no set of extensions allowing window surface
+ *  creation was found, this function returns `NULL`.  You may still use Vulkan
+ *  for off-screen rendering and compute work.
+ *
+ *  @param[out] count Where to store the number of extensions in the returned
+ *  array.  This is set to zero if an error occurred.
+ *  @return An array of ASCII encoded extension names, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_API_UNAVAILABLE.
+ *
+ *  @remarks Additional extensions may be required by future versions of GLFW.
+ *  You should check if any extensions you wish to enable are already in the
+ *  returned array, as it is an error to specify an extension more than once in
+ *  the `VkInstanceCreateInfo` struct.
+ *
+ *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+ *  should not free it yourself.  It is guaranteed to be valid only until the
+ *  library is terminated.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref vulkan_ext
+ *  @sa glfwCreateWindowSurface
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
+
+#if defined(VK_VERSION_1_0)
+
+/*! @brief Returns the address of the specified Vulkan instance function.
+ *
+ *  This function returns the address of the specified Vulkan core or extension
+ *  function for the specified instance.  If instance is set to `NULL` it can
+ *  return any function exported from the Vulkan loader, including at least the
+ *  following functions:
+ *
+ *  - `vkEnumerateInstanceExtensionProperties`
+ *  - `vkEnumerateInstanceLayerProperties`
+ *  - `vkCreateInstance`
+ *  - `vkGetInstanceProcAddr`
+ *
+ *  If Vulkan is not available on the machine, this function returns `NULL` and
+ *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+ *  to check whether Vulkan is available.
+ *
+ *  This function is equivalent to calling `vkGetInstanceProcAddr` with
+ *  a platform-specific query of the Vulkan loader as a fallback.
+ *
+ *  @param[in] instance The Vulkan instance to query, or `NULL` to retrieve
+ *  functions related to instance creation.
+ *  @param[in] procname The ASCII encoded name of the function.
+ *  @return The address of the function, or `NULL` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_API_UNAVAILABLE.
+ *
+ *  @pointer_lifetime The returned function pointer is valid until the library
+ *  is terminated.
+ *
+ *  @thread_safety This function may be called from any thread.
+ *
+ *  @sa @ref vulkan_proc
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* procname);
+
+/*! @brief Returns whether the specified queue family can present images.
+ *
+ *  This function returns whether the specified queue family of the specified
+ *  physical device supports presentation to the platform GLFW was built for.
+ *
+ *  If Vulkan or the required window surface creation instance extensions are
+ *  not available on the machine, or if the specified instance was not created
+ *  with the required extensions, this function returns `GLFW_FALSE` and
+ *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+ *  to check whether Vulkan is available and @ref
+ *  glfwGetRequiredInstanceExtensions to check what instance extensions are
+ *  required.
+ *
+ *  @param[in] instance The instance that the physical device belongs to.
+ *  @param[in] device The physical device that the queue family belongs to.
+ *  @param[in] queuefamily The index of the queue family to query.
+ *  @return `GLFW_TRUE` if the queue family supports presentation, or
+ *  `GLFW_FALSE` otherwise.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function may be called from any thread.  For
+ *  synchronization details of Vulkan objects, see the Vulkan specification.
+ *
+ *  @sa @ref vulkan_present
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
+
+/*! @brief Creates a Vulkan surface for the specified window.
+ *
+ *  This function creates a Vulkan surface for the specified window.
+ *
+ *  If the Vulkan loader was not found at initialization, this function returns
+ *  `VK_ERROR_INITIALIZATION_FAILED` and generates a @ref GLFW_API_UNAVAILABLE
+ *  error.  Call @ref glfwVulkanSupported to check whether the Vulkan loader was
+ *  found.
+ *
+ *  If the required window surface creation instance extensions are not
+ *  available or if the specified instance was not created with these extensions
+ *  enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT` and
+ *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref
+ *  glfwGetRequiredInstanceExtensions to check what instance extensions are
+ *  required.
+ *
+ *  The window surface must be destroyed before the specified Vulkan instance.
+ *  It is the responsibility of the caller to destroy the window surface.  GLFW
+ *  does not destroy it for you.  Call `vkDestroySurfaceKHR` to destroy the
+ *  surface.
+ *
+ *  @param[in] instance The Vulkan instance to create the surface in.
+ *  @param[in] window The window to create the surface for.
+ *  @param[in] allocator The allocator to use, or `NULL` to use the default
+ *  allocator.
+ *  @param[out] surface Where to store the handle of the surface.  This is set
+ *  to `VK_NULL_HANDLE` if an error occurred.
+ *  @return `VK_SUCCESS` if successful, or a Vulkan error code if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+ *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
+ *
+ *  @remarks If an error occurs before the creation call is made, GLFW returns
+ *  the Vulkan error code most appropriate for the error.  Appropriate use of
+ *  @ref glfwVulkanSupported and @ref glfwGetRequiredInstanceExtensions should
+ *  eliminate almost all occurrences of these errors.
+ *
+ *  @thread_safety This function may be called from any thread.  For
+ *  synchronization details of Vulkan objects, see the Vulkan specification.
+ *
+ *  @sa @ref vulkan_surface
+ *  @sa glfwGetRequiredInstanceExtensions
+ *
+ *  @since Added in version 3.2.
+ *
+ *  @ingroup vulkan
+ */
+GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
+
+#endif /*VK_VERSION_1_0*/
 
 
 /*************************************************************************

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -30,7 +30,7 @@ int main()
 
     glfwSetErrorCallback(errorcb);
     assert(glfwInit() == GL_TRUE);
-    assert(!strcmp(glfwGetVersionString(), "3.0.0 JS WebGL Emscripten"));
+    assert(!strcmp(glfwGetVersionString(), "3.2.1 JS WebGL Emscripten"));
 
     {
         int major, minor, rev;

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -36,8 +36,8 @@ int main()
         int major, minor, rev;
         glfwGetVersion(&major, &minor, &rev);
         assert(major == 3);
-        assert(minor == 0);
-        assert(rev == 0);
+        assert(minor == 2);
+        assert(rev == 1);
     }
 
     {


### PR DESCRIPTION
Updates emscripten's copy of glfw3's header file to 3.2.1 (released 2016), currently the latest version on http://www.glfw.org, from the old glfw 3.0 version (from 2013) originally included.

This is a large diff but mostly cosmetic (comment changes), though it does add some new functions. None of the new functions are implemented by this pull request (~~are stubs throwing "not implemented" needed?~~ update: added "not implemented" stub methods). The new functions could be implemented in future pull requests.

This change is backwards-compatible; the glfw tests continue to pass.