### PR TITLE
Set error flag if trying to pop empty matrix stack

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7128,6 +7128,10 @@ var LibraryGL = {
   },
 
   glPopMatrix: function() {
+    if(GLImmediate.matrixStack[GLImmediate.currentMatrix].length == 0) {
+      GL.recordError(0x0504/*GL_STACK_UNDERFLOW*/);
+      return;
+    }
     GLImmediate.matricesModified = true;
     GLImmediate.matrixVersion[GLImmediate.currentMatrix] = (GLImmediate.matrixVersion[GLImmediate.currentMatrix] + 1)|0;
     GLImmediate.matrix[GLImmediate.currentMatrix] = GLImmediate.matrixStack[GLImmediate.currentMatrix].pop();

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7128,7 +7128,7 @@ var LibraryGL = {
   },
 
   glPopMatrix: function() {
-    if(GLImmediate.matrixStack[GLImmediate.currentMatrix].length == 0) {
+    if (GLImmediate.matrixStack[GLImmediate.currentMatrix].length == 0) {
       GL.recordError(0x0504/*GL_STACK_UNDERFLOW*/);
       return;
     }

--- a/tests/gl_error.c
+++ b/tests/gl_error.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <GL/gl.h>
+#include <stdio.h>
+#include <string.h>
+#include "SDL/SDL.h"
+
+int main()
+{
+  SDL_Surface *screen;
+
+  assert(SDL_Init(SDL_INIT_VIDEO) == 0);
+  SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+  screen = SDL_SetVideoMode( 256, 256, 16, SDL_OPENGL );
+  assert(screen);
+
+  // pop from empty stack
+  glPopMatrix();
+  assert(glGetError() == GL_STACK_UNDERFLOW);
+
+  int result = 1;
+  REPORT_RESULT();
+  return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1883,6 +1883,9 @@ void *getBindBuffer() {
   def test_perspective(self):
     self.btest('perspective.c', reference='perspective.png', args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 
+  def test_glerror(self):
+    self.btest('gl_error.c', expected='1', args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL'])
+
   def test_runtimelink(self):
     main, supp = self.setup_runtimelink_test()
     open('supp.cpp', 'w').write(supp)


### PR DESCRIPTION
cf. https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glPushMatrix.xml

> Initially, each of the stacks contains one matrix, an identity matrix.
> It is an error to push a full matrix stack or to pop a matrix stack
> that contains only a single matrix. In either case, the error flag
> is set and no other change is made to GL state.

In the current implementation, GLImmediate.matrixStack doesn't have initial
identity matrix, so error should be returned when the stack is empty.