### PR TITLE
Fix for issue 5226

### DIFF
--- a/tests/optimizer/test-js-optimizer-shiftsAggressive-output.js
+++ b/tests/optimizer/test-js-optimizer-shiftsAggressive-output.js
@@ -3,9 +3,11 @@ function __ZNSt3__111__call_onceERVmPvPFvS2_E($flag, $arg, $func) {
  $arg = $arg | 0;
  $func = $func | 0;
  var $2 = 0;
+ 0;
  $2 = cheez();
  whee1($flag + 1 | 0);
  whee2($flag + 1 | 0);
  whee3($flag + 1 | 0);
+ whee4(1 + 0);
 }
 

--- a/tests/optimizer/test-js-optimizer-shiftsAggressive.js
+++ b/tests/optimizer/test-js-optimizer-shiftsAggressive.js
@@ -9,5 +9,6 @@ function __ZNSt3__111__call_onceERVmPvPFvS2_E($flag,$arg,$func){
  whee1($3);
  whee2($3);
  whee3($3);
+ whee4(1 + $1);
 }
 // EMSCRIPTEN_GENERATED_FUNCTIONS: ["__ZNSt3__111__call_onceERVmPvPFvS2_E"]

--- a/tests/optimizer/test-js-optimizer-shiftsAggressive.js
+++ b/tests/optimizer/test-js-optimizer-shiftsAggressive.js
@@ -2,13 +2,13 @@ function __ZNSt3__111__call_onceERVmPvPFvS2_E($flag,$arg,$func){
  $flag=($flag)|0;
  $arg=($arg)|0;
  $func=($func)|0;
- var $1=0,$2=0,$3=0;
+ var $1=0,$2=0,$3=0,$initializedAndNotReassigned=0;
  $1;
  $2 = cheez();
  $3 = $flag + 1 | 0;
  whee1($3);
  whee2($3);
  whee3($3);
- whee4(1 + $1);
+ whee4(1 + $initializedAndNotReassigned);
 }
 // EMSCRIPTEN_GENERATED_FUNCTIONS: ["__ZNSt3__111__call_onceERVmPvPFvS2_E"]

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -4847,6 +4847,11 @@ function aggressiveVariableEliminationInternal(func, asmData) {
       }
       values[name] = node;
     }
+    // 'def' is non-null only if the variable was explicitly re-assigned after its definition.
+    // If it wasn't, the initial value should be used, which is supposed to always be zero.
+    else if (name in asmData.vars) {
+      values[name] = makeAsmCoercedZero(asmData.vars[name])
+    }
     return node;
   }
 


### PR DESCRIPTION
Here a zero value is added to the list `values` inside `aggressiveVariableEliminationInternal.evaluate` for each variable that was defined but not assigned afterwards (why zero - as I understand, Emscripten never produces local variables, whose initial value is not zero, at least I noticed this assumption in other places in the code).

This change also affected older test data - the line `$1;`, which would produce an empty line previously, now produces `0;`. But, as I understand, aggressiveVariableElimination wasn't intended for the elimination of such expressions, and it's done by other optimization passes anyway.

Test suites run: main, other (got failures in test_legalize_js_ffi and test_crunch, but they were failing without my changes too)