### PR TITLE
Pass -g to wasm-as for wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1220,6 +1220,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
       shared.Settings.OPT_LEVEL = options.opt_level
       shared.Settings.DEBUG_LEVEL = options.debug_level
+      shared.Settings.PROFILING_FUNCS = options.profiling_funcs
 
       ## Compile source code to bitcode
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -1764,6 +1764,8 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
     # Also convert wasm text to binary
     wasm_as_args = [os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-as'),
                     wast, '-o', basename + '.wasm']
+    if settings['DEBUG_LEVEL'] >= 2 or settings['PROFILING_FUNCS']:
+      wasm_as_args += ['-g']
     logging.debug('  emscript: binaryen wasm-as: ' + ' '.join(wasm_as_args))
     shared.check_call(wasm_as_args)
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -435,6 +435,7 @@ var EMSCRIPTEN_VERSION = ''; // this will contain the emscripten version. you sh
                              // RETAIN_COMPILER_SETTINGS
 var OPT_LEVEL = 0;           // this will contain the optimization level (-Ox). you should not modify it.
 var DEBUG_LEVEL = 0;         // this will contain the debug level (-gx). you should not modify it.
+var PROFILING_FUNCS = 0;     // Whether we are profiling functions. you should not modify it.
 
 
 // JS library elements (C functions implemented in JS)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6118,7 +6118,6 @@ def process(filename):
     '''
     self.do_run(src, '|1.266,1|\n')
 
-  @no_wasm_backend('Need support for -g in wasm backend')
   def test_demangle_stacks(self):
     Settings.DEMANGLE_SUPPORT = 1
     if '-O' in str(self.emcc_args):
@@ -6127,7 +6126,7 @@ def process(filename):
     self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks')
 
   @no_emterpreter
-  @no_wasm_backend('Need support for -g in wasm backend')
+  @no_wasm_backend('s2wasm does not generate symbol maps')
   def test_demangle_stacks_symbol_map(self):
     Settings.DEMANGLE_SUPPORT = 1
     if '-O' in str(self.emcc_args) and '-O0' not in self.emcc_args and '-O1' not in self.emcc_args and '-g' not in self.emcc_args:


### PR DESCRIPTION
Not sure how I feel about the `PROFILING_FUNCS` pseudo-setting as a mechanism to forward that argument from `emcc.py` to `emscripten.py`, but we set `DEBUG_LEVEL` that way. If there are better suggestions I'm on board with them.