### PR TITLE
Implement glfw file drop API

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -684,7 +684,7 @@ var LibraryGLFW = {
 
       event.preventDefault();
 
-      var filenames = allocate(new Array(event.dataTransfer.files.length), 'i8*', ALLOC_NORMAL);
+      var filenames = allocate(new Array(event.dataTransfer.files.length*4), 'i8*', ALLOC_NORMAL);
       var filenamesArray = [];
       var count = event.dataTransfer.files.length;
 
@@ -705,7 +705,7 @@ var LibraryGLFW = {
 
         var filename = allocate(intArrayFromString(file.name), 'i8', ALLOC_NORMAL);
         filenamesArray.push(filename);
-        setValue(filenames + i, filename, 'i8*');
+        setValue(filenames + i*4, filename, 'i8*');
       }
 
       Module['dynCall_viii'](GLFW.active.dropFunc, GLFW.active.id, count, filenames);

--- a/tests/test_glfw_dropfile.c
+++ b/tests/test_glfw_dropfile.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+#define GLFW_INCLUDE_ES2
+#include <GLFW/glfw3.h>
+
+int result = 1;
+
+GLFWwindow* g_window;
+
+void render();
+
+void render() {
+  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void on_file_drop(GLFWwindow *window, int count, const char **paths) {
+  for (int i = 0; i < count; ++i) {
+    printf("dropped file %s\n", paths[i]);
+
+    // TODO: read file
+  }
+}
+
+int main() {
+  if (!glfwInit())
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif      
+    return -1;
+  }
+  glfwWindowHint(GLFW_RESIZABLE , 1);
+  g_window = glfwCreateWindow(600, 450, "GLFW drop file", NULL, NULL);
+  if (!g_window)
+  {
+    result = 0;
+    printf("Could not create window. Test failed.\n");      
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif           
+    glfwTerminate();
+    return -1;
+  }
+  glfwMakeContextCurrent(g_window);
+
+  // Install callbacks
+  glfwSetDropCallback(g_window, on_file_drop);
+
+  // Main loop
+  printf("Drag and drop a file from your desktop onto the green canvas.\n");
+  emscripten_set_main_loop(render, 0, 1);
+
+  glfwTerminate();
+
+  return 0;
+}

--- a/tests/test_glfw_dropfile.c
+++ b/tests/test_glfw_dropfile.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <assert.h>
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#endif
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 
@@ -69,7 +71,15 @@ int main() {
 
   // Main loop
   printf("Drag and drop a file from your desktop onto the green canvas.\n");
+#ifdef __EMSCRIPTEN__
   emscripten_set_main_loop(render, 0, 1);
+#else
+  while (!glfwWindowShouldClose(g_window)) {
+    render();
+    glfwSwapBuffers(g_window);
+    glfwPollEvents();
+  }
+#endif
 
   glfwTerminate();
 

--- a/tests/test_glfw_dropfile.c
+++ b/tests/test_glfw_dropfile.c
@@ -19,8 +19,25 @@ void on_file_drop(GLFWwindow *window, int count, const char **paths) {
   for (int i = 0; i < count; ++i) {
     printf("dropped file %s\n", paths[i]);
 
-    // TODO: read file
+    FILE *fp = fopen(paths[i], "rb");
+    if (!fp) {
+        printf("failed to open %s\n", paths[i]);
+        perror("fopen");
+        result = 0;
+        continue;
+    }
+    int c;
+    long size = 0;
+    while ((c = fgetc(fp) != -1)) {
+        ++size;
+    }
+    printf("read %ld bytes from %s\n", size, paths[i]);
+
+    fclose(fp);
   }
+#ifdef REPORT_RESULT
+  REPORT_RESULT();
+#endif
 }
 
 int main() {

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -134,6 +134,9 @@ class interactive(BrowserCore):
   def test_glfw_cursor_disabled(self):
     self.btest('test_glfw_cursor_disabled.c', expected='1', args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'])
 
+  def test_glfw_dropfile(self):
+    self.btest('test_glfw_dropfile.c', expected='1', args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'])
+
   def test_glfw_fullscreen(self):
     self.btest('test_glfw_fullscreen.c', expected='1', args=['-s', 'NO_EXIT_RUNTIME=1', '-s', 'USE_GLFW=3'])
 


### PR DESCRIPTION
Adds support for `glfwSetDropCallback`, using the HTML5 Drop API

* http://www.glfw.org/docs/latest/input_guide.html#path_drop
* https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API
