### PR TITLE
registerizeHarder should not dce out the contents of the dceable help…

### DIFF
--- a/tests/optimizer/test-js-optimizer-asm-regs-harder-output.js
+++ b/tests/optimizer/test-js-optimizer-asm-regs-harder-output.js
@@ -138,4 +138,17 @@ function b1() {
  abort(1);
  return SIMD_Float32x4(0, 0, 0, 0);
 }
+function __emscripten_dceable_type_decls() {
+ ___cxa_throw(0, 0, 0);
+ ___cxa_rethrow();
+ ___cxa_end_catch();
+ ___cxa_pure_virtual();
+ _getenv(0) | 0;
+ _pthread_mutex_lock(0) | 0;
+ _pthread_cond_broadcast(0) | 0;
+ _pthread_mutex_unlock(0) | 0;
+ _pthread_cond_wait(0, 0) | 0;
+ _strftime(0, 0, 0, 0) | 0;
+ +_fabs(+0);
+}
 

--- a/tests/optimizer/test-js-optimizer-asm-regs-harder-output2.js
+++ b/tests/optimizer/test-js-optimizer-asm-regs-harder-output2.js
@@ -138,4 +138,17 @@ function b1() {
  abort(1);
  return SIMD_Float32x4(0, 0, 0, 0);
 }
+function __emscripten_dceable_type_decls() {
+ ___cxa_throw(0, 0, 0);
+ ___cxa_rethrow();
+ ___cxa_end_catch();
+ ___cxa_pure_virtual();
+ _getenv(0) | 0;
+ _pthread_mutex_lock(0) | 0;
+ _pthread_cond_broadcast(0) | 0;
+ _pthread_mutex_unlock(0) | 0;
+ _pthread_cond_wait(0, 0) | 0;
+ _strftime(0, 0, 0, 0) | 0;
+ +_fabs(+0);
+}
 

--- a/tests/optimizer/test-js-optimizer-asm-regs-harder-output3.js
+++ b/tests/optimizer/test-js-optimizer-asm-regs-harder-output3.js
@@ -138,4 +138,17 @@ function b1() {
  abort(1);
  return SIMD_Float32x4(0, 0, 0, 0);
 }
+function __emscripten_dceable_type_decls() {
+ ___cxa_throw(0, 0, 0);
+ ___cxa_rethrow();
+ ___cxa_end_catch();
+ ___cxa_pure_virtual();
+ _getenv(0) | 0;
+ _pthread_mutex_lock(0) | 0;
+ _pthread_cond_broadcast(0) | 0;
+ _pthread_mutex_unlock(0) | 0;
+ _pthread_cond_wait(0, 0) | 0;
+ _strftime(0, 0, 0, 0) | 0;
+ +_fabs(+0);
+}
 

--- a/tests/optimizer/test-js-optimizer-asm-regs-harder.js
+++ b/tests/optimizer/test-js-optimizer-asm-regs-harder.js
@@ -159,5 +159,19 @@ function b1() {
  abort(1);
  return SIMD_Float32x4_check(SIMD_Float32x4(0, 0, 0, 0));
 }
-// EMSCRIPTEN_GENERATED_FUNCTIONS: ["asm", "_doit", "stackRestore", "switchey", "switchey2", "iffey", "labelledJump", "linkedVars", "deadCondExpr", "b1"]
+// this should be kept alive at all costs
+function __emscripten_dceable_type_decls() {
+ ___cxa_throw(0, 0, 0);
+ ___cxa_rethrow();
+ ___cxa_end_catch();
+ ___cxa_pure_virtual();
+ _getenv(0) | 0;
+ _pthread_mutex_lock(0) | 0;
+ _pthread_cond_broadcast(0) | 0;
+ _pthread_mutex_unlock(0) | 0;
+ _pthread_cond_wait(0, 0) | 0;
+ _strftime(0, 0, 0, 0) | 0;
+ +_fabs(+0);
+}
+// EMSCRIPTEN_GENERATED_FUNCTIONS: ["asm", "_doit", "stackRestore", "switchey", "switchey2", "iffey", "labelledJump", "linkedVars", "deadCondExpr", "b1", "__emscripten_dceable_type_decls"]
 

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -2606,6 +2606,10 @@ function registerizeHarder(ast) {
     });
     if (abort) return;
 
+    // Do not process the dceable helper function for wasm, which declares
+    // types, we need to alive for asm2wasm
+    if (fun[1] == '__emscripten_dceable_type_decls') return;
+
     var asmData = normalizeAsm(fun);
 
     var localVars = asmData.vars;

--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -631,6 +631,9 @@ StringSet BREAK_CAPTURERS("do while for switch"),
           CONTINUE_CAPTURERS("do while for"),
           FUNCTIONS_THAT_ALWAYS_THROW("abort ___resumeException ___cxa_throw ___cxa_rethrow");
 
+IString DCEABLE_TYPE_DECLS("__emscripten_dceable_type_decls");
+
+
 bool isFunctionTable(const char *name) {
   static const char *functionTable = "FUNCTION_TABLE";
   static unsigned size = strlen(functionTable);
@@ -2414,6 +2417,10 @@ void registerizeHarder(Ref ast) {
       if (node[0] == NEW) abort = true;
     });
     if (abort) return;
+
+    // Do not process the dceable helper function for wasm, which declares
+    // types, we need to alive for asm2wasm
+    if (fun[1] == DCEABLE_TYPE_DECLS) return;
 
     AsmData asmData(fun);
 


### PR DESCRIPTION
…er function for wasm, which declares types. without the types, asm2wasm will fail.

This only happened when using exceptions (so a throw* function was there) + wasm + something that makes us use the js optimizer even though wasm is on (like the emterpreter). In that case, the js optimizer would remove code from the dceable helper function, and asm2wasm would not find the info it needs.