### PR TITLE
Fix crash when calling pthread_mutex_lock on the main thread

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -25,6 +25,10 @@ var LibraryPThread = {
       // structure is 'alive'.
       {{{ makeSetValue('PThread.mainThreadBlock', C_STRUCTS.pthread.self, 'PThread.mainThreadBlock', 'i32') }}};
 
+      // pthread struct robust_list head should point to itself.
+      var headPtr = PThread.mainThreadBlock + {{{ C_STRUCTS.pthread.robust_list }}};
+      {{{ makeSetValue('headPtr', 0, 'headPtr', 'i32') }}};
+
       // Allocate memory for thread-local storage.
       var tlsMemory = allocate({{{ cDefine('PTHREAD_KEYS_MAX') }}} * 4, "i32*", ALLOC_STATIC);
       for (var i = 0; i < {{{ cDefine('PTHREAD_KEYS_MAX') }}}; ++i) HEAPU32[tlsMemory/4+i] = 0;

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -95,6 +95,9 @@ int main()
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 	pthread_mutex_init(&lock, &attr);
 
+	pthread_mutex_lock(&lock);
+	pthread_mutex_unlock(&lock);
+
 	if (emscripten_has_threading_support()) {
 		// Create new threads in parallel.
 		for(int i = 0; i < NUM_THREADS; ++i)
@@ -102,8 +105,6 @@ int main()
 
 		emscripten_set_main_loop(WaitToJoin, 0, 0);
 	} else {
-		pthread_mutex_lock(&lock);
-		pthread_mutex_unlock(&lock);
 #ifdef REPORT_RESULT
 		int result = 50;
 		REPORT_RESULT();


### PR DESCRIPTION
Related to https://github.com/kripken/emscripten/issues/5038, `robust_list.head` was being set properly for new threads but wasn't being set for the main thread so the error persisted.

I have copied the relevant code into `initMainThreadBlock` and I have moved the pthread_mutex_(un)lock calls out of the if block as they should be tested (and work) regardless of the browser's threading support.

