### PR TITLE
Fix embinding derived classes

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -25,6 +25,7 @@ namespace emscripten {
         typedef long GenericEnumValue;
 
         typedef void* GenericFunction;
+        typedef void (*VoidFunctionPtr)(void);
 
         // Implemented in JavaScript.  Don't call these directly.
         extern "C" {
@@ -1012,12 +1013,12 @@ namespace emscripten {
             }
 
             template<typename ClassType>
-            static GenericFunction getUpcaster() {
+            static VoidFunctionPtr getUpcaster() {
                 return nullptr;
             }
 
             template<typename ClassType>
-            static GenericFunction getDowncaster() {
+            static VoidFunctionPtr getDowncaster() {
                 return nullptr;
             }
         };
@@ -1116,13 +1117,12 @@ namespace emscripten {
 
         EMSCRIPTEN_ALWAYS_INLINE explicit class_(const char* name) {
             using namespace internal;
-            typedef void (*VoidFunctionPtr)(void);
 
             BaseSpecifier::template verify<ClassType>();
 
             auto _getActualType = &getActualType<ClassType>;
-            VoidFunctionPtr upcast   = (VoidFunctionPtr)BaseSpecifier::template getUpcaster<ClassType>();
-            VoidFunctionPtr downcast = (VoidFunctionPtr)BaseSpecifier::template getDowncaster<ClassType>();
+            auto upcast   = BaseSpecifier::template getUpcaster<ClassType>();
+            auto downcast = BaseSpecifier::template getDowncaster<ClassType>();
             auto destructor = &raw_destructor<ClassType>;
 
             _embind_register_class(

--- a/tests/core/test_embind_5.cpp
+++ b/tests/core/test_embind_5.cpp
@@ -2,29 +2,50 @@
 #include <emscripten/bind.h>
 
 using namespace emscripten;
+
+
 class MyFoo {
 public:
-    MyFoo() {
-        EM_ASM({print("constructing my foo");});
-    }
-    void doit() {
-        EM_ASM({print("doing it");});
-    }
+  MyFoo() {
+    EM_ASM({Module.print("constructing my foo");});
+  }
+  virtual void doit() {
+    EM_ASM({Module.print("doing it");});
+  }
 };
+
+class MyBar : public MyFoo {
+public:
+  MyBar() {
+    EM_ASM({Module.print("constructing my bar");});
+  }
+  void doit() override {
+    EM_ASM({Module.print("doing something else");});
+  }
+};
+
+
 EMSCRIPTEN_BINDINGS(my_module) {
-    class_<MyFoo>("MyFoo")
-      .constructor<>()
-      .function("doit", &MyFoo::doit)
-      ;
+  class_<MyFoo>("MyFoo")
+    .constructor<>()
+    .function("doit", &MyFoo::doit)
+    ;
+  class_<MyBar, base<MyFoo>>("MyBar")
+    .constructor<>()
+    ;
 }
+
+
 int main(int argc, char **argv) {
-    EM_ASM(
-      try {
-        var foo = new Module.MyFoo();
-        foo.doit();
-      } catch(e) {
-        Module.print(e);
-      }
-    );
-    return 0;
+  EM_ASM(
+    try {
+      var foo = new Module.MyFoo();
+      foo.doit();
+      var bar = new Module.MyBar();
+      bar.doit();
+    } catch(e) {
+      Module.print(e);
+    }
+  );
+  return 0;
 }

--- a/tests/core/test_embind_5.out
+++ b/tests/core/test_embind_5.out
@@ -1,2 +1,5 @@
 constructing my foo
 doing it
+constructing my foo
+constructing my bar
+doing something else


### PR DESCRIPTION
Fixes breakage introduced in https://github.com/kripken/emscripten/pull/5117
Added reproducer to `test_embind_5` (derived class embinding)
Tested with asmjs and asm2wasm with `*.test_embind*`, `other.test_embind` fails in the same way it did before #5117, no other failure
Tested with wasm backend with `binaryen*.test_embind*`, no failure