### PR TITLE
halt_early_on_emscript_failure

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -119,7 +119,7 @@ def compile_js(infile, settings, temp_files, DEBUG):
       logging.debug('emscript: llvm backend: ' + ' '.join(backend_args))
       t = time.time()
     with ToolchainProfiler.profile_block('emscript_llvm_backend'):
-      shared.jsrun.timeout_run(subprocess.Popen(backend_args, stdout=subprocess.PIPE))
+      shared.jsrun.timeout_run(subprocess.Popen(backend_args, stdout=subprocess.PIPE), note_args=backend_args)
     if DEBUG:
       logging.debug('  emscript: llvm backend took %s seconds' % (time.time() - t))
 

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -245,7 +245,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
     err_file_handle = open(err_file, 'w')
     proc = subprocess.Popen(shared.NODE_JS + [temp_file], stdout=out_file_handle, stderr=err_file_handle)
     try:
-      shared.jsrun.timeout_run(proc, timeout=10, full_output=True)
+      shared.jsrun.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
     except Exception, e:
       if 'Timed out' not in str(e): raise e
       shared.logging.debug('ctors timed out\n')


### PR DESCRIPTION
I'm seeing a scenario where if `clang` fails, Emscripten doesn't halt there but attempts to truck on, and then fails a second time, printing two failures in a row, such as

```
DEBUG:root:emscript: llvm backend: C:/code/emsdk/clang/fastcomp/build_incoming_vs2015_64/Debug/bin\llc c:\users\clb\appdata\local\temp\tmp_pghqb\a.bc -march=js -filetype=asm -o c:\users\clb\appdata\local\temp\emscripten_temp\tmpdyuqqh.4.js -emscripten-stack-size=5242880 -O0 -emscripten-assertions=1 -emscripten-no-aliasing-function-pointers -emscripten-global-base=8 -enable-emscripten-cpp-exceptions
Assertion failed: Index < Length && "Invalid index!", file C:\code\emsdk\clang\fastcomp\src\include\llvm/ADT/ArrayRef.h, line 241
Wrote crash dump file "C:\Users\clb\AppData\Local\Temp\llc.exe-ad76a0.dmp"
#0 0x00007ff7980992dc (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x22b92dc)
#1 0x00007ff88013fe21 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x7fe21)
#2 0x00007ff880141979 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x81979)
#3 0x00007ff8801473f5 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x873f5)
#4 0x00007ff880146f37 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x86f37)
#5 0x00007ff880144fc1 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x84fc1)
#6 0x00007ff8801477bf (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x877bf)
#7 0x00007ff7962236e9 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x4436e9)
#8 0x00007ff79738c4da (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15ac4da)
#9 0x00007ff797382b04 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15a2b04)
#10 0x00007ff797385492 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15a5492)
#11 0x00007ff7984bcb40 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x26dcb40)
#12 0x00007ff7984bb514 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x26db514)
#13 0x00007ff79740f24c (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x162f24c)
#14 0x00007ff79740fb71 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x162fb71)
#15 0x00007ff7974088a6 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x16288a6)
#16 0x00007ff795f673be (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x1873be)
#17 0x00007ff795f684fb (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x1884fb)
#18 0x00007ff798897874 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7874)
#19 0x00007ff798897737 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7737)
#20 0x00007ff7988975fe (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab75fe)
#21 0x00007ff798897899 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7899)
#22 0x00007ff8a71e2774 (C:\WINDOWS\System32\KERNEL32.DLL+0x12774)
#23 0x00007ff8a9440d61 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x70d61)
DEBUG:root:  emscript: llvm backend took 0.582000017166 seconds
Traceback (most recent call last):
  File "C:\code\emsdk\emscripten\incoming\\emcc", line 13, in <module>
    emcc.run()
  File "C:\code\emsdk\emscripten\incoming\emcc.py", line 1517, in run
    final = shared.Building.emscripten(final, append_ext=False, extra_args=extra_args)
  File "C:\code\emsdk\emscripten\incoming\tools\shared.py", line 2020, in emscripten
    call_emscripten(cmdline)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2209, in _main
    temp_files.run_and_clean(lambda: main(
  File "C:\code\emsdk\emscripten\incoming\tools\tempfiles.py", line 78, in run_and_clean
    return func()
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2214, in <lambda>
    DEBUG=DEBUG,
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2114, in main
    temp_files=temp_files, DEBUG=DEBUG)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 94, in emscript
    funcs, metadata, mem_init = parse_backend_output(backend_output, DEBUG)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 137, in parse_backend_output
    start_funcs = backend_output.index(start_funcs_marker)
ValueError: substring not found
```

