### PR TITLE
Refactor emcc py

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2078,7 +2078,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # If we were asked to also generate HTML, do that
       if final_suffix == 'html':
         generate_html(target, shell_path, js_target, target_basename, proxy_to_worker,
-                      separate_asm, memory_init_file, wasm_binary_target, output_eol)
+                      separate_asm, memory_init_file, wasm_binary_target, output_eol, optimizer)
       else:
         if proxy_to_worker:
           generate_worker_js(target, js_target, target_basename)

--- a/emcc.py
+++ b/emcc.py
@@ -2121,7 +2121,15 @@ def emterpretify(js_target, optimizer, options):
   try:
     # move temp js to final position, alongside its mem init file
     shutil.move(final, js_target)
-    args = [shared.PYTHON, shared.path_from_root('tools', 'emterpretify.py'), js_target, final + '.em.js', json.dumps(shared.Settings.EMTERPRETIFY_BLACKLIST), json.dumps(shared.Settings.EMTERPRETIFY_WHITELIST), '', str(shared.Settings.SWAPPABLE_ASM_MODULE)]
+    args = [shared.PYTHON,
+            shared.path_from_root('tools', 'emterpretify.py'),
+            js_target,
+            final + '.em.js',
+            json.dumps(shared.Settings.EMTERPRETIFY_BLACKLIST),
+            json.dumps(shared.Settings.EMTERPRETIFY_WHITELIST),
+            '',
+            str(shared.Settings.SWAPPABLE_ASM_MODULE),
+           ]
     if shared.Settings.EMTERPRETIFY_ASYNC:
       args += ['ASYNC=1']
     if shared.Settings.EMTERPRETIFY_ADVISE:

--- a/emcc.py
+++ b/emcc.py
@@ -2122,14 +2122,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           print jsrun.run_js(shared.path_from_root('tools', 'js-optimizer.js'), shared.NODE_JS, args=[asm_target, 'eliminateDeadGlobals', 'last', 'asm'], stdout=open(temp, 'w'))
           shutil.move(temp, asm_target)
 
