### PR TITLE
Default getenv('BINARYEM') to '' (avoid passing None to expanduser).

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -301,3 +301,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nazar Mokrynskyi <nazar@mokrynskyi.com>
 * Yury Delendik <ydelendik@mozilla.com> (copyright owned by Mozilla Foundation)
 * Kenneth Perry <thothonegan@gmail.com>
+* Jim Mussared <jim.mussared@gmail.com>

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -9,7 +9,7 @@ import os
 # this helps projects using emscripten find it
 EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '{{{ EMSCRIPTEN_ROOT }}}') # directory
 LLVM_ROOT = os.path.expanduser(os.getenv('LLVM') or '{{{ LLVM_ROOT }}}') # directory
-BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN')) # if not set, we will use it from ports
+BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '') # if not set, we will use it from ports
 
 # If not specified, defaults to sys.executable.
 #PYTHON = 'python'


### PR DESCRIPTION
I noticed this with a fresh install of emscripten, fails while loading the default ~/.emscripten.

#5344