### PR TITLE
Fix stride for GL state query functions

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2624,8 +2624,8 @@ var LibraryGL = {
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case 'Integer': {{{ makeSetValue('params', 'i', 'data[i]', 'i32') }}}; break;
-          case 'Float': {{{ makeSetValue('params', 'i', 'data[i]', 'float') }}}; break;
+          case 'Integer': {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case 'Float': {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
           default: throw 'internal emscriptenWebGLGetUniform() error, bad type: ' + type;
         }
       }
@@ -2722,9 +2722,9 @@ var LibraryGL = {
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case 'Integer': {{{ makeSetValue('params', 'i', 'data[i]', 'i32') }}}; break;
-          case 'Float': {{{ makeSetValue('params', 'i', 'data[i]', 'float') }}}; break;
-          case 'FloatToInteger': {{{ makeSetValue('params', 'i', 'Math.fround(data[i])', 'i32') }}}; break;
+          case 'Integer': {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case 'Float': {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
+          case 'FloatToInteger': {{{ makeSetValue('params', 'i*4', 'Math.fround(data[i])', 'i32') }}}; break;
           default: throw 'internal emscriptenWebGLGetVertexAttrib() error, bad type: ' + type;
         }
       }

--- a/tests/full_es2_sdlproc.c
+++ b/tests/full_es2_sdlproc.c
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <GL/gl.h>
 #include <GL/glut.h>
+#include <assert.h>
 
 #ifndef HAVE_BUILTIN_SINCOS
 #include "sincos.h"
@@ -697,6 +698,14 @@ gears_init(void)
 
    /* Set the LightSourcePosition uniform which is constant throught the program */
    glUniform4fv(LightSourcePosition_location, 1, LightSourcePosition);
+
+   {
+      GLfloat LightSourcePosition_copy[4];
+      glGetUniformfv(program, LightSourcePosition_location, LightSourcePosition_copy);
+      for (uint32_t i = 0; i < 4; ++i) {
+        assert(LightSourcePosition[i] == LightSourcePosition_copy[i]);
+      }
+   }
 
    /* make the gears */
    gear1 = create_gear(1.0, 4.0, 1.0, 20, 0.7);


### PR DESCRIPTION
The stride for the array version of `emscriptenWebGLGetUniform` and `emscriptenWebGLGetVertexAttrib` weren't using the right stride and were throwing SAFE_HEAP errors.

A test was added to `full_es2_sdlproc` and was run without regressions.