### PR TITLE
[One-Line/Trivial] Fix tiny copy&paste error in test_vr

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -306,3 +306,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mitchell Foley <mitchfoley@google.com> (copyright owned by Google, Inc.)
 * Oleksandr Chekhovskyi <oleksandr.chekhovskyi@gmail.com>
 * Michael Siebert <michael.siebert2k@gmail.com>
+* Jonathan Hale <squareys@googlemail.com>

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -71,7 +71,7 @@ mainloop()
 
         WebVREyeParameters leftParams, rightParams;
         emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeLeft, &leftParams);
-        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeLeft, &rightParams);
+        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeRight, &rightParams);
 
         WebVRFieldOfView leftFov = leftParams.currentFieldOfView, rightFov = rightParams.currentFieldOfView;
         printf("Left FOV: %f %f %f %f\n", leftFov.upDegrees, leftFov.downDegrees, leftFov.rightDegrees, leftFov.leftDegrees);


### PR DESCRIPTION
Hi everybody!

While having a look at the vr API of emscripten I noticed a tiny copy&paste mistake in the test `test_vr.c`. Here is a simple one line fix.

Cheers, Jonathan.