### PR TITLE
Add missing SIMD closure externs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -292,4 +292,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ryan Speets <ryan@speets.ca>
 * Fumiya Chiba <fumiya.chiba@nifty.com>
 * Ryan C. Gordon <icculus@icculus.org>
-
+* Inseok Lee <dlunch@gmail.com>

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -849,6 +849,64 @@ SIMD.Bool16x8.xor = function() {};
 SIMD.Bool32x4.xor = function() {};
 SIMD.Bool64x2.xor = function() {};
 
+SIMD.Float32x4.load1 = function() {};
+SIMD.Float32x4.load2 = function() {};
+SIMD.Float32x4.load3 = function() {};
+SIMD.Float32x4.load4 = function() {};
+SIMD.Float32x4.store1 = function() {};
+SIMD.Float32x4.store2 = function() {};
+SIMD.Float32x4.store3 = function() {};
+SIMD.Float32x4.store4 = function() {};
+
+SIMD.Int32x4.load1 = function() {};
+SIMD.Int32x4.load2 = function() {};
+SIMD.Int32x4.load3 = function() {};
+SIMD.Int32x4.load4 = function() {};
+SIMD.Int32x4.store1 = function() {};
+SIMD.Int32x4.store2 = function() {};
+SIMD.Int32x4.store3 = function() {};
+SIMD.Int32x4.store4 = function() {};
+
+SIMD.Uint32x4.load1 = function() {};
+SIMD.Uint32x4.load2 = function() {};
+SIMD.Uint32x4.load3 = function() {};
+SIMD.Uint32x4.load4 = function() {};
+SIMD.Uint32x4.store1 = function() {};
+SIMD.Uint32x4.store2 = function() {};
+SIMD.Uint32x4.store3 = function() {};
+SIMD.Uint32x4.store4 = function() {};
+
+SIMD.bool64x2.anyTrue = function() {};
+SIMD.bool32x4.anyTrue = function() {};
+SIMD.bool16x8.anyTrue = function() {};
+SIMD.bool8x16.anyTrue = function() {};
+
+SIMD.Float32x4.fromBool64x2Bits = function() {};
+SIMD.Float64x2.fromBool64x2Bits = function() {};
+SIMD.Int8x16.fromBool64x2Bits = function() {};
+SIMD.Int16x8.fromBool64x2Bits = function() {};
+SIMD.Int32x4.fromBool64x2Bits = function() {};
+SIMD.Uint8x16.fromBool64x2Bits = function() {};
+SIMD.Uint16x8.fromBool64x2Bits = function() {};
+SIMD.Uint32x4.fromBool64x2Bits = function() {};
+SIMD.Bool8x16.fromBool64x2Bits = function() {};
+SIMD.Bool16x8.fromBool64x2Bits = function() {};
+SIMD.Bool32x4.fromBool64x2Bits = function() {};
+SIMD.Bool64x2.fromBool64x2Bits = function() {};
+
+SIMD.Float32x4.fromFloat64x2 = function() {};
+SIMD.Float64x2.fromFloat64x2 = function() {};
+SIMD.Int8x16.fromFloat64x2 = function() {};
+SIMD.Int16x8.fromFloat64x2 = function() {};
+SIMD.Int32x4.fromFloat64x2 = function() {};
+SIMD.Uint8x16.fromFloat64x2 = function() {};
+SIMD.Uint16x8.fromFloat64x2 = function() {};
+SIMD.Uint32x4.fromFloat64x2 = function() {};
+SIMD.Bool8x16.fromFloat64x2 = function() {};
+SIMD.Bool16x8.fromFloat64x2 = function() {};
+SIMD.Bool32x4.fromFloat64x2 = function() {};
+SIMD.Bool64x2.fromFloat64x2 = function() {};
+
 var GLctx = {};
 
 /**

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4941,6 +4941,9 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-msse']
+      if '-O2' in self.emcc_args:
+        self.emcc_args += ['--closure', '1'] # Use closure here for some additional coverage
+
       self.do_run(open(path_from_root('tests', 'test_sse1.cpp'), 'r').read(), 'Success!')
 
   # ignore nans in some simd tests due to an LLVM regression still being investigated,
@@ -4961,6 +4964,9 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse']
+      if '-O2' in self.emcc_args:
+        self.emcc_args += ['--closure', '1'] # Use closure here for some additional coverage
+
       self.do_run(open(path_from_root('tests', 'test_sse1_full.cpp'), 'r').read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
 
   # Tests the full SSE2 API.
@@ -4981,6 +4987,9 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse2'] + args
+      if '-O2' in self.emcc_args:
+        self.emcc_args += ['--closure', '1'] # Use closure here for some additional coverage
+
       self.do_run(open(path_from_root('tests', 'test_sse2_full.cpp'), 'r').read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
 
   # Tests the full SSE3 API.


### PR DESCRIPTION
Some SIMD functions are missing on closure extern file, preventing SIMD.js code to run with closure compiler. This commit resolves the problem. 