### PR TITLE
sdl_touch_mouse_emulation

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -561,21 +561,23 @@ var LibrarySDL = {
           }
           
           var firstTouch = touches[0];
-          if (event.type == 'touchstart') {
-            SDL.DOMButtons[0] = 1;
+          if (firstTouch) {
+            if (event.type == 'touchstart') {
+              SDL.DOMButtons[0] = 1;
+            }
+            var mouseEventType;
+            switch(event.type) {
+              case 'touchstart': mouseEventType = 'mousedown'; break;
+              case 'touchmove': mouseEventType = 'mousemove'; break;
+            }
+            var mouseEvent = {
+              type: mouseEventType,
+              button: 0,
+              pageX: firstTouch.clientX,
+              pageY: firstTouch.clientY
+            };
+            SDL.events.push(mouseEvent);
           }
-          var mouseEventType;
-          switch(event.type) {
-            case 'touchstart': mouseEventType = 'mousedown'; break;
-            case 'touchmove': mouseEventType = 'mousemove'; break;
-          }
-          var mouseEvent = {
-            type: mouseEventType,
-            button: 0,
-            pageX: firstTouch.clientX,
-            pageY: firstTouch.clientY
-          };
-          SDL.events.push(mouseEvent);
 
           for (var i = 0; i < touches.length; i++) {
             var touch = touches[i];

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1164,6 +1164,16 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 #endif
 
 #if IN_TEST_HARNESS
+
+// Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', function(e) {
+    if (e == 'SimulateInfiniteLoop' || e.message.indexOf('SimulateInfiniteLoop') != -1) return;
+    console.error('Page threw an exception ' + e);
+    Module['pageThrewException'] = true;
+  });
+}
+
 #if USE_PTHREADS == 1
 if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
   xhr = new XMLHttpRequest();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1166,9 +1166,9 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 #if IN_TEST_HARNESS
 
 // Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
-if (typeof window !== 'undefined') {
+if (ENVIRONMENT_IS_WEB) {
   window.addEventListener('error', function(e) {
-    if (e == 'SimulateInfiniteLoop' || e.message.indexOf('SimulateInfiniteLoop') != -1) return;
+    if (e === 'SimulateInfiniteLoop' || e.message.indexOf('SimulateInfiniteLoop') != -1) return;
     console.error('Page threw an exception ' + e);
     Module['pageThrewException'] = true;
   });

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -819,9 +819,11 @@ class BrowserCore(RunnerCore):
   #define REPORT_RESULT_INTERNAL(sync) \
     EM_ASM_({ \
       var xhr = new XMLHttpRequest(); \
-      xhr.open('GET', 'http://localhost:8888/report_result?' + $0, !$1); \
+      var result = $0; \
+      if (Module['pageThrewException']) result = 12345; \
+      xhr.open('GET', 'http://localhost:8888/report_result?' + result, !$1); \
       xhr.send(); \
-      setTimeout(function() { window.close() }, 1000); \
+      if (!Module['pageThrewException'] /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000); \
     }, result, sync);
   #define REPORT_RESULT() REPORT_RESULT_INTERNAL(0)
 #endif
@@ -882,7 +884,7 @@ class BrowserCore(RunnerCore):
             xhr = new XMLHttpRequest();
             xhr.open('GET', 'http://localhost:8888/report_result?' + wrong);
             xhr.send();
-            setTimeout(function() { window.close() }, 1000);
+            if (wrong < 10 /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000);
           };
           actualImage.src = actualUrl;
         }

--- a/tests/sdl_touch.c
+++ b/tests/sdl_touch.c
@@ -69,6 +69,10 @@ int main() {
     // Pass test coordinates in canvas element coordinate frame.
     var x = Module['canvas'].getBoundingClientRect().left;
     var y = Module['canvas'].getBoundingClientRect().top;
+
+    // Test #5258: browser passing a touch event that does not contain any touches should not throw an exception from within SDL.
+    sendEvent('touchstart', { touches: [ ] });
+
     sendEvent('touchstart', { touches: [ { pageX: x+300, pageY: y+225, deviceID: 1, identifier: 1, force: 1 } ] });
     sendEvent('touchmove', { touches: [ { pageX: x+400, pageY: y+225, deviceID: 1, identifier: 1, force: 1 } ] });
     sendEvent('touchend', { changedTouches: [ { pageX: x+400, pageY: y+225, deviceID: 1, identifier: 1, force: 1 } ] });


### PR DESCRIPTION
Test that `firstTouch` field is valid before accessing it in SDL touch-mouse conversion emulation.