### PR TITLE
wire.h can now be compiled with -fno-rtti.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -305,3 +305,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dirk Vanden Boer <dirk.vdb@gmail.com>
 * Mitchell Foley <mitchfoley@google.com> (copyright owned by Google, Inc.)
 * Oleksandr Chekhovskyi <oleksandr.chekhovskyi@gmail.com>
+* Michael Siebert <michael.siebert2k@gmail.com>

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -57,18 +57,39 @@ namespace emscripten {
         struct LightTypeID {
             static constexpr TYPEID get() {
                 typedef typename Canonicalized<T>::type C;
-                return (has_unbound_type_names || std::is_polymorphic<C>::value)
-                    ? &typeid(C)
-                    : CanonicalizedID<C>::get();
+                if(has_unbound_type_names || std::is_polymorphic<C>::value) {
+#if __has_feature(cxx_rtti)
+                    return &typeid(T);
+#else
+                    static_assert(!has_unbound_type_names,
+                        "Unbound type names are illegal with RTTI disabled. "
+                        "Either add -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 to or remove -fno-rtti "
+                        "from the compiler arguments");
+                    static_assert(!std::is_polymorphic<C>::value,
+                        "Canonicalized<T>::type being polymorphic is illegal with RTTI disabled");
+#endif
+                }
+
+                return CanonicalizedID<C>::get();
             }
         };
 
         template<typename T>
         constexpr TYPEID getLightTypeID(const T& value) {
             typedef typename Canonicalized<T>::type C;
-            return (has_unbound_type_names || std::is_polymorphic<C>::value)
-                ? &typeid(value)
-                : LightTypeID<T>::get();
+            if(has_unbound_type_names || std::is_polymorphic<C>::value) {
+#if __has_feature(cxx_rtti)
+                return &typeid(value);
+#else
+                static_assert(!has_unbound_type_names,
+                    "Unbound type names are illegal with RTTI disabled. "
+                    "Either add -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 to or remove -fno-rtti "
+                    "from the compiler arguments");
+                static_assert(!std::is_polymorphic<C>::value,
+                    "Canonicalized<T>::type being polymorphic is illegal with RTTI disabled");
+#endif
+            }
+            return LightTypeID<T>::get();
         }
 
         template<typename T>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6401,6 +6401,19 @@ someweirdtext
     self.emcc_args += ['--bind', '--std=c++11']
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_unsigned.cpp'), path_from_root('tests', 'embind', 'test_unsigned.out'))
 
+  def test_embind_f_no_rtti(self):
+    self.emcc_args += ['--bind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
+    src = r'''
+      #include<emscripten/val.h>
+      #include<stdio.h>
+
+      int main(int argc, char** argv){
+        printf("418");
+        return 0;
+      }
+    '''
+    self.do_run(src, '418')
+
   @sync
   @no_wasm_backend()
   def test_scriptaclass(self):


### PR DESCRIPTION
This should resolve issue #4187.

Compare https://github.com/kripken/emscripten/pull/5356

Difference: my name is added to the authors list and I am using copy paste for the locally close error messages instead of a macro, since latter unnecessarily jams the global namespace. Unfortunately, static_assert does only accept string literals as second argument.