### PR TITLE
Implement glfw joystick API

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -685,6 +685,7 @@ var LibraryGLFW = {
     refreshJoystick: function(joy) {
       // TODO: refresh all joysticks, and call from render loop?
       var j = GLFW.active.joys[joy];
+      if (!j) return;
 
       var gamepad = navigator.getGamepads()[j.index];
       if (!gamepad) return;

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -651,6 +651,7 @@ var LibraryGLFW = {
 
     setJoystickCallback: function(cbfun) {
       GLFW.joystickFunc = cbfun;
+      GLFW.refreshJoysticks();
     },
 
     joys: {}, // glfw joystick data

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -395,6 +395,8 @@ var LibraryGLFW = {
       GLFW.active.joys[joy] = {
         index: event.gamepad.index,
         id: allocate(intArrayFromString(event.gamepad.id), 'i8', ALLOC_NORMAL),
+        buttonsCount: event.gamepad.buttons.length,
+        axesCount: event.gamepad.axes.length,
         buttons: allocate(new Array(event.gamepad.buttons.length), 'i8', ALLOC_NORMAL),
         axes: allocate(new Array(event.gamepad.axes.length), 'float', ALLOC_NORMAL)
       };
@@ -412,7 +414,9 @@ var LibraryGLFW = {
         Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
       }
 
-      // TODO: free memory .axes, .buttons
+      _free(GLFW.active.joys[joy].id);
+      _free(GLFW.active.joys[joy].buttons);
+      //_free(GLFW.active.joys[joy].axes); // TODO: fix abort, corrupted memory?
 
       delete GLFW.active.gamepad2joy[event.gamepad.index];
       delete GLFW.active.joys[joy];
@@ -691,13 +695,13 @@ var LibraryGLFW = {
       var gamepad = navigator.getGamepads()[j.index];
       if (!gamepad) return;
 
-      j.buttonsCount = gamepad.buttons.length;
-      for (var i = 0; i < gamepad.buttons.length; ++i) {
+      assert(gamepad.buttons.length === j.buttonsCount);
+      for (var i = 0; i < j.buttonsCount;  ++i) {
         setValue(j.buttons + i, gamepad.buttons[i].pressed, 'i8');
       }
 
-      j.axesCount = gamepad.axes.length;
-      for (var i = 0; i < gamepad.axes.length; ++i) {
+      assert(gamepad.axes.length === j.axesCount);
+      for (var i = 0; i < j.axesCount; ++i) {
         setValue(j.axes + i*4, gamepad.axes[i], 'float');
       }
     },

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -56,9 +56,9 @@ var LibraryGLFW = {
       };
       this.buttons = 0;
       this.keys = new Array();
-      this.joyLast = 0; // GLFW_JOYSTICK_1
-      this.joys = {};
-      this.index2joy = {};
+      this.joyLast = 0; // next available: GLFW_JOYSTICK_1, 2, ...
+      this.joys = {}; // glfw joystick data, indexed by glfw joy id
+      this.gamepad2joy = {}; // HTML5 Gamepad API index to glfw joy id
       this.domKeys = new Array();
       this.shouldClose = 0;
       this.title = null;
@@ -400,14 +400,14 @@ var LibraryGLFW = {
         buttons: allocate(new Array(event.gamepad.buttons.length), 'float', ALLOC_NORMAL),
         axes: allocate(event.gamepad.axes, 'float', ALLOC_NORMAL)
       };
-      GLFW.active.index2joy[event.gamepad.index] = joy;
+      GLFW.active.gamepad2joy[event.gamepad.index] = joy;
       Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040001); // GLFW_CONNECTED
     },
 
     onGamepadDisconnected: function(event) {
       if (!GLFW.active.joystickFunc) return;
 
-      var joy = GLFW.active.index2joy[event.gamepad.index];
+      var joy = GLFW.active.gamepad2joy[event.gamepad.index];
 
       Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
 
@@ -415,7 +415,7 @@ var LibraryGLFW = {
       _free(joy.buttons);
       _free(joy.axes);
 
-      delete GLFW.active.index2joy[event.gamepad.index];
+      delete GLFW.active.gamepad2joy[event.gamepad.index];
       delete GLFW.active.joys[joy];
     },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -412,9 +412,7 @@ var LibraryGLFW = {
         Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
       }
 
-      _free(joy.id);
-      _free(joy.buttons);
-      _free(joy.axes);
+      // TODO: free memory .axes, .buttons
 
       delete GLFW.active.gamepad2joy[event.gamepad.index];
       delete GLFW.active.joys[joy];

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -674,7 +674,7 @@ var LibraryGLFW = {
                 buttonsCount: gamepad.buttons.length,
                 axesCount: gamepad.axes.length,
                 buttons: allocate(new Array(gamepad.buttons.length), 'i8', ALLOC_NORMAL),
-                axes: allocate(new Array(gamepad.axes.length), 'float', ALLOC_NORMAL)
+                axes: allocate(new Array(gamepad.axes.length*4), 'float', ALLOC_NORMAL)
               };
 
               if (GLFW.joystickFunc) {
@@ -701,7 +701,7 @@ var LibraryGLFW = {
 
               _free(GLFW.joys[joy].id);
               _free(GLFW.joys[joy].buttons);
-              //_free(GLFW.joys[joy].axes); // TODO: fix abort, corrupted memory?
+              _free(GLFW.joys[joy].axes);
 
               delete GLFW.joys[joy];
             }

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -395,8 +395,8 @@ var LibraryGLFW = {
       GLFW.active.joys[joy] = {
         index: event.gamepad.index,
         id: allocate(intArrayFromString(event.gamepad.id), 'i8', ALLOC_NORMAL),
-        buttons: allocate(new Array(event.gamepad.buttons.length), 'float', ALLOC_NORMAL),
-        axes: allocate(event.gamepad.axes, 'float', ALLOC_NORMAL)
+        buttons: allocate(new Array(event.gamepad.buttons.length), 'i8', ALLOC_NORMAL),
+        axes: allocate(new Array(event.gamepad.axes.length), 'float', ALLOC_NORMAL)
       };
       GLFW.active.gamepad2joy[event.gamepad.index] = joy;
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -386,8 +386,6 @@ var LibraryGLFW = {
     },
 
     onGamepadConnected: function(event) {
-      if (!GLFW.active.joystickFunc) return;
-
       // HTML5 Gamepad API reuses indexes
       // glfw joystick API spreads them out
       // http://www.glfw.org/docs/latest/input_guide.html#joystick
@@ -401,15 +399,18 @@ var LibraryGLFW = {
         axes: allocate(event.gamepad.axes, 'float', ALLOC_NORMAL)
       };
       GLFW.active.gamepad2joy[event.gamepad.index] = joy;
-      Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040001); // GLFW_CONNECTED
+
+      if (GLFW.active.joystickFunc) {
+        Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040001); // GLFW_CONNECTED
+      }
     },
 
     onGamepadDisconnected: function(event) {
-      if (!GLFW.active.joystickFunc) return;
-
       var joy = GLFW.active.gamepad2joy[event.gamepad.index];
 
-      Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
+      if (GLFW.active.joystickFunc) {
+        Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
+      }
 
       _free(joy.id);
       _free(joy.buttons);

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1454,7 +1454,11 @@ var LibraryGLFW = {
   },
 
   glfwGetJoystickName: function(joy) {
-    return GLFW.active.joys[joy].id;
+    if (GLFW.active.joys[joy]) {
+      return GLFW.active.joys[joy].id;
+    } else {
+      return 0;
+    }
   },
 
   glfwSetJoystickCallback: function(cbfun) {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1429,6 +1429,8 @@ var LibraryGLFW = {
   glfwCreateWindowSurface: function(instance, winid, allocator, surface) { throw "glfwCreateWindowSurface is not implemented."; },
 
   glfwJoystickPresent: function(joy) {
+    GLFW.refreshJoysticks();
+
     return GLFW.active.joys[joy] !== undefined;
   },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -411,7 +411,9 @@ var LibraryGLFW = {
 
       Module['dynCall_vii'](GLFW.active.joystickFunc, joy, 0x00040002); // GLFW_DISCONNECTED
 
-      // TODO: free memory .axes, .buttons
+      _free(joy.id);
+      _free(joy.buttons);
+      _free(joy.axes);
 
       delete GLFW.active.index2joy[event.gamepad.index];
       delete GLFW.active.joys[joy];

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -670,7 +670,7 @@ var LibraryGLFW = {
             if (!GLFW.joys[joy]) {
               console.log('glfw joystick connected:',joy);
               GLFW.joys[joy] = {
-                id: allocate(intArrayFromString(event.gamepad.id), 'i8', ALLOC_NORMAL),
+                id: allocate(intArrayFromString(gamepad.id), 'i8', ALLOC_NORMAL),
                 buttonsCount: gamepad.buttons.length,
                 axesCount: gamepad.axes.length,
                 buttons: allocate(new Array(gamepad.buttons.length), 'i8', ALLOC_NORMAL),

--- a/tests/glfw_joystick.c
+++ b/tests/glfw_joystick.c
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+#define GLFW_INCLUDE_ES2
+#include <GLFW/glfw3.h>
+
+int result = 1;
+
+GLFWwindow* g_window;
+
+void render();
+void error_callback(int error, const char* description);
+
+void render() {
+  glClearColor(0.7f, 0.7f, 0.7f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  for (int j = GLFW_JOYSTICK_1; j < GLFW_JOYSTICK_16; ++j) {
+    int joy = GLFW_JOYSTICK_1 + j;
+    if (!glfwJoystickPresent(joy)) continue;
+
+    static struct {
+      int axes_count;
+      float axes[16];
+      int button_count;
+      unsigned char buttons[16];
+    } last_gamepad_state[16] = {0};
+
+    const char *name = glfwGetJoystickName(joy);
+
+    int axes_count = 0;
+    const float *axes = glfwGetJoystickAxes(joy, &axes_count);
+
+    int button_count = 0;
+    const unsigned char *buttons = glfwGetJoystickButtons(joy, &button_count);
+
+    last_gamepad_state[joy].axes_count = axes_count;
+    for (int i = 0; i < axes_count; ++i) {
+      if (last_gamepad_state[joy].axes[i] != axes[i]) {
+        printf("(%d %s) axis %d = %f\n", joy, name, i, axes[i]);
+      }
+
+      last_gamepad_state[joy].axes[i] = axes[i];
+    }
+
+    last_gamepad_state[joy].button_count =  button_count;
+    for (int i = 0; i < button_count; ++i) {
+      if (last_gamepad_state[joy].buttons[i] != buttons[i]) {
+        printf("(%d %s) button %d = %d\n", joy, name, i, buttons[i]);
+      }
+
+      last_gamepad_state[joy].buttons[i] = buttons[i];
+    }
+  }
+}
+
+void joystick_callback(int joy, int event)
+{
+  if (event == GLFW_CONNECTED) {
+    printf("Joystick %d was connected: %s\n", joy, glfwGetJoystickName(joy));
+  } else if (event == GLFW_DISCONNECTED) {
+    printf("Joystick %d was disconnected\n", joy);
+  }
+}
+
+int main() {
+  if (!glfwInit())
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    return -1;
+  }
+  glfwWindowHint(GLFW_RESIZABLE , 1);
+  g_window = glfwCreateWindow(600, 450, "GLFW joystick test", NULL, NULL);
+  if (!g_window)
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    glfwTerminate();
+    return -1;
+  }
+  glfwMakeContextCurrent(g_window);
+  glfwSetJoystickCallback(joystick_callback);
+
+#ifdef __EMSCRIPTEN__
+    emscripten_set_main_loop(render, 0, 1);
+#else
+  while (!glfwWindowShouldClose(window)) {
+    glfwPollEvents();
+  }
+#endif
+
+  glfwTerminate();
+
+  return 0;
+}

--- a/tests/test_glfw_joystick.c
+++ b/tests/test_glfw_joystick.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+#define GLFW_INCLUDE_ES2
+#include <GLFW/glfw3.h>
+
+int result = 1;
+
+GLFWwindow* g_window;
+
+void render();
+void error_callback(int error, const char* description);
+
+int joy_connected = -1;
+
+void render() {
+  glClearColor(0.7f, 0.7f, 0.7f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  if (joy_connected == -1) return;
+
+  static struct {
+    int axes_count;
+    float axes[16];
+    int button_count;
+    unsigned char buttons[16];
+  } last_gamepad_state = {0};
+
+
+  int axes_count = 0;
+  const float *axes = glfwGetJoystickAxes(joy_connected, &axes_count);
+
+  int button_count = 0;
+  const unsigned char *buttons = glfwGetJoystickButtons(joy_connected, &button_count);
+
+  last_gamepad_state.axes_count = axes_count;
+  for (int i = 0; i < axes_count; ++i) {
+    if (last_gamepad_state.axes[i] != axes[i]) {
+      printf("axes %d = %f\n", i, axes[i]);
+    }
+
+    last_gamepad_state.axes[i] = axes[i];
+  }
+
+  last_gamepad_state.button_count =  button_count;
+  for (int i = 0; i < button_count; ++i) {
+    if (last_gamepad_state.buttons[i] != buttons[i]) {
+      printf("button %d = %d\n", i, buttons[i]);
+    }
+
+    last_gamepad_state.buttons[i] = buttons[i];
+  }
+}
+
+void joystick_callback(int joy, int event)
+{
+  if (event == GLFW_CONNECTED) {
+    printf("Joystick %d was connected: %s\n", joy, glfwGetJoystickName(joy));
+    joy_connected = joy; // use the most recently connected joystick
+  } else if (event == GLFW_DISCONNECTED) {
+    printf("Joystick %d was disconnected\n", joy);
+    if (joy == joy_connected) joy_connected = -1;
+  }
+}
+
+void main_2(void *arg) {
+  printf("Testing adding new gamepads\n");
+  emscripten_run_script("window.addNewGamepad('Pad Thai', 4, 16)");
+  emscripten_run_script("window.addNewGamepad('Pad Kee Mao', 0, 4)");
+  // Check that the joysticks exist properly.
+  assert(glfwJoystickPresent(GLFW_JOYSTICK_1));
+  assert(glfwJoystickPresent(GLFW_JOYSTICK_2));
+
+  assert(strcmp(glfwGetJoystickName(GLFW_JOYSTICK_1), "Pad Thai") == 0);
+  assert(strcmp(glfwGetJoystickName(GLFW_JOYSTICK_2), "Pad Kee Mao") == 0);
+
+  int axes_count = 0;
+  int buttons_count = 0;
+
+  glfwGetJoystickAxes(GLFW_JOYSTICK_1, &axes_count);
+  glfwGetJoystickButtons(GLFW_JOYSTICK_1, &buttons_count);
+  assert(axes_count == 4);
+  assert(buttons_count == 16);
+
+  glfwGetJoystickAxes(GLFW_JOYSTICK_2, &axes_count);
+  glfwGetJoystickButtons(GLFW_JOYSTICK_2, &buttons_count);
+  assert(axes_count == 0);
+  assert(buttons_count == 4);
+
+  // Buttons
+  printf("Testing buttons\n");
+  const unsigned char *buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_1, &buttons_count);
+  assert(buttons_count == 16);
+  assert(buttons[0] == 0);
+  emscripten_run_script("window.simulateGamepadButtonDown(0, 1)");
+  buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_1, &buttons_count);
+  assert(buttons_count == 16);
+  assert(buttons[1] == 1);
+
+  emscripten_run_script("window.simulateGamepadButtonUp(0, 1)");
+  buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_1, &buttons_count);
+  assert(buttons_count == 16);
+  assert(buttons[1] == 0);
+
+
+  emscripten_run_script("window.simulateGamepadButtonDown(1, 0)");
+  buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_2, &buttons_count);
+  assert(buttons_count == 4);
+  assert(buttons[0] == 1);
+
+  emscripten_run_script("window.simulateGamepadButtonUp(1, 0)");
+  buttons = glfwGetJoystickButtons(GLFW_JOYSTICK_2, &buttons_count);
+  assert(buttons_count == 4);
+  assert(buttons[1] == 0);
+
+  // Joystick wiggling
+  printf("Testing joystick axes\n");
+  emscripten_run_script("window.simulateAxisMotion(0, 0, 1)");
+  const float *axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &axes_count);
+  assert(axes_count == 4);
+  assert(axes[0] == 1);
+
+  emscripten_run_script("window.simulateAxisMotion(0, 0, 0)");
+  axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &axes_count);
+  assert(axes_count == 4);
+  assert(axes[0] == 0);
+
+  emscripten_run_script("window.simulateAxisMotion(0, 1, -1)");
+  axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &axes_count);
+  assert(axes_count == 4);
+  assert(axes[1] == -1);
+
+  // End test.
+  result = 2;
+  printf("Test passed!\n");
+  REPORT_RESULT();
+}
+
+int main() {
+  if (!glfwInit())
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    return -1;
+  }
+  glfwWindowHint(GLFW_RESIZABLE , 1);
+  g_window = glfwCreateWindow(600, 450, "GLFW joystick test", NULL, NULL);
+  if (!g_window)
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+    glfwTerminate();
+    return -1;
+  }
+  glfwMakeContextCurrent(g_window);
+  glfwSetJoystickCallback(joystick_callback);
+
+  emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
+
+#ifdef __EMSCRIPTEN__
+  emscripten_set_main_loop(render, 0, 1);
+#else
+  while (!glfwWindowShouldClose(window)) {
+    glfwPollEvents();
+  }
+#endif
+
+  glfwTerminate();
+
+  return 0;
+}

--- a/tests/test_glfw_joystick.c
+++ b/tests/test_glfw_joystick.c
@@ -11,49 +11,9 @@ int result = 1;
 
 GLFWwindow* g_window;
 
-void render();
 void error_callback(int error, const char* description);
 
 int joy_connected = -1;
-
-void render() {
-  glClearColor(0.7f, 0.7f, 0.7f, 1.0f);
-  glClear(GL_COLOR_BUFFER_BIT);
-
-  if (joy_connected == -1) return;
-
-  static struct {
-    int axes_count;
-    float axes[16];
-    int button_count;
-    unsigned char buttons[16];
-  } last_gamepad_state = {0};
-
-
-  int axes_count = 0;
-  const float *axes = glfwGetJoystickAxes(joy_connected, &axes_count);
-
-  int button_count = 0;
-  const unsigned char *buttons = glfwGetJoystickButtons(joy_connected, &button_count);
-
-  last_gamepad_state.axes_count = axes_count;
-  for (int i = 0; i < axes_count; ++i) {
-    if (last_gamepad_state.axes[i] != axes[i]) {
-      printf("axes %d = %f\n", i, axes[i]);
-    }
-
-    last_gamepad_state.axes[i] = axes[i];
-  }
-
-  last_gamepad_state.button_count =  button_count;
-  for (int i = 0; i < button_count; ++i) {
-    if (last_gamepad_state.buttons[i] != buttons[i]) {
-      printf("button %d = %d\n", i, buttons[i]);
-    }
-
-    last_gamepad_state.buttons[i] = buttons[i];
-  }
-}
 
 void joystick_callback(int joy, int event)
 {

--- a/tests/test_glfw_joystick.c
+++ b/tests/test_glfw_joystick.c
@@ -166,9 +166,7 @@ int main() {
 
   emscripten_async_call(main_2, NULL, 3000); // avoid startup delays and intermittent errors
 
-#ifdef __EMSCRIPTEN__
-  emscripten_set_main_loop(render, 0, 1);
-#else
+#ifndef __EMSCRIPTEN__
   while (!glfwWindowShouldClose(window)) {
     glfwPollEvents();
   }

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -140,6 +140,9 @@ class interactive(BrowserCore):
   def test_glfw_get_key_stuck(self):
     self.btest('test_glfw_get_key_stuck.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
 
+  def test_glfw_joystick(self):
+    self.btest('glfw_joystick.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
+
   def test_glfw_pointerlock(self):
     self.btest('test_glfw_pointerlock.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
 


### PR DESCRIPTION
Adds support for glfw3's joystick functions: http://www.glfw.org/docs/latest/input_guide.html#joystick

- [x] glfwJoystickPresent
- [x] glfwGetJoystickAxes
- [x] glfwGetJoystickButtons
- [x] glfwGetJoystickName
- [x] glfwSetJoystickCallback

Includes a test based on the sdl joystick test:

```sh
python tests/runner.py browser.test_glfw_joystick
```

Also manually tested with a real joystick and a more complex real-world application which had native glfw joystick support (https://github.com/satoshinm/NetCraft/pull/80)

---

- [x] Add _free()s on gamepaddisconnect, .id .buttons
- [x] Add _free()s on gamepaddisconnect, .axes
- [x] Incorporate most review feedback
- [x] Browser test: `python tests/runner.py browser.test_glfw_joystick`
- [x] Interactive test: `python tests/runner.py interactive.test_glfw_joystick`
- [x] Test versus emscripten gamepad API, and native glfw API
- [x] Poll once per frame, see https://github.com/kripken/emscripten/pull/4292