### PR TITLE
include credentials when fetching wasm binaries

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1981,7 +1981,7 @@ addOnPreRun(function() {
     addRunDependency('preload_dynamicLibraries');
     var binaries = [];
     Module['dynamicLibraries'].forEach(function(lib) {
-      fetch(lib).then(function(response) {
+      fetch(lib, { credentials: 'include' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + lib + "'";
         }
@@ -2226,7 +2226,7 @@ function integrateWasmJS(Module) {
   function getBinaryPromise() {
     // if we don't have the binary yet, and have the Fetch api, use that
     if (!Module['wasmBinary'] && typeof fetch === 'function') {
-      return fetch(wasmBinaryFile).then(function(response) {
+      return fetch(wasmBinaryFile, { credentials: 'include' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";
         }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1981,7 +1981,7 @@ addOnPreRun(function() {
     addRunDependency('preload_dynamicLibraries');
     var binaries = [];
     Module['dynamicLibraries'].forEach(function(lib) {
-      fetch(lib, { credentials: 'include' }).then(function(response) {
+      fetch(lib, { credentials: 'same-origin' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + lib + "'";
         }
@@ -2226,7 +2226,7 @@ function integrateWasmJS(Module) {
   function getBinaryPromise() {
     // if we don't have the binary yet, and have the Fetch api, use that
     if (!Module['wasmBinary'] && typeof fetch === 'function') {
-      return fetch(wasmBinaryFile, { credentials: 'include' }).then(function(response) {
+      return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";
         }


### PR DESCRIPTION
Fetch API does not include cookies/credentials by default as XHR would.
To cause browsers to send a request with credentials included, add
credentials: 'include' to the init object you pass to the fetch()
method.