### PR TITLE
JS_FFI option to disable JS FFI mangling.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1364,6 +1364,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           newargs.append('-mllvm')
           newargs.append('-disable-llvm-optzns')
 
+      if not shared.Settings.LEGALIZE_JS_FFI:
+        assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+
       shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
       shared.Settings.OPT_LEVEL = opt_level
       shared.Settings.DEBUG_LEVEL = debug_level
@@ -2138,6 +2141,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             cmd += ['--mem-max=-1']
           elif shared.Settings.BINARYEN_MEM_MAX >= 0:
             cmd += ['--mem-max=' + str(shared.Settings.BINARYEN_MEM_MAX)]
+          if shared.Settings.LEGALIZE_JS_FFI != 1:
+            cmd += ['--no-legalize-javascript-ffi']
           if shared.Building.is_wasm_only():
             cmd += ['--wasm-only'] # this asm.js is code not intended to run as asm.js, it is only ever going to be wasm, an can contain special fastcomp-wasm support
           if debug_level >= 2 or profiling_funcs:

--- a/emscripten.py
+++ b/emscripten.py
@@ -435,6 +435,8 @@ def create_backend_args(infile, temp_js, settings):
     args += ['-emscripten-global-base=%d' % settings['GLOBAL_BASE']]
   if settings['SIDE_MODULE']:
     args += ['-emscripten-side-module']
+  if settings['LEGALIZE_JS_FFI'] != 1:
+    args += ['-emscripten-legalize-javascript-ffi=0']
   if settings['DISABLE_EXCEPTION_CATCHING'] != 1:
     args += ['-enable-emscripten-cpp-exceptions']
     if settings['DISABLE_EXCEPTION_CATCHING'] == 2:

--- a/src/settings.js
+++ b/src/settings.js
@@ -721,6 +721,13 @@ var BINARYEN_ASYNC_COMPILATION = 1; // Whether to compile the wasm asynchronousl
 var BINARYEN_ROOT = ""; // Directory where we can find Binaryen. Will be automatically set for you,
                         // but you can set it to override if you are a Binaryen developer.
 
+var LEGALIZE_JS_FFI = 1; // Whether to legalize the JS FFI interfaces (imports/exports) by wrapping
+                         // them to automatically demote i64 to i32 and promote f32 to f64. This is
+                         // necessary in order to interface with JavaScript, both for asm.js and wasm.
+                         // For non-web/non-JS embeddings, setting this to 0 may be desirable.
+                         // LEGALIZE_JS_FFI=0 is incompatible with RUNNING_JS_OPTS and using
+                         // non-wasm BINARYEN_METHOD settings.
+
 var WASM = 0; // Alias for BINARYEN, the two are identical. Both make us compile code to WebAssembly.
 
 var WASM_BACKEND = 0; // Whether to use the WebAssembly backend that is in development in LLVM.

--- a/tests/other/ffi.c
+++ b/tests/other/ffi.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <math.h>
+
+float add_f (float a, float b) {
+    return a + b;
+}
+
+long long add_ll (long long a, long long b) {
+    return a + b;
+}
+
+extern float import_f(float x);
+
+extern long long import_ll(long long x);
+
+int main () {
+    float a = 1.2,
+          b = import_f((float)3.4),
+          c;
+    c = add_f(a, b);
+
+    long long d = 1,
+              e = import_ll((long long)2),
+              f;
+    f = add_ll(d, e);
+}

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1981,7 +1981,7 @@ class Building:
     # fastcomp can emit wasm-only code.
     # also disable this mode if it depends on special optimizations that are not yet
     # compatible with it.
-    return 'asmjs' not in Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS and not Settings.EMULATED_FUNCTION_POINTERS and not Settings.EMULATE_FUNCTION_POINTER_CASTS
+    return ('asmjs' not in Settings.BINARYEN_METHOD and 'interpret-asm2wasm' not in Settings.BINARYEN_METHOD and not Settings.RUNNING_JS_OPTS and not Settings.EMULATED_FUNCTION_POINTERS and not Settings.EMULATE_FUNCTION_POINTER_CASTS) or not Settings.LEGALIZE_JS_FFI
 
   @staticmethod
   def get_safe_internalize():


### PR DESCRIPTION
For JS/Web platform, calls to JS imports are wrapped to convert i64 to
i32 and f32 to f64. Likewise calls from JS into exports do the inverse
wrapping. However, for non-web embeddings this is probably undesirable.
This change provides an option to disable that wrapping and use the
original types for the call.

This option invokes fastcomp using --emscripten-js-ffi=0 (https://github.com/kripken/emscripten-fastcomp/pull/181) and binaryen using --no-js-ffi (https://github.com/WebAssembly/binaryen/pull/984).