### PR TITLE
fix other.test_llvm_nativizer

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2323,9 +2323,9 @@ int f() {
     open(os.path.join(self.get_dir(), 'test.file'), 'w').write('''ay file..............,,,,,,,,,,,,,,''')
     open(os.path.join(self.get_dir(), 'stdin'), 'w').write('''inter-active''')
     subprocess.check_call([PYTHON, EMCC, os.path.join(self.get_dir(), 'files.cpp'), '-c'])
-    nativize_llvm = Popen([PYTHON, path_from_root('tools', 'nativize_llvm.py'), os.path.join(self.get_dir(), 'files.o')], stdout=PIPE, stderr=PIPE)
-    nativize_llvm.communicate(input)
-    assert nativize_llvm.returncode == 0
+    nativize_llvm = Popen([PYTHON, path_from_root('tools', 'nativize_llvm.py'), os.path.join(self.get_dir(), 'files.o')], stdout=PIPE)
+    out = nativize_llvm.communicate(input)
+    assert nativize_llvm.returncode == 0, out
     output = Popen([os.path.join(self.get_dir(), 'files.o.run')], stdin=open(os.path.join(self.get_dir(), 'stdin')), stdout=PIPE, stderr=PIPE).communicate()
     self.assertContained('''size: 37
 data: 119,97,107,97,32,119,97,107,97,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -28,6 +28,7 @@ class Cache(object):
     self.filelock = filelock.FileLock(self.filelock_name)
 
     if use_subdir:
+      import shared
       if shared.Settings.WASM_BACKEND:
         dirname = os.path.join(dirname, 'wasm')
       else:

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -28,7 +28,6 @@ class Cache(object):
     self.filelock = filelock.FileLock(self.filelock_name)
 
     if use_subdir:
-      import shared
       if shared.Settings.WASM_BACKEND:
         dirname = os.path.join(dirname, 'wasm')
       else:

--- a/tools/nativize_llvm.py
+++ b/tools/nativize_llvm.py
@@ -12,10 +12,11 @@ from exec_llvm) fails for some reason.
 import os, sys
 from subprocess import Popen, PIPE, STDOUT
 
+from shared import *
+
 __rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 def path_from_root(*pathelems):
   return os.path.join(__rootpath__, *pathelems)
-exec(open(path_from_root('tools', 'shared.py'), 'r').read())
 
 filename = sys.argv[1]
 libs = sys.argv[2:] # e.g.: dl for dlopen/dlclose, util for openpty/forkpty


### PR DESCRIPTION
which regressed in 519de4c4160f3

cc @sbc100 - it looks like that commit's changes to `cache.py` may never have been executed (aside from this one test that broke)? Or I may be missing something here.

I just put an import of `shared` right before the use, since that file is imported from `shared` and a regular import would be recursive.