### PR TITLE
use the binaryen ctor-eval tool for wasm instead of the js-based one

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1329,9 +1329,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
           shared.Settings.RUNNING_JS_OPTS = 1
         else:
-          # for wasm, we really want no-exit-runtime, so that atexits don't stop us
-          if not shared.Settings.NO_EXIT_RUNTIME:
-            logging.warning('you should enable  -s NO_EXIT_RUNTIME=1  so that EVAL_CTORS can work at full efficiency (it gets rid of atexit calls which might disrupt EVAL_CTORS)')
+          if 'interpret' in shared.Settings.BINARYEN_METHOD:
+            logging.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
+            shared.Settings.EVAL_CTORS = 0
+          else:
+            # for wasm, we really want no-exit-runtime, so that atexits don't stop us
+            if not shared.Settings.NO_EXIT_RUNTIME:
+              logging.warning('you should enable  -s NO_EXIT_RUNTIME=1  so that EVAL_CTORS can work at full efficiency (it gets rid of atexit calls which might disrupt EVAL_CTORS)')
 
       if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
         # this is an issue in asm.js, but not wasm

--- a/emcc.py
+++ b/emcc.py
@@ -1939,7 +1939,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if opt_level >= 2:
           # simplify ifs if it is ok to make the code somewhat unreadable, and unless outlining (simplified ifs
           # with commaified code breaks late aggressive variable elimination)
-          if shared.Settings.SIMPLIFY_IFS and (debug_level == 0 or profiling) and shared.Settings.OUTLINING_LIMIT == 0: JSOptimizer.queue += ['simplifyIfs']
+          # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
+          if shared.Settings.SIMPLIFY_IFS and (debug_level == 0 or profiling) and shared.Settings.OUTLINING_LIMIT == 0 and not shared.Settings.BINARYEN:
+            JSOptimizer.queue += ['simplifyIfs']
 
           if shared.Settings.PRECISE_F32: JSOptimizer.queue += ['optimizeFrounds']
 
@@ -2179,7 +2181,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             subprocess.check_call(cmd)
           if import_mem_init:
             # remove and forget about the mem init file in later processing; it does not need to be prefetched in the html, etc.
-            os.unlink(memfile)
+            if DEBUG:
+              safe_move(memfile, os.path.join(emscripten_temp_dir, os.path.basename(memfile)))
+            else:
+              os.unlink(memfile)
             memory_init_file = False
           log_time('asm2wasm')
         if shared.Settings.BINARYEN_PASSES:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6113,9 +6113,12 @@ def process(filename):
 
     self.do_run_in_out_file_test('tests', 'core', 'test_tracing')
 
-  @no_wasm # TODO: ctor evaller in binaryen
+  @no_wasm_backend('TODO')
   def test_eval_ctors(self):
     if '-O2' not in str(self.emcc_args) or '-O1' in str(self.emcc_args): return self.skip('need js optimizations')
+
+    if self.is_wasm():
+      self.emcc_args += ['-s', 'NO_EXIT_RUNTIME=1']
 
     orig_args = self.emcc_args[:] + ['-s', 'EVAL_CTORS=0']
 
@@ -6143,13 +6146,15 @@ def process(filename):
       code_size = os.stat(code_file).st_size
       if self.uses_memory_init_file():
         mem_size = os.stat('src.cpp.o.js.mem').st_size
-      # if we are wasm, then eval-ctors disables wasm-only, losing i64 opts, increasing size
+      # if we are wasm, then the mem init is inside the wasm too, so the total change in code+data may grow *or* shrink
       code_size_should_shrink = not self.is_wasm()
       print code_size, ' => ', ec_code_size, ', are we testing code size?', code_size_should_shrink
       if self.uses_memory_init_file():
         print mem_size, ' => ', ec_mem_size
       if code_size_should_shrink:
         assert ec_code_size < code_size
+      else:
+        assert ec_code_size != code_size, 'should at least change'
       if self.uses_memory_init_file():
         assert ec_mem_size > mem_size
 

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -9,10 +9,13 @@ import shared, js_optimizer
 from tempfiles import try_delete
 
 js_file = sys.argv[1]
-mem_init_file = sys.argv[2]
+binary_file = sys.argv[2] # mem init for js, wasm binary for wasm
 total_memory = int(sys.argv[3])
 total_stack = int(sys.argv[4])
 global_base = int(sys.argv[5])
+binaryen_bin = sys.argv[6]
+
+wasm = not not binaryen_bin
 
 assert global_base > 0
 
@@ -32,7 +35,17 @@ def find_ctors(js):
   ctors_end += 3
   return (ctors_start, ctors_end)
 
-def eval_ctors(js, mem_init, num):
+def find_ctors_data(js, num):
+  ctors_start, ctors_end = find_ctors(js)
+  assert ctors_start > 0
+  ctors_text = js[ctors_start:ctors_end]
+  all_ctors = filter(lambda ctor: ctor.endswith('()') and not ctor == 'function()' and '.' not in ctor, ctors_text.split(' '))
+  all_ctors = map(lambda ctor: ctor.replace('()', ''), all_ctors)
+  assert len(all_ctors) > 0
+  ctors = all_ctors[:num]
+  return ctors_start, ctors_end, all_ctors, ctors
+
+def eval_ctors_js(js, mem_init, num):
 
   def kill_func(asm, name):
     before = len(asm)
