### PR TITLE
Fix sanity.test_binaryen test

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -980,7 +980,7 @@ fi
         # if BINARYEN_ROOT is set, we don't build the port. Check we do build it if not
         if binaryen_root_in_config:
           config = open(CONFIG_FILE).read()
-          assert '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN'))''' in config, config # setup created it to be ''
+          assert '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '')''' in config, config # setup created it to be ''
           print 'created config:'
           print config
           restore()


### PR DESCRIPTION
PR #5411 changed the default config but the expectations
in test_sanity.py were not updated.