### PR TITLE
Support mode 2 in SIDE_MODULE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -943,7 +943,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
         assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
-        if shared.Settings.MAIN_MODULE != 2:
+        if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
           shared.Settings.LINKABLE = 1
         shared.Settings.RELOCATABLE = 1
         shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it

--- a/src/settings.js
+++ b/src/settings.js
@@ -479,7 +479,7 @@ var MAIN_MODULE = 0; // A main module is a file compiled in a way that allows us
                      //  2: DCE'd main module. We eliminate dead code normally. If a side
                      //     module needs something from main, it is up to you to make sure
                      //     it is kept alive.
-var SIDE_MODULE = 0; // Corresponds to MAIN_MODULE
+var SIDE_MODULE = 0; // Corresponds to MAIN_MODULE (also supports modes 1 and 2)
 
 var RUNTIME_LINKED_LIBS = []; // If this is a main module (MAIN_MODULE == 1), then
                               // we will link these at runtime. They must have been built with


### PR DESCRIPTION
Like MAIN_MODULE mode 2: enables dce so you need to manually keep alive what you need. Fixes #5419.

Trivial to support, was just an oversight.