### PR TITLE
Enable wasm source maps.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -145,6 +145,7 @@ class EmccOptions(object):
     self.exclude_files = []
     self.ignore_dynamic_linking = False
     self.shell_path = shared.path_from_root('src', 'shell.html')
+    self.source_map_base = None
     self.js_libraries = []
     self.bind = False
     self.emrun = False
@@ -1768,8 +1769,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.CYBERDWARF:
           execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
 
-      if options.debug_level >= 4:
-        emit_source_maps(target, optimizer.js_transform_tempfiles)
+      if options.debug_level >= 4 and not shared.Settings.BINARYEN:
+        emit_js_source_maps(target, optimizer.js_transform_tempfiles)
 
       # track files that will need native eols
       generated_text_files_with_native_eols = []
@@ -1951,6 +1952,11 @@ def parse_args(newargs):
     elif newargs[i].startswith('--shell-file'):
       check_bad_eq(newargs[i])
       options.shell_path = newargs[i+1]
+      newargs[i] = ''
+      newargs[i+1] = ''
+    elif newargs[i].startswith('--source-map-base'):
+      check_bad_eq(newargs[i])
+      options.source_map_base = newargs[i+1]
       newargs[i] = ''
       newargs[i+1] = ''
     elif newargs[i].startswith('--js-library'):
@@ -2139,7 +2145,7 @@ def emterpretify(js_target, optimizer, options):
     final = real
 
 
-def emit_source_maps(target, js_transform_tempfiles):
+def emit_js_source_maps(target, js_transform_tempfiles):
   logging.debug('generating source maps')
   jsrun.run_js(shared.path_from_root('tools', 'source-maps', 'sourcemapper.js'),
     shared.NODE_JS, js_transform_tempfiles +
@@ -2252,6 +2258,10 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
       cmd = [os.path.join(binaryen_bin, 'wasm-as'), wasm_text_target, '-o', wasm_binary_target]
       if options.debug_level >= 2 or options.profiling_funcs:
         cmd += ['-g']
+        if options.debug_level >= 4:
+          cmd += ['--source-map=' + wasm_binary_target + '.map']
+          if options.source_map_base:
+            cmd += ['--source-map-url=' + options.source_map_base + wasm_binary_target + '.map']
       logging.debug('wasm-as (text => binary): ' + ' '.join(cmd))
       subprocess.check_call(cmd)
     if import_mem_init:

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -350,6 +350,12 @@ Options that are modified or new in *emcc* are listed below:
      * This argument is ignored if a target other than HTML is
        specified using the "-o" option.
 
+"--source-map-base <base-url>"
+   The URL for the location where WebAssembly source maps will be
+   published. When this option is provided, the **.wasm** file is
+   updated to have a "sourceMappingURL" section. The resulting URL
+   will have format: "<base-url>" + "<wasm-file-name>" + ".map".
+
 "--minify 0"
    Identical to "-g1".
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -304,6 +304,11 @@ Options that are modified or new in *emcc* are listed below:
 	
 		- See `src/shell.html <https://github.com/kripken/emscripten/blob/master/src/shell.html>`_ and `src/shell_minimal.html <https://github.com/kripken/emscripten/blob/master/src/shell_minimal.html>`_ for examples.                  
 		- This argument is ignored if a target other than HTML is specified using the ``-o`` option.
+
+.. _emcc-source-map-base:
+
+``--source-map-base <base-url>``
+	The URL for the location where WebAssembly source maps will be published. When this option is provided, the **.wasm** file is updated to have a ``sourceMappingURL`` section. The resulting URL will have format: ``<base-url>`` + ``<wasm-file-name>`` + ``.map``.
 	
 .. _emcc-minify:
 						   

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_33'
+TAG = 'version_34'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
Creates source map file for ".wasm" during compilation with `-g4`. Also adds `--source-map-base` option to provide a complete solution -- currently the .wasm file must contain `sourceMappingURL` section to make it work (per https://github.com/WebAssembly/design/pull/1051).

The patch requires binaryen with patch https://github.com/WebAssembly/binaryen/pull/1017

The [example](https://yurydelendik.github.io/wasm-source-map-emscripten/pi.html) output can be found at https://github.com/yurydelendik/wasm-source-map-emscripten/ 