-      if shared.Settings.BINARYEN_METHOD:
-        methods = shared.Settings.BINARYEN_METHOD.split(',')
-        valid_methods = ['asmjs', 'native-wasm', 'interpret-s-expr', 'interpret-binary', 'interpret-asm2wasm']
-        for m in methods:
-          if not m.strip() in valid_methods:
-            logging.error('Unrecognized BINARYEN_METHOD "' + m.strip() + '" specified! Please pass a comma-delimited list containing one or more of: ' + ','.join(valid_methods))
-            sys.exit(1)
-
+      binaryen_method_sanity_check()
       if shared.Settings.BINARYEN:
         (final, memory_init_file) = do_binaryen(
           final, asm_target, opt_level, shrink_level, memory_init_file, memfile,
@@ -2168,6 +2161,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass
     else:
       logging.info('emcc saved files are in:' + temp_dir)
+
+
+def binaryen_method_sanity_check():
+  if shared.Settings.BINARYEN_METHOD:
+    methods = shared.Settings.BINARYEN_METHOD.split(',')
+    valid_methods = ['asmjs', 'native-wasm', 'interpret-s-expr', 'interpret-binary', 'interpret-asm2wasm']
+    for m in methods:
+      if not m.strip() in valid_methods:
+        logging.error('Unrecognized BINARYEN_METHOD "' + m.strip() + '" specified! Please pass a comma-delimited list containing one or more of: ' + ','.join(valid_methods))
+        sys.exit(1)
 
 
 def do_binaryen(final, asm_target, opt_level, shrink_level, memory_init_file, memfile,

--- a/emcc.py
+++ b/emcc.py
@@ -1780,7 +1780,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
 
       if options.debug_level >= 4:
-        emit_source_maps(target, js_transform_tempfiles)
+        emit_source_maps(target, optimizer.js_transform_tempfiles)
 
       # track files that will need native eols
       generated_text_files_with_native_eols = []

--- a/emcc.py
+++ b/emcc.py
@@ -126,7 +126,8 @@ def log_time(name):
 
 
 class JSOptimizer:
-  def __init__(self):
+  def __init__(self, opt_level, debug_level, emit_symbol_map, profiling_funcs,
+               use_closure_compiler, misc_temp_files, js_transform_tempfiles):
     self.queue = []
     self.extra_info = {}
     self.queue_history = []
@@ -134,14 +135,13 @@ class JSOptimizer:
     self.minify_whitespace = False
     self.cleanup_shell = False
 
-    # Temp : figure out better way to pass this data to relevant functions
-    self.opt_level = 0
-    self.debug_level = 0
-    self.emit_symbol_map = False
-    self.profiling_funcs = False
-    self.use_closure_compiler = False
-    self.misc_temp_files = None
-    self.js_transform_tempfiles = None
+    self.opt_level = opt_level
+    self.debug_level = debug_level
+    self.emit_symbol_map = emit_symbol_map
+    self.profiling_funcs = profiling_funcs
+    self.use_closure_compiler = use_closure_compiler
+    self.misc_temp_files = misc_temp_files
+    self.js_transform_tempfiles = js_transform_tempfiles
 
   def flush(self, title='js_opts'):
     self.queue = filter(lambda p: p not in self.blacklist, self.queue)
@@ -1933,16 +1933,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # exit block 'memory initializer'
     log_time('memory initializer')
 
-    optimizer = JSOptimizer()
+    optimizer = JSOptimizer(
+      opt_level=opt_level,
+      debug_level=debug_level,
+      emit_symbol_map=emit_symbol_map,
+      profiling_funcs=profiling_funcs,
+      use_closure_compiler=use_closure_compiler,
+      misc_temp_files=misc_temp_files,
+      js_transform_tempfiles=js_transform_tempfiles,
+    )
     with ToolchainProfiler.profile_block('js opts'):
       # It is useful to run several js optimizer passes together, to save on unneeded unparsing/reparsing
-      optimizer.opt_level = opt_level
-      optimizer.debug_level = debug_level
-      optimizer.emit_symbol_map = emit_symbol_map
-      optimizer.profiling_funcs = profiling_funcs
-      optimizer.use_closure_compiler = use_closure_compiler
-      optimizer.misc_temp_files = misc_temp_files
-      optimizer.js_transform_tempfiles = js_transform_tempfiles
 
       if shared.Settings.DEAD_FUNCTIONS:
         optimizer.queue += ['eliminateDeadFuncs']

--- a/emcc.py
+++ b/emcc.py
@@ -2278,7 +2278,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if final_suffix == 'html':
         generate_html(target, shell_path, js_target, target_basename, proxy_to_worker,
                       separate_asm, memory_init_file, wasm_binary_target, output_eol)
-      else: # final_suffix != html
+      else:
         if proxy_to_worker:
           generate_worker_js(target, js_target, target_basename)
 

--- a/emcc.py
+++ b/emcc.py
@@ -2110,17 +2110,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # track files that will need native eols
       generated_text_files_with_native_eols = []
 
-      # Separate out the asm.js code, if asked. Or, if necessary for another option
       if (separate_asm or shared.Settings.BINARYEN) and not shared.Settings.WASM_BACKEND:
-        logging.debug('separating asm')
-        subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), final, asm_target, final])
+        separate_asm_js(final, asm_target)
         generated_text_files_with_native_eols += [asm_target]
-
-        # extra only-my-code logic
-        if shared.Settings.ONLY_MY_CODE:
-          temp = asm_target + '.only.js'
-          print jsrun.run_js(shared.path_from_root('tools', 'js-optimizer.js'), shared.NODE_JS, args=[asm_target, 'eliminateDeadGlobals', 'last', 'asm'], stdout=open(temp, 'w'))
-          shutil.move(temp, asm_target)
 
       binaryen_method_sanity_check()
       if shared.Settings.BINARYEN:
@@ -2161,6 +2153,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass
     else:
       logging.info('emcc saved files are in:' + temp_dir)
+
+
+def separate_asm_js(final, asm_target):
+  """Separate out the asm.js code, if asked. Or, if necessary for another option"""
+  logging.debug('separating asm')
+  subprocess.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), final, asm_target, final])
+
+  # extra only-my-code logic
+  if shared.Settings.ONLY_MY_CODE:
+    temp = asm_target + '.only.js'
+    print jsrun.run_js(shared.path_from_root('tools', 'js-optimizer.js'), shared.NODE_JS, args=[asm_target, 'eliminateDeadGlobals', 'last', 'asm'], stdout=open(temp, 'w'))
+    shutil.move(temp, asm_target)
 
 
 def binaryen_method_sanity_check():

