### PR TITLE
benchmark_matrix_multiply

### DIFF
--- a/tests/matrix_multiply.cpp
+++ b/tests/matrix_multiply.cpp
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <stdlib.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+#include "tick.h"
+
+// Naively computes dst = a * b, where a is a matrix of size YxI, and b is a matrix of size IxX. The output matrix dst will be of size YxX.
+void mul(float *dst, float *a, float *b, int Y, int I, int X)
+{
+  for(int y = 0; y < Y; ++y)
+  {
+    for(int x = 0; x < X; ++x)
+    {
+      float *A = a;
+      float *AEnd = a + I;
+      float *B = b + x;
+      float acc = 0.f;
+      while(A < AEnd)
+      {
+        acc += *A++ * *B;
+        B += X;
+      }
+      *dst++ = acc;
+    }
+    a += I;
+  }
+}
+
+float Sum(float *m, int A, int B)
+{
+  float acc = 0.f;
+  for(int i = 0; i < A*B; ++i)
+    acc += m[i];
+  return acc;
+}
+
+void Init(float *m, int A, int B)
+{
+  for(int i = 0; i < A*B; ++i)
+    m[i] = (float)i;
+}
+
+float sums = 0.0f;
+
+void Benchmark(int Num, float *mDst, float *mA, float *mB, int A, int B, int C)
+{
+  for(int i = 0; i < Num; ++i)
+  {
+    mul(mDst, mA, mB, A, B, C);
+    sums += Sum(mDst, A, C);
+  }
+}
+
+int ENVIRONMENT_IS_WEB;
+int A;
+int B;
+int C;
+int NumFrames;
+int NumFramesDone = 0;
+int ItersPerFrame;
+int Method;
+float *mA;
+float *mB;
+float *mDst;
+tick_t t0;
+
+void Done()
+{
+  tick_t t1 = tick();
+  printf("Ran %d matrix multiplications (across %d frames). Total elapsed: %f seconds. Checksum: %f.\n", NumFrames*ItersPerFrame, NumFrames, (double)(t1-t0)/ticks_per_sec(), sums);
+}
+
+void Tick()
+{
+  Benchmark(ItersPerFrame, mDst, mA, mB, A, B, C);
+  if (++NumFramesDone >= NumFrames)
+  {
+    Done();
+#ifdef __EMSCRIPTEN__
+    if (ENVIRONMENT_IS_WEB)
+      emscripten_cancel_main_loop();
+#endif
+    exit(0);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  if (argc < 7)
+  {
+    printf("Usage: matrix_multiply A B C NumFrames ItersPerFrame Method\n");
+    printf("Method is one of: 0=setTimeout, 1=requestAnimationFrame, 2=setImmediate\n");
+    A = 100;
+    B = 20;
+    C = 100;
+    NumFrames = 10;
+    ItersPerFrame = 1000;
+    Method = 2;
+    printf("Not enough parameters specified. Running with defaults: A=%d B=%d C=%d NumFrames=%d ItersPerFrame=%d Method=%d.\n", A, B, C, NumFrames, ItersPerFrame, Method);
+  }
+  else
+  {
+    A = atoi(argv[1]);
+    B = atoi(argv[2]);
+    C = atoi(argv[3]);
+    NumFrames = atoi(argv[4]);
+    ItersPerFrame = atoi(argv[5]);
+    Method = atoi(argv[6]);
+  }
+#ifdef __EMSCRIPTEN__
+  ENVIRONMENT_IS_WEB = EM_ASM_INT_V(return ENVIRONMENT_IS_WEB);
+#endif
+  printf("Performing %d multiplications of matrices of size %dx%d and %dx%d. Distributing multiplication across %d animation frames (matrix muls per frame=%d).\n", NumFrames*ItersPerFrame, A, B, B, C, NumFrames, ItersPerFrame);
+
+// #define EM_TIMING_SETTIMEOUT 0
+// #define EM_TIMING_RAF 1
+// #define EM_TIMING_SETIMMEDIATE 2
+
+  mA = new float[A*B];
+  mB = new float[B*C];
+  mDst = new float[A*C];
+  Init(mA, A, B);
+  Init(mB, B, C);
+
+#ifdef __EMSCRIPTEN__
+  if (ENVIRONMENT_IS_WEB)
+  {
+    switch(Method)
+    {
+      case EM_TIMING_SETTIMEOUT: printf("Using setTimeout(0) to schedule frames.\n"); break;
+      case EM_TIMING_RAF: printf("Using requestAnimationFrame() to schedule frames.\n"); break;
+      case EM_TIMING_SETIMMEDIATE: printf("Using setImmediate/postMessage() to schedule frames.\n"); break;
+      default: printf("Invalid frame scheduling method %d specifiec!\n", Method); exit(1);
+    }
+    emscripten_set_main_loop(Tick, 0, 0);
+    emscripten_set_main_loop_timing(Method, 0);
+  }
+#endif
+
+  t0 = tick();
+
+  if (!ENVIRONMENT_IS_WEB)
+  {
+    for(int i = 0; i < NumFrames; ++i)
+      Tick();
+  }
+}

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -658,6 +658,11 @@ class benchmark(RunnerCore):
       return float(re.search('Total time: ([\d\.]+)', output).group(1))
     self.do_benchmark('memset_16mb', open(path_from_root('tests', 'benchmark_memset.cpp')).read(), '''Total time:''', output_parser=output_parser, shared_args=['-DMIN_COPY=1048576', '-DBUILD_FOR_SHELL', '-I'+path_from_root('tests')])
 
+  def test_matrix_multiply(self):
+    def output_parser(output):
+      return float(re.search('Total elapsed: ([\d\.]+)', output).group(1))
+    self.do_benchmark('matrix_multiply', open(path_from_root('tests', 'matrix_multiply.cpp')).read(), '''Total time:''', output_parser=output_parser, shared_args=['-I'+path_from_root('tests')])
+
   def test_zzz_java_nbody(self): # tests xmlvm compiled java, including bitcasts of doubles, i64 math, etc.
     if CORE_BENCHMARKS: return
     args = [path_from_root('tests', 'nbody-java', x) for x in os.listdir(path_from_root('tests', 'nbody-java')) if x.endswith('.c')] + \


### PR DESCRIPTION
Add benchmark for matrix multiplication.

Wrote this one to experiment with what the performance effects are for doing lots of work in single event tick, or when distributing the same work across multiple event ticks. Added as a benchmark to the benchmark suite.