### PR TITLE
Implement all missing OpenAL functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -293,3 +293,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Fumiya Chiba <fumiya.chiba@nifty.com>
 * Ryan C. Gordon <icculus@icculus.org>
 * Inseok Lee <dlunch@gmail.com>
+* Yoan Lecoq <yoanlecoq.io@gmail.com>

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1612,12 +1612,14 @@ var LibraryOpenAL = {
     }
   },
 
+  // http://openal.996291.n3.nabble.com/alSpeedOfSound-or-alDopperVelocity-tp1960.html
   alDopplerVelocity: function(value) {
     Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for binary compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     AL.setSpeedOfSound(value);
   },
+
   alSpeedOfSound: function(value) {
-    Runtime.warnOnce('alSpeedOfSound() is not yet implemented! Ignoring all calls to it.');
+    Runtime.warnOnce('alSpeedOfSound() is not yet implemented!');
     AL.setSpeedOfSound(value);
   },
 
@@ -1626,7 +1628,7 @@ var LibraryOpenAL = {
         AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
         return;
     }
-    // TODO
+    // TODO implement the rest
   },
 
 
@@ -1637,7 +1639,33 @@ var LibraryOpenAL = {
 
 
   alcGetEnumValue: function(device, name) {
-    // TODO(yoanlcq)
+    if (device != 1) {
+      return 0;
+    }
+    name = Pointer_stringify(name);
+    switch(name) {
+    case "ALC_NO_ERROR": return 0;
+    case "ALC_INVALID_DEVICE": return 0xA001;
+    case "ALC_INVALID_CONTEXT": return 0xA002;
+    case "ALC_INVALID_ENUM": return 0xA003;
+    case "ALC_INVALID_VALUE": return 0xA004;
+    case "ALC_OUT_OF_MEMORY": return 0xA005;
+    case "ALC_MAJOR_VERSION": return 0x1000;
+    case "ALC_MINOR_VERSION": return 0x1001;
+    case "ALC_ATTRIBUTES_SIZE": return 0x1002;
+    case "ALC_ALL_ATTRIBUTES": return 0x1003;
+    case "ALC_DEFAULT_DEVICE_SPECIFIER": return 0x1004;
+    case "ALC_DEVICE_SPECIFIER": return 0x1005;
+    case "ALC_EXTENSIONS": return 0x1006;
+    case "ALC_FREQUENCY": return 0x1007;
+    case "ALC_REFRESH": return 0x1008;
+    case "ALC_SYNC": return 0x1009;
+    case "ALC_MONO_SOURCES": return 0x1010;
+    case "ALC_STEREO_SOURCES": return 0x1011;
+    case "ALC_CAPTURE_DEVICE_SPECIFIER": return 0x310;
+    case "ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER": return 0x311;
+    case "ALC_CAPTURE_SAMPLES": return 0x312;
+    }
     AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
     return 0;
   },
@@ -1721,7 +1749,7 @@ var LibraryOpenAL = {
   alGetIntegerv: function(param, data) {
     // TODO(yoanlcq)
     Runtime.warnOnce('alGetIntegerv() is not yet implemented! Ignoring all calls to it.');
-  }
+  },
 
   alGetBoolean: function(param) {
     // TODO(yoanlcq)

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1685,7 +1685,7 @@ var LibraryOpenAL = {
 
     AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
 #if OPENAL_DEBUG
-    console.error(name + " cannot be queried with alGetEnumValue()");
+    console.error("No value for `" + name + "`` is known by alGetEnumValue()");
 #endif
     return 0;
   },
@@ -1710,7 +1710,7 @@ var LibraryOpenAL = {
   // It's deprecated since it's equivalent to directly calling
   // alSpeedOfSound() with an appropriately premultiplied value.
   alDopplerVelocity: function(value) {
-    Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for binary compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
+    Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSpeedOfSound called without a valid context");
@@ -1742,7 +1742,7 @@ var LibraryOpenAL = {
     // Spec says :
     //   Using a NULL handle is legal, but only the
     //   tokens defined by the AL core are guaranteed.
-    if (device!==0 && device!==1) {
+    if (device != 0 && device != 1) {
 #if OPENAL_DEBUG
       console.error("alcGetEnumValue called with an invalid device");
 #endif
@@ -1777,7 +1777,7 @@ var LibraryOpenAL = {
     }
     AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
 #if OPENAL_DEBUG
-    console.error(name + " cannot be queried with alcGetEnumValue()");
+    console.error("No value for `" + name + "`` is known by alcGetEnumValue()");
 #endif
     return 0 /* AL_NONE */;
   },
@@ -1849,14 +1849,15 @@ var LibraryOpenAL = {
   // For v-suffixed variants, the spec requires that NULL destination 
   // pointers be quietly ignored.
   
-  getDouble: function getDouble(funcname, param) {
+  getDoubleHelper: function getDoubleHelper(funcname, param) {
      if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error(funcname + " called without a valid context");
 #endif
       return 0;
     }
-    // TODO(yoanlcq): check context, make a helper
+    // Right now, none of these can be set, so we directly return
+    // the values we support.
     switch (param) {
     case 0xC000 /* AL_DOPPLER_FACTOR */: return 1;
     case 0xC003 /* AL_SPEED_OF_SOUND */: return 343.3;
@@ -1870,46 +1871,46 @@ var LibraryOpenAL = {
   },
 
   alGetDouble: function(param) {
-    return AL.getDouble("alGetDouble", param);
+    return AL.getDoubleHelper("alGetDouble", param);
   },
 
   alGetDoublev: function(param, data) {
     if (!data)
       return;
-    var val = AL.getDouble("alGetDoublev", param);
+    var val = AL.getDoubleHelper("alGetDoublev", param);
     {{{ makeSetValue('data', '0', 'val', 'double') }}};
   },
 
   alGetFloat: function(param) {
-    return AL.getDouble("alGetFloat", param);
+    return AL.getDoubleHelper("alGetFloat", param);
   },
 
   alGetFloatv: function(param, data) {
     if (!data)
       return;
-    var val = AL.getDouble("alGetFloatv", param);
+    var val = AL.getDoubleHelper("alGetFloatv", param);
     {{{ makeSetValue('data', '0', 'val', 'float') }}};
   },
 
   alGetInteger: function(param) {
-    return AL.getDouble("alGetInteger", param);
+    return AL.getDoubleHelper("alGetInteger", param);
   },
 
   alGetIntegerv: function(param, data) {
     if (!data)
       return;
-    var val = AL.getDouble("alGetIntegerv", param);
+    var val = AL.getDoubleHelper("alGetIntegerv", param);
     {{{ makeSetValue('data', '0', 'val', 'i32') }}};
   },
 
   alGetBoolean: function(param) {
-    return !!AL.getDouble("alGetBoolean", param);
+    return !!AL.getDoubleHelper("alGetBoolean", param);
   },
 
   alGetBooleanv: function(param, data) {
     if (!data)
       return;
-    var val = !!AL.getDouble("alGetBooleanv", param);
+    var val = !!AL.getDoubleHelper("alGetBooleanv", param);
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
   },
 
@@ -1919,7 +1920,7 @@ var LibraryOpenAL = {
     // Quoting the programmer's guide:
     // There are no integer listener attributes defined for OpenAL 1.1,
     // but this function may be used by an extension.
-    AL.currentContext.err = AL_INVALID_ENUM;
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
   },
 
   alListener3i__deps: ['alListener3f'],
@@ -1989,7 +1990,7 @@ var LibraryOpenAL = {
   },
 
   // Helper for getting listener attributes as an array of numbers
-  getListenerXxx: function getListenerXxx(funcname, param) {
+  getListenerHelper: function getListenerHelper(funcname, param) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error(funcname + " called without a valid context");
@@ -2014,7 +2015,7 @@ var LibraryOpenAL = {
   },
 
   alGetListener3f: function(param, v1, v2, v3) {
-    var v = AL.getListenerXxx("alGetListener3f", param);
+    var v = AL.getListenerHelper("alGetListener3f", param);
     if (!v)
       return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
@@ -2023,7 +2024,7 @@ var LibraryOpenAL = {
   },
 
   alGetListener3i: function(param, v1, v2, v3) {
-    var v = AL.getListenerXxx("alGetListener3i", param);
+    var v = AL.getListenerHelper("alGetListener3i", param);
     if (!v)
       return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
@@ -2032,7 +2033,7 @@ var LibraryOpenAL = {
   },
 
   alGetListeneriv: function(param, data) {
-    var v = AL.getListenerXxx("alGetListeneriv", param);
+    var v = AL.getListenerHelper("alGetListeneriv", param);
     if (!v)
       return;
     {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
@@ -2062,7 +2063,7 @@ var LibraryOpenAL = {
 
 
   // Another helper
-  getSource3Xxx: function getSource3Xxx(funcname, source, param) {
+  getSource3Helper: function getSource3Helper(funcname, source, param) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error(funcname + " called without a valid context");
@@ -2089,7 +2090,7 @@ var LibraryOpenAL = {
   },
 
   alGetSource3f: function(source, param, v1, v2, v3) {
-    var v = AL.getSource3Xxx("alGetSource3f", source, param);
+    var v = AL.getSource3Helper("alGetSource3f", source, param);
     if (!v)
         return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
@@ -2098,7 +2099,7 @@ var LibraryOpenAL = {
   },
 
   alGetSource3i: function(source, param, v1, v2, v3) {
-    var v = AL.getSource3Xxx("alGetSource3i", source, param);
+    var v = AL.getSource3Helper("alGetSource3i", source, param);
     if (!v)
         return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
@@ -2118,53 +2119,53 @@ var LibraryOpenAL = {
   // Better error messages;
 
   alSourcePlayv__deps: ['alSourcePlay'],
-  alSourcePlayv: function(n, sources) {
+  alSourcePlayv: function(count, sources) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSourcePlayv called without a valid context");
 #endif
       return;
     }
-    for(var i=0 ; i<n ; ++i) {
+    for (var i = 0; i < count; ++i) {
       _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourceStopv__deps: ['alSourceStop'],
-  alSourceStopv: function(n, sources) {
+  alSourceStopv: function(count, sources) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSourceStopv called without a valid context");
 #endif
       return;
     }
-    for(var i=0 ; i<n ; ++i) {
+    for (var i = 0; i < count; ++i) {
       _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourceRewindv__deps: ['alSourceRewind'],
-  alSourceRewindv: function(n, sources) {
+  alSourceRewindv: function(count, sources) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSourceRewindv called without a valid context");
 #endif
       return;
     }
-    for(var i=0 ; i<n ; ++i) {
+    for (var i = 0; i < count; ++i) {
       _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourcePausev__deps: ['alSourcePause'],
-  alSourcePausev: function(n, sources) {
+  alSourcePausev: function(count, sources) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSourcePausev called without a valid context");
 #endif
       return;
     }
-    for(var i=0 ; i<n ; ++i) {
+    for (var i = 0; i < count; ++i) {
       _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
@@ -2230,7 +2231,7 @@ var LibraryOpenAL = {
   },
 
   // These in particular can error with AL_INVALID_VALUE
-  // if "the destination pointer is not valid"
+  // "if the destination pointer is not valid"
   // (from the programming guide)
 
   alGetBufferf: function(buffer, pname, value) {

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1613,6 +1613,9 @@ var LibraryOpenAL = {
   },
 
   // http://openal.996291.n3.nabble.com/alSpeedOfSound-or-alDopperVelocity-tp1960.html
+  // alDopplerVelocity() sets a multiplier for the speed of sound.
+  // It's deprecated since it's equivalent to directly call alSpeedOfSound()
+  // with an appropriately premultiplied value.
   alDopplerVelocity: function(value) {
     Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for binary compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     AL.setSpeedOfSound(value);
@@ -1709,68 +1712,55 @@ var LibraryOpenAL = {
 #endif
       return false;
     }
-    // There's no capability yet
+    // There's no defined capability yet
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     return false;
   },
 
 
 
-
-
-  // In this section, all alget*() functions
-  // return the current value of either :
-  // AL_DOPPLER_FACTOR
-  // AL_SPEED_OF_SOUND
-  // AL_DISTANCE_MODEL
-  // All of them can be implemented by casting the
+  // In this section, all alGet*() functions can be implemented by casting the
   // return value of alGetDouble().
   // IMO that's a poor API design, but we have to support it.
   alGetDouble: function(param) {
-    // TODO(yoanlcq)
     switch (param) {
-    case TODO /* AL_DOPPLER_FACTOR */: return TODO;
-    case TODO /* AL_SPEED_OF_SOUND */: return TODO;
-    case TODO /* AL_DISTANCE_MODEL */: return TODO;
+    case 0xC000 /* AL_DOPPLER_FACTOR */: return 1;
+    case 0xC003 /* AL_SPEED_OF_SOUND */: return 343.3;
+    case 0xD000 /* AL_DISTANCE_MODEL */: return 0 /* AL_NONE */;
+    case 0xC001 /* AL_DOPPLER_VELOCITY */:
+        Runtime.warnOnce('Getting the value for AL_DOPPLER_VELOCITY is deprecated!');
+        return 1;
     }
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-
-    Runtime.warnOnce('alGetDouble() is not yet implemented! Ignoring all calls to it.');
+    return 0;
   },
 
   alGetDoublev: function(param, data) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetDoublev() is not yet implemented! Ignoring all calls to it.');
+    {{{ makeSetValue('data', '0', 'AL.alGetDouble(param)', 'double') }}};
   },
 
   alGetFloat: function(param) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetFloat() is not yet implemented! Ignoring all calls to it.');
+    return AL.alGetDouble(param);
   },
 
   alGetFloatv: function(param, data) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetFloatv() is not yet implemented! Ignoring all calls to it.');
+    {{{ makeSetValue('data', '0', 'AL.alGetFloat(param)', 'float') }}};
   },
 
   alGetInteger: function(param) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetInteger() is not yet implemented! Ignoring all calls to it.');
+    return AL.alGetDouble(param);
   },
 
   alGetIntegerv: function(param, data) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetIntegerv() is not yet implemented! Ignoring all calls to it.');
+    {{{ makeSetValue('data', '0', 'AL.alGetInteger(param)', 'i32') }}};
   },
 
   alGetBoolean: function(param) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetBoolean() is not yet implemented! Ignoring all calls to it.');
+    return !!AL.alGetInteger(param);
   },
 
   alGetBooleanv: function(param, data) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetBooleanv() is not yet implemented! Ignoring all calls to it.');
+    {{{ makeSetValue('data', '0', 'AL.alGetBoolean(param)', 'u8') }}};
   },
 
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1597,10 +1597,82 @@ var LibraryOpenAL = {
   alGetEnumValue: function(name) {
     name = Pointer_stringify(name);
 
-    if (name == "AL_FORMAT_MONO_FLOAT32") return 0x10010;
-    if (name == "AL_FORMAT_STEREO_FLOAT32") return 0x10011;
+    switch(name) {
+     case "AL_FORMAT_MONO_FLOAT32": return 0x10010;
+     case "AL_FORMAT_STEREO_FLOAT32": return 0x10011;
+
+     case "AL_BITS": return 0x2002;
+     case "AL_BUFFER": return 0x1009;
+     case "AL_BUFFERS_PROCESSED": return 0x1016;
+     case "AL_BUFFERS_QUEUED": return 0x1015;
+     case "AL_BYTE_OFFSET": return 0x1026;
+     case "AL_CHANNELS": return 0x2003;
+     case "AL_CONE_INNER_ANGLE": return 0x1001;
+     case "AL_CONE_OUTER_ANGLE": return 0x1002;
+     case "AL_CONE_OUTER_GAIN": return 0x1022;
+     case "AL_DIRECTION": return 0x1005;
+     case "AL_DISTANCE_MODEL": return 0xD000;
+     case "AL_DOPPLER_FACTOR": return 0xC000;
+     case "AL_DOPPLER_VELOCITY": return 0xC001;
+     case "AL_EXPONENT_DISTANCE": return 0xD005;
+     case "AL_EXPONENT_DISTANCE_CLAMPED": return 0xD006;
+     case "AL_EXTENSIONS": return 0xB004;
+     case "AL_FORMAT_MONO16": return 0x1101;
+     case "AL_FORMAT_MONO8": return 0x1100;
+     case "AL_FORMAT_STEREO16": return 0x1103;
+     case "AL_FORMAT_STEREO8": return 0x1102;
+     case "AL_FREQUENCY": return 0x2001;
+     case "AL_GAIN": return 0x100A;
+     case "AL_INITIAL": return 0x1011;
+     case "AL_INVALID": return -1;
+     case "AL_ILLEGAL_ENUM": // fallthrough
+     case "AL_INVALID_ENUM": return 0xA002;
+     case "AL_INVALID_NAME": return 0xA001;
+     case "AL_ILLEGAL_COMMAND": // fallthrough
+     case "AL_INVALID_OPERATION": return 0xA004;
+     case "AL_INVALID_VALUE": return 0xA003;
+     case "AL_INVERSE_DISTANCE": return 0xD001;
+     case "AL_INVERSE_DISTANCE_CLAMPED": return 0xD002;
+     case "AL_LINEAR_DISTANCE": return 0xD003;
+     case "AL_LINEAR_DISTANCE_CLAMPED": return 0xD004;
+     case "AL_LOOPING": return 0x1007;
+     case "AL_MAX_DISTANCE": return 0x1023;
+     case "AL_MAX_GAIN": return 0x100E;
+     case "AL_MIN_GAIN": return 0x100D;
+     case "AL_NONE": return 0;
+     case "AL_NO_ERROR": return 0;
+     case "AL_ORIENTATION": return 0x100F;
+     case "AL_OUT_OF_MEMORY": return 0xA005;
+     case "AL_PAUSED": return 0x1013;
+     case "AL_PENDING": return 0x2011;
+     case "AL_PITCH": return 0x1003;
+     case "AL_PLAYING": return 0x1012;
+     case "AL_POSITION": return 0x1004;
+     case "AL_PROCESSED": return 0x2012;
+     case "AL_REFERENCE_DISTANCE": return 0x1020;
+     case "AL_RENDERER": return 0xB003;
+     case "AL_ROLLOFF_FACTOR": return 0x1021;
+     case "AL_SAMPLE_OFFSET": return 0x1025;
+     case "AL_SEC_OFFSET": return 0x1024;
+     case "AL_SIZE": return 0x2004;
+     case "AL_SOURCE_RELATIVE": return 0x202;
+     case "AL_SOURCE_STATE": return 0x1010;
+     case "AL_SOURCE_TYPE": return 0x1027;
+     case "AL_SPEED_OF_SOUND": return 0xC003;
+     case "AL_STATIC": return 0x1028;
+     case "AL_STOPPED": return 0x1014;
+     case "AL_STREAMING": return 0x1029;
+     case "AL_UNDETERMINED": return 0x1030;
+     case "AL_UNUSED": return 0x2010;
+     case "AL_VELOCITY": return 0x1006;
+     case "AL_VENDOR": return 0xB001;
+     case "AL_VERSION": return 0xB002;
+    }
 
     AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+#if OPENAL_DEBUG
+    console.error(name + " cannot be queried with alGetEnumValue()");
+#endif
     return 0;
   },
 
@@ -1670,6 +1742,9 @@ var LibraryOpenAL = {
     case "ALC_CAPTURE_SAMPLES": return 0x312;
     }
     AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
+#if OPENAL_DEBUG
+    console.error(name + " cannot be queried with alcGetEnumValue()");
+#endif
     return 0;
   },
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1601,6 +1601,11 @@ var LibraryOpenAL = {
      case "AL_FORMAT_MONO_FLOAT32": return 0x10010;
      case "AL_FORMAT_STEREO_FLOAT32": return 0x10011;
 
+     // Spec doesn't clearly state that alGetEnumValue() is required to
+     // support _only_ extension tokens.
+     // We should probably follow OpenAL-Soft's example and support all
+     // of the names we know.
+     // See http://repo.or.cz/openal-soft.git/blob/HEAD:/Alc/ALc.c
      case "AL_BITS": return 0x2002;
      case "AL_BUFFER": return 0x1009;
      case "AL_BUFFERS_PROCESSED": return 0x1016;
@@ -1710,15 +1715,15 @@ var LibraryOpenAL = {
 
 
   alcGetEnumValue: function(device, name) {
-    // Actually, ALC_INVALID_DEVICE is not a possible error state for
-    // this function.
-    // The spec says that the NULL device is legal here, but only for
-    // querying ALC enums that are not device-specific extensions, 
-    // and so far we have none.
-    if(device!=0 && device!=1) {
+    // Spec says :
+    //   Using a NULL handle is legal, but only the
+    //   tokens defined by the AL core are guaranteed.
+    if(device!==0 && device!==1) {
 #if OPENAL_DEBUG
       console.error("alcGetEnumValue called with an invalid device");
 #endif
+      // ALC_INVALID_DEVICE is not listed as a possible error state for
+      // this function, sadly.
       return 0 /* AL_NONE */;
     }
     name = Pointer_stringify(name);

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2114,10 +2114,6 @@ var LibraryOpenAL = {
   // instead of the other way around (with for loops), but right now
   // it's less error-prone.
 
-  // TODO(yoanlcq)
-  // Check context validity;
-  // Better error messages;
-
   alSourcePlayv__deps: ['alSourcePlay'],
   alSourcePlayv: function(count, sources) {
     if (!AL.currentContext) {

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1786,9 +1786,6 @@ var LibraryOpenAL = {
   },
 
 
-
-
-
   alIsEnabled: function(capability) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -1804,56 +1801,70 @@ var LibraryOpenAL = {
 
 
 
+
+
   // In this section, all alGet*() functions can be implemented by casting the
   // return value of alGetDouble().
-  // The spec requires that NULL destination pointers be quietly ignored.
+  // For v-suffixed variants, the spec requires that NULL destination 
+  // pointers be quietly ignored.
   alGetDouble: function(param) {
     switch (param) {
     case 0xC000 /* AL_DOPPLER_FACTOR */: return 1;
     case 0xC003 /* AL_SPEED_OF_SOUND */: return 343.3;
     case 0xD000 /* AL_DISTANCE_MODEL */: return 0 /* AL_NONE */;
     case 0xC001 /* AL_DOPPLER_VELOCITY */:
-        Runtime.warnOnce('Getting the value for AL_DOPPLER_VELOCITY is deprecated!');
+        Runtime.warnOnce('Getting the value for AL_DOPPLER_VELOCITY is deprecated as of OpenAL 1.1!');
         return 1;
     }
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     return 0;
   },
 
+  alGetDoublev__deps: ['alGetDouble'],
   alGetDoublev: function(param, data) {
-    if(data == 0)
+    if(data === 0)
         return;
-    {{{ makeSetValue('data', '0', 'AL.alGetDouble(param)', 'double') }}};
+    var val = _alGetDouble(param);
+    {{{ makeSetValue('data', '0', 'val', 'double') }}};
   },
 
+  alGetFloat__deps: ['alGetDouble'],
   alGetFloat: function(param) {
-    return AL.alGetDouble(param);
+    return _alGetDouble(param);
   },
 
+  alGetFloatv__deps: ['alGetFloat'],
   alGetFloatv: function(param, data) {
-    if(data == 0)
+    if(data === 0)
         return;
-    {{{ makeSetValue('data', '0', 'AL.alGetFloat(param)', 'float') }}};
+    var val = _alGetFloat(param);
+    {{{ makeSetValue('data', '0', 'val', 'float') }}};
   },
 
+  alGetInteger__deps: ['alGetDouble'],
   alGetInteger: function(param) {
-    return AL.alGetDouble(param);
+    return _alGetDouble(param);
   },
 
+  alGetIntegerv__deps: ['alGetInteger'],
   alGetIntegerv: function(param, data) {
-    if(data == 0)
+    if(data === 0)
         return;
-    {{{ makeSetValue('data', '0', 'AL.alGetInteger(param)', 'i32') }}};
+    var val = _alGetInteger(param);
+    {{{ makeSetValue('data', '0', 'val', 'i32') }}};
   },
 
+  alGetBoolean__deps: ['alGetInteger'],
   alGetBoolean: function(param) {
-    return !!AL.alGetInteger(param);
+    return !!_alGetInteger(param);
   },
 
+  alGetBooleanv__deps: ['alGetBoolean'],
   alGetBooleanv: function(param, data) {
-    if(data == 0)
+    if(data === 0)
         return;
-    {{{ makeSetValue('data', '0', 'AL.alGetBoolean(param)', 'i8') }}};
+    var val = _alGetBoolean(param);
+    {{{ makeSetValue('data', '0', 'val', 'i8') }}};
   },
 
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2005,20 +2005,61 @@ var LibraryOpenAL = {
 
 
 
-  alSourceiv: function(value) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alSourceiv() is not yet implemented! Ignoring all calls to it.');
+  alSourceiv__deps: ['alSource3i'],
+  alSourceiv: function(source, param, values) {
+    _alSource3i(source, param,
+      {{{ makeGetValue('values', '0', 'i32') }}},
+      {{{ makeGetValue('values', '4', 'i32') }}},
+      {{{ makeGetValue('values', '8', 'i32') }}});
   },
 
-  alGetSource3f: function(value) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetSource3f() is not yet implemented! Ignoring all calls to it.');
+
+  getSource3Xxx: function getSource3Xxx(funcname, source, param) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called without a valid context");
+#endif
+      return null;
+    }
+    var src = AL.currentContext.src[source];
+    if (!src) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called with an invalid source");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return null;
+    }
+    switch (param) {
+    case 0x1004 /* AL_POSITION */:  return src.position;
+    case 0x1005 /* AL_DIRECTION */: return src.direction;
+    case 0x1006 /* AL_VELOCITY */:  return src.velocity;
+    }
+ #if OPENAL_DEBUG
+    console.error(funcname + " with param " + param + " not implemented yet");
+#endif
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+
   },
 
-  alGetSource3i: function(value) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetSource3i() is not yet implemented! Ignoring all calls to it.');
+  alGetSource3f: function(source, param, v1, v2, v3) {
+    var v = AL.getSource3Xxx("alGetSource3f", source, param);
+    if(!v)
+        return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
   },
+
+  alGetSource3i: function(source, param, v1, v2, v3) {
+    var v = AL.getSource3Xxx("alGetSource3i", source, param);
+    if(!v)
+        return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
+  },
+
+
 
   alSourcePlayv: function(n, sources) {
     // TODO(yoanlcq)

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1842,23 +1842,19 @@ var LibraryOpenAL = {
 
 
   alListeneri: function(param, value) {
-    // TODO(yoanlcq)
-    // AL_INVALID_VALUE
-    // AL_INVALID_ENUM
     // Quoting the programmer's guide:
     // There are no integer listener attributes defined for OpenAL 1.1,
     // but this function may be used by an extension.
-    AL.currentContext.err = AL_INVALID_ENUM
+    AL.currentContext.err = AL_INVALID_ENUM;
   },
 
   alListener3i: function(param, v1, v2, v3) {
-    // TODO(yoanlcq)
-    // AL_POSITION
-    // AL_VELOCITY
-    Runtime.warnOnce('alListener3i() is not yet implemented! Ignoring all calls to it.');
+    // FIXME: Potential error message will mention alListener3f instead
+    AL.alListener3f(param, v1, v2, v3);
   },
 
   alListeneriv: function(param, values) {
+    // HARD
     // TODO(yoanlcq)
     // AL_POSITION
     // AL_VELOCITY
@@ -1867,8 +1863,35 @@ var LibraryOpenAL = {
   },
 
   alGetListener3f: function(param, v1, v2, v3) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alGetListener3f() is not yet implemented! Ignoring all calls to it.');
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alGetListener3f called without a valid context");
+#endif
+      return;
+    }
+
+    var x, y, z;
+    switch (param) {
+    case 0x1004 /* AL_POSITION */:
+      x = AL.currentContext.ctx.listener._position[0];
+      y = AL.currentContext.ctx.listener._position[1];
+      z = AL.currentContext.ctx.listener._position[2];
+      break;
+    case 0x1006 /* AL_VELOCITY */:
+      x = AL.currentContext.ctx.listener._velocity[0];
+      y = AL.currentContext.ctx.listener._velocity[1];
+      z = AL.currentContext.ctx.listener._velocity[2];
+      break;
+    default:
+#if OPENAL_DEBUG
+      console.error("alGetListener3f with param " + param + " not implemented yet");
+#endif
+      AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+      return;
+    }
+    {{{ makeSetValue('v1', '0', 'x', 'float') }}};
+    {{{ makeSetValue('v2', '0', 'y', 'float') }}};
+    {{{ makeSetValue('v3', '0', 'z', 'float') }}};
   },
 
   alGetListener3i: function(param, v1, v2, v3) {

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1594,13 +1594,6 @@ var LibraryOpenAL = {
     return 0;
   },
 
-
-
-
-
-
-
-
   alGetEnumValue: function(name) {
     // alGetEnumValue() doesn't require a valid context
 
@@ -1732,8 +1725,8 @@ var LibraryOpenAL = {
       return;
     }
     if (value <= 0) { // Negative or zero values are disallowed
-        AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-        return;
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
     }
     // TODO actual impl here
   },
@@ -1840,10 +1833,6 @@ var LibraryOpenAL = {
     return false;
   },
 
-
-
-
-
   // In this section, all alGet*() functions can be implemented by casting the
   // return value of alGetDouble().
   // For v-suffixed variants, the spec requires that NULL destination 
@@ -1875,8 +1864,7 @@ var LibraryOpenAL = {
   },
 
   alGetDoublev: function(param, data) {
-    if (!data)
-      return;
+    if (!data) return;
     var val = AL.getDoubleHelper("alGetDoublev", param);
     {{{ makeSetValue('data', '0', 'val', 'double') }}};
   },
@@ -1886,8 +1874,7 @@ var LibraryOpenAL = {
   },
 
   alGetFloatv: function(param, data) {
-    if (!data)
-      return;
+    if (!data) return;
     var val = AL.getDoubleHelper("alGetFloatv", param);
     {{{ makeSetValue('data', '0', 'val', 'float') }}};
   },
@@ -1897,8 +1884,7 @@ var LibraryOpenAL = {
   },
 
   alGetIntegerv: function(param, data) {
-    if (!data)
-      return;
+    if (!data) return;
     var val = AL.getDoubleHelper("alGetIntegerv", param);
     {{{ makeSetValue('data', '0', 'val', 'i32') }}};
   },
@@ -1908,13 +1894,10 @@ var LibraryOpenAL = {
   },
 
   alGetBooleanv: function(param, data) {
-    if (!data)
-      return;
+    if (!data) return;
     var val = !!AL.getDoubleHelper("alGetBooleanv", param);
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
   },
-
-
 
   alListeneri: function(param, value) {
     // Quoting the programmer's guide:
@@ -2016,8 +1999,7 @@ var LibraryOpenAL = {
 
   alGetListener3f: function(param, v1, v2, v3) {
     var v = AL.getListenerHelper("alGetListener3f", param);
-    if (!v)
-      return;
+    if (!v) return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
     {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
@@ -2025,8 +2007,7 @@ var LibraryOpenAL = {
 
   alGetListener3i: function(param, v1, v2, v3) {
     var v = AL.getListenerHelper("alGetListener3i", param);
-    if (!v)
-      return;
+    if (!v) return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
     {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
@@ -2034,8 +2015,7 @@ var LibraryOpenAL = {
 
   alGetListeneriv: function(param, data) {
     var v = AL.getListenerHelper("alGetListeneriv", param);
-    if (!v)
-      return;
+    if (!v) return;
     {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('data',  '4', 'v[1]', 'i32') }}};
     {{{ makeSetValue('data',  '8', 'v[2]', 'i32') }}};
@@ -2061,8 +2041,6 @@ var LibraryOpenAL = {
       {{{ makeGetValue('values', '8', 'i32') }}});
   },
 
-
-  // Another helper
   getSource3Helper: function getSource3Helper(funcname, source, param) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -2091,8 +2069,7 @@ var LibraryOpenAL = {
 
   alGetSource3f: function(source, param, v1, v2, v3) {
     var v = AL.getSource3Helper("alGetSource3f", source, param);
-    if (!v)
-        return;
+    if (!v) return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
     {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
@@ -2100,14 +2077,11 @@ var LibraryOpenAL = {
 
   alGetSource3i: function(source, param, v1, v2, v3) {
     var v = AL.getSource3Helper("alGetSource3i", source, param);
-    if (!v)
-        return;
+    if (!v) return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
     {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
   },
-
-
 
   // It would probably be more correct to implement 
   // alSourceXxx(src) as alSourceXxxv(1, src)

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1594,84 +1594,91 @@ var LibraryOpenAL = {
     return 0;
   },
 
+
+
+
+
+
+
+
   alGetEnumValue: function(name) {
     name = Pointer_stringify(name);
 
     switch(name) {
-     case "AL_FORMAT_MONO_FLOAT32": return 0x10010;
-     case "AL_FORMAT_STEREO_FLOAT32": return 0x10011;
+    case "AL_FORMAT_MONO_FLOAT32": return 0x10010;
+    case "AL_FORMAT_STEREO_FLOAT32": return 0x10011;
 
-     // Spec doesn't clearly state that alGetEnumValue() is required to
-     // support _only_ extension tokens.
-     // We should probably follow OpenAL-Soft's example and support all
-     // of the names we know.
-     // See http://repo.or.cz/openal-soft.git/blob/HEAD:/Alc/ALc.c
-     case "AL_BITS": return 0x2002;
-     case "AL_BUFFER": return 0x1009;
-     case "AL_BUFFERS_PROCESSED": return 0x1016;
-     case "AL_BUFFERS_QUEUED": return 0x1015;
-     case "AL_BYTE_OFFSET": return 0x1026;
-     case "AL_CHANNELS": return 0x2003;
-     case "AL_CONE_INNER_ANGLE": return 0x1001;
-     case "AL_CONE_OUTER_ANGLE": return 0x1002;
-     case "AL_CONE_OUTER_GAIN": return 0x1022;
-     case "AL_DIRECTION": return 0x1005;
-     case "AL_DISTANCE_MODEL": return 0xD000;
-     case "AL_DOPPLER_FACTOR": return 0xC000;
-     case "AL_DOPPLER_VELOCITY": return 0xC001;
-     case "AL_EXPONENT_DISTANCE": return 0xD005;
-     case "AL_EXPONENT_DISTANCE_CLAMPED": return 0xD006;
-     case "AL_EXTENSIONS": return 0xB004;
-     case "AL_FORMAT_MONO16": return 0x1101;
-     case "AL_FORMAT_MONO8": return 0x1100;
-     case "AL_FORMAT_STEREO16": return 0x1103;
-     case "AL_FORMAT_STEREO8": return 0x1102;
-     case "AL_FREQUENCY": return 0x2001;
-     case "AL_GAIN": return 0x100A;
-     case "AL_INITIAL": return 0x1011;
-     case "AL_INVALID": return -1;
-     case "AL_ILLEGAL_ENUM": // fallthrough
-     case "AL_INVALID_ENUM": return 0xA002;
-     case "AL_INVALID_NAME": return 0xA001;
-     case "AL_ILLEGAL_COMMAND": // fallthrough
-     case "AL_INVALID_OPERATION": return 0xA004;
-     case "AL_INVALID_VALUE": return 0xA003;
-     case "AL_INVERSE_DISTANCE": return 0xD001;
-     case "AL_INVERSE_DISTANCE_CLAMPED": return 0xD002;
-     case "AL_LINEAR_DISTANCE": return 0xD003;
-     case "AL_LINEAR_DISTANCE_CLAMPED": return 0xD004;
-     case "AL_LOOPING": return 0x1007;
-     case "AL_MAX_DISTANCE": return 0x1023;
-     case "AL_MAX_GAIN": return 0x100E;
-     case "AL_MIN_GAIN": return 0x100D;
-     case "AL_NONE": return 0;
-     case "AL_NO_ERROR": return 0;
-     case "AL_ORIENTATION": return 0x100F;
-     case "AL_OUT_OF_MEMORY": return 0xA005;
-     case "AL_PAUSED": return 0x1013;
-     case "AL_PENDING": return 0x2011;
-     case "AL_PITCH": return 0x1003;
-     case "AL_PLAYING": return 0x1012;
-     case "AL_POSITION": return 0x1004;
-     case "AL_PROCESSED": return 0x2012;
-     case "AL_REFERENCE_DISTANCE": return 0x1020;
-     case "AL_RENDERER": return 0xB003;
-     case "AL_ROLLOFF_FACTOR": return 0x1021;
-     case "AL_SAMPLE_OFFSET": return 0x1025;
-     case "AL_SEC_OFFSET": return 0x1024;
-     case "AL_SIZE": return 0x2004;
-     case "AL_SOURCE_RELATIVE": return 0x202;
-     case "AL_SOURCE_STATE": return 0x1010;
-     case "AL_SOURCE_TYPE": return 0x1027;
-     case "AL_SPEED_OF_SOUND": return 0xC003;
-     case "AL_STATIC": return 0x1028;
-     case "AL_STOPPED": return 0x1014;
-     case "AL_STREAMING": return 0x1029;
-     case "AL_UNDETERMINED": return 0x1030;
-     case "AL_UNUSED": return 0x2010;
-     case "AL_VELOCITY": return 0x1006;
-     case "AL_VENDOR": return 0xB001;
-     case "AL_VERSION": return 0xB002;
+    // Spec doesn't clearly state that alGetEnumValue() is required to
+    // support _only_ extension tokens.
+    // We should probably follow OpenAL-Soft's example and support all
+    // of the names we know.
+    // See http://repo.or.cz/openal-soft.git/blob/HEAD:/Alc/ALc.c
+    case "AL_BITS": return 0x2002;
+    case "AL_BUFFER": return 0x1009;
+    case "AL_BUFFERS_PROCESSED": return 0x1016;
+    case "AL_BUFFERS_QUEUED": return 0x1015;
+    case "AL_BYTE_OFFSET": return 0x1026;
+    case "AL_CHANNELS": return 0x2003;
+    case "AL_CONE_INNER_ANGLE": return 0x1001;
+    case "AL_CONE_OUTER_ANGLE": return 0x1002;
+    case "AL_CONE_OUTER_GAIN": return 0x1022;
+    case "AL_DIRECTION": return 0x1005;
+    case "AL_DISTANCE_MODEL": return 0xD000;
+    case "AL_DOPPLER_FACTOR": return 0xC000;
+    case "AL_DOPPLER_VELOCITY": return 0xC001;
+    case "AL_EXPONENT_DISTANCE": return 0xD005;
+    case "AL_EXPONENT_DISTANCE_CLAMPED": return 0xD006;
+    case "AL_EXTENSIONS": return 0xB004;
+    case "AL_FORMAT_MONO16": return 0x1101;
+    case "AL_FORMAT_MONO8": return 0x1100;
+    case "AL_FORMAT_STEREO16": return 0x1103;
+    case "AL_FORMAT_STEREO8": return 0x1102;
+    case "AL_FREQUENCY": return 0x2001;
+    case "AL_GAIN": return 0x100A;
+    case "AL_INITIAL": return 0x1011;
+    case "AL_INVALID": return -1;
+    case "AL_ILLEGAL_ENUM": // fallthrough
+    case "AL_INVALID_ENUM": return 0xA002;
+    case "AL_INVALID_NAME": return 0xA001;
+    case "AL_ILLEGAL_COMMAND": // fallthrough
+    case "AL_INVALID_OPERATION": return 0xA004;
+    case "AL_INVALID_VALUE": return 0xA003;
+    case "AL_INVERSE_DISTANCE": return 0xD001;
+    case "AL_INVERSE_DISTANCE_CLAMPED": return 0xD002;
+    case "AL_LINEAR_DISTANCE": return 0xD003;
+    case "AL_LINEAR_DISTANCE_CLAMPED": return 0xD004;
+    case "AL_LOOPING": return 0x1007;
+    case "AL_MAX_DISTANCE": return 0x1023;
+    case "AL_MAX_GAIN": return 0x100E;
+    case "AL_MIN_GAIN": return 0x100D;
+    case "AL_NONE": return 0;
+    case "AL_NO_ERROR": return 0;
+    case "AL_ORIENTATION": return 0x100F;
+    case "AL_OUT_OF_MEMORY": return 0xA005;
+    case "AL_PAUSED": return 0x1013;
+    case "AL_PENDING": return 0x2011;
+    case "AL_PITCH": return 0x1003;
+    case "AL_PLAYING": return 0x1012;
+    case "AL_POSITION": return 0x1004;
+    case "AL_PROCESSED": return 0x2012;
+    case "AL_REFERENCE_DISTANCE": return 0x1020;
+    case "AL_RENDERER": return 0xB003;
+    case "AL_ROLLOFF_FACTOR": return 0x1021;
+    case "AL_SAMPLE_OFFSET": return 0x1025;
+    case "AL_SEC_OFFSET": return 0x1024;
+    case "AL_SIZE": return 0x2004;
+    case "AL_SOURCE_RELATIVE": return 0x202;
+    case "AL_SOURCE_STATE": return 0x1010;
+    case "AL_SOURCE_TYPE": return 0x1027;
+    case "AL_SPEED_OF_SOUND": return 0xC003;
+    case "AL_STATIC": return 0x1028;
+    case "AL_STOPPED": return 0x1014;
+    case "AL_STREAMING": return 0x1029;
+    case "AL_UNDETERMINED": return 0x1030;
+    case "AL_UNUSED": return 0x2010;
+    case "AL_VELOCITY": return 0x1006;
+    case "AL_VENDOR": return 0xB001;
+    case "AL_VERSION": return 0xB002;
     }
 
     AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
@@ -1682,10 +1689,10 @@ var LibraryOpenAL = {
   },
 
   alDopplerFactor: function(value) {
-    Runtime.warnOnce('alDopplerFactor() is not yet implemented! Ignoring all calls to it.');
+    Runtime.warnOnce('alDopplerFactor() is not yet implemented!');
     if(value < 0) { // Strictly negative values are disallowed
-        AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-        return;
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
     }
     // TODO actual impl here
   },
@@ -1706,13 +1713,6 @@ var LibraryOpenAL = {
     }
     // TODO actual impl here
   },
-
-
-
-
-
-
-
 
   alcGetEnumValue: function(device, name) {
     // Spec says :
@@ -1813,8 +1813,8 @@ var LibraryOpenAL = {
     case 0xC003 /* AL_SPEED_OF_SOUND */: return 343.3;
     case 0xD000 /* AL_DISTANCE_MODEL */: return 0 /* AL_NONE */;
     case 0xC001 /* AL_DOPPLER_VELOCITY */:
-        Runtime.warnOnce('Getting the value for AL_DOPPLER_VELOCITY is deprecated as of OpenAL 1.1!');
-        return 1;
+      Runtime.warnOnce('Getting the value for AL_DOPPLER_VELOCITY is deprecated as of OpenAL 1.1!');
+      return 1;
     }
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     return 0;
@@ -1823,7 +1823,7 @@ var LibraryOpenAL = {
   alGetDoublev__deps: ['alGetDouble'],
   alGetDoublev: function(param, data) {
     if(data === 0)
-        return;
+      return;
     var val = _alGetDouble(param);
     {{{ makeSetValue('data', '0', 'val', 'double') }}};
   },
@@ -1836,7 +1836,7 @@ var LibraryOpenAL = {
   alGetFloatv__deps: ['alGetFloat'],
   alGetFloatv: function(param, data) {
     if(data === 0)
-        return;
+      return;
     var val = _alGetFloat(param);
     {{{ makeSetValue('data', '0', 'val', 'float') }}};
   },
@@ -1849,7 +1849,7 @@ var LibraryOpenAL = {
   alGetIntegerv__deps: ['alGetInteger'],
   alGetIntegerv: function(param, data) {
     if(data === 0)
-        return;
+      return;
     var val = _alGetInteger(param);
     {{{ makeSetValue('data', '0', 'val', 'i32') }}};
   },
@@ -1862,7 +1862,7 @@ var LibraryOpenAL = {
   alGetBooleanv__deps: ['alGetBoolean'],
   alGetBooleanv: function(param, data) {
     if(data === 0)
-        return;
+      return;
     var val = _alGetBoolean(param);
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
   },
@@ -1951,6 +1951,7 @@ var LibraryOpenAL = {
 #endif
       return null;
     }
+
     switch (param) {
     case 0x1004 /* AL_POSITION */:
       return AL.currentContext.ctx.listener._position;
@@ -1958,12 +1959,12 @@ var LibraryOpenAL = {
       return AL.currentContext.ctx.listener._velocity;
     case 0x100F /* AL_ORIENTATION */:
       return AL.currentContext.ctx.listener._orientation;
-    default:
-#if OPENAL_DEBUG
-      console.error(funcname + " with param " + param + " not implemented yet");
-#endif
-      AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     }
+
+#if OPENAL_DEBUG
+    console.error(funcname + " with param " + param + " not implemented yet");
+#endif
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     return null;
   },
 
@@ -1989,7 +1990,6 @@ var LibraryOpenAL = {
     var v = AL.getListenerXxx("alGetListeneriv", param);
     if(!v)
       return;
-
     {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('data',  '4', 'v[1]', 'i32') }}};
     {{{ makeSetValue('data',  '8', 'v[2]', 'i32') }}};
@@ -2001,10 +2001,6 @@ var LibraryOpenAL = {
     }
   },
 
-
-
-
-
   alSourceiv__deps: ['alSource3i'],
   alSourceiv: function(source, param, values) {
     _alSource3i(source, param,
@@ -2014,6 +2010,7 @@ var LibraryOpenAL = {
   },
 
 
+  // Another helper
   getSource3Xxx: function getSource3Xxx(funcname, source, param) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -2038,7 +2035,6 @@ var LibraryOpenAL = {
     console.error(funcname + " with param " + param + " not implemented yet");
 #endif
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-
   },
 
   alGetSource3f: function(source, param, v1, v2, v3) {
@@ -2069,34 +2065,34 @@ var LibraryOpenAL = {
   alSourcePlayv__deps: ['alSourcePlay'],
   alSourcePlayv: function(n, sources) {
     for(var i=0 ; i<n ; ++i) {
-        _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+      _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourceStopv__deps: ['alSourceStop'],
   alSourceStopv: function(n, sources) {
     for(var i=0 ; i<n ; ++i) {
-        _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+      _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourceRewindv__deps: ['alSourceRewind'],
   alSourceRewindv: function(n, sources) {
     for(var i=0 ; i<n ; ++i) {
-        _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+      _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alSourcePausev__deps: ['alSourcePause'],
   alSourcePausev: function(n, sources) {
     for(var i=0 ; i<n ; ++i) {
-        _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+      _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
     }
   },
 
   alGetBufferiv__deps: ['alGetBufferi'],
   alGetBufferiv: function(buffer, pname, values) {
-      _alGetBufferi(buffer, pname, values);
+    _alGetBufferi(buffer, pname, values);
   }
 
   // All of the remaining alBuffer* setters and getters are only of interest
@@ -2181,7 +2177,7 @@ var LibraryOpenAL = {
       return;
     }
     AL.bufferDummyAccessor("alGetBuffer3i", buffer);
-  },
+  }
 
 };
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2061,25 +2061,39 @@ var LibraryOpenAL = {
 
 
 
+  // It would probably be more correct to implement 
+  // alSourceXxx(src) as alSourceXxxv(1, src)
+  // instead of the other way around (with for loops), but right now
+  // it's less error-prone.
+
+  alSourcePlayv__deps: ['alSourcePlay'],
   alSourcePlayv: function(n, sources) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alSourcePlayv() is not yet implemented! Ignoring all calls to it.');
+    for(var i=0 ; i<n ; ++i) {
+        _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
   },
 
+  alSourceStopv__deps: ['alSourceStop'],
   alSourceStopv: function(n, sources) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alSourceStopv() is not yet implemented! Ignoring all calls to it.');
+    for(var i=0 ; i<n ; ++i) {
+        _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
   },
 
+  alSourceRewindv__deps: ['alSourceRewind'],
   alSourceRewindv: function(n, sources) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alSourceRewindv() is not yet implemented! Ignoring all calls to it.');
+    for(var i=0 ; i<n ; ++i) {
+        _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
   },
 
+  alSourcePausev__deps: ['alSourcePause'],
   alSourcePausev: function(n, sources) {
-    // TODO(yoanlcq)
-    Runtime.warnOnce('alSourcePausev() is not yet implemented! Ignoring all calls to it.');
+    for(var i=0 ; i<n ; ++i) {
+        _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
   },
+
 
   alBufferf: function(buffer, param, value) {
     // TODO(yoanlcq)

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -635,6 +635,20 @@ var LibraryOpenAL = {
     _alSource3f(source, param, v1, v2, v3);
   },
 
+  alSourceiv__deps: ['alSource3i'],
+  alSourceiv: function(source, param, values) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourceiv called without a valid context");
+#endif
+      return;
+    }
+    _alSource3i(source, param,
+      {{{ makeGetValue('values', '0', 'i32') }}},
+      {{{ makeGetValue('values', '4', 'i32') }}},
+      {{{ makeGetValue('values', '8', 'i32') }}});
+  },
+
   alSource3f: function(source, param, v1, v2, v3) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -946,6 +960,102 @@ var LibraryOpenAL = {
     }
   },
 
+  alGetBufferiv__deps: ['alGetBufferi'],
+  alGetBufferiv: function(buffer, pname, values) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alGetBufferiv called without a valid context");
+#endif
+      return;
+    }
+    _alGetBufferi(buffer, pname, values);
+  },
+
+  // All of the remaining alBuffer* setters and getters are only of interest
+  // to extensions which need them. Core OpenAL alone defines no valid
+  // property for these.
+
+  // For lack of a better name...
+  bufferDummyAccessor: function bufferDummyAccessor(funcname, buffer) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called without a valid context");
+#endif
+      return;
+    }
+    var buf = AL.currentContext.buf[buffer - 1];
+    if (!buf) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called with an invalid buffer");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return;
+    }
+
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+  },
+
+  alBufferf: function(buffer, param, value) {
+    AL.bufferDummyAccessor("alBufferf", buffer);
+  },
+
+  alBuffer3f: function(buffer, param, v1, v2, v3) {
+    AL.bufferDummyAccessor("alBuffer3f", buffer);
+  },
+
+  alBufferfv: function(buffer, param, values) {
+    AL.bufferDummyAccessor("alBufferfv", buffer);
+  },
+
+  alBufferi: function(buffer, param, value) {
+    AL.bufferDummyAccessor("alBufferi", buffer);
+  },
+
+  alBuffer3i: function(buffer, param, v1, v2, v3) {
+    AL.bufferDummyAccessor("alBuffer3i", buffer);
+  },
+
+  alBufferiv: function(buffer, params, values) {
+    AL.bufferDummyAccessor("alBufferiv", buffer);
+  },
+
+  // These in particular can error with AL_INVALID_VALUE
+  // "if the destination pointer is not valid"
+  // (from the programming guide)
+
+  alGetBufferf: function(buffer, pname, value) {
+    if (!value) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBufferf", buffer);
+  },
+
+  alGetBuffer3f: function(buffer, pname, v1, v2, v3) {
+    if (!v1 || !v2 || !v3) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBuffer3f", buffer);
+  },
+
+  alGetBufferfv: function(buffer, pname, values) {
+    if (!values) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBufferfv", buffer);
+  },
+
+  alGetBuffer3i: function(buffer, pname, v1, v2, v3) {
+    if (!v1 || !v2 || !v3) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBuffer3i", buffer);
+  },
+
+
   alSourcePlay: function(source) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -1020,6 +1130,64 @@ var LibraryOpenAL = {
     }
     AL.setSourceState(src, 0x1013 /* AL_PAUSED */);
   },
+
+  // It would probably be more correct to implement 
+  // alSourceXxx(src) as alSourceXxxv(1, src)
+  // instead of the other way around (with for loops), but right now
+  // it's less error-prone.
+
+  alSourcePlayv__deps: ['alSourcePlay'],
+  alSourcePlayv: function(count, sources) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourcePlayv called without a valid context");
+#endif
+      return;
+    }
+    for (var i = 0; i < count; ++i) {
+      _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
+  },
+
+  alSourceStopv__deps: ['alSourceStop'],
+  alSourceStopv: function(count, sources) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourceStopv called without a valid context");
+#endif
+      return;
+    }
+    for (var i = 0; i < count; ++i) {
+      _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
+  },
+
+  alSourceRewindv__deps: ['alSourceRewind'],
+  alSourceRewindv: function(count, sources) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourceRewindv called without a valid context");
+#endif
+      return;
+    }
+    for (var i = 0; i < count; ++i) {
+      _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
+  },
+
+  alSourcePausev__deps: ['alSourcePause'],
+  alSourcePausev: function(count, sources) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourcePausev called without a valid context");
+#endif
+      return;
+    }
+    for (var i = 0; i < count; ++i) {
+      _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
+    }
+  },
+
 
   alGetSourcei: function(source, param, value) {
     if (!AL.currentContext) {
@@ -1244,13 +1412,48 @@ var LibraryOpenAL = {
     }
   },
 
-  alDistanceModel: function(model) {
-    if (model !== 0 /* AL_NONE */) {
+  getSource3Helper: function getSource3Helper(funcname, source, param) {
+    if (!AL.currentContext) {
 #if OPENAL_DEBUG
-      console.log("Only alDistanceModel(AL_NONE) is currently supported");
+      console.error(funcname + " called without a valid context");
 #endif
+      return null;
     }
+    var src = AL.currentContext.src[source];
+    if (!src) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called with an invalid source");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return null;
+    }
+    switch (param) {
+    case 0x1004 /* AL_POSITION */:  return src.position;
+    case 0x1005 /* AL_DIRECTION */: return src.direction;
+    case 0x1006 /* AL_VELOCITY */:  return src.velocity;
+    }
+#if OPENAL_DEBUG
+    console.error(funcname + " with param " + param + " not implemented yet");
+#endif
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
   },
+
+  alGetSource3f: function(source, param, v1, v2, v3) {
+    var v = AL.getSource3Helper("alGetSource3f", source, param);
+    if (!v) return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
+  },
+
+  alGetSource3i: function(source, param, v1, v2, v3) {
+    var v = AL.getSource3Helper("alGetSource3i", source, param);
+    if (!v) return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
+  },
+
 
   alGetListenerf: function(pname, value) {
     if (!AL.currentContext) {
@@ -1311,6 +1514,8 @@ var LibraryOpenAL = {
     }
   },
 
+
+
   alGetListeneri: function(pname, value) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -1348,6 +1553,82 @@ var LibraryOpenAL = {
     }
   },
 
+  alListeneri: function(param, value) {
+    // Quoting the programmer's guide:
+    // There are no integer listener attributes defined for OpenAL 1.1,
+    // but this function may be used by an extension.
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+  },
+
+  alListener3i__deps: ['alListener3f'],
+  alListener3i: function(param, v1, v2, v3) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alListener3i called without a valid context");
+#endif
+      return;
+    }
+
+    _alListener3f(param, v1, v2, v3);
+  },
+
+  // Helper for getting listener attributes as an array of numbers
+  getListenerHelper: function getListenerHelper(funcname, param) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called without a valid context");
+#endif
+      return null;
+    }
+
+    switch (param) {
+    case 0x1004 /* AL_POSITION */:
+      return AL.currentContext.ctx.listener._position;
+    case 0x1006 /* AL_VELOCITY */:
+      return AL.currentContext.ctx.listener._velocity;
+    case 0x100F /* AL_ORIENTATION */:
+      return AL.currentContext.ctx.listener._orientation;
+    }
+
+#if OPENAL_DEBUG
+    console.error(funcname + " with param " + param + " not implemented yet");
+#endif
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+    return null;
+  },
+
+  alGetListener3f: function(param, v1, v2, v3) {
+    var v = AL.getListenerHelper("alGetListener3f", param);
+    if (!v) return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
+  },
+
+  alGetListener3i: function(param, v1, v2, v3) {
+    var v = AL.getListenerHelper("alGetListener3i", param);
+    if (!v) return;
+    {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
+    {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
+    {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
+  },
+
+  alGetListeneriv: function(param, data) {
+    var v = AL.getListenerHelper("alGetListeneriv", param);
+    if (!v) return;
+    {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
+    {{{ makeSetValue('data',  '4', 'v[1]', 'i32') }}};
+    {{{ makeSetValue('data',  '8', 'v[2]', 'i32') }}};
+
+    if (param == 0x100F /* AL_ORIENTATION */) {
+      {{{ makeSetValue('data', '12', 'v[3]', 'i32') }}};
+      {{{ makeSetValue('data', '16', 'v[4]', 'i32') }}};
+      {{{ makeSetValue('data', '20', 'v[5]', 'i32') }}};
+    }
+  },
+
+
+
   alEnable: function(param) {
     if (!AL.currentContext) {
 #if OPENAL_DEBUG
@@ -1381,6 +1662,20 @@ var LibraryOpenAL = {
       break;
     }
   },
+
+  alIsEnabled: function(capability) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alIsEnabled called without a valid context");
+#endif
+      return false;
+    }
+    // There's no defined capability for this yet - but extensions may want
+    // to use it.
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+    return false;
+  },
+
 
   alListener3f: function(param, v1, v2, v3) {
     if (!AL.currentContext) {
@@ -1465,6 +1760,61 @@ var LibraryOpenAL = {
     }
   },
 
+  // Would have liked to leverage alListenerfv(), but saw no "nice enough" way
+  // to do it. Copy pasta.
+  alListeneriv: function(param, values) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alListeneriv called without a valid context");
+#endif
+      return;
+    }
+    switch (param) {
+    case 0x1004 /* AL_POSITION */:
+      var x = {{{ makeGetValue('values', '0', 'i32') }}};
+      var y = {{{ makeGetValue('values', '4', 'i32') }}};
+      var z = {{{ makeGetValue('values', '8', 'i32') }}};
+      AL.currentContext.ctx.listener._position[0] = x;
+      AL.currentContext.ctx.listener._position[1] = y;
+      AL.currentContext.ctx.listener._position[2] = z;
+      AL.currentContext.ctx.listener.setPosition(x, y, z);
+      break;
+    case 0x1006 /* AL_VELOCITY */:
+      var x = {{{ makeGetValue('values', '0', 'i32') }}};
+      var y = {{{ makeGetValue('values', '4', 'i32') }}};
+      var z = {{{ makeGetValue('values', '8', 'i32') }}};
+      AL.currentContext.ctx.listener._velocity[0] = x;
+      AL.currentContext.ctx.listener._velocity[1] = y;
+      AL.currentContext.ctx.listener._velocity[2] = z;
+      // TODO: The velocity values are not currently used to implement a doppler effect.
+      // If support for doppler effect is reintroduced, compute the doppler
+      // speed pitch factor and apply it here.
+      break;
+    case 0x100F /* AL_ORIENTATION */:
+      var x  = {{{ makeGetValue('values',  '0', 'i32') }}};
+      var y  = {{{ makeGetValue('values',  '4', 'i32') }}};
+      var z  = {{{ makeGetValue('values',  '8', 'i32') }}};
+      var x2 = {{{ makeGetValue('values', '12', 'i32') }}};
+      var y2 = {{{ makeGetValue('values', '16', 'i32') }}};
+      var z2 = {{{ makeGetValue('values', '20', 'i32') }}};
+      AL.currentContext.ctx.listener._orientation[0] = x;
+      AL.currentContext.ctx.listener._orientation[1] = y;
+      AL.currentContext.ctx.listener._orientation[2] = z;
+      AL.currentContext.ctx.listener._orientation[3] = x2;
+      AL.currentContext.ctx.listener._orientation[4] = y2;
+      AL.currentContext.ctx.listener._orientation[5] = z2;
+      AL.currentContext.ctx.listener.setOrientation(x, y, z, x2, y2, z2);
+      break;
+    default:
+#if OPENAL_DEBUG
+      console.error("alListeneriv with param " + param + " not implemented yet");
+#endif
+      AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+      break;
+    }
+  },
+
+
   alIsExtensionPresent: function(extName) {
     extName = Pointer_stringify(extName);
 
@@ -1524,73 +1874,6 @@ var LibraryOpenAL = {
   },
 
   alGetProcAddress: function(fname) {
-    return 0;
-  },
-
-  alcGetString: function(device, param) {
-    if (AL.alcStringCache[param]) return AL.alcStringCache[param];
-    var ret;
-    switch (param) {
-    case 0 /* ALC_NO_ERROR */:
-      ret = 'No Error';
-      break;
-    case 0xA001 /* ALC_INVALID_DEVICE */:
-      ret = 'Invalid Device';
-      break;
-    case 0xA002 /* ALC_INVALID_CONTEXT */:
-      ret = 'Invalid Context';
-      break;
-    case 0xA003 /* ALC_INVALID_ENUM */:
-      ret = 'Invalid Enum';
-      break;
-    case 0xA004 /* ALC_INVALID_VALUE */:
-      ret = 'Invalid Value';
-      break;
-    case 0xA005 /* ALC_OUT_OF_MEMORY */:
-      ret = 'Out of Memory';
-      break;
-    case 0x1004 /* ALC_DEFAULT_DEVICE_SPECIFIER */:
-      if (typeof(AudioContext) !== "undefined" ||
-          typeof(webkitAudioContext) !== "undefined") {
-        ret = 'Device';
-      } else {
-        return 0;
-      }
-      break;
-    case 0x1005 /* ALC_DEVICE_SPECIFIER */:
-      if (typeof(AudioContext) !== "undefined" ||
-          typeof(webkitAudioContext) !== "undefined") {
-        ret = 'Device\0';
-      } else {
-        ret = '\0';
-      }
-      break;
-    case 0x311 /* ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER */:
-      return 0;
-      break;
-    case 0x310 /* ALC_CAPTURE_DEVICE_SPECIFIER */:
-      ret = '\0'
-      break;
-    case 0x1006 /* ALC_EXTENSIONS */:
-      if (!device) {
-        AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
-        return 0;
-      }
-      ret = '';
-      break;
-    default:
-      AL.alcErr = 0xA003 /* ALC_INVALID_ENUM */;
-      return 0;
-    }
-
-    ret = allocate(intArrayFromString(ret), 'i8', ALLOC_NORMAL);
-
-    AL.alcStringCache[param] = ret;
-
-    return ret;
-  },
-
-  alcGetProcAddress: function(device, fname) {
     return 0;
   },
 
@@ -1683,6 +1966,126 @@ var LibraryOpenAL = {
     return 0;
   },
 
+
+  alcGetString: function(device, param) {
+    if (AL.alcStringCache[param]) return AL.alcStringCache[param];
+    var ret;
+    switch (param) {
+    case 0 /* ALC_NO_ERROR */:
+      ret = 'No Error';
+      break;
+    case 0xA001 /* ALC_INVALID_DEVICE */:
+      ret = 'Invalid Device';
+      break;
+    case 0xA002 /* ALC_INVALID_CONTEXT */:
+      ret = 'Invalid Context';
+      break;
+    case 0xA003 /* ALC_INVALID_ENUM */:
+      ret = 'Invalid Enum';
+      break;
+    case 0xA004 /* ALC_INVALID_VALUE */:
+      ret = 'Invalid Value';
+      break;
+    case 0xA005 /* ALC_OUT_OF_MEMORY */:
+      ret = 'Out of Memory';
+      break;
+    case 0x1004 /* ALC_DEFAULT_DEVICE_SPECIFIER */:
+      if (typeof(AudioContext) !== "undefined" ||
+          typeof(webkitAudioContext) !== "undefined") {
+        ret = 'Device';
+      } else {
+        return 0;
+      }
+      break;
+    case 0x1005 /* ALC_DEVICE_SPECIFIER */:
+      if (typeof(AudioContext) !== "undefined" ||
+          typeof(webkitAudioContext) !== "undefined") {
+        ret = 'Device\0';
+      } else {
+        ret = '\0';
+      }
+      break;
+    case 0x311 /* ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER */:
+      return 0;
+      break;
+    case 0x310 /* ALC_CAPTURE_DEVICE_SPECIFIER */:
+      ret = '\0'
+      break;
+    case 0x1006 /* ALC_EXTENSIONS */:
+      if (!device) {
+        AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
+        return 0;
+      }
+      ret = '';
+      break;
+    default:
+      AL.alcErr = 0xA003 /* ALC_INVALID_ENUM */;
+      return 0;
+    }
+
+    ret = allocate(intArrayFromString(ret), 'i8', ALLOC_NORMAL);
+
+    AL.alcStringCache[param] = ret;
+
+    return ret;
+  },
+
+  alcGetProcAddress: function(device, fname) {
+    return 0;
+  },
+
+  alcGetEnumValue: function(device, name) {
+    // Spec says :
+    //   Using a NULL handle is legal, but only the
+    //   tokens defined by the AL core are guaranteed.
+    if (device != 0 && device != 1) {
+#if OPENAL_DEBUG
+      console.error("alcGetEnumValue called with an invalid device");
+#endif
+      // ALC_INVALID_DEVICE is not listed as a possible error state for
+      // this function, sadly.
+      return 0 /* AL_NONE */;
+    }
+    name = Pointer_stringify(name);
+    // See alGetEnumValue(), but basically behave the same as OpenAL-Soft
+    switch(name) {
+    case "ALC_NO_ERROR": return 0;
+    case "ALC_INVALID_DEVICE": return 0xA001;
+    case "ALC_INVALID_CONTEXT": return 0xA002;
+    case "ALC_INVALID_ENUM": return 0xA003;
+    case "ALC_INVALID_VALUE": return 0xA004;
+    case "ALC_OUT_OF_MEMORY": return 0xA005;
+    case "ALC_MAJOR_VERSION": return 0x1000;
+    case "ALC_MINOR_VERSION": return 0x1001;
+    case "ALC_ATTRIBUTES_SIZE": return 0x1002;
+    case "ALC_ALL_ATTRIBUTES": return 0x1003;
+    case "ALC_DEFAULT_DEVICE_SPECIFIER": return 0x1004;
+    case "ALC_DEVICE_SPECIFIER": return 0x1005;
+    case "ALC_EXTENSIONS": return 0x1006;
+    case "ALC_FREQUENCY": return 0x1007;
+    case "ALC_REFRESH": return 0x1008;
+    case "ALC_SYNC": return 0x1009;
+    case "ALC_MONO_SOURCES": return 0x1010;
+    case "ALC_STEREO_SOURCES": return 0x1011;
+    case "ALC_CAPTURE_DEVICE_SPECIFIER": return 0x310;
+    case "ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER": return 0x311;
+    case "ALC_CAPTURE_SAMPLES": return 0x312;
+    }
+    AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
+#if OPENAL_DEBUG
+    console.error("No value for `" + name + "`` is known by alcGetEnumValue()");
+#endif
+    return 0 /* AL_NONE */;
+  },
+
+  alDistanceModel: function(model) {
+    if (model !== 0 /* AL_NONE */) {
+#if OPENAL_DEBUG
+      console.log("Only alDistanceModel(AL_NONE) is currently supported");
+#endif
+    }
+  },
+
   alDopplerFactor: function(value) {
     Runtime.warnOnce('alDopplerFactor() is not yet implemented!');
     if (!AL.currentContext) {
@@ -1731,51 +2134,6 @@ var LibraryOpenAL = {
     // TODO actual impl here
   },
 
-  alcGetEnumValue: function(device, name) {
-    // Spec says :
-    //   Using a NULL handle is legal, but only the
-    //   tokens defined by the AL core are guaranteed.
-    if (device != 0 && device != 1) {
-#if OPENAL_DEBUG
-      console.error("alcGetEnumValue called with an invalid device");
-#endif
-      // ALC_INVALID_DEVICE is not listed as a possible error state for
-      // this function, sadly.
-      return 0 /* AL_NONE */;
-    }
-    name = Pointer_stringify(name);
-    // See alGetEnumValue(), but basically behave the same as OpenAL-Soft
-    switch(name) {
-    case "ALC_NO_ERROR": return 0;
-    case "ALC_INVALID_DEVICE": return 0xA001;
-    case "ALC_INVALID_CONTEXT": return 0xA002;
-    case "ALC_INVALID_ENUM": return 0xA003;
-    case "ALC_INVALID_VALUE": return 0xA004;
-    case "ALC_OUT_OF_MEMORY": return 0xA005;
-    case "ALC_MAJOR_VERSION": return 0x1000;
-    case "ALC_MINOR_VERSION": return 0x1001;
-    case "ALC_ATTRIBUTES_SIZE": return 0x1002;
-    case "ALC_ALL_ATTRIBUTES": return 0x1003;
-    case "ALC_DEFAULT_DEVICE_SPECIFIER": return 0x1004;
-    case "ALC_DEVICE_SPECIFIER": return 0x1005;
-    case "ALC_EXTENSIONS": return 0x1006;
-    case "ALC_FREQUENCY": return 0x1007;
-    case "ALC_REFRESH": return 0x1008;
-    case "ALC_SYNC": return 0x1009;
-    case "ALC_MONO_SOURCES": return 0x1010;
-    case "ALC_STEREO_SOURCES": return 0x1011;
-    case "ALC_CAPTURE_DEVICE_SPECIFIER": return 0x310;
-    case "ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER": return 0x311;
-    case "ALC_CAPTURE_SAMPLES": return 0x312;
-    }
-    AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
-#if OPENAL_DEBUG
-    console.error("No value for `" + name + "`` is known by alcGetEnumValue()");
-#endif
-    return 0 /* AL_NONE */;
-  },
-
-
   // Might be very interesting to implement that !
   alcCaptureOpenDevice: function(deviceName, freq, format, bufferSize) {
     Runtime.warnOnce('alcCapture*() functions are not supported yet.');
@@ -1819,19 +2177,6 @@ var LibraryOpenAL = {
     AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
   },
 
-
-  alIsEnabled: function(capability) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alIsEnabled called without a valid context");
-#endif
-      return false;
-    }
-    // There's no defined capability for this yet - but extensions may want
-    // to use it.
-    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-    return false;
-  },
 
   // In this section, all alGet*() functions can be implemented by casting the
   // return value of alGetDouble().
@@ -1897,345 +2242,7 @@ var LibraryOpenAL = {
     var val = !!AL.getDoubleHelper("alGetBooleanv", param);
     if (!data) return;
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
-  },
-
-  alListeneri: function(param, value) {
-    // Quoting the programmer's guide:
-    // There are no integer listener attributes defined for OpenAL 1.1,
-    // but this function may be used by an extension.
-    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-  },
-
-  alListener3i__deps: ['alListener3f'],
-  alListener3i: function(param, v1, v2, v3) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alListener3i called without a valid context");
-#endif
-      return;
-    }
-
-    _alListener3f(param, v1, v2, v3);
-  },
-
-  // Would have liked to leverage alListenerfv(), but saw no "nice enough" way
-  // to do it. Copy pasta.
-  alListeneriv: function(param, values) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alListeneriv called without a valid context");
-#endif
-      return;
-    }
-    switch (param) {
-    case 0x1004 /* AL_POSITION */:
-      var x = {{{ makeGetValue('values', '0', 'i32') }}};
-      var y = {{{ makeGetValue('values', '4', 'i32') }}};
-      var z = {{{ makeGetValue('values', '8', 'i32') }}};
-      AL.currentContext.ctx.listener._position[0] = x;
-      AL.currentContext.ctx.listener._position[1] = y;
-      AL.currentContext.ctx.listener._position[2] = z;
-      AL.currentContext.ctx.listener.setPosition(x, y, z);
-      break;
-    case 0x1006 /* AL_VELOCITY */:
-      var x = {{{ makeGetValue('values', '0', 'i32') }}};
-      var y = {{{ makeGetValue('values', '4', 'i32') }}};
-      var z = {{{ makeGetValue('values', '8', 'i32') }}};
-      AL.currentContext.ctx.listener._velocity[0] = x;
-      AL.currentContext.ctx.listener._velocity[1] = y;
-      AL.currentContext.ctx.listener._velocity[2] = z;
-      // TODO: The velocity values are not currently used to implement a doppler effect.
-      // If support for doppler effect is reintroduced, compute the doppler
-      // speed pitch factor and apply it here.
-      break;
-    case 0x100F /* AL_ORIENTATION */:
-      var x  = {{{ makeGetValue('values',  '0', 'i32') }}};
-      var y  = {{{ makeGetValue('values',  '4', 'i32') }}};
-      var z  = {{{ makeGetValue('values',  '8', 'i32') }}};
-      var x2 = {{{ makeGetValue('values', '12', 'i32') }}};
-      var y2 = {{{ makeGetValue('values', '16', 'i32') }}};
-      var z2 = {{{ makeGetValue('values', '20', 'i32') }}};
-      AL.currentContext.ctx.listener._orientation[0] = x;
-      AL.currentContext.ctx.listener._orientation[1] = y;
-      AL.currentContext.ctx.listener._orientation[2] = z;
-      AL.currentContext.ctx.listener._orientation[3] = x2;
-      AL.currentContext.ctx.listener._orientation[4] = y2;
-      AL.currentContext.ctx.listener._orientation[5] = z2;
-      AL.currentContext.ctx.listener.setOrientation(x, y, z, x2, y2, z2);
-      break;
-    default:
-#if OPENAL_DEBUG
-      console.error("alListeneriv with param " + param + " not implemented yet");
-#endif
-      AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-      break;
-    }
-  },
-
-  // Helper for getting listener attributes as an array of numbers
-  getListenerHelper: function getListenerHelper(funcname, param) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error(funcname + " called without a valid context");
-#endif
-      return null;
-    }
-
-    switch (param) {
-    case 0x1004 /* AL_POSITION */:
-      return AL.currentContext.ctx.listener._position;
-    case 0x1006 /* AL_VELOCITY */:
-      return AL.currentContext.ctx.listener._velocity;
-    case 0x100F /* AL_ORIENTATION */:
-      return AL.currentContext.ctx.listener._orientation;
-    }
-
-#if OPENAL_DEBUG
-    console.error(funcname + " with param " + param + " not implemented yet");
-#endif
-    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-    return null;
-  },
-
-  alGetListener3f: function(param, v1, v2, v3) {
-    var v = AL.getListenerHelper("alGetListener3f", param);
-    if (!v) return;
-    {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
-    {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
-    {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
-  },
-
-  alGetListener3i: function(param, v1, v2, v3) {
-    var v = AL.getListenerHelper("alGetListener3i", param);
-    if (!v) return;
-    {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
-    {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
-    {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
-  },
-
-  alGetListeneriv: function(param, data) {
-    var v = AL.getListenerHelper("alGetListeneriv", param);
-    if (!v) return;
-    {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
-    {{{ makeSetValue('data',  '4', 'v[1]', 'i32') }}};
-    {{{ makeSetValue('data',  '8', 'v[2]', 'i32') }}};
-
-    if (param == 0x100F /* AL_ORIENTATION */) {
-      {{{ makeSetValue('data', '12', 'v[3]', 'i32') }}};
-      {{{ makeSetValue('data', '16', 'v[4]', 'i32') }}};
-      {{{ makeSetValue('data', '20', 'v[5]', 'i32') }}};
-    }
-  },
-
-  alSourceiv__deps: ['alSource3i'],
-  alSourceiv: function(source, param, values) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alSourceiv called without a valid context");
-#endif
-      return;
-    }
-    _alSource3i(source, param,
-      {{{ makeGetValue('values', '0', 'i32') }}},
-      {{{ makeGetValue('values', '4', 'i32') }}},
-      {{{ makeGetValue('values', '8', 'i32') }}});
-  },
-
-  getSource3Helper: function getSource3Helper(funcname, source, param) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error(funcname + " called without a valid context");
-#endif
-      return null;
-    }
-    var src = AL.currentContext.src[source];
-    if (!src) {
-#if OPENAL_DEBUG
-      console.error(funcname + " called with an invalid source");
-#endif
-      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
-      return null;
-    }
-    switch (param) {
-    case 0x1004 /* AL_POSITION */:  return src.position;
-    case 0x1005 /* AL_DIRECTION */: return src.direction;
-    case 0x1006 /* AL_VELOCITY */:  return src.velocity;
-    }
-#if OPENAL_DEBUG
-    console.error(funcname + " with param " + param + " not implemented yet");
-#endif
-    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-  },
-
-  alGetSource3f: function(source, param, v1, v2, v3) {
-    var v = AL.getSource3Helper("alGetSource3f", source, param);
-    if (!v) return;
-    {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
-    {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
-    {{{ makeSetValue('v3', '0', 'v[2]', 'float') }}};
-  },
-
-  alGetSource3i: function(source, param, v1, v2, v3) {
-    var v = AL.getSource3Helper("alGetSource3i", source, param);
-    if (!v) return;
-    {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
-    {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
-    {{{ makeSetValue('v3', '0', 'v[2]', 'i32') }}};
-  },
-
-  // It would probably be more correct to implement 
-  // alSourceXxx(src) as alSourceXxxv(1, src)
-  // instead of the other way around (with for loops), but right now
-  // it's less error-prone.
-
-  alSourcePlayv__deps: ['alSourcePlay'],
-  alSourcePlayv: function(count, sources) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alSourcePlayv called without a valid context");
-#endif
-      return;
-    }
-    for (var i = 0; i < count; ++i) {
-      _alSourcePlay({{{ makeGetValue('sources', 'i*4', 'i32') }}});
-    }
-  },
-
-  alSourceStopv__deps: ['alSourceStop'],
-  alSourceStopv: function(count, sources) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alSourceStopv called without a valid context");
-#endif
-      return;
-    }
-    for (var i = 0; i < count; ++i) {
-      _alSourceStop({{{ makeGetValue('sources', 'i*4', 'i32') }}});
-    }
-  },
-
-  alSourceRewindv__deps: ['alSourceRewind'],
-  alSourceRewindv: function(count, sources) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alSourceRewindv called without a valid context");
-#endif
-      return;
-    }
-    for (var i = 0; i < count; ++i) {
-      _alSourceRewind({{{ makeGetValue('sources', 'i*4', 'i32') }}});
-    }
-  },
-
-  alSourcePausev__deps: ['alSourcePause'],
-  alSourcePausev: function(count, sources) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alSourcePausev called without a valid context");
-#endif
-      return;
-    }
-    for (var i = 0; i < count; ++i) {
-      _alSourcePause({{{ makeGetValue('sources', 'i*4', 'i32') }}});
-    }
-  },
-
-
-  alGetBufferiv__deps: ['alGetBufferi'],
-  alGetBufferiv: function(buffer, pname, values) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error("alGetBufferiv called without a valid context");
-#endif
-      return;
-    }
-    _alGetBufferi(buffer, pname, values);
-  },
-
-  // All of the remaining alBuffer* setters and getters are only of interest
-  // to extensions which need them. Core OpenAL alone defines no valid
-  // property for these.
-
-  // For lack of a better name...
-  bufferDummyAccessor: function bufferDummyAccessor(funcname, buffer) {
-    if (!AL.currentContext) {
-#if OPENAL_DEBUG
-      console.error(funcname + " called without a valid context");
-#endif
-      return;
-    }
-    var buf = AL.currentContext.buf[buffer - 1];
-    if (!buf) {
-#if OPENAL_DEBUG
-      console.error(funcname + " called with an invalid buffer");
-#endif
-      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
-      return;
-    }
-
-    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
-  },
-
-  alBufferf: function(buffer, param, value) {
-    AL.bufferDummyAccessor("alBufferf", buffer);
-  },
-
-  alBuffer3f: function(buffer, param, v1, v2, v3) {
-    AL.bufferDummyAccessor("alBuffer3f", buffer);
-  },
-
-  alBufferfv: function(buffer, param, values) {
-    AL.bufferDummyAccessor("alBufferfv", buffer);
-  },
-
-  alBufferi: function(buffer, param, value) {
-    AL.bufferDummyAccessor("alBufferi", buffer);
-  },
-
-  alBuffer3i: function(buffer, param, v1, v2, v3) {
-    AL.bufferDummyAccessor("alBuffer3i", buffer);
-  },
-
-  alBufferiv: function(buffer, params, values) {
-    AL.bufferDummyAccessor("alBufferiv", buffer);
-  },
-
-  // These in particular can error with AL_INVALID_VALUE
-  // "if the destination pointer is not valid"
-  // (from the programming guide)
-
-  alGetBufferf: function(buffer, pname, value) {
-    if (!value) {
-      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-      return;
-    }
-    AL.bufferDummyAccessor("alGetBufferf", buffer);
-  },
-
-  alGetBuffer3f: function(buffer, pname, v1, v2, v3) {
-    if (!v1 || !v2 || !v3) {
-      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-      return;
-    }
-    AL.bufferDummyAccessor("alGetBuffer3f", buffer);
-  },
-
-  alGetBufferfv: function(buffer, pname, values) {
-    if (!values) {
-      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-      return;
-    }
-    AL.bufferDummyAccessor("alGetBufferfv", buffer);
-  },
-
-  alGetBuffer3i: function(buffer, pname, v1, v2, v3) {
-    if (!v1 || !v2 || !v3) {
-      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-      return;
-    }
-    AL.bufferDummyAccessor("alGetBuffer3i", buffer);
   }
-
 };
 
 autoAddDeps(LibraryOpenAL, '$AL');

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1604,16 +1604,29 @@ var LibraryOpenAL = {
     return 0;
   },
 
-  alSpeedOfSound: function(value) {
-    Runtime.warnOnce('alSpeedOfSound() is not yet implemented! Ignoring all calls to it.');
-  },
-
   alDopplerFactor: function(value) {
     Runtime.warnOnce('alDopplerFactor() is not yet implemented! Ignoring all calls to it.');
+    if(value < 0) { // Strictly negative values are disallowed
+        AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+        return;
+    }
   },
 
   alDopplerVelocity: function(value) {
-    Runtime.warnOnce('alDopplerVelocity() is not yet implemented! Ignoring all calls to it.');
+    Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for binary compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
+    AL.setSpeedOfSound(value);
+  },
+  alSpeedOfSound: function(value) {
+    Runtime.warnOnce('alSpeedOfSound() is not yet implemented! Ignoring all calls to it.');
+    AL.setSpeedOfSound(value);
+  },
+
+  setSpeedOfSound: function doSetSpeedOfSound(value) {
+    if(value <= 0) { // Negative or zero values are disallowed
+        AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+        return;
+    }
+    // TODO
   },
 
 
@@ -1630,8 +1643,11 @@ var LibraryOpenAL = {
   },
 
   alcCaptureOpenDevice: function(deviceName, freq, format, bufferSize) {
-      // From the programmer's guide, ALC_OUT_OF_MEMORY here means:
-      // "The specified device is invalid, or can not capture audio."
+    Runtime.warnOnce('alcCapture*() functions don\'t do anything yet.');
+    // From the programmer's guide, ALC_OUT_OF_MEMORY's meaning is
+    // overloaded here, to mean:
+    // "The specified device is invalid, or can not capture audio."
+    // This may be misleading to API users.
     AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
     return 0; // NULL device pointer
   },

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1692,13 +1692,13 @@ var LibraryOpenAL = {
 
   alDopplerFactor: function(value) {
     Runtime.warnOnce('alDopplerFactor() is not yet implemented!');
-    if(!AL.currentContext) {
+    if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alDopplerFactor called without a valid context");
 #endif
       return;
     }
-    if(value < 0) { // Strictly negative values are disallowed
+    if (value < 0) { // Strictly negative values are disallowed
       AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
@@ -1711,13 +1711,13 @@ var LibraryOpenAL = {
   // alSpeedOfSound() with an appropriately premultiplied value.
   alDopplerVelocity: function(value) {
     Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for binary compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
-    if(!AL.currentContext) {
+    if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSpeedOfSound called without a valid context");
 #endif
       return;
     }
-    if(value <= 0) { // Negative or zero values are disallowed
+    if (value <= 0) { // Negative or zero values are disallowed
         AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
         return;
     }
@@ -1725,13 +1725,13 @@ var LibraryOpenAL = {
 
   alSpeedOfSound: function(value) {
     Runtime.warnOnce('alSpeedOfSound() is not yet implemented!');
-    if(!AL.currentContext) {
+    if (!AL.currentContext) {
 #if OPENAL_DEBUG
       console.error("alSpeedOfSound called without a valid context");
 #endif
       return;
     }
-    if(value <= 0) { // Negative or zero values are disallowed
+    if (value <= 0) { // Negative or zero values are disallowed
         AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
         return;
     }
@@ -1742,7 +1742,7 @@ var LibraryOpenAL = {
     // Spec says :
     //   Using a NULL handle is legal, but only the
     //   tokens defined by the AL core are guaranteed.
-    if(device!==0 && device!==1) {
+    if (device!==0 && device!==1) {
 #if OPENAL_DEBUG
       console.error("alcGetEnumValue called with an invalid device");
 #endif
@@ -1874,7 +1874,7 @@ var LibraryOpenAL = {
   },
 
   alGetDoublev: function(param, data) {
-    if(!data)
+    if (!data)
       return;
     var val = AL.getDouble("alGetDoublev", param);
     {{{ makeSetValue('data', '0', 'val', 'double') }}};
@@ -1885,7 +1885,7 @@ var LibraryOpenAL = {
   },
 
   alGetFloatv: function(param, data) {
-    if(!data)
+    if (!data)
       return;
     var val = AL.getDouble("alGetFloatv", param);
     {{{ makeSetValue('data', '0', 'val', 'float') }}};
@@ -1896,7 +1896,7 @@ var LibraryOpenAL = {
   },
 
   alGetIntegerv: function(param, data) {
-    if(!data)
+    if (!data)
       return;
     var val = AL.getDouble("alGetIntegerv", param);
     {{{ makeSetValue('data', '0', 'val', 'i32') }}};
@@ -1907,7 +1907,7 @@ var LibraryOpenAL = {
   },
 
   alGetBooleanv: function(param, data) {
-    if(!data)
+    if (!data)
       return;
     var val = !!AL.getDouble("alGetBooleanv", param);
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
@@ -2015,7 +2015,7 @@ var LibraryOpenAL = {
 
   alGetListener3f: function(param, v1, v2, v3) {
     var v = AL.getListenerXxx("alGetListener3f", param);
-    if(!v)
+    if (!v)
       return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
@@ -2024,7 +2024,7 @@ var LibraryOpenAL = {
 
   alGetListener3i: function(param, v1, v2, v3) {
     var v = AL.getListenerXxx("alGetListener3i", param);
-    if(!v)
+    if (!v)
       return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
@@ -2033,13 +2033,13 @@ var LibraryOpenAL = {
 
   alGetListeneriv: function(param, data) {
     var v = AL.getListenerXxx("alGetListeneriv", param);
-    if(!v)
+    if (!v)
       return;
     {{{ makeSetValue('data',  '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('data',  '4', 'v[1]', 'i32') }}};
     {{{ makeSetValue('data',  '8', 'v[2]', 'i32') }}};
 
-    if(param == 0x100F /* AL_ORIENTATION */) {
+    if (param == 0x100F /* AL_ORIENTATION */) {
       {{{ makeSetValue('data', '12', 'v[3]', 'i32') }}};
       {{{ makeSetValue('data', '16', 'v[4]', 'i32') }}};
       {{{ makeSetValue('data', '20', 'v[5]', 'i32') }}};
@@ -2082,7 +2082,7 @@ var LibraryOpenAL = {
     case 0x1005 /* AL_DIRECTION */: return src.direction;
     case 0x1006 /* AL_VELOCITY */:  return src.velocity;
     }
- #if OPENAL_DEBUG
+#if OPENAL_DEBUG
     console.error(funcname + " with param " + param + " not implemented yet");
 #endif
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
@@ -2090,7 +2090,7 @@ var LibraryOpenAL = {
 
   alGetSource3f: function(source, param, v1, v2, v3) {
     var v = AL.getSource3Xxx("alGetSource3f", source, param);
-    if(!v)
+    if (!v)
         return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'float') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'float') }}};
@@ -2099,7 +2099,7 @@ var LibraryOpenAL = {
 
   alGetSource3i: function(source, param, v1, v2, v3) {
     var v = AL.getSource3Xxx("alGetSource3i", source, param);
-    if(!v)
+    if (!v)
         return;
     {{{ makeSetValue('v1', '0', 'v[0]', 'i32') }}};
     {{{ makeSetValue('v2', '0', 'v[1]', 'i32') }}};
@@ -2234,7 +2234,7 @@ var LibraryOpenAL = {
   // (from the programming guide)
 
   alGetBufferf: function(buffer, pname, value) {
-    if(!value) {
+    if (!value) {
       AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
@@ -2242,7 +2242,7 @@ var LibraryOpenAL = {
   },
 
   alGetBuffer3f: function(buffer, pname, v1, v2, v3) {
-    if(!v1 || !v2 || !v3) {
+    if (!v1 || !v2 || !v3) {
       AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
@@ -2250,7 +2250,7 @@ var LibraryOpenAL = {
   },
 
   alGetBufferfv: function(buffer, pname, values) {
-    if(!values) {
+    if (!values) {
       AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
@@ -2258,7 +2258,7 @@ var LibraryOpenAL = {
   },
 
   alGetBuffer3i: function(buffer, pname, v1, v2, v3) {
-    if(!v1 || !v2 || !v3) {
+    if (!v1 || !v2 || !v3) {
       AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2094,72 +2094,94 @@ var LibraryOpenAL = {
     }
   },
 
+  alGetBufferiv__deps: ['alGetBufferi'],
+  alGetBufferiv: function(buffer, pname, values) {
+      _alGetBufferi(buffer, pname, values);
+  }
+
+  // All of the remaining alBuffer* setters and getters are only of interest
+  // to extensions which need them. Core OpenAL alone defines no valid
+  // property for these.
+
+  // For lack of a better name...
+  bufferDummyAccessor: function bufferDummyAccessor(funcname, buffer) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called without a valid context");
+#endif
+      return;
+    }
+    var buf = AL.currentContext.buf[buffer - 1];
+    if (!buf) {
+#if OPENAL_DEBUG
+      console.error(funcname + " called with an invalid buffer");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return;
+    }
+
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+  }
 
   alBufferf: function(buffer, param, value) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBufferf() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBufferf", buffer);
   },
 
   alBuffer3f: function(buffer, param, v1, v2, v3) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBuffer3f() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBuffer3f", buffer);
   },
 
   alBufferfv: function(buffer, param, values) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBufferfv() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBufferfv", buffer);
   },
 
   alBufferi: function(buffer, param, value) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBufferi() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBufferi", buffer);
   },
 
   alBuffer3i: function(buffer, param, v1, v2, v3) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBuffer3i() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBuffer3i", buffer);
   },
 
   alBufferiv: function(buffer, params, values) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alBufferiv() is not yet implemented! Ignoring all calls to it.');
+    AL.bufferDummyAccessor("alBufferiv", buffer);
   },
 
+  // These in particular can error with AL_INVALID_VALUE
+  // if "the destination pointer is not valid"
+  // (from the programming guide)
+
   alGetBufferf: function(buffer, pname, value) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alGetBufferf() is not yet implemented! Ignoring all calls to it.');
+    if(value == 0) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBufferf", buffer);
   },
 
   alGetBuffer3f: function(buffer, pname, v1, v2, v3) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alGetBuffer3f() is not yet implemented! Ignoring all calls to it.');
+    if(v1 == 0 || v2 == 0 || v3 == 0) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBuffer3f", buffer);
   },
 
   alGetBufferfv: function(buffer, pname, values) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alGetBufferfv() is not yet implemented! Ignoring all calls to it.');
+    if(values == 0) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBufferfv", buffer);
   },
 
   alGetBuffer3i: function(buffer, pname, v1, v2, v3) {
-    // TODO(yoanlcq)
-      // only used by extensions
-    Runtime.warnOnce('alGetBuffer3i() is not yet implemented! Ignoring all calls to it.');
+    if(v1 == 0 || v2 == 0 || v3 == 0) {
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
+    }
+    AL.bufferDummyAccessor("alGetBuffer3i", buffer);
   },
-
-  alGetBufferiv: function(buffer, pname, values) {
-    // TODO(yoanlcq)
-      // See alGetBufferi().
-    Runtime.warnOnce('alGetBufferiv() is not yet implemented! Ignoring all calls to it.');
-  }
 
 };
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1711,8 +1711,8 @@ var LibraryOpenAL = {
       return;
     }
     if (value <= 0) { // Negative or zero values are disallowed
-        AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
-        return;
+      AL.currentContext.err = 0xA003 /* AL_INVALID_VALUE */;
+      return;
     }
   },
 

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1614,7 +1614,252 @@ var LibraryOpenAL = {
 
   alDopplerVelocity: function(value) {
     Runtime.warnOnce('alDopplerVelocity() is not yet implemented! Ignoring all calls to it.');
+  },
+
+
+
+
+
+
+
+
+  alcGetEnumValue: function(device, name) {
+    // TODO(yoanlcq)
+    AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
+    return 0;
+  },
+
+  alcCaptureOpenDevice: function(deviceName, freq, format, bufferSize) {
+      // From the programmer's guide, ALC_OUT_OF_MEMORY here means:
+      // "The specified device is invalid, or can not capture audio."
+    AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
+    return 0; // NULL device pointer
+  },
+
+  alcCaptureCloseDevice: function(device) {
+    AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
+    return 0 /* ALC_FALSE */;
+  },
+
+  alcCaptureStart: function(device) {
+    AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
+  },
+
+  alcCaptureStop: function(device) {
+    AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
+  },
+
+  alcCaptureSamples: function(device, buffer, num_samples) {
+    AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
+  },
+
+  alIsEnabled: function(capability) {
+    // TODO(yoanlcq)
+    // returns ALboolean
+    // AL_INVALID_OPERATION if there's no context
+    // AL_INVALID_ENUM if capability is not valid
+    Runtime.warnOnce('alIsEnabled() is not yet implemented! Ignoring all calls to it.');
+    return 0;
+  },
+
+  // In this section, all alget*() functions
+  // return the current value of either :
+  // AL_DOPPLER_FACTOR
+  // AL_SPEED_OF_SOUND
+  // AL_DISTANCE_MODEL
+  // All of them can be implemented by casting the
+  // return value of alGetDouble().
+  // IMO that's a poor API design, but we have to support it.
+  alGetDouble: function(param) {
+    // TODO(yoanlcq)
+    switch (param) {
+    case TODO /* AL_DOPPLER_FACTOR */: return TODO;
+    case TODO /* AL_SPEED_OF_SOUND */: return TODO;
+    case TODO /* AL_DISTANCE_MODEL */: return TODO;
+    }
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+
+    Runtime.warnOnce('alGetDouble() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetDoublev: function(param, data) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetDoublev() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetFloat: function(param) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetFloat() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetFloatv: function(param, data) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetFloatv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetInteger: function(param) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetInteger() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetIntegerv: function(param, data) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetIntegerv() is not yet implemented! Ignoring all calls to it.');
   }
+
+  alGetBoolean: function(param) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetBoolean() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBooleanv: function(param, data) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetBooleanv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+
+
+  alListeneri: function(param, value) {
+    // TODO(yoanlcq)
+    // AL_INVALID_VALUE
+    // AL_INVALID_ENUM
+    // Quoting the programmer's guide:
+    // There are no integer listener attributes defined for OpanAL 1.1,
+    // but this function may be used by an extension.
+    AL.currentContext.err = AL_INVALID_ENUM
+  },
+
+  alListener3i: function(param, v1, v2, v3) {
+    // TODO(yoanlcq)
+    // AL_POSITION
+    // AL_VELOCITY
+    Runtime.warnOnce('alListener3i() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alListeneriv: function(param, values) {
+    // TODO(yoanlcq)
+    // AL_POSITION
+    // AL_VELOCITY
+    // AL_ORIENTATION
+    Runtime.warnOnce('alListeneriv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetListener3f: function(param, v1, v2, v3) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetListener3f() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetListener3i: function(param, v1, v2, v3) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetListener3i() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetListeneriv: function(param, data) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetListeneriv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alSourceiv: function(value) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alSourceiv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetSource3f: function(value) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetSource3f() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetSource3i: function(value) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alGetSource3i() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alSourcePlayv: function(n, sources) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alSourcePlayv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alSourceStopv: function(n, sources) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alSourceStopv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alSourceRewindv: function(n, sources) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alSourceRewindv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alSourcePausev: function(n, sources) {
+    // TODO(yoanlcq)
+    Runtime.warnOnce('alSourcePausev() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBufferf: function(buffer, param, value) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBufferf() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBuffer3f: function(buffer, param, v1, v2, v3) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBuffer3f() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBufferfv: function(buffer, param, values) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBufferfv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBufferi: function(buffer, param, value) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBufferi() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBuffer3i: function(buffer, param, v1, v2, v3) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBuffer3i() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alBufferiv: function(buffer, params, values) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alBufferiv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBufferf: function(buffer, pname, value) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alGetBufferf() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBuffer3f: function(buffer, pname, v1, v2, v3) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alGetBuffer3f() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBufferfv: function(buffer, pname, values) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alGetBufferfv() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBuffer3i: function(buffer, pname, v1, v2, v3) {
+    // TODO(yoanlcq)
+      // only used by extensions
+    Runtime.warnOnce('alGetBuffer3i() is not yet implemented! Ignoring all calls to it.');
+  },
+
+  alGetBufferiv: function(buffer, pname, values) {
+    // TODO(yoanlcq)
+      // See alGetBufferi().
+    Runtime.warnOnce('alGetBufferiv() is not yet implemented! Ignoring all calls to it.');
+  }
+
 };
 
 autoAddDeps(LibraryOpenAL, '$AL');

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1670,19 +1670,20 @@ var LibraryOpenAL = {
     return 0;
   },
 
+
   alcCaptureOpenDevice: function(deviceName, freq, format, bufferSize) {
     Runtime.warnOnce('alcCapture*() functions don\'t do anything yet.');
     // From the programmer's guide, ALC_OUT_OF_MEMORY's meaning is
     // overloaded here, to mean:
     // "The specified device is invalid, or can not capture audio."
-    // This may be misleading to API users.
+    // This may be misleading to API users, but well.
     AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
     return 0; // NULL device pointer
   },
 
   alcCaptureCloseDevice: function(device) {
     AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
-    return 0 /* ALC_FALSE */;
+    return false;
   },
 
   alcCaptureStart: function(device) {
@@ -1697,14 +1698,25 @@ var LibraryOpenAL = {
     AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
   },
 
+
+
+
+
   alIsEnabled: function(capability) {
-    // TODO(yoanlcq)
-    // returns ALboolean
-    // AL_INVALID_OPERATION if there's no context
-    // AL_INVALID_ENUM if capability is not valid
-    Runtime.warnOnce('alIsEnabled() is not yet implemented! Ignoring all calls to it.');
-    return 0;
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alIsEnabled() called without a valid context");
+#endif
+      return false;
+    }
+    // There's no capability yet
+    AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
+    return false;
   },
+
+
+
+
 
   // In this section, all alget*() functions
   // return the current value of either :

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1787,7 +1787,8 @@ var LibraryOpenAL = {
 #endif
       return false;
     }
-    // There's no defined capability yet
+    // There's no defined capability for this yet - but extensions may want
+    // to use it.
     AL.currentContext.err = 0xA002 /* AL_INVALID_ENUM */;
     return false;
   },
@@ -1835,7 +1836,7 @@ var LibraryOpenAL = {
   },
 
   alGetBooleanv: function(param, data) {
-    {{{ makeSetValue('data', '0', 'AL.alGetBoolean(param)', 'u8') }}};
+    {{{ makeSetValue('data', '0', 'AL.alGetBoolean(param)', 'i8') }}};
   },
 
 
@@ -1845,7 +1846,7 @@ var LibraryOpenAL = {
     // AL_INVALID_VALUE
     // AL_INVALID_ENUM
     // Quoting the programmer's guide:
-    // There are no integer listener attributes defined for OpanAL 1.1,
+    // There are no integer listener attributes defined for OpenAL 1.1,
     // but this function may be used by an extension.
     AL.currentContext.err = AL_INVALID_ENUM
   },

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1864,8 +1864,8 @@ var LibraryOpenAL = {
   },
 
   alGetDoublev: function(param, data) {
-    if (!data) return;
     var val = AL.getDoubleHelper("alGetDoublev", param);
+    if (!data) return;
     {{{ makeSetValue('data', '0', 'val', 'double') }}};
   },
 
@@ -1874,8 +1874,8 @@ var LibraryOpenAL = {
   },
 
   alGetFloatv: function(param, data) {
-    if (!data) return;
     var val = AL.getDoubleHelper("alGetFloatv", param);
+    if (!data) return;
     {{{ makeSetValue('data', '0', 'val', 'float') }}};
   },
 
@@ -1884,8 +1884,8 @@ var LibraryOpenAL = {
   },
 
   alGetIntegerv: function(param, data) {
-    if (!data) return;
     var val = AL.getDoubleHelper("alGetIntegerv", param);
+    if (!data) return;
     {{{ makeSetValue('data', '0', 'val', 'i32') }}};
   },
 
@@ -1894,8 +1894,8 @@ var LibraryOpenAL = {
   },
 
   alGetBooleanv: function(param, data) {
-    if (!data) return;
     var val = !!AL.getDoubleHelper("alGetBooleanv", param);
+    if (!data) return;
     {{{ makeSetValue('data', '0', 'val', 'i8') }}};
   },
 

--- a/tests/openal_playback.cpp
+++ b/tests/openal_playback.cpp
@@ -58,7 +58,7 @@ void main_tick(void *arg)
 int main() {
   int major, minor;
   alcGetIntegerv(NULL, ALC_MAJOR_VERSION, 1, &major);
-  alcGetIntegerv(NULL, ALC_MAJOR_VERSION, 1, &minor);
+  alcGetIntegerv(NULL, ALC_MINOR_VERSION, 1, &minor);
 
   assert(major == 1);
 


### PR DESCRIPTION
This is of primary interest to projects that need to link against the entire OpenAL API (e.g bindings, and, in my particular case, [https://github.com/jpernst/alto/issues/30](https://github.com/jpernst/alto/issues/30)).
The PR also adds a minor fix in a test, and improves the existing `alGetEnumValue` implementation.

Tests as run with `pyhton tests/runner.py interactive.test_openal_*` passed.  I ran no tests other than these because all I did was add new functions.  
I did not create new tests either, since most of said functions are mere wrappers, and as such, their correctness is easy to prove with a review (IMO).  
  
Finally, I hope the commits are OK - I've tried a few things to somehow turn them all into a single one, but it messed up things every time, and I still have no clue.  