--- a/emcc.py
+++ b/emcc.py
@@ -2280,10 +2280,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
                       separate_asm, memory_init_file, wasm_binary_target, output_eol)
       else: # final_suffix != html
         if proxy_to_worker:
-          shutil.move(js_target, js_target[:-3] + '.worker.js') # compiler output goes in .worker.js file
-          worker_target_basename = target_basename + '.worker'
-          target_contents = open(shared.path_from_root('src', 'webGLClient.js')).read() + '\n' + open(shared.path_from_root('src', 'proxyClient.js')).read().replace('{{{ filename }}}', shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename).replace('{{{ IDBStore.js }}}', open(shared.path_from_root('src', 'IDBStore.js')).read())
-          open(target, 'w').write(target_contents)
+          generate_worker_js(target, js_target, target_basename)
 
       for f in generated_text_files_with_native_eols:
         tools.line_endings.convert_line_endings_in_file(f, os.linesep, output_eol)
@@ -2441,6 +2438,13 @@ def generate_html(target, shell_path, js_target, target_basename, proxy_to_worke
         html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', output_eol)
         html.write(html_contents)
         html.close()
+
+
+def generate_worker_js(target, js_target, target_basename):
+  shutil.move(js_target, js_target[:-3] + '.worker.js') # compiler output goes in .worker.js file
+  worker_target_basename = target_basename + '.worker'
+  target_contents = open(shared.path_from_root('src', 'webGLClient.js')).read() + '\n' + open(shared.path_from_root('src', 'proxyClient.js')).read().replace('{{{ filename }}}', shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename).replace('{{{ IDBStore.js }}}', open(shared.path_from_root('src', 'IDBStore.js')).read())
+  open(target, 'w').write(target_contents)
 
 
 if __name__ == '__main__':

--- a/emcc.py
+++ b/emcc.py
@@ -2409,7 +2409,9 @@ def generate_html(target, options, js_target, target_basename,
 
   # Download .asm.js if --separate-asm was passed in an asm.js build, or if 'asmjs' is one
   # of the wasm run methods.
-  if options.separate_asm and (not shared.Settings.BINARYEN or 'asmjs' in shared.Settings.BINARYEN_METHOD):
+  if not options.separate_asm or (shared.Settings.BINARYEN and 'asmjs' not in shared.Settings.BINARYEN_METHOD):
+    assert len(asm_mods) == 0, 'no --separate-asm means no client code mods are possible'
+  else:
     script.un_src()
     if len(asm_mods) == 0:
       # just load the asm, then load the rest
@@ -2446,8 +2448,6 @@ def generate_html(target, options, js_target, target_basename,
     };
     codeXHR.send(null);
 ''' % (os.path.basename(asm_target), '\n'.join(asm_mods), script.inline)
-  else:
-    assert len(asm_mods) == 0, 'no --separate-asm means no client code mods are possible'
 
   if shared.Settings.BINARYEN and not shared.Settings.BINARYEN_ASYNC_COMPILATION:
     # We need to load the wasm file before anything else, it has to be synchronously ready TODO: optimize

--- a/emcc.py
+++ b/emcc.py
@@ -2098,14 +2098,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.CYBERDWARF:
           execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
 
-      # Emit source maps, if needed
       if debug_level >= 4:
-        logging.debug('generating source maps')
-        jsrun.run_js(shared.path_from_root('tools', 'source-maps', 'sourcemapper.js'),
-          shared.NODE_JS, js_transform_tempfiles +
-            ['--sourceRoot', os.getcwd(),
-             '--mapFileBaseName', target,
-             '--offset', str(0)])
+        emit_source_maps(target, js_transform_tempfiles)
 
       # track files that will need native eols
       generated_text_files_with_native_eols = []
@@ -2153,6 +2147,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass
     else:
       logging.info('emcc saved files are in:' + temp_dir)
+
+
+def emit_source_maps(target, js_transform_tempfiles):
+  logging.debug('generating source maps')
+  jsrun.run_js(shared.path_from_root('tools', 'source-maps', 'sourcemapper.js'),
+    shared.NODE_JS, js_transform_tempfiles +
+      ['--sourceRoot', os.getcwd(),
+        '--mapFileBaseName', target,
+        '--offset', str(0)])
 
 
 def separate_asm_js(final, asm_target):

--- a/emcc.py
+++ b/emcc.py
@@ -2237,6 +2237,8 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['--mem-max=-1']
     elif shared.Settings.BINARYEN_MEM_MAX >= 0:
       cmd += ['--mem-max=' + str(shared.Settings.BINARYEN_MEM_MAX)]
+    if shared.Settings.LEGALIZE_JS_FFI != 1:
+      cmd += ['--no-legalize-javascript-ffi']
     if shared.Building.is_wasm_only():
       cmd += ['--wasm-only'] # this asm.js is code not intended to run as asm.js, it is only ever going to be wasm, an can contain special fastcomp-wasm support
     if options.debug_level >= 2 or options.profiling_funcs:

--- a/emcc.py
+++ b/emcc.py
@@ -1879,6 +1879,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     log_time('source transforms')
 
     with ToolchainProfiler.profile_block('memory initializer'):
+      memfile = None
       if shared.Settings.MEM_INIT_METHOD > 0:
         memfile = target + '.mem'
         shared.try_delete(memfile)
@@ -2078,7 +2079,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # If we were asked to also generate HTML, do that
       if final_suffix == 'html':
         generate_html(target, shell_path, js_target, target_basename, proxy_to_worker,
-                      separate_asm, memory_init_file, wasm_binary_target, output_eol, optimizer)
+                      separate_asm, memory_init_file, asm_target, wasm_binary_target,
+                      output_eol, memfile, optimizer)
       else:
         if proxy_to_worker:
           generate_worker_js(target, js_target, target_basename)
@@ -2341,7 +2343,8 @@ def modularize(final):
 
 
 def generate_html(target, shell_path, js_target, target_basename, proxy_to_worker,
-                  separate_asm, memory_init_file, wasm_binary_target, output_eol, optimizer):
+                  separate_asm, memory_init_file, asm_target, wasm_binary_target,
+                  output_eol, memfile, optimizer):
   global script_src, script_inline
   logging.debug('generating HTML')
   shell = open(shell_path).read()

--- a/emcc.py
+++ b/emcc.py
@@ -824,7 +824,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if error_on_missing_libraries_cmdline:
         shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
 
-      settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes))
+      settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
 
       # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
       # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
@@ -2490,7 +2490,7 @@ def worker_js_script(proxy_worker_filename):
   return web_gl_client_src + '\n' + proxy_client_src
 
 
-def system_js_libraries_setting_str(libs, lib_dirs, settings_changes):
+def system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files):
   libraries = []
 
   # Find library files

--- a/emcc.py
+++ b/emcc.py
@@ -2443,7 +2443,16 @@ def generate_html(target, shell_path, js_target, target_basename, proxy_to_worke
 def generate_worker_js(target, js_target, target_basename):
   shutil.move(js_target, js_target[:-3] + '.worker.js') # compiler output goes in .worker.js file
   worker_target_basename = target_basename + '.worker'
-  target_contents = open(shared.path_from_root('src', 'webGLClient.js')).read() + '\n' + open(shared.path_from_root('src', 'proxyClient.js')).read().replace('{{{ filename }}}', shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename).replace('{{{ IDBStore.js }}}', open(shared.path_from_root('src', 'IDBStore.js')).read())
+  proxy_worker_filename = shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename
+  web_gl_client_src = open(shared.path_from_root('src', 'webGLClient.js')).read()
+  idb_store_src = open(shared.path_from_root('src', 'IDBStore.js')).read()
+  proxy_client_src = (
+    open(shared.path_from_root('src', 'proxyClient.js')).read()
+    .replace('{{{ filename }}}', proxy_worker_filename)
+    .replace('{{{ IDBStore.js }}}', idb_store_src)
+  )
+
+  target_contents = web_gl_client_src + '\n' + proxy_client_src
   open(target, 'w').write(target_contents)
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -2253,21 +2253,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             if DEBUG: save_intermediate('postclean', 'js')
 
       if shared.Settings.MODULARIZE:
-        logging.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
-        src = open(final).read()
-        final = final + '.modular.js'
-        f = open(final, 'w')
-        f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
-        f.write('  ' + shared.Settings.EXPORT_NAME + ' = ' + shared.Settings.EXPORT_NAME + ' || {};\n')
-        f.write('  var Module = ' + shared.Settings.EXPORT_NAME + ';\n') # included code may refer to Module (e.g. from file packager), so alias it
-        f.write('\n')
-        f.write(src)
-        f.write('\n')
-        f.write('  return ' + shared.Settings.EXPORT_NAME + ';\n')
-        f.write('};\n')
-        f.close()
-        src = None
-        if DEBUG: save_intermediate('modularized', 'js')
+        final = modularize(final)
 
       # The JS is now final. Move it to its final location
       shutil.move(final, js_target)
@@ -2297,6 +2283,24 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass
     else:
       logging.info('emcc saved files are in:' + temp_dir)
+
+
+def modularize(final):
+  logging.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
+  src = open(final).read()
+  final = final + '.modular.js'
+  f = open(final, 'w')
+  f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
+  f.write('  ' + shared.Settings.EXPORT_NAME + ' = ' + shared.Settings.EXPORT_NAME + ' || {};\n')
+  f.write('  var Module = ' + shared.Settings.EXPORT_NAME + ';\n') # included code may refer to Module (e.g. from file packager), so alias it
+  f.write('\n')
+  f.write(src)
+  f.write('\n')
+  f.write('  return ' + shared.Settings.EXPORT_NAME + ';\n')
+  f.write('};\n')
+  f.close()
+  if DEBUG: save_intermediate('modularized', 'js')
+  return final
 
 
 def generate_html(target, shell_path, js_target, target_basename, proxy_to_worker,

--- a/emcc.py
+++ b/emcc.py
@@ -1886,18 +1886,18 @@ def parse_args(newargs):
     newargs[i] = newargs[i].strip()
     if newargs[i].startswith('-O'):
       # Let -O default to -O2, which is what gcc does.
-      requested_level = newargs[i][2:] or '2'
-      if requested_level == 's':
+      options.requested_level = newargs[i][2:] or '2'
+      if options.requested_level == 's':
         options.llvm_opts = ['-Os']
         options.requested_level = 2
         options.shrink_level = 1
         settings_changes.append('INLINING_LIMIT=50')
-      elif requested_level == 'z':
+      elif options.requested_level == 'z':
         options.llvm_opts = ['-Oz']
         options.requested_level = 2
         options.shrink_level = 2
         settings_changes.append('INLINING_LIMIT=25')
-      options.opt_level = validate_arg_level(requested_level, 3, 'Invalid optimization level: ' + newargs[i])
+      options.opt_level = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + newargs[i])
     elif newargs[i].startswith('--js-opts'):
       check_bad_eq(newargs[i])
       options.js_opts = eval(newargs[i+1])

--- a/emscripten.py
+++ b/emscripten.py
@@ -388,11 +388,11 @@ def write_output_file(metadata, post, module, function_table_data, settings, out
     t = time.time()
 
   for i in range(len(module)): # do this loop carefully to save memory
-    if WINDOWS: module[i] = module[i].replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
+    module[i] = normalize_line_endings(module[i])
     outfile.write(module[i])
   module = None
 
-  if WINDOWS: post = post.replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
+  post = normalize_line_endings(post)
   outfile.write(post)
 
   if DEBUG:
@@ -1729,11 +1729,11 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   module = create_module_wasm(sending, receiving, invoke_funcs, settings)
 
   for i in range(len(module)): # do this loop carefully to save memory
-    if WINDOWS: module[i] = module[i].replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
+    module[i] = normalize_line_endings(module[i])
     outfile.write(module[i])
   module = None
 
-  if WINDOWS: post = post.replace('\r\n', '\n') # Normalize to UNIX line endings, otherwise writing to text file will duplicate \r\n to \r\r\n!
+  post = normalize_line_endings(post)
   outfile.write(post)
 
   outfile.close()
@@ -2058,6 +2058,16 @@ def asmjs_mangle(name):
 if os.environ.get('EMCC_FAST_COMPILER') == '0':
   logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
   sys.exit(1)
+
+
+def normalize_line_endings(text):
+  """Normalize to UNIX line endings.
+
+  On Windows, writing to text file will duplicate \r\n to \r\r\n otherwise.
+  """
+  if WINDOWS:
+    return text.replace('\r\n', '\n')
+  return text
 
 
 def main(args, compiler_engine, cache, temp_files, DEBUG):


### PR DESCRIPTION
In the same line as emscripten.py cleanups, start taking the same approach to emcc.py.

Main points:
* extract a bunch of methods from inline code to standalone methods
* promote nested classes and functions to top-level helper functions
* make global variables non-global
  * except for `final`, which will be much harder to untangle. Which makes it twice as worth doing. Eventually.
* bundle most command line args into `EmccOptions` class, for ease of passing around

Will test with asm0-3,binaryen0-3,browser,other , posting for review concurrently