### PR TITLE
Wasm browser modules

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -320,12 +320,20 @@ var Runtime = {
   loadedDynamicLibraries: [],
 
   loadDynamicLibrary: function(lib) {
+    var libModule;
 #if BINARYEN
-    var bin = Module['readBinary'](lib);
-    var libModule = Runtime.loadWebAssemblyModule(bin);
+    var bin;
+    if (lib.buffer) {
+      // we were provided the binary, in a typed array
+      bin = lib;
+    } else {
+      // load the binary synchronously
+      bin = Module['readBinary'](lib);
+    }
+    libModule = Runtime.loadWebAssemblyModule(bin);
 #else
     var src = Module['read'](lib);
-    var libModule = eval(src)(
+    libModule = eval(src)(
       Runtime.alignFunctionTables(),
       Module
     );

--- a/src/shell.js
+++ b/src/shell.js
@@ -175,7 +175,7 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
       xhr.open('GET', url, false);
       xhr.responseType = 'arraybuffer';
       xhr.send(null);
-      return xhr.response;
+      return new Uint8Array(xhr.response);
     };
   }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3014,8 +3014,16 @@ window.close = function() {
       }
     ''')
     Popen([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.js']).communicate()
-
     self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js'])
+
+    print 'wasm'
+    # note that we must proxy-to-worker, as there we can ready binary data synchronously, which is what dynamicLibraries requires
+
+    open('pre.js', 'w').write('''
+      var Module = { dynamicLibraries: ['side.wasm'] };
+  ''')
+    Popen([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.js', '-s', 'WASM=1']).communicate()
+    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '-g', '--proxy-to-worker'])
 
   def test_dynamic_link_glemu(self):
     open('pre.js', 'w').write('''


### PR DESCRIPTION
Fix and test loading shared modules in wasm in the browser. Things are trickier than the shell because we can't always load binary data synchronously on the web.

This worked before in workers, where we do have sync binary reading. Added a test for that. For the main thread where we don't have sync binary reading, this preloads the binaries during startup.