@@ -48,14 +61,7 @@ def eval_ctors(js, mem_init, num):
     return asm
 
   # Find the global ctors
-  ctors_start, ctors_end = find_ctors(js)
-  assert ctors_start > 0
-  ctors_text = js[ctors_start:ctors_end]
-  all_ctors = filter(lambda ctor: ctor.endswith('()') and not ctor == 'function()' and '.' not in ctor, ctors_text.split(' '))
-  all_ctors = map(lambda ctor: ctor.replace('()', ''), all_ctors)
-  total_ctors = len(all_ctors)
-  assert total_ctors > 0
-  ctors = all_ctors[:num]
+  ctors_start, ctors_end, all_ctors, ctors = find_ctors_data(js, num)
   shared.logging.debug('trying to eval ctors: ' + ', '.join(ctors))
   # Find the asm module, and receive the mem init.
   asm = get_asm(js)
@@ -257,6 +263,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
   # out contains the new mem init and other info
   num_successful, mem_init_raw, atexits = json.loads(out_result)
   mem_init = ''.join(map(chr, mem_init_raw))
+  total_ctors = len(all_ctors)
   if num_successful < total_ctors:
     shared.logging.debug('not all ctors could be evalled, something was used that was not safe (and therefore was not defined, and caused an error):\n========\n' + err_result + '========')
   # Remove the evalled ctors, add a new one for atexits if needed, and write that out
@@ -271,6 +278,23 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
     new_ctors = '__ATINIT__.push(' + ', '.join(elements) + ');'
   js = js[:ctors_start] + new_ctors + js[ctors_end:]
   return (num_successful, js, mem_init, ctors)
+
+def eval_ctors_wasm(js, wasm_file, num):
+  ctors_start, ctors_end, all_ctors, ctors = find_ctors_data(js, num)
+  cmd = [os.path.join(binaryen_bin, 'wasm-ctor-eval'), wasm_file, '-o', wasm_file, '--ctors=' + ','.join(ctors)]
+  shared.logging.debug('wasm ctor cmd: ' + str(cmd))
+  out, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+  num_successful = err.count('success on')
+
+  if len(ctors) == len(all_ctors):
+    new_ctors = ''
+  else:
+    elements = []
+    for ctor in all_ctors[num:]:
+      elements.append('{ func: function() { %s() } }' % ctor)
+    new_ctors = '__ATINIT__.push(' + ', '.join(elements) + ');'
+  js = js[:ctors_start] + new_ctors + js[ctors_end:]
+  return num_successful, js
 
 # main
 if __name__ == '__main__':
@@ -288,50 +312,63 @@ if __name__ == '__main__':
   num_ctors = ctors_text.count('function()')
   shared.logging.debug('ctor_evaller: %d ctors, from |%s|' % (num_ctors, ctors_text))
 
-  if os.path.exists(mem_init_file):
-    mem_init = json.dumps(map(ord, open(mem_init_file, 'rb').read()))
+  if not wasm:
+    # js path
+    mem_init_file = binary_file
+    if os.path.exists(mem_init_file):
+      mem_init = json.dumps(map(ord, open(mem_init_file, 'rb').read()))
+    else:
+      mem_init = []
+
+    # find how many ctors we can remove, by bisection (if there are hundreds, running them sequentially is silly slow)
+
+    shared.logging.debug('ctor_evaller: trying to eval %d global constructors' % num_ctors)
+    num_successful, new_js, new_mem_init, removed = eval_ctors_js(js, mem_init, num_ctors)
+    if num_successful == 0:
+      shared.logging.debug('ctor_evaller: not successful')
+      sys.exit(0)
+
+    shared.logging.debug('ctor_evaller: we managed to remove %d ctors' % num_successful)
+    if num_successful == num_ctors:
+      js = new_js
+      mem_init = new_mem_init
+    else:
+      shared.logging.debug('ctor_evaller: final execution')
+      check, js, mem_init, removed = eval_ctors_js(js, mem_init, num_successful)
+      assert check == num_successful
+    open(js_file, 'w').write(js)
+    open(mem_init_file, 'wb').write(mem_init)
+
+    # Dead function elimination can help us
+
+    shared.logging.debug('ctor_evaller: eliminate no longer needed functions after ctor elimination')
+    # find exports
+    asm = get_asm(open(js_file).read())
+    exports_start = asm.find('return {')
+    exports_end = asm.find('};', exports_start)
+    exports_text = asm[asm.find('{', exports_start) + 1 : exports_end]
+    exports = map(lambda x: x.split(':')[1].strip(), exports_text.replace(' ', '').split(','))
+    for r in removed:
+      assert r in exports, 'global ctors were exported'
+    exports = filter(lambda e: e not in removed, exports)
+    # fix up the exports
+    js = open(js_file).read()
+    absolute_exports_start = js.find(exports_text)
+    js = js[:absolute_exports_start] + ', '.join(map(lambda e: e + ': ' + e, exports)) + js[absolute_exports_start + len(exports_text):]
+    open(js_file, 'w').write(js)
+    # find unreachable methods and remove them
+    reachable = shared.Building.calculate_reachable_functions(js_file, exports, can_reach=False)['reachable']
+    for r in removed:
+      assert r not in reachable, 'removed ctors must NOT be reachable'
+    shared.Building.js_optimizer(js_file, ['removeFuncs'], extra_info={ 'keep': reachable }, output_filename=js_file)
   else:
