### PR TITLE
Remove -vectorize-slp-aggressive=false opt argument

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1876,7 +1876,10 @@ class Building(object):
     opts = opts[:]
     #opts += ['-debug-pass=Arguments']
     if not Settings.SIMD:
-      opts += ['-disable-loop-vectorization', '-disable-slp-vectorization', '-vectorize-loops=false', '-vectorize-slp=false', '-vectorize-slp-aggressive=false']
+      opts += ['-disable-loop-vectorization', '-disable-slp-vectorization', '-vectorize-loops=false', '-vectorize-slp=false']
+      if not Settings.WASM_BACKEND:
+        # This option have been removed in llvm ToT
+        opts += ['-vectorize-slp-aggressive=false']
     else:
       opts += ['-bb-vectorize-vector-bits=128']
 


### PR DESCRIPTION
This argument is no longer supported in llvm since:
https://github.com/llvm-mirror/llvm/commit/cebf3467bc