### PR TITLE
Pass d8 flag to disable wasm async compilation

### DIFF
--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -33,9 +33,13 @@ def make_command(filename, engine=None, args=[]):
   # label a path to nodejs containing a 'd8' as spidermonkey instead.
   jsengine = os.path.split(engine[0])[-1]
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
+  is_d8 = 'd8' in jsengine
   # Disable true async compilation (async apis will in fact be synchronous) for now
   # due to https://bugs.chromium.org/p/v8/issues/detail?id=6263
-  return engine + [filename] + (['--no-wasm-async-compilation', '--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
+  shell_option_flags = ['--no-wasm-async-compilation'] if is_d8 else []
+  # Separates engine flags from script flags
+  flag_separateor = ['--'] if is_d8 or 'jsc' in jsengine else []
+  return engine + [filename] + shell_option_flags + flag_separator + args
 
 
 def check_engine(engine):

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -38,7 +38,7 @@ def make_command(filename, engine=None, args=[]):
   # due to https://bugs.chromium.org/p/v8/issues/detail?id=6263
   shell_option_flags = ['--no-wasm-async-compilation'] if is_d8 else []
   # Separates engine flags from script flags
-  flag_separateor = ['--'] if is_d8 or 'jsc' in jsengine else []
+  flag_separator = ['--'] if is_d8 or 'jsc' in jsengine else []
   return engine + [filename] + shell_option_flags + flag_separator + args
 
 

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -33,7 +33,9 @@ def make_command(filename, engine=None, args=[]):
   # label a path to nodejs containing a 'd8' as spidermonkey instead.
   jsengine = os.path.split(engine[0])[-1]
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
-  return engine + [filename] + (['--expose-wasm', '--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
+  # Disable true async compilation (async apis will in fact be synchronous) for now
+  # due to https://bugs.chromium.org/p/v8/issues/detail?id=6263
+  return engine + [filename] + (['--no-wasm-async-compilation', '--'] if 'd8' in jsengine or 'jsc' in jsengine else []) + args
 
 
 def check_engine(engine):


### PR DESCRIPTION
Tests are currently failing due to V8 bug
https://bugs.chromium.org/p/v8/issues/detail?id=6263 so pass a flag to disable
async compilation (the same APIs are used but they will not actually be
async). Also remove --expose-wasm as wasm is now on by default.