### PR TITLE
Use second argument to os.getenv() to set defaults

### DIFF
--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -56,7 +56,7 @@ The file simply assigns paths to a number of *variables* representing the main t
 
 The default *emcc* configuration file often gets the paths from environment variables if defined. If no variable is defined the system will also attempt to find "system executables". For example:  ::
 
-	PYTHON = os.path.expanduser(os.getenv('PYTHON') or 'C:\\Python27\\python2.exe')
+	PYTHON = os.path.expanduser(os.getenv('PYTHON', 'C:\\Python27\\python2.exe'))
 
 You can find out the other variable names from the default *.emscripten* file or the :ref:`example here <compiler-configuration-file>`. 
 
@@ -70,7 +70,7 @@ The compiler configuration file can be edited with the text editor of your choic
    
 	::
    
-		LLVM_ROOT = 'os.path.expanduser(os.getenv('LLVM') or '/home/ubuntu/a-path/emscripten-fastcomp/build/bin')'
+		LLVM_ROOT = 'os.path.expanduser(os.getenv('LLVM', '/home/ubuntu/a-path/emscripten-fastcomp/build/bin'))'
 
 	.. note:: Use forward slashes!
 
@@ -80,7 +80,7 @@ The compiler configuration file can be edited with the text editor of your choic
    
 	::
    
-		EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '/home/ubuntu/yourpath/emscripten') # directory
+		EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '/home/ubuntu/yourpath/emscripten')) # directory
  
 
 .. comment .. The settings are now correct in the configuration file, but the paths and environment variables are not set in the command prompt/terminal. **HamishW** Follow up with Jukka on this.

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -906,7 +906,7 @@ fi
     assert not os.environ.get('LLVM'), 'we need to modify LLVM env var for this'
 
     f = open(CONFIG_FILE, 'a')
-    f.write('LLVM_ROOT = os.getenv("LLVM") or "' + path_from_root('tests', 'fake1', 'bin') + '"\n')
+    f.write('LLVM_ROOT = os.getenv("LLVM", "' + path_from_root('tests', 'fake1', 'bin') + '")\n')
     f.close()
 
     safe_ensure_dirs(path_from_root('tests', 'fake1', 'bin'))
@@ -980,12 +980,12 @@ fi
         # if BINARYEN_ROOT is set, we don't build the port. Check we do build it if not
         if binaryen_root_in_config:
           config = open(CONFIG_FILE).read()
-          assert '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '')''' in config, config # setup created it to be ''
+          assert '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', ''))''' in config, config # setup created it to be ''
           print 'created config:'
           print config
           restore()
           config = open(CONFIG_FILE).read()
-          config = config.replace('BINARYEN_ROOT', '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '') # ''')
+          config = config.replace('BINARYEN_ROOT', '''BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # ''')
         else:
           restore()
           config = open(CONFIG_FILE).read()

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -7,9 +7,9 @@
 import os
 
 # this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '{{{ EMSCRIPTEN_ROOT }}}') # directory
-LLVM_ROOT = os.path.expanduser(os.getenv('LLVM') or '{{{ LLVM_ROOT }}}') # directory
-BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '') # if not set, we will use it from ports
+EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '{{{ EMSCRIPTEN_ROOT }}}')) # directory
+LLVM_ROOT = os.path.expanduser(os.getenv('LLVM', '{{{ LLVM_ROOT }}}')) # directory
+BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # if not set, we will use it from ports
 
 # If not specified, defaults to sys.executable.
 #PYTHON = 'python'
@@ -19,15 +19,15 @@ BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN') or '') # if not set, we
 # EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
 
 # See below for notes on which JS engine(s) you need
-NODE_JS = os.path.expanduser(os.getenv('NODE') or '{{{ NODE }}}') # executable
-SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js')] # executable
-V8_ENGINE = os.path.expanduser(os.getenv('V8') or 'd8') # executable
+NODE_JS = os.path.expanduser(os.getenv('NODE', '{{{ NODE }}}')) # executable
+SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY', 'js'))] # executable
+V8_ENGINE = os.path.expanduser(os.getenv('V8', 'd8')) # executable
 
 JAVA = 'java' # executable
 
 TEMP_DIR = '{{{ TEMP }}}'
 
-CRUNCH = os.path.expanduser(os.getenv('CRUNCH') or 'crunch') # executable
+CRUNCH = os.path.expanduser(os.getenv('CRUNCH', 'crunch')) # executable
 
 #CLOSURE_COMPILER = '..' # define this to not use the bundled version
 


### PR DESCRIPTION
This is what the second argument is for.  It has has added benefit
of not treating variables set to '' as unset.