### PR TITLE
Make JavaScript file smaller for native-wasm and asmjs builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -297,3 +297,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Matjaž Drolc <mdrolc@gmail.com>
 * James Swift <james@3dengineer.com> (copyright owned by PSPDFKit GmbH)
 * Ryan Lester <ryan@cyph.com> (copyright owned by Cyph, Inc.)
+* Nazar Mokrynskyi <nazar@mokrynskyi.com>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2496,6 +2496,12 @@ function integrateWasmJS(Module) {
     // try the methods. each should return the exports if it succeeded
 
     var exports;
+#if BINARYEN_METHOD == 'native-wasm'
+    exports = doNativeWasm(global, env, providedBuffer);
+#else
+#if BINARYEN_METHOD == 'asmjs'
+    exports = doJustAsm(global, env, providedBuffer);
+#else
     var methods = method.split(',');
 
     for (var i = 0; i < methods.length; i++) {
@@ -2519,6 +2525,8 @@ function integrateWasmJS(Module) {
     }
 
     if (!exports) throw 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods';
+#endif
+#endif
 
 #if RUNTIME_LOGGING
     Module['printErr']('binaryen method succeeded.');


### PR DESCRIPTION
When making native-wasm or asmjs only builds, lets avoid some of the code from being included into resulting JavaScript code (more code will be removed by closure compiler)

In my case JavaScript file was reduced in size from 20.4 KiB to 18.8 KiB