### PR TITLE
Fix an elimination of the function named hasOwnProperty in JSDCE

### DIFF
--- a/tests/optimizer/JSDCE-hasOwnProperty-output.js
+++ b/tests/optimizer/JSDCE-hasOwnProperty-output.js
@@ -1,0 +1,6 @@
+function hasOwnProperty(obj, prop) {
+ return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+if (hasOwnProperty({}, "prop_name")) {
+ console.log("yeah");
+}

--- a/tests/optimizer/JSDCE-hasOwnProperty.js
+++ b/tests/optimizer/JSDCE-hasOwnProperty.js
@@ -1,0 +1,7 @@
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+if (hasOwnProperty({}, 'prop_name')) {
+  console.log('yeah');
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2124,6 +2124,8 @@ int f() {
        ['JSDCE']),
       (path_from_root('tests', 'optimizer', 'JSDCE-uglifyjsNodeTypes.js'), open(path_from_root('tests', 'optimizer', 'JSDCE-uglifyjsNodeTypes-output.js')).read(),
        ['JSDCE']),
+      (path_from_root('tests', 'optimizer', 'JSDCE-hasOwnProperty.js'), open(path_from_root('tests', 'optimizer', 'JSDCE-hasOwnProperty-output.js')).read(),
+       ['JSDCE']),
     ]:
       print input, passes
 

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7809,7 +7809,7 @@ function JSDCE(ast) {
     printErr('^^^^^^^^^^^^^^');
   }
   function ensureData(scope, name) {
-    if (scope[name]) return scope[name];
+    if (Object.prototype.hasOwnProperty.call(scope, name)) return scope[name];
     scope[name] = {
       def: 0,
       use: 0,
@@ -7819,7 +7819,7 @@ function JSDCE(ast) {
   }
   function cleanUp(ast, names) {
     traverse(ast, function(node, type) {
-      if (type === 'defun' && node[1] in names) return emptyNode();
+      if (type === 'defun' && Object.prototype.hasOwnProperty.call(names, node[1])) return emptyNode();
       if (type === 'defun' || type === 'function') return null; // do not enter other scopes
       if (type === 'var') {
         node[1] = node[1].filter(function(varItem, j) {


### PR DESCRIPTION
Currently, the function `hasOwnProperty()` is deleted after a JSDCE phase in `js-optimizer.js`.

```javascript
function hasOwnProperty(obj, prop) {
  return Object.prototype.hasOwnProperty.call(obj, prop);
}

if (hasOwnProperty({}, 'prop_name')) {
  console.log('yeah');
}
```

This pull request fixes the problem by using `Object.prototype.hasOwnProperty.call(obj, property)`.