### PR TITLE
Initialize numGamepadsConnected Fixes #5169

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -289,3 +289,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jean-François Geyelin <jfgeyelin@gmail.com>
 * Matthew Collins <thethinkofdeath@gmail.com>
 * Satoshi N. M <snmatsutake@yahoo.co.jp>
+* Ryan Speets <ryan@speets.ca>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -40,6 +40,8 @@ var LibraryJSEvents = {
         window.addEventListener("gamepadconnected", function() { ++JSEvents.numGamepadsConnected; });
         window.addEventListener("gamepaddisconnected", function() { --JSEvents.numGamepadsConnected; });
         
+        // Chromium does not fire the gamepadconnected event on reload, so we need to get the number of gamepads here as a workaround.
+        // See https://bugs.chromium.org/p/chromium/issues/detail?id=502824
         var firstState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null);
         if (firstState) {
           JSEvents.numGamepadsConnected = firstState.length;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -39,6 +39,11 @@ var LibraryJSEvents = {
       if (typeof window !== 'undefined') {
         window.addEventListener("gamepadconnected", function() { ++JSEvents.numGamepadsConnected; });
         window.addEventListener("gamepaddisconnected", function() { --JSEvents.numGamepadsConnected; });
+        
+        var firstState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null);
+        if (firstState) {
+          JSEvents.numGamepadsConnected = firstState.length;
+        }
       }
     },
 


### PR DESCRIPTION
Chrome currently has [an issue](https://bugs.chromium.org/p/chromium/issues/detail?id=502824) where the `gamepadconnected` event won't fire in some cases. This can cause Emscripten to not think any gamepads are connected, even after pressing a button.

This is a workaround for that bug by setting `numGamepadsConnected` to the number of gamepads returned from the Gamepad API during initialization.

Fixes #5169