### PR TITLE
Update ftrylockfile.c

### DIFF
--- a/system/lib/libc/musl/src/stdio/ftrylockfile.c
+++ b/system/lib/libc/musl/src/stdio/ftrylockfile.c
@@ -5,7 +5,7 @@
 int ftrylockfile(FILE *f)
 {
 	int tid = pthread_self()->tid;
-	if (f->lock == tid) {
+	if (f->lock != tid) {
 		if (f->lockcount == LONG_MAX)
 			return -1;
 		f->lockcount++;


### PR DESCRIPTION
The problem comes from musl It's when the thread is not the locker that we increase the lockcount.
resolve #5402