### PR TITLE
wasm runtime misuse assertions

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1256,7 +1256,9 @@ def create_the_global(metadata, settings):
 
 def create_receiving(function_table_data, function_tables_defs, exported_implemented_functions, settings):
   receiving = ''
-  if settings['ASSERTIONS']:
+  if not settings['ASSERTIONS']:
+    runtime_assertions = ''
+  else:
     # assert on the runtime being in a valid state when calling into compiled code. The only exceptions are
     # some support code
     runtime_assertions = '''
@@ -1266,8 +1268,6 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
     receiving = '\n'.join(['var real_' + s + ' = asm["' + s + '"]; asm["' + s + '''"] = function() {''' + runtime_assertions + '''  return real_''' + s + '''.apply(null, arguments);
 };
 ''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory', '__start_module']])
-  else:
-    runtime_assertions = ''
   if not settings['SWAPPABLE_ASM_MODULE']:
     receiving += ';\n'.join(['var ' + s + ' = Module["' + s + '"] = asm["' + s + '"]' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
   else:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1259,17 +1259,19 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
   if settings['ASSERTIONS']:
     # assert on the runtime being in a valid state when calling into compiled code. The only exceptions are
     # some support code
-    receiving = '\n'.join(['var real_' + s + ' = asm["' + s + '"]; asm["' + s + '''"] = function() {
-assert(runtimeInitialized, 'you need to wait for the runtime to be ready (e.g. wait for main() to be called)');
-assert(!runtimeExited, 'the runtime was exited (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
-return real_''' + s + '''.apply(null, arguments);
+    runtime_assertions = '''
+  assert(runtimeInitialized, 'you need to wait for the runtime to be ready (e.g. wait for main() to be called)');
+  assert(!runtimeExited, 'the runtime was exited (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
+'''
+    receiving = '\n'.join(['var real_' + s + ' = asm["' + s + '"]; asm["' + s + '''"] = function() {''' + runtime_assertions + '''  return real_''' + s + '''.apply(null, arguments);
 };
 ''' for s in exported_implemented_functions if s not in ['_memcpy', '_memset', 'runPostSets', '_emscripten_replace_memory', '__start_module']])
-
+  else:
+    runtime_assertions = ''
   if not settings['SWAPPABLE_ASM_MODULE']:
     receiving += ';\n'.join(['var ' + s + ' = Module["' + s + '"] = asm["' + s + '"]' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
   else:
-    receiving += 'Module["asm"] = asm;\n' + ';\n'.join(['var ' + s + ' = Module["' + s + '"] = function() { return Module["asm"]["' + s + '"].apply(null, arguments) }' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
+    receiving += 'Module["asm"] = asm;\n' + ';\n'.join(['var ' + s + ' = Module["' + s + '"] = function() {' + runtime_assertions + '  return Module["asm"]["' + s + '"].apply(null, arguments) }' for s in exported_implemented_functions + function_tables(function_table_data, settings)])
   receiving += ';\n'
 
   if settings['EXPORT_FUNCTION_TABLES'] and not settings['BINARYEN']:


### PR DESCRIPTION
Use runtime assertions on misuse (calling code before runtime is read, or after it was exited) in wasm async mode (in which async compilation means we need the assertions in another place, as we use a swappable asm module there).

No need for new tests here, it was enough to enable the existing test for wasm.