### PR TITLE
Duplicate function elimination fixes

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1284,6 +1284,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
         assert not shared.Settings.SPLIT_MEMORY, 'WebAssembly does not support split memory'
         assert not shared.Settings.USE_PTHREADS, 'WebAssembly does not support pthreads'
+        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
+          logging.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
+          shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
         # if root was not specified in -s, it might be fixed in ~/.emscripten, copy from there
         if not shared.Settings.BINARYEN_ROOT:
           try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5398,7 +5398,6 @@ def process(filename):
                      #, build_ll_hook=self.do_autodebug)
 
     test()
-    num_original_funcs = self.count_funcs('src.cpp.o.js')
 
     if not self.is_wasm(): # wasm does this all the time
       # Run with duplicate function elimination turned on
@@ -5407,12 +5406,11 @@ def process(filename):
       for opt_level in dfe_supported_opt_levels:
         if opt_level in self.emcc_args:
           print >> sys.stderr, "Testing poppler with ELIMINATE_DUPLICATE_FUNCTIONS set to 1"
+          num_original_funcs = self.count_funcs('src.cpp.o.js')
           Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
           test()
-
           # Make sure that DFE ends up eliminating more than 200 functions (if we can view source)
-          if not self.is_wasm():
-            assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
+          assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
           break
 
   @sync

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,7 +41,8 @@ def no_wasm_backend(note=''):
 # Async wasm compilation can't work in some tests, they are set up synchronously
 def sync(f):
   def decorated(self):
-    self.emcc_args += ['-s', 'BINARYEN_ASYNC_COMPILATION=0'] # test is set up synchronously
+    if self.is_wasm():
+      self.emcc_args += ['-s', 'BINARYEN_ASYNC_COMPILATION=0'] # test is set up synchronously
     f(self)
   return decorated
 
@@ -5399,19 +5400,20 @@ def process(filename):
     test()
     num_original_funcs = self.count_funcs('src.cpp.o.js')
 
-    # Run with duplicate function elimination turned on
-    dfe_supported_opt_levels = ['-O2', '-O3', '-Oz', '-Os']
+    if not self.is_wasm(): # wasm does this all the time
+      # Run with duplicate function elimination turned on
+      dfe_supported_opt_levels = ['-O2', '-O3', '-Oz', '-Os']
 
-    for opt_level in dfe_supported_opt_levels:
-      if opt_level in self.emcc_args:
-        print >> sys.stderr, "Testing poppler with ELIMINATE_DUPLICATE_FUNCTIONS set to 1"
-        Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
-        test()
+      for opt_level in dfe_supported_opt_levels:
+        if opt_level in self.emcc_args:
+          print >> sys.stderr, "Testing poppler with ELIMINATE_DUPLICATE_FUNCTIONS set to 1"
+          Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
+          test()
 
-        # Make sure that DFE ends up eliminating more than 200 functions (if we can view source)
-        if not self.is_wasm():
-          assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
-        break
+          # Make sure that DFE ends up eliminating more than 200 functions (if we can view source)
+          if not self.is_wasm():
+            assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
+          break
 
   @sync
   def test_openjpeg(self):


### PR DESCRIPTION
 ELIMINATE_DUPLICATE_FUNCTIONS is not needed in wasm, as we have the binaryen optimizer do that for us anyhow when optimizing. remove unneeded testing of that option for wasm in test_poppler. also fix testing of that option for asm.js: we were misidentifying ourselves as wasm due to disabling binaryen async compilation (the options string contains BINARYEN), so just add that when in wasm mode.