-    mem_init = []
-
-  # find how many ctors we can remove, by bisection (if there are hundreds, running them sequentially is silly slow)
-
-  shared.logging.debug('ctor_evaller: trying to eval %d global constructors' % num_ctors)
-  num_successful, new_js, new_mem_init, removed = eval_ctors(js, mem_init, num_ctors)
-  if num_successful == 0:
-    shared.logging.debug('ctor_evaller: not successful')
-    sys.exit(0)
-
-  shared.logging.debug('ctor_evaller: we managed to remove %d ctors' % num_successful)
-  if num_successful == num_ctors:
-    js = new_js
-    mem_init = new_mem_init
-  else:
-    shared.logging.debug('ctor_evaller: final execution')
-    check, js, mem_init, removed = eval_ctors(js, mem_init, num_successful)
-    assert check == num_successful
-  open(js_file, 'w').write(js)
-  open(mem_init_file, 'wb').write(mem_init)
-
-  # Dead function elimination can help us
-
-  shared.logging.debug('ctor_evaller: eliminate no longer needed functions after ctor elimination')
-  # find exports
-  asm = get_asm(open(js_file).read())
-  exports_start = asm.find('return {')
-  exports_end = asm.find('};', exports_start)
-  exports_text = asm[asm.find('{', exports_start) + 1 : exports_end]
-  exports = map(lambda x: x.split(':')[1].strip(), exports_text.replace(' ', '').split(','))
-  for r in removed:
-    assert r in exports, 'global ctors were exported'
-  exports = filter(lambda e: e not in removed, exports)
-  # fix up the exports
-  js = open(js_file).read()
-  absolute_exports_start = js.find(exports_text)
-  js = js[:absolute_exports_start] + ', '.join(map(lambda e: e + ': ' + e, exports)) + js[absolute_exports_start + len(exports_text):]
-  open(js_file, 'w').write(js)
-  # find unreachable methods and remove them
-  reachable = shared.Building.calculate_reachable_functions(js_file, exports, can_reach=False)['reachable']
-  for r in removed:
-    assert r not in reachable, 'removed ctors must NOT be reachable'
-  shared.Building.js_optimizer(js_file, ['removeFuncs'], extra_info={ 'keep': reachable }, output_filename=js_file)
+    # wasm path
+    wasm_file = binary_file
+    shared.logging.debug('ctor_evaller (wasm): trying to eval %d global constructors' % num_ctors)
+    num_successful, new_js = eval_ctors_wasm(js, wasm_file, num_ctors)
+    if num_successful == 0:
+      shared.logging.debug('ctor_evaller: not successful')
+      sys.exit(0)
+    shared.logging.debug('ctor_evaller: we managed to remove %d ctors' % num_successful)
+    open(js_file, 'w').write(new_js)
 

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -285,7 +285,7 @@ def eval_ctors_wasm(js, wasm_file, num):
   shared.logging.debug('wasm ctor cmd: ' + str(cmd))
   out, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
   num_successful = err.count('success on')
-
+  shared.logging.debug(err)
   if len(ctors) == len(all_ctors):
     new_ctors = ''
   else:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1186,7 +1186,7 @@ class Settings2(type):
         self.attrs['ASSERTIONS'] = 0
         self.attrs['DISABLE_EXCEPTION_CATCHING'] = 1
         self.attrs['ALIASING_FUNCTION_POINTERS'] = 1
-      if shrink_level >= 2:
+      if shrink_level >= 2 and not self.attrs['BINARYEN']:
         self.attrs['EVAL_CTORS'] = 1
 
     def __getattr__(self, attr):
@@ -2056,9 +2056,10 @@ class Building:
     subprocess.check_call(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes, stdout=open(next, 'w'))
     return next
 
+  # evals ctors. if binaryen_bin is provided, it is the dir of the binaryen tool for this, and we are in wasm mode
   @staticmethod
-  def eval_ctors(js_file, mem_init_file):
-    subprocess.check_call([PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, mem_init_file, str(Settings.TOTAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE)])
+  def eval_ctors(js_file, binary_file, binaryen_bin=''):
+    subprocess.check_call([PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(Settings.TOTAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE), binaryen_bin])
 
   @staticmethod
   def eliminate_duplicate_funcs(filename):


### PR DESCRIPTION
This is much faster. Also it means we can eval ctors in wasm-only mode (before, we used the ctor evaller for js, so we had to emit valid js).

Depends on https://github.com/WebAssembly/binaryen/pull/996