### PR TITLE
Specify void as arguments

### DIFF
--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -422,7 +422,7 @@ extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const cha
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context();
+extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 


### PR DESCRIPTION
Calling emscripten_webgl_get_current_context() causes arguments number unmatch warning.

>warning: unexpected number of arguments 0 in call to 'emscripten_webgl_get_current_context', should be 1

If no arguments are needed, void should be specified explicitly in C.
