### PR TITLE
Fix llvm version warnings

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -66,7 +66,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # -v, without input files
       output = Popen([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE).communicate()
-      self.assertContained('''clang version %s.0 ''' % '.'.join(map(str, EXPECTED_LLVM_VERSION)), output[1].replace('\r', ''), output[1].replace('\r', ''))
+      self.assertContained('''clang version %s.0 ''' % expected_llvm_version(), output[1].replace('\r', ''), output[1].replace('\r', ''))
       self.assertContained('''GNU''', output[0])
       self.assertNotContained('this is dangerous', output[0])
       self.assertNotContained('this is dangerous', output[1])

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -186,10 +186,11 @@ class sanity(RunnerCore):
         for y in range(-2, 3):
           f = open(path_from_root('tests', 'fake', 'clang'), 'w')
           f.write('#!/bin/sh\n')
-          expected_x = EXPECTED_LLVM_VERSION[0] + x
-          expected_y = EXPECTED_LLVM_VERSION[1] + y
+          expected_x, expected_y = (int(x) for x in expected_llvm_version().split('.'))
+          expected_x += x
+          expected_y += y
           if expected_x < 0 or expected_y < 0: continue # must be a valid llvm version
-          print EXPECTED_LLVM_VERSION, x, y, expected_x, expected_y
+          print expected_llvm_version(), x, y, expected_x, expected_y
           f.write('echo "clang version %d.%d" 1>&2\n' % (expected_x, expected_y))
           f.close()
           shutil.copyfile(path_from_root('tests', 'fake', 'clang'), path_from_root('tests', 'fake', 'clang++'))
@@ -240,7 +241,7 @@ class sanity(RunnerCore):
     output = self.check_working(EMCC, WARNING)
     # make sure sanity checks notice there is no source dir with version #
     open(path_from_root('tests', 'fake', 'bin', 'llc'), 'w').write('#!/bin/sh\necho "Registered Targets: there IZ a js backend: JavaScript (asm.js, emscripten) backend"')
-    open(path_from_root('tests', 'fake', 'bin', 'clang++'), 'w').write('#!/bin/sh\necho "clang version %s (blah blah)" >&2\necho "..." >&2\n' % '.'.join(map(str, EXPECTED_LLVM_VERSION)))
+    open(path_from_root('tests', 'fake', 'bin', 'clang++'), 'w').write('#!/bin/sh\necho "clang version %s (blah blah)" >&2\necho "..." >&2\n' % expected_llvm_version())
     os.chmod(path_from_root('tests', 'fake', 'bin', 'llc'), stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
     os.chmod(path_from_root('tests', 'fake', 'bin', 'clang++'), stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
     try_delete(SANITY_FILE)
@@ -273,7 +274,7 @@ class sanity(RunnerCore):
     open(path_from_root('tests', 'fake', 'tools', 'clang', 'emscripten-version.txt'), 'w').write(EMSCRIPTEN_VERSION)
     output = self.check_working(EMCC)
     assert VERSION_WARNING not in output
-    fake = '#!/bin/sh\necho "clang version %s (blah blah) (emscripten waka : waka)"\necho "..."\n' % '.'.join(map(str, EXPECTED_LLVM_VERSION))
+    fake = '#!/bin/sh\necho "clang version %s (blah blah) (emscripten waka : waka)"\necho "..."\n' % expected_llvm_version()
     open(path_from_root('tests', 'fake', 'bin', 'clang'), 'w').write(fake)
     open(path_from_root('tests', 'fake', 'bin', 'clang++'), 'w').write(fake)
     os.chmod(path_from_root('tests', 'fake', 'bin', 'clang'), stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -320,9 +320,13 @@ EM_BUILD_VERBOSE_LEVEL = int(os.getenv('EM_BUILD_VERBOSE')) if os.getenv('EM_BUI
 
 # Expectations
 
-EXPECTED_LLVM_VERSION = (4, 0)
-
 actual_clang_version = None
+
+def expected_llvm_version():
+  if get_llvm_target() == WASM_TARGET:
+    return "5.0"
+  else:
+    return "4.0"
 
 def get_clang_version():
   global actual_clang_version
@@ -333,7 +337,7 @@ def get_clang_version():
   return actual_clang_version
 
 def check_clang_version():
-  expected = '.'.join(map(str, EXPECTED_LLVM_VERSION))
+  expected = expected_llvm_version()
   actual = get_clang_version()
   if expected in actual:
     return True


### PR DESCRIPTION
Without this I always see this when building with the wasm backend:
WARNING:root:LLVM version appears incorrect (seeing "5.0", expected "4.0")
