### PR TITLE
Fix glfwSetTime() setting incorrect time offset

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1012,7 +1012,7 @@ var LibraryGLFW = {
   },
 
   glfwSetTime: function(time) {
-    GLFW.initialTime = GLFW.getTime() + time;
+    GLFW.initialTime = GLFW.getTime() - time;
   },
 
   glfwExtensionSupported: function(extension) {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1359,6 +1359,9 @@ keydown(100);keyup(100); // trigger the end
   def test_glfw_minimal(self):
     self.btest('glfw_minimal.c', '1', args=['-lglfw', '-lGL'])
     self.btest('glfw_minimal.c', '1', args=['-s', 'USE_GLFW=2', '-lglfw', '-lGL'])
+
+  def test_glfw_time(self):
+    self.btest('test_glfw_time.c', '1', args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'])
     
   def test_egl(self):
     open(os.path.join(self.get_dir(), 'test_egl.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'test_egl.c')).read()))

--- a/tests/test_glfw_time.c
+++ b/tests/test_glfw_time.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <GLFW/glfw3.h>
+
+int result = 0;
+int main() {
+    if (!glfwInit()) {
+        return -1;
+    }
+
+    float t = glfwGetTime();
+    printf("glfwGetTime() = %f\n", t);
+
+    printf("glfwSetTime(50)\n");
+    glfwSetTime(50);
+
+    // Expect time to be slightly greater than what we set
+    t = glfwGetTime();
+    printf("glfwGetTime() = %f\n", t);
+
+    if (t < 50 + 1e-3) {
+        result = 1;
+    }
+
+    glfwTerminate();
+
+#ifdef REPORT_RESULT
+                REPORT_RESULT();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
The implementation of `glfwSetTime()` was wrong, adding the passed time argument to the current time instead of subtracting it from. This causes an incorrect time to be set when built for emscripten versus native glfw, I noticed a discrepancy in my app, and compared to the [native glfw implementation](https://github.com/glfw/glfw/blob/78666204a1bb374a4f4752804ff48c55c070906d/src/input.c#L770-L789):

```c
GLFWAPI double glfwGetTime(void)
{
    _GLFW_REQUIRE_INIT_OR_RETURN(0.0);
    return (double) (_glfwPlatformGetTimerValue() - _glfw.timer.offset) /
        _glfwPlatformGetTimerFrequency();
}

GLFWAPI void glfwSetTime(double time)
{
    _GLFW_REQUIRE_INIT();

    if (time != time || time < 0.0 || time > 18446744073.0)
    {
        _glfwInputError(GLFW_INVALID_VALUE, "Invalid time %f", time);
        return;
    }

    _glfw.timer.offset = _glfwPlatformGetTimerValue() -
        (uint64_t) (time * _glfwPlatformGetTimerFrequency());
}
````

compare to [emscripten](https://github.com/kripken/emscripten/blob/6dc4ac5f9e4d8484e273e4dcc554f809738cedd6/src/library_glfw.js#L993-L999):

```js
  glfwGetTime: function() {
    return GLFW.getTime() - GLFW.initialTime;
  },

  glfwSetTime: function(time) {
    GLFW.initialTime = GLFW.getTime() + time;
  },
```

The timer frequency is factored into `GLFW.getTime()` so the only real discrepancy is native glfw uses `-` in set time but emscripten glfw used `+`. This PR changes emscripten to subtract the time, giving identical results to native glfw. This bug has been present since the initial glfw emscripten port, but fortunately its a simple one-character fix.