### PR TITLE
Explicitly pass zero as the high bits of the offset in __stdio_seek a…

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -665,8 +665,8 @@ var SyscallsLibrary = {
   },
   __syscall140: function(which, varargs) { // llseek
     var stream = SYSCALLS.getStreamFromFD(), offset_high = SYSCALLS.get(), offset_low = SYSCALLS.get(), result = SYSCALLS.get(), whence = SYSCALLS.get();
+    // NOTE: offset_high is unused - Emscripten's off_t is 32-bit
     var offset = offset_low;
-    assert(offset_high === 0);
     FS.llseek(stream, offset, whence);
     {{{ makeSetValue('result', '0', 'stream.position', 'i32') }}};
     if (stream.getdents && offset === 0 && whence === {{{ cDefine('SEEK_SET') }}}) stream.getdents = null; // reset readdir state

--- a/system/lib/libc/musl/src/stdio/__stdio_seek.c
+++ b/system/lib/libc/musl/src/stdio/__stdio_seek.c
@@ -4,7 +4,13 @@ off_t __stdio_seek(FILE *f, off_t off, int whence)
 {
 	off_t ret;
 #ifdef SYS__llseek
-	if (syscall(SYS__llseek, f->fd, off>>32, off, &ret, whence)<0)
+	off_t off_hi =
+#ifndef __EMSCRIPTEN__
+		off >> 32;
+#else
+		0;
+#endif
+	if (syscall(SYS__llseek, f->fd, off_hi, off, &ret, whence)<0)
 		ret = -1;
 #else
 	ret = syscall(SYS_lseek, f->fd, off, whence);

--- a/system/lib/libc/musl/src/stdio/__stdio_seek.c
+++ b/system/lib/libc/musl/src/stdio/__stdio_seek.c
@@ -4,13 +4,7 @@ off_t __stdio_seek(FILE *f, off_t off, int whence)
 {
 	off_t ret;
 #ifdef SYS__llseek
-	off_t off_hi =
-#ifndef __EMSCRIPTEN__
-		off >> 32;
-#else
-		0;
-#endif
-	if (syscall(SYS__llseek, f->fd, off_hi, off, &ret, whence)<0)
+	if (syscall(SYS__llseek, f->fd, off>>32, off, &ret, whence)<0)
 		ret = -1;
 #else
 	ret = syscall(SYS_lseek, f->fd, off, whence);

--- a/system/lib/libc/musl/src/unistd/lseek.c
+++ b/system/lib/libc/musl/src/unistd/lseek.c
@@ -6,13 +6,7 @@ off_t lseek(int fd, off_t offset, int whence)
 {
 #ifdef SYS__llseek
 	off_t result;
-	off_t offset_hi =
-#ifndef __EMSCRIPTEN__
-		offset >> 32;
-#else
-		0;
-#endif
-	return syscall(SYS__llseek, fd, offset_hi, offset, &result, whence) ? -1 : result;
+	return syscall(SYS__llseek, fd, offset>>32, offset, &result, whence) ? -1 : result;
 #else
 	return syscall(SYS_lseek, fd, offset, whence);
 #endif


### PR DESCRIPTION
…s well as lseek

Fixes `test_fs_append` for wasm backend.

So this is the same type of fix I applied in `lseek.c`, and the way I see it there's three ways to get around this:

1. This fix - explicitly pass 0 for the high bits. If a new version of musl starts using `SYS__lseek` elsewhere we'll have to reapply this fix there too.
2. Remove the line in `__syscall140` that asserts that the high bits are 0. We can continue to just not use that field, which makes sense because we know that `off_t` is always a 32-bit value so there's nothing interesting there regardless.
3. Change `off_t` to be 64-bit. The problem is that every other arch assumes `off_t` is 64 bits, so we're free to shift by 32. With 32-bit `off_t`s like Emscripten has, we run in to undefined behavior. Asm.js zeroes this out, wasm backend does not. This makes Emscripten more like other arches, which is probably good. The bad news is that asm.js doesn't natively support 64-bit ints. Maybe we only change the size when compiling wasm?

I *like* 3 there, but I suspect there's practical concerns that make it non-viable. Between 2 and 1, I probably prefer 2. Thoughts?