### PR TITLE
Add stubs for sigsetjmp / siglongjmp

### DIFF
--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -125,16 +125,13 @@ var funs = {
     return -1;
   },
 #if ASSERTIONS
-  $siglongjmpWarningShown: false,
-  siglongjmp__deps: ['$siglongjmpWarningShown', 'longjmp'],
+  siglongjmp__deps: ['longjmp'],
   siglongjmp: function(env, value) {
     // We cannot wrap the sigsetjmp, but I hope that
     // in most cases siglongjmp will be called later.
-    if (!siglongjmpWarningShown) {
-      // siglongjmp can be called very many times, so don't flood the stderr.
-      Module.printErr("Calling longjmp() instead of siglongjmp()");
-      siglongjmpWarningShown = true;
-    }
+
+    // siglongjmp can be called very many times, so don't flood the stderr.
+    Runtime.warnOnce("Calling longjmp() instead of siglongjmp()");
     _longjmp(env, value);
   },
 #else

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -124,6 +124,22 @@ var funs = {
     ___setErrNo(ERRNO_CODES.EINTR);
     return -1;
   },
+#if ASSERTIONS
+  $siglongjmpWarningShown: false,
+  siglongjmp__deps: ['$siglongjmpWarningShown', 'longjmp'],
+  siglongjmp: function(env, value) {
+    // We cannot wrap the sigsetjmp, but I hope that
+    // in most cases siglongjmp will be called later.
+    if (!siglongjmpWarningShown) {
+      // siglongjmp can be called very many times, so don't flood the stderr.
+      Module.printErr("Calling longjmp() instead of siglongjmp()");
+      siglongjmpWarningShown = true;
+    }
+    _longjmp(env, value);
+  },
+#else
+  siglongjmp: 'longjmp',
+#endif
   sigpending: function(set) {
     {{{ makeSetValue('set', 0, 0, 'i32') }}};
     return 0;

--- a/system/include/libc/setjmp.h
+++ b/system/include/libc/setjmp.h
@@ -19,11 +19,7 @@ typedef struct __jmp_buf_tag {
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
 
-#if !defined(_EMSCRIPTEN_SIGLONGJMP_STUB)
-typedef jmp_buf sigjmp_buf;
-int sigsetjmp (sigjmp_buf, int);
-_Noreturn void siglongjmp (sigjmp_buf, int);
-#else
+#if defined(_EMSCRIPTEN_SIGLONGJMP_STUB)
 typedef jmp_buf sigjmp_buf;
 #define sigsetjmp(buf, x) setjmp((buf))
 #define siglongjmp(buf, x) longjmp((buf), (x))

--- a/system/include/libc/setjmp.h
+++ b/system/include/libc/setjmp.h
@@ -18,9 +18,17 @@ typedef struct __jmp_buf_tag {
 #if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
+
+#if !defined(_EMSCRIPTEN_SIGLONGJMP_STUB)
 typedef jmp_buf sigjmp_buf;
 int sigsetjmp (sigjmp_buf, int);
 _Noreturn void siglongjmp (sigjmp_buf, int);
+#else
+typedef jmp_buf sigjmp_buf;
+#define sigsetjmp(buf, x) setjmp((buf))
+#define siglongjmp(buf, x) longjmp((buf), (x))
+#endif
+
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \

--- a/system/include/libc/setjmp.h
+++ b/system/include/libc/setjmp.h
@@ -18,16 +18,14 @@ typedef struct __jmp_buf_tag {
 #if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
-
-/* XXX EMSCRIPTEN: No signals support, alias sigsetjmp and siglongjmp to their non-signals counterparts. */
 typedef jmp_buf sigjmp_buf;
+/* XXX EMSCRIPTEN: No signals support, alias sigsetjmp and siglongjmp to their non-signals counterparts. */
 #if __EMSCRIPTEN__
 #define sigsetjmp(buf, x) setjmp((buf))
 #else
 int sigsetjmp (sigjmp_buf, int);
 #endif
 _Noreturn void siglongjmp (sigjmp_buf, int);
-
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \

--- a/system/include/libc/setjmp.h
+++ b/system/include/libc/setjmp.h
@@ -19,11 +19,14 @@ typedef struct __jmp_buf_tag {
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
 
-#if defined(_EMSCRIPTEN_SIGLONGJMP_STUB)
+/* XXX EMSCRIPTEN: No signals support, alias sigsetjmp and siglongjmp to their non-signals counterparts. */
 typedef jmp_buf sigjmp_buf;
+#if __EMSCRIPTEN__
 #define sigsetjmp(buf, x) setjmp((buf))
-#define siglongjmp(buf, x) longjmp((buf), (x))
+#else
+int sigsetjmp (sigjmp_buf, int);
 #endif
+_Noreturn void siglongjmp (sigjmp_buf, int);
 
 #endif
 

--- a/tests/core/test_siglongjmp.c
+++ b/tests/core/test_siglongjmp.c
@@ -1,0 +1,19 @@
+#include <setjmp.h>
+#include <stdio.h>
+
+int main() {
+    sigjmp_buf env;
+    volatile int flag = 0;
+    if (sigsetjmp(env, 1) == 0) {
+        // Cannot print anything here, because siglongjmp will
+        // print a warning in between but only with ASSERTIONS enabled
+        flag = 1;
+        siglongjmp(env, 1);
+    } else {
+        if (flag) {
+            puts("Success");
+        }
+    }
+    return 0;
+}
+

--- a/tests/core/test_siglongjmp.c
+++ b/tests/core/test_siglongjmp.c
@@ -1,6 +1,8 @@
 #include <setjmp.h>
 #include <stdio.h>
 
+// TODO: Once signals are supported, improve this test to verify preservation of signals state
+
 int main() {
     sigjmp_buf env;
     volatile int flag = 0;

--- a/tests/core/test_siglongjmp.out
+++ b/tests/core/test_siglongjmp.out
@@ -1,0 +1,1 @@
+Success

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -779,6 +779,9 @@ base align: 0, 0, 0, 0'''])
       Settings.DISABLE_EXCEPTION_CATCHING = disable_throw
       self.do_run_in_out_file_test('tests', 'core', 'test_longjmp_throw')
 
+  def test_siglongjmp(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_siglongjmp')
+
   def test_setjmp_many(self):
     src = r'''
       #include <stdio.h>


### PR DESCRIPTION
Define `sigsetjmp` / `siglongjmp` to be equivalent to `setjmp` / `longjmp`
if _EMSCRIPTEN_SIGLONGJMP_STUB macro is defined, so calls to these
functions will not result in crash due to undefined function and will
work except for `savesigs` semantics.

This `sigsetjmp` stub does not respect `savesigs` argument, but at the time
of writing this AFAIK Emscripten does not support signals.