### PR TITLE
Added emscripten_webgl_get_drawing_buffer_size to html5.h

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2045,13 +2045,15 @@ Functions
 	
 	
 	
-.. c:function:: void emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height)
+.. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height)
 
-	Gets the drawingBufferWidth/drawingBufferHeight of the specified WebGL context.
+	Gets the ``drawingBufferWidth`` and ``drawingBufferHeight`` of the specified WebGL context.
 
 	:param EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context: The WebGL context to get width/height of.
-	:param int* width: The context's drawingBufferWidth.
-	:param int* height: The context's drawingBufferHeight.
+	:param int *width: The context's ``drawingBufferWidth``.
+	:param int *height: The context's ``drawingBufferHeight``.
+	:returns: :c:data:`EMSCRIPTEN_RESULT_SUCCESS`, or one of the other result values.
+	:rtype: |EMSCRIPTEN_RESULT|
 	
 
 .. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context)

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2044,6 +2044,16 @@ Functions
 	:rtype: |EMSCRIPTEN_WEBGL_CONTEXT_HANDLE|
 	
 	
+	
+.. c:function:: void emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height)
+
+	Gets the drawingBufferWidth/drawingBufferHeight of the specified WebGL context.
+
+	:param EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context: The WebGL context to get width/height of.
+	:param int* width: The context's drawingBufferWidth.
+	:param int* height: The context's drawingBufferHeight.
+	
+
 .. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context)
 
 	Deletes the given WebGL context. If that context was active, then the no context is set to active.

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1866,9 +1866,14 @@ var LibraryJSEvents = {
   },
 
   emscripten_webgl_get_drawing_buffer_size: function(contextHandle, width, height) {
-    var GLContext = GL.getContext(contextHandle).GLctx;
-    {{{ makeSetValue('width', '0', 'GLContext.drawingBufferWidth', 'i32') }}};
-    {{{ makeSetValue('height', '0', 'GLContext.drawingBufferHeight', 'i32') }}};
+    var GLContext = GL.getContext(contextHandle);
+
+    if(!GLContext || !GLContext.GLctx || !width || !height) {
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    }
+    {{{ makeSetValue('width', '0', 'GLContext.GLctx.drawingBufferWidth', 'i32') }}};
+    {{{ makeSetValue('height', '0', 'GLContext.GLctx.drawingBufferHeight', 'i32') }}};
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
   emscripten_webgl_commit_frame: function() {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1865,6 +1865,12 @@ var LibraryJSEvents = {
     return GL.currentContext ? GL.currentContext.handle : 0;
   },
 
+  emscripten_webgl_get_drawing_buffer_size: function(contextHandle, width, height) {
+    var GLContext = GL.getContext(contextHandle).GLctx;
+    {{{ makeSetValue('width', '0', 'GLContext.drawingBufferWidth', 'i32') }}};
+    {{{ makeSetValue('height', '0', 'GLContext.drawingBufferHeight', 'i32') }}};
+  },
+
   emscripten_webgl_commit_frame: function() {
     if (!GL.currentContext || !GL.currentContext.GLctx) {
 #if GL_DEBUG

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -424,6 +424,8 @@ extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_
 
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
+extern void emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
+
 extern EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 extern EM_BOOL emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension);

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -424,7 +424,7 @@ extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_
 
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
-extern void emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
+extern EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 


### PR DESCRIPTION
There wasn't a way of getting this info before, so I added it. In most cases, this will return the same width and height as the canvas width/height, but that depends on the implementation.