### PR TITLE
Allow deferred calls in 'touchstart' and 'touchend' event handlers (fixes #5052)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -304,3 +304,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jim Mussared <jim.mussared@gmail.com>
 * Dirk Vanden Boer <dirk.vdb@gmail.com>
 * Mitchell Foley <mitchfoley@google.com> (copyright owned by Google, Inc.)
+* Oleksandr Chekhovskyi <oleksandr.chekhovskyi@gmail.com>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -913,9 +913,7 @@ var LibraryJSEvents = {
 
       var eventHandler = {
         target: target,
-        allowsDeferredCalls: false, // XXX Currently disabled, see bug https://bugzilla.mozilla.org/show_bug.cgi?id=966493
-        // Once the above bug is resolved, enable the following condition if possible:
-        // allowsDeferredCalls: eventTypeString == 'touchstart',
+        allowsDeferredCalls: eventTypeString == 'touchstart' || eventTypeString == 'touchend',
         eventTypeString: eventTypeString,
         callbackfunc: callbackfunc,
         handlerFunc: handlerFunc,


### PR DESCRIPTION
I have tested entering fullscreen from touch events on both Chrome and Firefox on Android, and it works now, so no reason to block it anymore. Firefox bug referenced in the original code comment has been fixed years ago.