Make `timeout_run` expect 0 return code by default, and throw if `returncode != 0`.

With this, we get

```
DEBUG:root:emscript: llvm backend: C:/code/emsdk/clang/fastcomp/build_incoming_vs2015_64/Debug/bin\llc c:\users\clb\appdata\local\temp\tmpcluzbm\a.bc -march=js -filetype=asm -o c:\users\clb\appdata\local\temp\emscripten_temp\tmpkgzmus.4.js -emscripten-stack-size=5242880 -O0 -emscripten-assertions=1 -emscripten-no-aliasing-function-pointers -emscripten-global-base=8 -enable-emscripten-cpp-exceptions
Assertion failed: Index < Length && "Invalid index!", file C:\code\emsdk\clang\fastcomp\src\include\llvm/ADT/ArrayRef.h, line 241
Wrote crash dump file "C:\Users\clb\AppData\Local\Temp\llc.exe-8d3e50.dmp"
#0 0x00007ff7980992dc (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x22b92dc)
#1 0x00007ff88013fe21 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x7fe21)
#2 0x00007ff880141979 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x81979)
#3 0x00007ff8801473f5 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x873f5)
#4 0x00007ff880146f37 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x86f37)
#5 0x00007ff880144fc1 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x84fc1)
#6 0x00007ff8801477bf (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x877bf)
#7 0x00007ff7962236e9 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x4436e9)
#8 0x00007ff79738c4da (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15ac4da)
#9 0x00007ff797382b04 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15a2b04)
#10 0x00007ff797385492 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x15a5492)
#11 0x00007ff7984bcb40 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x26dcb40)
#12 0x00007ff7984bb514 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x26db514)
#13 0x00007ff79740f24c (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x162f24c)
#14 0x00007ff79740fb71 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x162fb71)
#15 0x00007ff7974088a6 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x16288a6)
#16 0x00007ff795f673be (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x1873be)
#17 0x00007ff795f684fb (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x1884fb)
#18 0x00007ff798897874 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7874)
#19 0x00007ff798897737 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7737)
#20 0x00007ff7988975fe (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab75fe)
#21 0x00007ff798897899 (C:\code\emsdk\clang\fastcomp\build_incoming_vs2015_64\Debug\bin\llc.exe+0x2ab7899)
#22 0x00007ff8a71e2774 (C:\WINDOWS\System32\KERNEL32.DLL+0x12774)
#23 0x00007ff8a9440d61 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x70d61)
Traceback (most recent call last):
  File "C:\code\emsdk\emscripten\incoming\\emcc", line 13, in <module>
    emcc.run()
  File "C:\code\emsdk\emscripten\incoming\emcc.py", line 1517, in run
    final = shared.Building.emscripten(final, append_ext=False, extra_args=extra_args)
  File "C:\code\emsdk\emscripten\incoming\tools\shared.py", line 2020, in emscripten
    call_emscripten(cmdline)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2209, in _main
    temp_files.run_and_clean(lambda: main(
  File "C:\code\emsdk\emscripten\incoming\tools\tempfiles.py", line 78, in run_and_clean
    return func()
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2214, in <lambda>
    DEBUG=DEBUG,
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 2114, in main
    temp_files=temp_files, DEBUG=DEBUG)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 93, in emscript
    backend_output = compile_js(infile, settings, temp_files, DEBUG)
  File "C:\code\emsdk\emscripten\incoming\emscripten.py", line 122, in compile_js
    shared.jsrun.timeout_run(subprocess.Popen(backend_args, stdout=subprocess.PIPE), note_args=backend_args)
  File "C:\code\emsdk\emscripten\incoming\tools\jsrun.py", line 20, in timeout_run
    raise Exception('Subprocess "' + ' '.join(note_args) + '" failed with exit code ' + str(proc.returncode) + '!')
Exception: Subprocess "C:/code/emsdk/clang/fastcomp/build_incoming_vs2015_64/Debug/bin\llc c:\users\clb\appdata\local\temp\tmpcluzbm\a.bc -march=js -filetype=asm -o c:\users\clb\appdata\local\temp\emscripten_temp\tmpkgzmus.4.js -emscripten-stack-size=5242880 -O0 -emscripten-assertions=1 -emscripten-no-aliasing-function-pointers -emscripten-global-base=8 -enable-emscripten-cpp-exceptions" failed with exit code -2147483645!
```