### PR TITLE
remove_atomics_exchange_polyfill

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1777,21 +1777,6 @@ function writeAsciiToMemory(str, buffer, dontAddNull) {
 {{{ unSign }}}
 {{{ reSign }}}
 
-#if USE_PTHREADS
-// Atomics.exchange is not yet implemented in the spec, so polyfill that in via compareExchange in the meanwhile.
-// TODO: Keep an eye out for the opportunity to remove this once Atomics.exchange is available.
-if (typeof Atomics !== 'undefined' && !Atomics['exchange']) {
-  Atomics['exchange'] = function(heap, index, val) {
-    var oldVal, oldVal2;
-    do {
-      oldVal = Atomics['load'](heap, index);
-      oldVal2 = Atomics['compareExchange'](heap, index, oldVal, val);
-    } while(oldVal != oldVal2);
-    return oldVal;
-  }
-}
-#endif
-
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
 if (!Math['imul'] || Math['imul'](0xffffffff, 5) !== -5) Math['imul'] = function imul(a, b) {
   var ah  = a >>> 16;

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -517,16 +517,6 @@ float EMSCRIPTEN_KEEPALIVE emscripten_atomic_load_f32(const void *addr)
 #define NUM_64BIT_LOCKS 256
 static int emulated64BitAtomicsLocks[NUM_64BIT_LOCKS] = {};
 
-uint32_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_exchange_u32(void/*uint32_t*/ *addr, uint32_t newVal)
-{
-	uint32_t oldVal, oldVal2;
-	do {
-		oldVal = emscripten_atomic_load_u32(addr);
-		oldVal2 = emscripten_atomic_cas_u32(addr, oldVal, newVal);
-	} while (oldVal != oldVal2);
-	return oldVal;
-}
-
 #define SPINLOCK_ACQUIRE(addr) do { while(emscripten_atomic_exchange_u32((void*)(addr), 1)) /*nop*/; } while(0)
 #define SPINLOCK_RELEASE(addr) emscripten_atomic_store_u32((void*)(addr), 0)
 

--- a/system/lib/pthreads.symbols
+++ b/system/lib/pthreads.symbols
@@ -60,7 +60,7 @@
          T emscripten_atomic_and_u64
          U emscripten_atomic_cas_u32
          T emscripten_atomic_cas_u64
-         T emscripten_atomic_exchange_u32
+         U emscripten_atomic_exchange_u32
          T emscripten_atomic_exchange_u64
          T emscripten_atomic_load_f32
          T emscripten_atomic_load_f64


### PR DESCRIPTION
Remove software implemented emscripten_atomic_exchange_u32() polyfill, which is not needed anymore since Atomics.exchange() is part of the spec and implemented in shipping browsers. #3498