### PR TITLE
Removing "gl-prefetch" runDependency if browser does not support webGL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -293,3 +293,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Fumiya Chiba <fumiya.chiba@nifty.com>
 * Ryan C. Gordon <icculus@icculus.org>
 * Inseok Lee <dlunch@gmail.com>
+* Yair Levinson (copyright owned by Autodesk, Inc.)

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -317,7 +317,7 @@ WebGLClient.prefetch = function() {
   var canvas = document.createElement('canvas');
   var ctx = canvas.getContext('webgl-experimental') || canvas.getContext('webgl');
   if (!ctx) {
-    //remove run dependency created in proxyWorker
+    // If we have no webGL support, we still notify that prefetching is done, as the app blocks on that
     worker.postMessage({ target: 'gl', op: 'setPrefetched', preMain: true });
     return;
   } 

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -318,7 +318,7 @@ WebGLClient.prefetch = function() {
   var ctx = canvas.getContext('webgl-experimental') || canvas.getContext('webgl');
   if (!ctx) {
     //remove run dependency created in proxyWorker
-    worker.postMessage({ target: 'gl', op: 'removeRunDependency', preMain: true });
+    worker.postMessage({ target: 'gl', op: 'setPrefetched', preMain: true });
     return;
   } 
 

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -316,7 +316,11 @@ WebGLClient.prefetch = function() {
   // Create a fake temporary GL context
   var canvas = document.createElement('canvas');
   var ctx = canvas.getContext('webgl-experimental') || canvas.getContext('webgl');
-  if (!ctx) return;
+  if (!ctx) {
+    //remove run dependency created in proxyWorker
+    worker.postMessage({ target: 'gl', op: 'removeRunDependency', preMain: true });
+    return;
+  } 
 
   // Fetch the parameters and proxy them
   var parameters = {};

--- a/src/webGLWorker.js
+++ b/src/webGLWorker.js
@@ -500,10 +500,6 @@ function WebGLWorker() {
         removeRunDependency('gl-prefetch');
         break;
       }
-      case 'removeRunDependency': {
-        removeRunDependency('gl-prefetch');
-        break;
-      }
       default: throw 'weird gl onmessage ' + JSON.stringify(msg);
     }
   };

--- a/src/webGLWorker.js
+++ b/src/webGLWorker.js
@@ -500,6 +500,10 @@ function WebGLWorker() {
         removeRunDependency('gl-prefetch');
         break;
       }
+      case 'removeRunDependency': {
+        removeRunDependency('gl-prefetch');
+        break;
+      }
       default: throw 'weird gl onmessage ' + JSON.stringify(msg);
     }
   };


### PR DESCRIPTION
This submission fixes the issue were emscripten's runtime does not initialize correctly on web-workers for browser's who don't support WebGL.

See [issue 5208](https://github.com/kripken/emscripten/issues/5208) for further details.

