### PR TITLE
refactor_report_result

### DIFF
--- a/tests/asm_swap.cpp
+++ b/tests/asm_swap.cpp
@@ -7,7 +7,7 @@ int EMSCRIPTEN_KEEPALIVE func() {
 }
 
 void EMSCRIPTEN_KEEPALIVE report(int result) {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 }

--- a/tests/asm_swap2.cpp
+++ b/tests/asm_swap2.cpp
@@ -7,7 +7,7 @@ int EMSCRIPTEN_KEEPALIVE func() {
 }
 
 void EMSCRIPTEN_KEEPALIVE report(int result) {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 }

--- a/tests/asmfs/fopen_write.cpp
+++ b/tests/asmfs/fopen_write.cpp
@@ -29,7 +29,6 @@ int main()
   read_file();
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/asmfs/hello_file.cpp
+++ b/tests/asmfs/hello_file.cpp
@@ -26,7 +26,6 @@ int main()
   fclose(file);
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/asmfs/read_file_twice.cpp
+++ b/tests/asmfs/read_file_twice.cpp
@@ -31,7 +31,6 @@ int main()
   read_file();
   read_file();
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/asmfs/relative_paths.cpp
+++ b/tests/asmfs/relative_paths.cpp
@@ -29,7 +29,6 @@ int main()
   assert(!strcmp(str, "test"));
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/benchmark_utf16.cpp
+++ b/tests/benchmark_utf16.cpp
@@ -60,7 +60,6 @@ int main() {
   printf("OK. Time: %f (%f).\n", t, t3-t2);
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/benchmark_utf8.cpp
+++ b/tests/benchmark_utf8.cpp
@@ -61,7 +61,6 @@ int main() {
   printf("OK. Time: %f (%f).\n", t, t3-t2);
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/binaryen_async.c
+++ b/tests/binaryen_async.c
@@ -7,7 +7,7 @@ int main() {
   int result = EM_ASM_INT_V({
     return Module.sawAsyncCompilation | 0;
   });
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/browser_gc.cpp
+++ b/tests/browser_gc.cpp
@@ -48,8 +48,7 @@ void waiter(void*) {
     assert(!global);
     if (freed == 5) {
       printf("Ok.\n");
-      int result = 1;
-      REPORT_RESULT();
+      REPORT_RESULT(1);
       return;
     }
     if (emscripten_get_now() - start > 2100) {

--- a/tests/browser_main.cpp
+++ b/tests/browser_main.cpp
@@ -31,7 +31,7 @@ void next(const char *x) {
   assert(twofunc() == 7);
   onefunc();
   int result = twofunc();
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main() {

--- a/tests/browser_test_hello_world.c
+++ b/tests/browser_test_hello_world.c
@@ -18,8 +18,7 @@ int main() {
     assert(Module.prints.length === 1, 'bad length');
     assert(Module.prints[0] == 'hello, world!', 'bad contents: ' + Module.prints[0]);
   });
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
   return 0;
 }
 

--- a/tests/canvas_size_proxy.c
+++ b/tests/canvas_size_proxy.c
@@ -10,6 +10,6 @@ int main()
     {
         result = 1;
     }
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     return 0;
 }

--- a/tests/codemods.cpp
+++ b/tests/codemods.cpp
@@ -16,6 +16,6 @@ int main() {
   int result;
   if (ok) result = 1;
   else result = diff+2; // add two to this >= number to avoid conflicts with 1
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 

--- a/tests/core/test_strftime.cpp
+++ b/tests/core/test_strftime.cpp
@@ -175,7 +175,6 @@ int main() {
   test(!cmp(s, "12 01 PM"), "strftime test #35", s);
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/cstdio/test_remove.cpp
+++ b/tests/cstdio/test_remove.cpp
@@ -61,8 +61,7 @@ int main() {
   test();
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return EXIT_SUCCESS;
 }

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -177,8 +177,7 @@ int main() {
   test_scandir();
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return EXIT_SUCCESS;
 }

--- a/tests/dirent/test_readdir_empty.c
+++ b/tests/dirent/test_readdir_empty.c
@@ -44,8 +44,7 @@ int main(int argc, char** argv) {
   printf("success\n"); 
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return 0;
 }

--- a/tests/doublestart.c
+++ b/tests/doublestart.c
@@ -4,8 +4,7 @@
 int times = 0;
 
 void later(void* nada) {
-  int result = times;
-  REPORT_RESULT();
+  REPORT_RESULT(times);
 }
 
 void main_loop(void) {

--- a/tests/emscripten_api_browser.cpp
+++ b/tests/emscripten_api_browser.cpp
@@ -38,8 +38,7 @@ void argey(void* arg) {
   printf("argey: %d\n", counter);
   if (counter == 5) {
     emscripten_cancel_main_loop();
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
   }
 }
 
@@ -86,8 +85,7 @@ void second(void *arg) {
 }
 
 void never() {
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 }
 
 int main() {

--- a/tests/emscripten_api_browser2.cpp
+++ b/tests/emscripten_api_browser2.cpp
@@ -29,8 +29,7 @@ void load2() {
   fclose(f);
   assert(strcmp(buffer, "second") == 0);
 
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 void error2() {
   printf("fail2\n");

--- a/tests/emscripten_api_browser_infloop.cpp
+++ b/tests/emscripten_api_browser_infloop.cpp
@@ -14,8 +14,7 @@ struct Class {
     printf("waka %d\n", x++);
 
     if (x == 7 || x < 0) {
-      int result = x;
-      REPORT_RESULT();
+      REPORT_RESULT(x);
       emscripten_cancel_main_loop();
     }
   }

--- a/tests/emscripten_fs_api_browser.cpp
+++ b/tests/emscripten_fs_api_browser.cpp
@@ -60,7 +60,7 @@ void wait_wgets() {
     assert(IMG_Load("/tmp/screen_shot.png"));
     assert(data_ok == 1 && data_bad == 1);
     emscripten_cancel_main_loop();
-    REPORT_RESULT();
+    REPORT_RESULT(result);
   }
   assert(get_count <= 8);
 }

--- a/tests/emscripten_fs_api_browser2.cpp
+++ b/tests/emscripten_fs_api_browser2.cpp
@@ -34,7 +34,7 @@ void onLoaded(const char* file) {
 
   if (get_count == 2) {
     emscripten_cancel_main_loop();
-    REPORT_RESULT();
+    REPORT_RESULT(result);
   }
 }
 

--- a/tests/emscripten_get_now.cpp
+++ b/tests/emscripten_get_now.cpp
@@ -3,7 +3,7 @@
 
 #ifndef REPORT_RESULT
 // To be able to run this test outside the browser harness in node.js/spidermonkey:
-#define REPORT_RESULT()
+#define REPORT_RESULT(result)
 #endif
 
 int result = 0;
@@ -41,6 +41,6 @@ int main() {
     printf("Error: Bad timer precision: Smallest timer delta: %f msecs\\n", smallest_delta);
     result = 0;
   }
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }

--- a/tests/emscripten_log/emscripten_log.cpp
+++ b/tests/emscripten_log/emscripten_log.cpp
@@ -162,7 +162,7 @@ int main()
   DoubleTest();
 
 #ifdef REPORT_RESULT
-	REPORT_RESULT();
+	REPORT_RESULT(result);
 #endif
 	if (result)
 		printf("Success!\n");

--- a/tests/emscripten_main_loop.cpp
+++ b/tests/emscripten_main_loop.cpp
@@ -8,9 +8,9 @@ int frame = 0;
 
 void final(void*) {
   assert(frame == 100);
-  int result = 0;
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  printf("Test passed.\n");
+  REPORT_RESULT(0);
 #endif
 }
 
@@ -22,9 +22,8 @@ void looper() {
   if (timeSincePrevious <= 1.0)
   {
     printf("Abort: main loop tick was called too quickly after the previous frame!\n");
-    int result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     emscripten_cancel_main_loop();
     exit(0);
@@ -32,9 +31,8 @@ void looper() {
   prevTime = curTime;
   if ((frame == 25 || frame == 45 || frame == 65) && timeSincePrevious < 30) {
     printf("Abort: With swap interval of 4, we should be running at most 15fps! (or 30fps on 120Hz displays) but seems like swap control is not working and we are running at 60fps!\n");
-    int result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     emscripten_cancel_main_loop();
     exit(0);

--- a/tests/emscripten_main_loop_and_blocker.cpp
+++ b/tests/emscripten_main_loop_and_blocker.cpp
@@ -9,17 +9,15 @@ bool blockerExecuted = false;
 
 void final(void*) {
   assert(frame == 20);
-  int result = 0;
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }
 
 void looper() {
   if (blockerExecuted == false) {
-    int result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
   }
 
@@ -31,9 +29,8 @@ void looper() {
   if (frame > 1 && timeSincePrevious <= 14.5) // should be 16, but browser jitter
   {
     printf("Abort: main loop tick was called too quickly (%f ms > 16) after the previous frame!\n", timeSincePrevious);
-    int result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     emscripten_cancel_main_loop();
     exit(0);

--- a/tests/emscripten_main_loop_setimmediate.cpp
+++ b/tests/emscripten_main_loop_setimmediate.cpp
@@ -18,7 +18,7 @@ void looper() {
     printf("Avg. msecs/frame: %f\n", msecsPerFrame);
 #ifdef REPORT_RESULT
     int result = (msecsPerFrame < 5); // Expecting to run extremely fast unthrottled, and certainly not bounded by vsync, so less than common 16.667 msecs per frame (this is assuming 60hz display)
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     emscripten_cancel_main_loop();
   }

--- a/tests/emscripten_main_loop_settimeout.cpp
+++ b/tests/emscripten_main_loop_settimeout.cpp
@@ -18,7 +18,7 @@ void looper() {
     printf("Avg. msecs/frame: %f\n", msecsPerFrame);
 #ifdef REPORT_RESULT
     int result = (msecsPerFrame > 350 && msecsPerFrame < 650); // Expecting 500msecs/frame, but allow a lot of leeway. Bad value would be 900msecs/frame (400msecs of processing below and 500msecs of delay)
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     emscripten_cancel_main_loop();
   }

--- a/tests/emterpreter_async.cpp
+++ b/tests/emterpreter_async.cpp
@@ -9,8 +9,7 @@ int main() {
     printf("frame: %d\n", ++counter);
     emscripten_sleep(100);
     if (counter == 10) {
-      int result = 1;
-      REPORT_RESULT();
+      REPORT_RESULT(1);
       break;
     }
   }

--- a/tests/emterpreter_async_2.cpp
+++ b/tests/emterpreter_async_2.cpp
@@ -28,6 +28,6 @@ int main() {
   volatile int x = 100;
   volatile int result = calc(x);
   printf("calc(%d) = %d\n", x, result);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 

--- a/tests/emterpreter_async_bad.cpp
+++ b/tests/emterpreter_async_bad.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 
 void EMSCRIPTEN_KEEPALIVE finish(int result) {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int counter = 0;

--- a/tests/emterpreter_async_iostream.cpp
+++ b/tests/emterpreter_async_iostream.cpp
@@ -32,15 +32,13 @@ void mainLoop() {
   if (seen >= 10) {
     emscripten_cancel_main_loop();
     cout << "Success.\n";
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
     return;
   }
   if (counter >= 100) {
     emscripten_cancel_main_loop();
     cout << "FAIL\n";
-    int result = 9999;
-    REPORT_RESULT();
+    REPORT_RESULT(9999);
     return;
   }
 }

--- a/tests/emterpreter_async_mainloop.cpp
+++ b/tests/emterpreter_async_mainloop.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 
 void EMSCRIPTEN_KEEPALIVE finish(int result) {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int counter = 0;

--- a/tests/emterpreter_async_sleep2.cpp
+++ b/tests/emterpreter_async_sleep2.cpp
@@ -9,8 +9,7 @@ int main(void) {
     printf("Again no yield:\n");
     emscripten_sleep(500);
     printf("Done!\n");
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
     return 0;
 }
 

--- a/tests/emterpreter_async_sleep2_safeheap.cpp
+++ b/tests/emterpreter_async_sleep2_safeheap.cpp
@@ -28,7 +28,7 @@ int main(void) {
   printf("Sleep:\n");
   emscripten_sleep(1000);
   printf("Done!\n");
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/emterpreter_async_virtual.cpp
+++ b/tests/emterpreter_async_virtual.cpp
@@ -25,6 +25,6 @@ int main(void) {
     printf("main loop %i\n", ++cnt);
     result += bf->ReadLine(0);
   }
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 

--- a/tests/emterpreter_async_virtual_2.cpp
+++ b/tests/emterpreter_async_virtual_2.cpp
@@ -40,7 +40,6 @@ int main(void) {
     Devices[0] = &con;
     DOS_Device dev;
     dev.Read(0,0);
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 }
 

--- a/tests/emterpreter_async_with_manual.cpp
+++ b/tests/emterpreter_async_with_manual.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 
 void EMSCRIPTEN_KEEPALIVE finish(int result) {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int counter = 0;

--- a/tests/fcntl-open/src.c
+++ b/tests/fcntl-open/src.c
@@ -146,8 +146,7 @@ int main() {
   setup();
   test();
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return EXIT_SUCCESS;
 }

--- a/tests/fetch/cached_xhr.cpp
+++ b/tests/fetch/cached_xhr.cpp
@@ -19,8 +19,7 @@ void fetchFromIndexedDB()
     emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
 
   };

--- a/tests/fetch/example_synchronous_fetch.cpp
+++ b/tests/fetch/example_synchronous_fetch.cpp
@@ -16,6 +16,6 @@ int main()
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 }

--- a/tests/fetch/idb_delete.cpp
+++ b/tests/fetch/idb_delete.cpp
@@ -48,7 +48,6 @@ int main()
   printf("Test succeeded!\n");
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/fetch/idb_store.cpp
+++ b/tests/fetch/idb_store.cpp
@@ -61,7 +61,6 @@ int main()
   printf("Test succeeded!\n");
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/fetch/stream_file.cpp
+++ b/tests/fetch/stream_file.cpp
@@ -24,8 +24,7 @@ int main()
     emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
   };
   attr.onprogress = [](emscripten_fetch_t *fetch) {

--- a/tests/fetch/sync_fetch_in_main_thread.cpp
+++ b/tests/fetch/sync_fetch_in_main_thread.cpp
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include <emscripten/fetch.h>
 
-int result = 0;
-
 int main()
 {
   emscripten_fetch_attr_t attr;
@@ -31,6 +29,6 @@ int main()
   emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -25,7 +25,7 @@ int main()
 
     if (result == 0) result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
   };
 
@@ -48,6 +48,6 @@ int main()
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 }

--- a/tests/fetch/to_indexeddb.cpp
+++ b/tests/fetch/to_indexeddb.cpp
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include <emscripten/fetch.h>
 
-int result = 0;
-
 int main()
 {
   emscripten_fetch_attr_t attr;
@@ -25,8 +23,7 @@ int main()
     emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
   };
 

--- a/tests/fetch/to_memory.cpp
+++ b/tests/fetch/to_memory.cpp
@@ -43,7 +43,7 @@ int main()
 #ifndef FILE_DOES_NOT_EXIST
     result = 1;
 #endif
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
   };
 
@@ -82,7 +82,7 @@ int main()
 #ifdef FILE_DOES_NOT_EXIST
     result = 1;
 #endif
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
   };
 

--- a/tests/force_exit.c
+++ b/tests/force_exit.c
@@ -9,7 +9,7 @@ void EMSCRIPTEN_KEEPALIVE success() {
   printf("success? %d\n", result);
   assert(result == 10);
   result += 7;
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 void EMSCRIPTEN_KEEPALIVE later() {

--- a/tests/fs/test_idbfs_fsync.c
+++ b/tests/fs/test_idbfs_fsync.c
@@ -10,7 +10,7 @@ int result = 1;
 
 void success()
 {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main() {
@@ -42,7 +42,7 @@ int main() {
       result = -5000 - errno;
   }
 
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 
 #else
 

--- a/tests/fs/test_idbfs_sync.c
+++ b/tests/fs/test_idbfs_sync.c
@@ -10,7 +10,7 @@ int result = 1;
 
 void success()
 {
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 void test() {

--- a/tests/fs/test_lz4fs.cpp
+++ b/tests/fs/test_lz4fs.cpp
@@ -118,7 +118,7 @@ void EMSCRIPTEN_KEEPALIVE finish() {
 #else
   result = 2;
 #endif
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 }

--- a/tests/fs/test_memfs_fsync.c
+++ b/tests/fs/test_memfs_fsync.c
@@ -35,5 +35,5 @@ int main() {
       result = -5000 - errno;
   }
 
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }

--- a/tests/fs/test_workerfs_package.cpp
+++ b/tests/fs/test_workerfs_package.cpp
@@ -31,8 +31,7 @@ void EMSCRIPTEN_KEEPALIVE finish() {
 
   // all done
   printf("success\n");
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 
 }

--- a/tests/fs/test_workerfs_read.c
+++ b/tests/fs/test_workerfs_read.c
@@ -98,5 +98,5 @@ int main() {
 
 
 exit:
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }

--- a/tests/full_es2_sdlproc.c
+++ b/tests/full_es2_sdlproc.c
@@ -731,8 +731,7 @@ main(int argc, char *argv[])
    gears_init();
    gears_draw();
 
-   int result = 1;
-   REPORT_RESULT();
+   REPORT_RESULT(1);
 
    return 0;
 }

--- a/tests/gauge_available_memory.cpp
+++ b/tests/gauge_available_memory.cpp
@@ -22,6 +22,6 @@ int main()
 	printf("Total memory available: %llu\n", availableMemory);
 #ifdef REPORT_RESULT
 	int result = (availableMemory > 10*1024*1024);
-	REPORT_RESULT();
+	REPORT_RESULT(result);
 #endif
 }

--- a/tests/gl_error.c
+++ b/tests/gl_error.c
@@ -19,7 +19,6 @@ int main()
   glPopMatrix();
   assert(glGetError() == GL_STACK_UNDERFLOW);
 
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
   return 0;
 }

--- a/tests/gl_in_mainthread_after_pthread.cpp
+++ b/tests/gl_in_mainthread_after_pthread.cpp
@@ -55,8 +55,7 @@ void CreateThread()
   {
     printf("Test Skipped! OffscreenCanvas is not supported!\n");
 #ifdef REPORT_RESULT
-    int result = 0; // But report success, so that runs on non-supporting browsers don't raise noisy errors.
-    REPORT_RESULT();
+    REPORT_RESULT(0); // But report success, so that runs on non-supporting browsers don't raise noisy errors.
 #endif
     exit(0);
   }
@@ -85,8 +84,7 @@ void MainThreadRender()
     printf("Test finished.\n");
     emscripten_cancel_main_loop();
 #ifdef REPORT_RESULT
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
   }
 }

--- a/tests/gl_in_pthread.cpp
+++ b/tests/gl_in_pthread.cpp
@@ -68,8 +68,7 @@ void CreateThread()
   {
     printf("Test Skipped! OffscreenCanvas is not supported!\n");
 #ifdef REPORT_RESULT
-    result = 1; // But report success, so that runs on non-supporting browsers don't raise noisy errors.
-    REPORT_RESULT();
+    REPORT_RESULT(1); // But report success, so that runs on non-supporting browsers don't raise noisy errors.
 #endif
     exit(0);
   }  
@@ -86,7 +85,7 @@ void PollThreadExit(void *)
     {
       emscripten_atomic_store_u32(&result, 1);
 #ifdef REPORT_RESULT
-      REPORT_RESULT();
+      REPORT_RESULT(result);
 #endif
       return;
     }
@@ -120,8 +119,7 @@ int main()
   {
     printf("Test Skipped! OffscreenCanvas is not supported!\n");
 #ifdef REPORT_RESULT
-    result = 1; // But report success, so that runs on non-supporting browsers don't raise noisy errors.
-    REPORT_RESULT();
+    REPORT_RESULT(1); // But report success, so that runs on non-supporting browsers don't raise noisy errors.
 #endif
     exit(0);
   }

--- a/tests/gl_matrix_identity.c
+++ b/tests/gl_matrix_identity.c
@@ -39,8 +39,7 @@ void verify() {
     if (x % 4 != 3) sum += x * data[x];
   }
 #ifdef __EMSCRIPTEN__
-  int result = sum;
-  REPORT_RESULT();
+  REPORT_RESULT(sum);
 #endif
 }
 

--- a/tests/gl_teximage.c
+++ b/tests/gl_teximage.c
@@ -23,7 +23,7 @@ static void exit_with_status(TestStatus code)
 {
 #ifdef REPORT_RESULT
     int result = (code == TEST_STATUS_SUCCESS) ? 1 : 0;
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 
     exit(code);

--- a/tests/gl_textures.cpp
+++ b/tests/gl_textures.cpp
@@ -14,7 +14,7 @@ void report_result(int result)
     printf("Test failed!\n");
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/gles2_conformance.cpp
+++ b/tests/gles2_conformance.cpp
@@ -77,6 +77,6 @@ int main(int argc, char *argv[])
     assert(f == 1.f);
     
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 }

--- a/tests/gles2_uniform_arrays.cpp
+++ b/tests/gles2_uniform_arrays.cpp
@@ -137,8 +137,7 @@ int main(int argc, char *argv[])
         RunTest(i);
 
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
 
     return 0;

--- a/tests/glew.c
+++ b/tests/glew.c
@@ -44,8 +44,7 @@ int main()
     }
 
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     return 0;
 }

--- a/tests/glfw.c
+++ b/tests/glfw.c
@@ -411,7 +411,6 @@ void PullInfo(){
   printf("================================================================================\n");
   
 #ifdef REPORT_RESULT  
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 }

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -184,8 +184,7 @@ int main()
     glfwTerminate();
 
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     return 0;
 }

--- a/tests/glfw_events.c
+++ b/tests/glfw_events.c
@@ -283,7 +283,7 @@
         glfwTerminate();
 
     #ifdef REPORT_RESULT
-        REPORT_RESULT();
+        REPORT_RESULT(result);
     #else
         printf("%d == %d = %d", g_state, success, g_state == success);
     #endif

--- a/tests/glfw_joystick.c
+++ b/tests/glfw_joystick.c
@@ -7,8 +7,6 @@
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 
-int result = 1;
-
 GLFWwindow* g_window;
 
 void render();
@@ -69,10 +67,9 @@ void joystick_callback(int joy, int event)
 int main() {
   if (!glfwInit())
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     return -1;
   }
@@ -80,10 +77,9 @@ int main() {
   g_window = glfwCreateWindow(600, 450, "GLFW joystick test", NULL, NULL);
   if (!g_window)
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     glfwTerminate();
     return -1;

--- a/tests/glfw_minimal.c
+++ b/tests/glfw_minimal.c
@@ -19,8 +19,7 @@ int main() {
         }
     }
 #ifdef REPORT_RESULT  
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     return EXIT_SUCCESS;
 }

--- a/tests/glgetattachedshaders.c
+++ b/tests/glgetattachedshaders.c
@@ -86,8 +86,7 @@ int main(int argc, char *argv[])
          die("unknown shader returned");
    }
 
-   int result = 1;
-   REPORT_RESULT();
+   REPORT_RESULT(1);
 
    return 0;
 }

--- a/tests/glgettexenv.c
+++ b/tests/glgettexenv.c
@@ -64,8 +64,7 @@ int main(int argc, char *argv[])
     SDL_Quit();
     
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     return 0;
 }

--- a/tests/glshaderinfo.cpp
+++ b/tests/glshaderinfo.cpp
@@ -39,12 +39,10 @@ int main(int argc, char *argv[])
       printf("In current environment, the GLES2 implementation IS NOT standard conforming! "
            "GL_SHADER_COMPILER == GL_FALSE and GL_NUM_SHADER_BINARY_FORMATS == 0! "
            "In GLES2 spec, either compiling shaders or binary shaders must be supported! (Section 2.10 - Vertex Shaders)\n");
-      int result = 0;
-      REPORT_RESULT();
+      REPORT_RESULT(0);
    } else {
       assert(numShaderBinaryFormats == 0);
-      int result = 1;
-      REPORT_RESULT();
+      REPORT_RESULT(1);
    }
    return 0;
 }

--- a/tests/glut_touchevents.c
+++ b/tests/glut_touchevents.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     printf("touchstarted: button:%d x:%d y:%d\n", touch_started_button, touch_started_x, touch_started_y);
     printf("touchended:   button:%d x:%d y:%d\n", touch_ended_button, touch_ended_x, touch_ended_y);
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     return 0;
 }

--- a/tests/glut_wheelevents.c
+++ b/tests/glut_wheelevents.c
@@ -63,6 +63,6 @@ int main(int argc, char *argv[])
     
     result = wheel_up && wheel_down;
   
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     return 0;
 }

--- a/tests/hello_world_gles.c
+++ b/tests/hello_world_gles.c
@@ -641,7 +641,7 @@ gears_idle(void)
 #ifdef TEST_MEMORYPROFILER_ALLOCATIONS_MAP
         result = 0;
 #endif
-        REPORT_RESULT();
+        REPORT_RESULT(result);
       }
 #endif
    }

--- a/tests/hello_world_gles_proxy.c
+++ b/tests/hello_world_gles_proxy.c
@@ -651,8 +651,7 @@ gears_idle(void)
       static runs = 0;
       runs++;
       if (runs == 4) {
-        int result = fps;
-        REPORT_RESULT();
+        REPORT_RESULT(fps);
       }
 #endif
    }

--- a/tests/http.cpp
+++ b/tests/http.cpp
@@ -233,8 +233,7 @@ void wait_https() {
 	if (num_request == 0) {
 		printf("End of all download ... %fs\n",(emscripten_get_now() - time_elapsed) / 1000.f);
 		emscripten_cancel_main_loop();
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 	}
 }
 

--- a/tests/idbstore.c
+++ b/tests/idbstore.c
@@ -13,14 +13,13 @@ int result;
 void ok(void* arg)
 {
   assert(expected == (int)arg);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 void onerror(void* arg)
 {
   assert(expected == (int)arg);
-  result = 999;
-  REPORT_RESULT();
+  REPORT_RESULT(999);
 }
 
 void onload(void* arg, void* ptr, int num)
@@ -29,15 +28,13 @@ void onload(void* arg, void* ptr, int num)
   printf("loaded %s\n", ptr);
   assert(num == strlen(SECRET)+1);
   assert(strcmp(ptr, SECRET) == 0);
-  result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 
 void onbadload(void* arg, void* ptr, int num)
 {
   printf("load failed, surprising\n");
-  result = 999;
-  REPORT_RESULT();
+  REPORT_RESULT(999);
 }
 
 void oncheck(void* arg, int exists)
@@ -45,7 +42,7 @@ void oncheck(void* arg, int exists)
   assert(expected == (int)arg);
   printf("exists? %d\n", exists);
   assert(exists);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 void onchecknope(void* arg, int exists)
@@ -53,7 +50,7 @@ void onchecknope(void* arg, int exists)
   assert(expected == (int)arg);
   printf("exists (hopefully not)? %d\n", exists);
   assert(!exists);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 void test() {

--- a/tests/idbstore_sync.c
+++ b/tests/idbstore_sync.c
@@ -49,8 +49,7 @@ void test() {
   assert(!exists);
   sum++;
 
-  int result = sum;
-  REPORT_RESULT();
+  REPORT_RESULT(sum);
 }
 
 void never() {

--- a/tests/idbstore_sync_worker.c
+++ b/tests/idbstore_sync_worker.c
@@ -86,8 +86,7 @@ void test() {
 
   // finish up
 
-  int result = sum;
-  REPORT_RESULT();
+  REPORT_RESULT(sum);
 }
 
 void never() {

--- a/tests/in_flight_memfile_request.c
+++ b/tests/in_flight_memfile_request.c
@@ -6,7 +6,7 @@ int main() {
     return !!Module['memoryInitializerRequest'];
   });
   printf("memory init request: %d\n", result);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/keydown_preventdefault_proxy.cpp
+++ b/tests/keydown_preventdefault_proxy.cpp
@@ -15,7 +15,7 @@ extern "C"
     }
     else
     {
-      REPORT_RESULT();
+      REPORT_RESULT(result);
       emscripten_run_script("throw 'done'");
     }
     return 0;

--- a/tests/mainloop_infloop.cpp
+++ b/tests/mainloop_infloop.cpp
@@ -15,8 +15,7 @@ void loop(void) {
     assert(mains == 1); // never re-enter main
     assert(inners == 1); // never re-enter inner
     assert(nevers == 0); // never reach never
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
     return;
   }
 }

--- a/tests/mainloop_reschedule.cpp
+++ b/tests/mainloop_reschedule.cpp
@@ -16,7 +16,7 @@ void main_loop(void) {
       emscripten_cancel_main_loop();
       int result = rate > 600;
       printf("Final rate: %.2f, success: %d\n", rate, result);
-      REPORT_RESULT();
+      REPORT_RESULT(result);
       return;
     }
   }

--- a/tests/manual_download_data.cpp
+++ b/tests/manual_download_data.cpp
@@ -13,6 +13,6 @@ int main()
 	printf("OK\n");
 #ifdef REPORT_RESULT
 	int result = EM_ASM_INT_V({return Module.manuallyDownloadedData;});
-	REPORT_RESULT();
+	REPORT_RESULT(result);
 #endif
 }

--- a/tests/manual_wasm_instantiate.cpp
+++ b/tests/manual_wasm_instantiate.cpp
@@ -6,6 +6,6 @@ int main()
 	printf("OK\n");
 #ifdef REPORT_RESULT
 	int result = EM_ASM_INT_V({return Module.testWasmInstantiationSucceeded;});
-	REPORT_RESULT();
+	REPORT_RESULT(result);
 #endif
 }

--- a/tests/mem_init.cpp
+++ b/tests/mem_init.cpp
@@ -10,8 +10,7 @@ char* EMSCRIPTEN_KEEPALIVE note(int n) {
   noted = noted | n;
   EM_ASM_({ Module.print(['noted is now', $0]) }, noted);
   if (noted == 3) {
-    int result = noted;
-    REPORT_RESULT();
+    REPORT_RESULT(noted);
   }
   return "silly-string";
 }

--- a/tests/mem_init_request.cpp
+++ b/tests/mem_init_request.cpp
@@ -13,7 +13,7 @@ int main() {
   putc('o', stdout);
   putc('n', stdout);
   putc('e', stdout);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/meminit_pairs.c
+++ b/tests/meminit_pairs.c
@@ -14,5 +14,5 @@ int main() {
       }
     }
   }
-  REPORT_RESULT()
+  REPORT_RESULT(result);
 }

--- a/tests/mmap_file.c
+++ b/tests/mmap_file.c
@@ -18,8 +18,7 @@ int main() {
     printf("\n*\n");
 
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     return 0;
 }

--- a/tests/openal_buffers.c
+++ b/tests/openal_buffers.c
@@ -86,8 +86,7 @@ void iter() {
   // Exit once we've processed the entire clip.
   if (offset >= size) {
 #ifdef __EMSCRIPTEN__
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     exit(0);
   }

--- a/tests/openal_playback.cpp
+++ b/tests/openal_playback.cpp
@@ -19,8 +19,7 @@ extern "C"
 void EMSCRIPTEN_KEEPALIVE test_finished()
 {
 #ifdef REPORT_RESULT
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 }
 }

--- a/tests/pre_run_deps.cpp
+++ b/tests/pre_run_deps.cpp
@@ -4,7 +4,7 @@
 int main() {
   printf("main() called.\n");
   int result = emscripten_run_script_int("Module.okk");
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 1;
 }
 

--- a/tests/preinitialized_webgl_context.cpp
+++ b/tests/preinitialized_webgl_context.cpp
@@ -16,6 +16,6 @@ int main()
   printf("GL_ACTIVE_TEXTURE: %d\n", activeTexture - GL_TEXTURE0);
 #ifdef REPORT_RESULT
   int result = activeTexture - GL_TEXTURE0;
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -133,11 +133,10 @@ int main()
 	globalDouble = 5.0;
 	globalU64 = 5;
 
-	int result = 0;
 	if (!emscripten_has_threading_support())
 	{
 #ifdef REPORT_RESULT
-		REPORT_RESULT();
+		REPORT_RESULT(0);
 #endif
 		printf("Skipped: Threading is not supported.\n");
 		return 0;
@@ -160,8 +159,8 @@ int main()
 	else
 		printf("64-bit CAS test failed! totalRead != totalWritten (%llu != %llu)\n", totalRead, totalWritten);
 #ifdef REPORT_RESULT
-	if (totalRead != totalWritten) result = 1;
-	REPORT_RESULT();
+	int result = (totalRead != totalWritten) ? 1 : 0;
+	REPORT_RESULT(result);
 #else
 	EM_ASM(Module['print']('Main: Test successfully finished.'));
 #endif

--- a/tests/pthread/test_pthread_64bit_cxx11_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_cxx11_atomics.cpp
@@ -55,8 +55,7 @@ int main(void)
     assert(c.load(std::memory_order_relaxed) == 0x0F0F0F0F0F0F0F0FULL);
 
 #ifdef REPORT_RESULT
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
 
     return 0;

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -148,15 +148,13 @@ int main()
 	globalDouble = 5.0;
 	globalU64 = 5;
 
-	int result = 0;
-
 	emscripten_atomic_fence();
 	__sync_synchronize();
 
 	if (!emscripten_has_threading_support())
 	{
 #ifdef REPORT_RESULT
-		REPORT_RESULT();
+		REPORT_RESULT(0);
 #endif
 		printf("Skipped: Threading is not supported.\n");
 		return 0;
@@ -179,8 +177,8 @@ int main()
 	else
 		printf("32-bit CAS test failed! totalRead != totalWritten (%llu != %llu)\n", totalRead, totalWritten);
 #ifdef REPORT_RESULT
-	if (totalRead != totalWritten) result = 1;
-	REPORT_RESULT();
+	int result = (totalRead != totalWritten) ? 1 : 0;
+	REPORT_RESULT(result);
 #else
 	EM_ASM(Module['print']('Main: Test successfully finished.'));
 #endif

--- a/tests/pthread/test_pthread_barrier.cpp
+++ b/tests/pthread/test_pthread_barrier.cpp
@@ -78,7 +78,6 @@ int main(int argc, char **argv)
     }
 
 #ifdef REPORT_RESULT
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -32,12 +32,10 @@ pthread_t thr;
 
 int main()
 {
-  int result;
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -51,12 +49,12 @@ int main()
 
   for(;;)
   {
-    result = emscripten_atomic_load_u32((const void*)&res);
+    int result = emscripten_atomic_load_u32((const void*)&res);
     if (result == 1)
     {
       EM_ASM_INT( { Module['print']('After canceling, shared variable = ' + $0 + '.'); }, result);
 #ifdef REPORT_RESULT
-      REPORT_RESULT();
+      REPORT_RESULT(1);
 #endif
       return 0;
     }

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -69,8 +69,7 @@ int main()
    if (!emscripten_has_threading_support())
    {
 #ifdef REPORT_RESULT
-      result = 907640832;
-      REPORT_RESULT();
+      REPORT_RESULT(907640832);
 #endif
       printf("Skipped: Threading is not supported.\n");
       return 0;
@@ -97,8 +96,7 @@ int main()
    EM_ASM_INT( { console.log('Cleanup state variable: ' + $0); }, cleanupState);
 
 #ifdef REPORT_RESULT
-   result = cleanupState;
-   REPORT_RESULT();
+   REPORT_RESULT(cleanupState);
 #endif
 
    exit(EXIT_SUCCESS);

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -102,8 +102,7 @@ int main (int argc, char *argv[])
   pthread_mutex_destroy(&count_mutex);
   pthread_cond_destroy(&count_threshold_cv);
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   pthread_exit(NULL);
 }

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -69,12 +69,10 @@ void CreateThread(int i)
 
 int main()
 {
-	int result = 0;
-
 	if (!emscripten_has_threading_support())
 	{
 #ifdef REPORT_RESULT
-		REPORT_RESULT();
+		REPORT_RESULT(0);
 #endif
 		printf("Skipped: Threading is not supported.\n");
 		return 0;
@@ -103,6 +101,6 @@ int main()
 		}
 	}
 #ifdef REPORT_RESULT
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -28,8 +28,7 @@ int main()
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -50,6 +49,6 @@ int main()
   pthread_join(thr, 0);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -25,11 +25,10 @@ static void *thread1_start(void *arg)
 
 int main()
 {
-  int result = 0;
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -49,6 +48,6 @@ int main()
   assert(!strcmp(str, "hello2!"));
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
@@ -192,7 +192,6 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
@@ -192,7 +192,6 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
@@ -179,7 +179,6 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
@@ -174,7 +174,6 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_atomics.cpp
+++ b/tests/pthread/test_pthread_gcc_atomics.cpp
@@ -104,7 +104,6 @@ int main()
 	}
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_gcc_spinlock.cpp
+++ b/tests/pthread/test_pthread_gcc_spinlock.cpp
@@ -45,8 +45,7 @@ int main()
 	if (!emscripten_has_threading_support())
 	{
 #ifdef REPORT_RESULT
-		result = 800;
-		REPORT_RESULT();
+		REPORT_RESULT(800);
 #endif
 		printf("Skipped: Threading is not supported.\n");
 		return 0;
@@ -73,7 +72,6 @@ int main()
 
 	printf("counter: %d\n", counter);
 #ifdef REPORT_RESULT
-	result = counter;
-	REPORT_RESULT();
+	REPORT_RESULT(counter);
 #endif
 }

--- a/tests/pthread/test_pthread_iostream.cpp
+++ b/tests/pthread/test_pthread_iostream.cpp
@@ -17,11 +17,10 @@ int numThreadsToCreate = 1000;
 
 int main()
 {
-  int result = 0;
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -37,6 +36,6 @@ int main()
 	std::cout << "The thread should print 'Hello from thread'" << std::endl;
 
 #ifdef REPORT_RESULT
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_join.cpp
+++ b/tests/pthread/test_pthread_join.cpp
@@ -30,12 +30,10 @@ int main()
   struct timespec ts = { 1, 0 };
   nanosleep(&ts, 0);
 
-  int result = 0;
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    result = 6765;
-    REPORT_RESULT();
+    REPORT_RESULT(6765);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -48,11 +46,12 @@ int main()
   int s = pthread_create(&thr, NULL, thread_start, (void*)n);
   assert(s == 0);
   EM_ASM(Module['print']('Main: Waiting for thread to join.'););
+  int result = 0;
   s = pthread_join(thr, (void**)&result);
   assert(s == 0);
   EM_ASM_INT( { Module['print']('Main: Thread joined with result: '+$0+'.'); }, result);
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -33,12 +33,10 @@ void BusySleep(double msecs)
 
 int main()
 {
-  int result;
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -76,7 +74,6 @@ int main()
   assert(emscripten_atomic_load_u32((void*)&sharedVar) == 0);
   EM_ASM_INT( { Module['print']('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'); }, sharedVar);
 #ifdef REPORT_RESULT
-  result = sharedVar;
-  REPORT_RESULT();
+  REPORT_RESULT(sharedVar);
 #endif
 }

--- a/tests/pthread/test_pthread_locale.c
+++ b/tests/pthread/test_pthread_locale.c
@@ -47,7 +47,7 @@ int main (int argc, char *argv[])
 
 #ifdef REPORT_RESULT
   int result = (main_loc == child_loc);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 
   pthread_exit(NULL);

--- a/tests/pthread/test_pthread_malloc.cpp
+++ b/tests/pthread/test_pthread_malloc.cpp
@@ -35,10 +35,9 @@ static void *thread_start(void *arg)
 
 int main()
 {
-  int result = 0;
   if (!emscripten_has_threading_support()) {
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: threading support is not available!\n");
     return 0;
@@ -47,6 +46,7 @@ int main()
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
     pthread_create(&thr[i], NULL, thread_start, (void*)(i*N));
+  int result = 0;
   for(int i = 0; i < NUM_THREADS; ++i) {
     int res = 0;
     pthread_join(thr[i], (void**)&res);
@@ -55,6 +55,6 @@ int main()
   printf("Test finished with result %d\n", result);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_malloc_free.cpp
+++ b/tests/pthread/test_pthread_malloc_free.cpp
@@ -30,7 +30,7 @@ int main()
   int result = 0;
   if (!emscripten_has_threading_support()) {
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: threading support is not available!\n");
     return 0;
@@ -43,7 +43,7 @@ int main()
     {
 #ifdef REPORT_RESULT
       result = (rc != EAGAIN);
-      REPORT_RESULT();
+      REPORT_RESULT(result);
       return 0;
 #endif
     }
@@ -67,6 +67,6 @@ int main()
   }
   printf("Test finished successfully!\n");
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_mandelbrot.cpp
+++ b/tests/pthread/test_pthread_mandelbrot.cpp
@@ -402,8 +402,7 @@ void main_tick()
 #if defined(TEST_THREAD_PROFILING) && defined(REPORT_RESULT)
   if (numItersDoneOnCanvas > 50000)
   {
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
   }
 #endif
 

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -81,8 +81,7 @@ void WaitToJoin()
 		else
 			EM_ASM_INT( { console.error('All threads finished, but counter = ' + $0 + ' != ' + $1 + '!'); }, counter, numThreadsToCreateTotal);
 #ifdef REPORT_RESULT
-		int result = counter;
-		REPORT_RESULT();
+		REPORT_RESULT(counter);
 #endif
 		emscripten_cancel_main_loop();
 	}
@@ -106,8 +105,7 @@ int main()
 		emscripten_set_main_loop(WaitToJoin, 0, 0);
 	} else {
 #ifdef REPORT_RESULT
-		int result = 50;
-		REPORT_RESULT();
+		REPORT_RESULT(50);
 #endif
 	}
 }

--- a/tests/pthread/test_pthread_nested_spawns.cpp
+++ b/tests/pthread/test_pthread_nested_spawns.cpp
@@ -29,7 +29,7 @@ int main(void) {
   }
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/pthread/test_pthread_num_logical_cores.cpp
+++ b/tests/pthread/test_pthread_num_logical_cores.cpp
@@ -8,7 +8,6 @@ int main()
 {
 	printf("emscripten_num_logical_cores returns %d.\n", (int)emscripten_num_logical_cores());
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_once.cpp
+++ b/tests/pthread/test_pthread_once.cpp
@@ -34,7 +34,6 @@ int main()
 	}
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_printf.cpp
+++ b/tests/pthread/test_pthread_printf.cpp
@@ -29,7 +29,6 @@ int main()
 	}
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
+++ b/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
@@ -29,8 +29,7 @@ int main()
 	if (!emscripten_has_threading_support())
 	{
 #ifdef REPORT_RESULT
-		result = 0;
-		REPORT_RESULT();
+		REPORT_RESULT(0);
 #endif
 		printf("Skipped: Threading is not supported.\n");
 		return 0;
@@ -48,7 +47,7 @@ int main()
 		printf("ERROR! futex wait timed out!\n");
 		result = 2;
 #ifdef REPORT_RESULT
-		REPORT_RESULT();
+		REPORT_RESULT(result);
 #endif
 		exit(1);
 	}
@@ -56,6 +55,6 @@ int main()
 	pthread_join(thread, 0);		
 
 #ifdef REPORT_RESULT
-	REPORT_RESULT();
+	REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_run_on_main_thread.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread.cpp
@@ -155,7 +155,6 @@ int main()
 	test_async();
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
@@ -79,7 +79,6 @@ int main()
 	test_async();
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_sbrk.cpp
+++ b/tests/pthread/test_pthread_sbrk.cpp
@@ -74,7 +74,7 @@ int main()
   int result = 0;
   if (!emscripten_has_threading_support()) {
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     printf("Skipped: threading support is not available!\n");
     return 0;
@@ -107,6 +107,6 @@ int main()
   printf("Test finished with result %d\n", result);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/pthread/test_pthread_setspecific_mainthread.cpp
+++ b/tests/pthread/test_pthread_setspecific_mainthread.cpp
@@ -12,7 +12,6 @@ int main()
 	assert(val == (void*)1);
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_spawns.cpp
+++ b/tests/pthread/test_pthread_spawns.cpp
@@ -19,7 +19,6 @@ int main()
 			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
 	}
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_supported.cpp
+++ b/tests/pthread/test_pthread_supported.cpp
@@ -25,7 +25,6 @@ int main()
 	else assert(rc == EAGAIN);
 
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 }

--- a/tests/pthread/test_pthread_thread_local_storage.cpp
+++ b/tests/pthread/test_pthread_thread_local_storage.cpp
@@ -86,8 +86,7 @@ int main()
 		}
 	}
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 
 	for(int i = 0; i < NUM_KEYS; ++i)

--- a/tests/pthread/test_pthread_volatile.cpp
+++ b/tests/pthread/test_pthread_volatile.cpp
@@ -25,8 +25,7 @@ int main()
   if (!emscripten_has_threading_support())
   {
 #ifdef REPORT_RESULT
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
@@ -38,7 +37,7 @@ int main()
   {
 #ifdef REPORT_RESULT
     int result = (rc != EAGAIN);
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     return 0;
 #endif
   }
@@ -51,7 +50,6 @@ int main()
 #endif
 
 #ifdef REPORT_RESULT
-  result = sharedVar;
-  REPORT_RESULT();
+  REPORT_RESULT(sharedVar);
 #endif
 }

--- a/tests/sdl2_audio_beep.cpp
+++ b/tests/sdl2_audio_beep.cpp
@@ -173,8 +173,7 @@ void nextTest(void *unused = 0) {
 #ifdef __EMSCRIPTEN__
         emscripten_cancel_main_loop();
 #ifdef REPORT_RESULT
-        int result = 1;
-        REPORT_RESULT();
+        REPORT_RESULT(1);
 #endif
 #endif
         return;

--- a/tests/sdl2_canvas_size.c
+++ b/tests/sdl2_canvas_size.c
@@ -44,8 +44,7 @@ int main(int argc, char *argv[])
 
     SDL_DestroyWindow(window);
     SDL_Quit();
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 
     return 0;
 }

--- a/tests/sdl2_canvas_write.cpp
+++ b/tests/sdl2_canvas_write.cpp
@@ -67,6 +67,6 @@ int main(void) {
     draw(window, surface);
 
     int result = verify();
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 }
 

--- a/tests/sdl2_custom_cursor.c
+++ b/tests/sdl2_custom_cursor.c
@@ -43,8 +43,7 @@ int main(int argc, char *argv[])
 
     SDL_DestroyWindow(window);
     SDL_Quit();
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 
     return 0;
 }

--- a/tests/sdl2_gl_read.c
+++ b/tests/sdl2_gl_read.c
@@ -135,7 +135,7 @@ void Verify() {
     ok = ok && (data[x*4+1] == 0);
   }
   int result = seen && ok;
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl2_image.c
+++ b/tests/sdl2_image.c
@@ -65,7 +65,7 @@ int main() {
 
   SDL_Quit();
 
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 
   return 0;
 }

--- a/tests/sdl2_key.c
+++ b/tests/sdl2_key.c
@@ -22,7 +22,7 @@ int EventHandler(void *userdata, SDL_Event *event) {
             printf("b scancode\n"); result *= 23; break;
           }
           printf("unknown key: sym %d scancode %d\n", event->key.keysym.sym, event->key.keysym.scancode);
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'"); // comment this out to leave event handling active. Use the following to log DOM keys:
                                                  // addEventListener('keyup', function(event) { console.log(event->keyCode) }, true)
         }

--- a/tests/sdl2_mouse.c
+++ b/tests/sdl2_mouse.c
@@ -28,7 +28,7 @@ void one() {
       case SDL_MOUSEBUTTONDOWN: {
         SDL_MouseButtonEvent *m = (SDL_MouseButtonEvent*)&event;
         if (m->button == 2) {
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'");
         }
         printf("button down : %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);

--- a/tests/sdl2_net_client.c
+++ b/tests/sdl2_net_client.c
@@ -35,7 +35,7 @@ void finish(int result) {
     SDLNet_Quit();
   }
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sdl2_pumpevents.c
+++ b/tests/sdl2_pumpevents.c
@@ -72,6 +72,6 @@ int main(int argc, char *argv[])
   result += loop2();
   emscripten_run_script("keydown(65);"); // A
   result += alphakey();
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }

--- a/tests/sdl2_swsurface.c
+++ b/tests/sdl2_swsurface.c
@@ -19,8 +19,7 @@ int main(int argc, char** argv) {
   SDL_Quit();
 
 #ifdef __EMSCRIPTEN__
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 
   return 0;

--- a/tests/sdl2_text.c
+++ b/tests/sdl2_text.c
@@ -16,7 +16,7 @@ void one() {
         if (!strcmp("a", event.text.text)) {
           result = 1;
         } else if (!strcmp("A", event.text.text)) {
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'");
         }
         break;

--- a/tests/sdl2_timer.c
+++ b/tests/sdl2_timer.c
@@ -7,7 +7,7 @@ Uint32 SDLCALL report_result(Uint32 interval, void *param) {
   SDL_Quit();
   int result = *(int *)param;
   printf("%p %d\n", param, result);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/sdl2_unwasteful.cpp
+++ b/tests/sdl2_unwasteful.cpp
@@ -43,8 +43,7 @@ static void main_loop(void)
     runs++;
     if (runs >= TOTAL_RUNS) {
         emscripten_cancel_main_loop();
-        int result = 1;
-        REPORT_RESULT();
+        REPORT_RESULT(1);
     }
 }
 

--- a/tests/sdl_alloctext.c
+++ b/tests/sdl_alloctext.c
@@ -4,8 +4,6 @@
 
 int main()
 {
-    int result = 0;
-
     SDL_Init(SDL_INIT_VIDEO);
     SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
 
@@ -26,8 +24,7 @@ int main()
     }
 
 #ifdef __EMSCRIPTEN__
-    result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
 }
 

--- a/tests/sdl_audio.c
+++ b/tests/sdl_audio.c
@@ -21,8 +21,7 @@ int play() {
 void done(int channel) {
   assert(channel == 1);
 
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 
 int play2() {

--- a/tests/sdl_audio_beep.cpp
+++ b/tests/sdl_audio_beep.cpp
@@ -173,8 +173,7 @@ void nextTest(void *unused = 0) {
 #ifdef __EMSCRIPTEN__
         emscripten_cancel_main_loop();
 #ifdef REPORT_RESULT
-        int result = 1;
-        REPORT_RESULT();
+        REPORT_RESULT(1);
 #endif
 #endif
         return;

--- a/tests/sdl_audio_beep_sleep.cpp
+++ b/tests/sdl_audio_beep_sleep.cpp
@@ -177,8 +177,7 @@ void nextTest(void *unused = 0) {
 #ifdef __EMSCRIPTEN__
         emscripten_cancel_main_loop();
 #ifdef REPORT_RESULT
-        int result = 1;
-        REPORT_RESULT();
+        REPORT_RESULT(1);
 #endif
 #endif
         return;

--- a/tests/sdl_audio_mix.c
+++ b/tests/sdl_audio_mix.c
@@ -57,9 +57,8 @@ void one_iter() {
     case 120:
       Mix_HaltChannel(soundChannel);
       Mix_HaltMusic();
-      int result = 1;
 #ifdef REPORT_RESULT
-      REPORT_RESULT();
+      REPORT_RESULT(1);
 #endif
       break;
   };

--- a/tests/sdl_audio_mix_channels.c
+++ b/tests/sdl_audio_mix_channels.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
 
 #ifdef __EMSCRIPTEN__
   int result = (lastChannel == -1);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 
   assert(lastChannel == -1);

--- a/tests/sdl_audio_panning.c
+++ b/tests/sdl_audio_panning.c
@@ -10,8 +10,7 @@
 Mix_Chunk *sound;
 
 void done() {
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 
 void pan() {

--- a/tests/sdl_canvas.c
+++ b/tests/sdl_canvas.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   printf("done.\n");
 
   int result = sum > 3000 && sum < 5000; // varies a little on different browsers, font differences?
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 
   return 0;
 }

--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -8,8 +8,6 @@
 
 #include <emscripten.h>
 
-int result = 1;
-
 int main(int argc, char *argv[])
 {
     SDL_Surface *screen;
@@ -38,6 +36,6 @@ int main(int argc, char *argv[])
     assert(h == 480);
 
     SDL_Quit();
-    REPORT_RESULT();
+    REPORT_RESULT(1);
     return 0;
 }

--- a/tests/sdl_gl_mapbuffers.c
+++ b/tests/sdl_gl_mapbuffers.c
@@ -151,7 +151,7 @@ void Verify() {
     ok = ok && (data[x*4+1] == 0);
   }
   int result = seen && ok;
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl_gl_read.c
+++ b/tests/sdl_gl_read.c
@@ -136,7 +136,7 @@ void Verify() {
     ok = ok && (data[x*4+1] == 0);
   }
   int result = seen && ok;
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main(int argc, char *argv[])

--- a/tests/sdl_image.c
+++ b/tests/sdl_image.c
@@ -53,7 +53,7 @@ int main() {
   SDL_Quit();
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 
   return 0;

--- a/tests/sdl_joystick.c
+++ b/tests/sdl_joystick.c
@@ -5,8 +5,6 @@
 #include <string.h>
 #include <emscripten.h>
 
-int result = 1;
-
 void assertJoystickEvent(int expectedGamepad, int expectedType, int expectedIndex, int expectedValue) {
   SDL_Event event;
   while(1) {
@@ -121,8 +119,7 @@ void main_2(void* arg) {
   assertNoJoystickEvent();
 
   // End test.
-  result = 2;
   printf("Test passed!\n");
-  REPORT_RESULT();
+  REPORT_RESULT(2);
 }
 

--- a/tests/sdl_key.c
+++ b/tests/sdl_key.c
@@ -35,7 +35,7 @@ int SDLCALL EventHandler(void *userdata, SDL_Event *event) {
             printf("b scancode\n"); result *= 23; break;
           }
           printf("unknown key: sym %d scancode %d\n", event->key.keysym.sym, event->key.keysym.scancode);
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'"); // comment this out to leave event handling active. Use the following to log DOM keys:
                                                  // addEventListener('keyup', function(event) { console.log(event->keyCode) }, true)
         }

--- a/tests/sdl_key_proxy.c
+++ b/tests/sdl_key_proxy.c
@@ -38,7 +38,7 @@ void one() {
               printf("b scancode\n"); result *= 23; break;
             }
             printf("unknown key: sym %d scancode %d\n", event.key.keysym.sym, event.key.keysym.scancode);
-            REPORT_RESULT();
+            REPORT_RESULT(result);
             emscripten_run_script("throw 'done'"); // comment this out to leave event handling active. Use the following to log DOM keys:
                                                    // addEventListener('keyup', function(event) { console.log(event.keyCode) }, true)
           }

--- a/tests/sdl_mouse.c
+++ b/tests/sdl_mouse.c
@@ -29,7 +29,7 @@ void one() {
       case SDL_MOUSEBUTTONDOWN: {
         SDL_MouseButtonEvent *m = (SDL_MouseButtonEvent*)&event;
         if (m->button == 2) {
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'");
         }
         printf("button down: %d,%d  %d,%d\n", m->button, m->state, m->x, m->y);

--- a/tests/sdl_pumpevents.c
+++ b/tests/sdl_pumpevents.c
@@ -65,6 +65,6 @@ int main(int argc, char *argv[])
    result += loop2();
    emscripten_run_script("keydown(65);"); // A
    result += alphakey();
-   REPORT_RESULT();
+   REPORT_RESULT(result);
    return 0;
 }

--- a/tests/sdl_quit.c
+++ b/tests/sdl_quit.c
@@ -13,7 +13,7 @@ void one() {
       case SDL_QUIT: {
         if (!result) { // prevent infinite recursion since REPORT_RESULT does window.close too.
           result = 1;
-          REPORT_RESULT_INTERNAL(1);
+          REPORT_RESULT_SYNC(1);
         }
       }
     }

--- a/tests/sdl_resize.c
+++ b/tests/sdl_resize.c
@@ -23,8 +23,7 @@ void loop() {
           case 1:
             assert(r->w == 123);
             assert(r->h == 246);
-            int result = 1;
-            REPORT_RESULT();
+            REPORT_RESULT(1);
             break;
         }
       }

--- a/tests/sdl_stb_image_cleanup.c
+++ b/tests/sdl_stb_image_cleanup.c
@@ -22,7 +22,7 @@ int main() {
   });
 
   printf("Total memory allocated %d Mb\n", result);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
 

--- a/tests/sdl_surface_refcount.c
+++ b/tests/sdl_surface_refcount.c
@@ -23,6 +23,6 @@ int main(int argc, char *argv[])
     SDL_FreeSurface(surface);
     SDL_FreeSurface(reference);
     int result = is_surface_freed(surface);
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     return 0;
 }

--- a/tests/sdl_swsurface.c
+++ b/tests/sdl_swsurface.c
@@ -13,8 +13,7 @@ int main(int argc, char** argv) {
   SDL_Quit();
 
 #ifdef __EMSCRIPTEN__
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 
   return 0;

--- a/tests/sdl_text.c
+++ b/tests/sdl_text.c
@@ -16,7 +16,7 @@ void one() {
         if (!strcmp("a", event.text.text)) {
           result = 1;
         } else if (!strcmp("A", event.text.text)) {
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           emscripten_run_script("throw 'done'");
         }
         break;

--- a/tests/sdl_togglefullscreen.c
+++ b/tests/sdl_togglefullscreen.c
@@ -109,7 +109,7 @@ static void mainloop() {
   case STATE_SUCCESS:
 #ifdef REPORT_RESULT
     {
-      REPORT_RESULT();
+      REPORT_RESULT(result);
     }
 #endif
     emscripten_cancel_main_loop();

--- a/tests/sdl_touch.c
+++ b/tests/sdl_touch.c
@@ -23,9 +23,8 @@ void progress() {
   else if (!got_up) printf("Release a finger to generate a touch up event.\n");
   else
   {
-    int result = 0;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
   }
 }

--- a/tests/sdl_wm_togglefullscreen.c
+++ b/tests/sdl_wm_togglefullscreen.c
@@ -35,9 +35,8 @@ void mainloop() {
   
   if (wasFullscreen && !isInFullscreen) {
     printf("Exited fullscreen. Test succeeded.\n");
-    result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     wasFullscreen = isInFullscreen;
     finished = 1;
@@ -58,7 +57,7 @@ void mainloop() {
             printf("Exited fullscreen. Test failed, fullscreen transition did not happen!\n");
           }
 #ifdef REPORT_RESULT
-          REPORT_RESULT();
+          REPORT_RESULT(result);
 #endif
           finished = 1;
           return;

--- a/tests/sdlglshader2.c
+++ b/tests/sdlglshader2.c
@@ -158,8 +158,7 @@ int main(int argc, char *argv[])
     SDL_GL_SwapBuffers();
     
 #ifdef REPORT_RESULT
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
 
     SDL_Quit();

--- a/tests/sigalrm.cpp
+++ b/tests/sigalrm.cpp
@@ -8,8 +8,7 @@ void alarm_handler(int dummy)
 {
 	printf("Received alarm!\n");
 #ifdef REPORT_RESULT
-	int result = 0;
-	REPORT_RESULT();
+	REPORT_RESULT(0);
 #endif
 	exit(0);
 }
@@ -20,8 +19,7 @@ int main()
 	{
 		printf("Error in signal()!\n");
 #ifdef REPORT_RESULT
-		int result = 1;
-		REPORT_RESULT();
+		REPORT_RESULT(1);
 #endif
 		exit(1);
 	}

--- a/tests/sockets/test_enet_client.c
+++ b/tests/sockets/test_enet_client.c
@@ -35,7 +35,7 @@ void main_loop() {
 
       int result = strcmp("packetfoo", event.packet->data);
 #ifdef __EMSCRIPTEN__
-      REPORT_RESULT();
+      REPORT_RESULT(result);
 #else
       exit(EXIT_SUCCESS);
 #endif

--- a/tests/sockets/test_sockets_echo_client.c
+++ b/tests/sockets/test_sockets_echo_client.c
@@ -43,7 +43,7 @@ void finish(int result) {
     server.fd = 0;
   }
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sockets/test_sockets_partial_client.c
+++ b/tests/sockets/test_sockets_partial_client.c
@@ -20,7 +20,7 @@ int sum = 0;
 void finish(int result) {
   close(sockfd);
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sockets/test_sockets_select_server_closes_connection_client_rw.c
+++ b/tests/sockets/test_sockets_select_server_closes_connection_client_rw.c
@@ -25,7 +25,7 @@ msg_t writemsg;
 void finish(int result) {
   close(sockfd);
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sockets/test_sockets_select_server_down_client.c
+++ b/tests/sockets/test_sockets_select_server_down_client.c
@@ -21,7 +21,7 @@ int sockfd = -1;
 void finish(int result) {
   close(sockfd);
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sockets/webrtc_host.c
+++ b/tests/sockets/webrtc_host.c
@@ -42,7 +42,7 @@ void iter() {
        0 == strncmp((char*)hdr.msg_iov[0].iov_base, expected, strlen(expected))) {
       result = 1;
     }
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     exit(EXIT_SUCCESS);
     emscripten_cancel_main_loop();
 #endif

--- a/tests/split_memory_large_file.cpp
+++ b/tests/split_memory_large_file.cpp
@@ -28,7 +28,6 @@ int main() {
     if ((i & (1024*1024-1)) == 0) printf("%d of %d ..\n", i, TOTAL_SIZE);
   }
   printf("%d all ok.\n", i);
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -157,7 +157,7 @@ If manually bisecting:
           printf("|%%s|\n", buf);
 
           int result = !strcmp("load me right before", buf);
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           return 0;
         }
         ''' % path))
@@ -240,7 +240,7 @@ If manually bisecting:
           if (f != NULL)
             result = 0;
 
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           return 0;
         }
       ''' % (path1, path2, nonexistingpath)))
@@ -322,7 +322,7 @@ If manually bisecting:
         fclose(f);
         printf("|%%s|\n", buf);
         int result = !strcmp("|load me right before|", buf);
-        REPORT_RESULT();
+        REPORT_RESULT(result);
         return 0;
       }
     ''' % (txt.replace('\'', '\\\'').replace('\"', '\\"'))))
@@ -361,7 +361,7 @@ If manually bisecting:
           result += !strcmp("load me right before", buf);
           result += checkPreloadResults();
 
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           return 0;
         }
       ''' % path))
@@ -412,7 +412,7 @@ If manually bisecting:
           result += !strcmp("load me right before", buf);
           result += checkPreloadResults();
 
-          REPORT_RESULT();
+          REPORT_RESULT(result);
           return 0;
         }
       ''' % path))
@@ -466,7 +466,7 @@ If manually bisecting:
         printf("|%s|\n", buf);
         result = result && !strcmp("3.14159265358979", buf);
 
-        REPORT_RESULT();
+        REPORT_RESULT(result);
         return 0;
       }
     '''))
@@ -504,7 +504,7 @@ If manually bisecting:
         printf("|%s|\n", buf);
         int result = !strcmp("1214141516171819", buf);
 
-        REPORT_RESULT();
+        REPORT_RESULT(result);
         return 0;
       }
     '''))
@@ -526,8 +526,7 @@ If manually bisecting:
         #include <emscripten.h>
         int main() {
           // This code should never be executed in terms of missing required dependency file.
-          int result = 0;
-          REPORT_RESULT();
+          REPORT_RESULT(0);
           return 0;
         }
       '''))
@@ -2389,7 +2388,7 @@ open(filename, 'w').write(replaced)
         fclose(f);
         int result = !strcmp("load me right before", buf);
         printf("|%s| : %d\n", buf, result);
-        REPORT_RESULT();
+        REPORT_RESULT(result);
         return 0;
       }
     '''))
@@ -2435,7 +2434,7 @@ int main() {
     return Module['memoryInitializerRequest'].status;
   });
   printf("memory init request: %d\n", result);
-  REPORT_RESULT();
+  REPORT_RESULT(result);
   return 0;
 }
     '''))
@@ -2966,8 +2965,7 @@ window.close = function() {
             var totalMemory = eval('Module.TOTAL_MEMORY');
             assert(totalMemory === %d, 'bad memory size');
           });
-          int result = 0;
-          REPORT_RESULT();
+          REPORT_RESULT(0);
           return 0;
         }
       ''' % totalMemory
@@ -3020,8 +3018,7 @@ window.close = function() {
         });
         puts(ret);
         EM_ASM({ assert(Module.printed === 'hello through side', ['expected', Module.printed]); });
-        int result = 2;
-        REPORT_RESULT();
+        REPORT_RESULT(2);
         return 0;
       }
     ''')
@@ -3067,8 +3064,7 @@ window.close = function() {
         const char *exts = side();
         puts(side());
         assert(strstr(exts, "GL_EXT_texture_env_combine"));
-        int result = 1;
-        REPORT_RESULT();
+        REPORT_RESULT(1);
         return 0;
       }
     ''')
@@ -3276,7 +3272,7 @@ window.close = function() {
         } else {
           result = 1;
         }
-        REPORT_RESULT();
+        REPORT_RESULT(result);
       }
     '''))
 

--- a/tests/test_egl.c
+++ b/tests/test_egl.c
@@ -134,6 +134,6 @@ int main(int argc, char *argv[])
     assert(eglGetProcAddress("glWakaWaka") == 0);
 
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 }

--- a/tests/test_egl_width_height.c
+++ b/tests/test_egl_width_height.c
@@ -35,6 +35,6 @@ int main(int argc, char *argv[])
     {
         result = 1;
     }
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 }

--- a/tests/test_glfw_cursor_disabled.c
+++ b/tests/test_glfw_cursor_disabled.c
@@ -28,8 +28,7 @@ void render() {
 
             if (step == 5) {
                 printf("All tests passed.\n");
-                result = 1;
-                REPORT_RESULT();
+                REPORT_RESULT(1);
                 exit(0);
             }
 
@@ -37,7 +36,7 @@ void render() {
             else printf("Click again to enable Pointer Lock\n");
         } else {
             printf("FAIL: cursor_disabled(%d) != pointerlock_isActive(%d)\n", cursor_disabled, pointerlock_isActive);
-            REPORT_RESULT();
+            REPORT_RESULT(result);
             exit(1);
         }
     }
@@ -68,7 +67,7 @@ int main() {
     if (glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED) {
         // Browsers do not allow disabling the cursor (Pointer Lock) without a gesture.
         printf("FAIL: glfwGetInputMode returned GLFW_CURSOR_DISABLED prematurely\n");
-        REPORT_RESULT();
+        REPORT_RESULT(result);
         exit(1);
     }
     printf("Pass 1: glfwGetInputMode not prematurely returning cursor disabled\n");

--- a/tests/test_glfw_dropfile.c
+++ b/tests/test_glfw_dropfile.c
@@ -9,8 +9,6 @@
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 
-int result = 1;
-
 GLFWwindow* g_window;
 
 void render();
@@ -28,8 +26,10 @@ void on_file_drop(GLFWwindow *window, int count, const char **paths) {
     if (!fp) {
         printf("failed to open %s\n", paths[i]);
         perror("fopen");
-        result = 0;
-        continue;
+#ifdef REPORT_RESULT
+        REPORT_RESULT(0);
+#endif
+        return;
     }
     int c;
     long size = 0;
@@ -53,17 +53,16 @@ void on_file_drop(GLFWwindow *window, int count, const char **paths) {
 
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 }
 
 int main() {
   if (!glfwInit())
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif      
     return -1;
   }
@@ -71,10 +70,9 @@ int main() {
   g_window = glfwCreateWindow(600, 450, "GLFW drop file", NULL, NULL);
   if (!g_window)
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif           
     glfwTerminate();
     return -1;

--- a/tests/test_glfw_fullscreen.c
+++ b/tests/test_glfw_fullscreen.c
@@ -4,8 +4,6 @@
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 
-int result = 1;
-
 GLFWwindow* g_window;
 
 int inFullscreen = 0;
@@ -32,9 +30,8 @@ void windowSizeCallback(GLFWwindow* window, int width, int height) {
   
   if (wasFullscreen && !isInFullscreen) {
     printf("Exited fullscreen. Test succeeded.\n");
-    result = 1;
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(1);
 #endif
     wasFullscreen = isInFullscreen;
     emscripten_cancel_main_loop();
@@ -47,10 +44,9 @@ int main() {
   glfwSetErrorCallback(error_callback);
   if (!glfwInit())
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif      
     return -1;
   }
@@ -58,10 +54,9 @@ int main() {
   g_window = glfwCreateWindow(600, 450, "GLFW resizing test - windowed", NULL, NULL);
   if (!g_window)
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif           
     glfwTerminate();
     return -1;

--- a/tests/test_glfw_get_key_stuck.c
+++ b/tests/test_glfw_get_key_stuck.c
@@ -47,7 +47,7 @@ EM_BOOL on_focuspocus(int eventType, const EmscriptenFocusEvent *focusEvent, voi
             if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS) {
                 printf("FAIL: glfwGetKey() is stuck after blur\n");
 #ifdef REPORT_RESULT
-                REPORT_RESULT();
+                REPORT_RESULT(result);
 #endif
             }
             break;
@@ -62,7 +62,7 @@ EM_BOOL on_focuspocus(int eventType, const EmscriptenFocusEvent *focusEvent, voi
                     result = 1;
                 }
 #ifdef REPORT_RESULT
-                REPORT_RESULT();
+                REPORT_RESULT(result);
 #endif
                 glfwTerminate();
             }

--- a/tests/test_glfw_joystick.c
+++ b/tests/test_glfw_joystick.c
@@ -7,8 +7,6 @@
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 
-int result = 1;
-
 GLFWwindow* g_window;
 
 void error_callback(int error, const char* description);
@@ -94,18 +92,16 @@ void main_2(void *arg) {
   assert(axes[1] == -1);
 
   // End test.
-  result = 2;
   printf("Test passed!\n");
-  REPORT_RESULT();
+  REPORT_RESULT(2);
 }
 
 int main() {
   if (!glfwInit())
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     return -1;
   }
@@ -113,10 +109,9 @@ int main() {
   g_window = glfwCreateWindow(600, 450, "GLFW joystick test", NULL, NULL);
   if (!g_window)
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     glfwTerminate();
     return -1;

--- a/tests/test_glfw_pointerlock.c
+++ b/tests/test_glfw_pointerlock.c
@@ -23,7 +23,7 @@ void OnMouseClick(GLFWwindow *window, int button, int action, int mods) {
   printf("mouse actions: %d / 4\n", actions);
   if (actions >= 4) {
     printf("done.\n");
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     emscripten_cancel_main_loop();
   }
 }
@@ -33,10 +33,9 @@ int main() {
   glfwSetErrorCallback(error_callback);
   if (!glfwInit())
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
     return -1;
   }
@@ -44,10 +43,9 @@ int main() {
   g_window = glfwCreateWindow(600, 450, "GLFW pointerlock test", NULL, NULL);
   if (!g_window)
   {
-    result = 0;
     printf("Could not create window. Test failed.\n");      
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     glfwTerminate();
     return -1;

--- a/tests/test_glfw_time.c
+++ b/tests/test_glfw_time.c
@@ -24,7 +24,7 @@ int main() {
     glfwTerminate();
 
 #ifdef REPORT_RESULT
-                REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
 
     return 0;

--- a/tests/test_html5.c
+++ b/tests/test_html5.c
@@ -288,8 +288,7 @@ void mainloop()
 #ifdef REPORT_RESULT
 void report_result(void *arg)
 {
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 }
 #endif
 

--- a/tests/test_html5_fullscreen.c
+++ b/tests/test_html5_fullscreen.c
@@ -13,7 +13,7 @@ void report_result(int result)
     printf("Test failed!\n");
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/test_html5_mouse.c
+++ b/tests/test_html5_mouse.c
@@ -11,7 +11,7 @@ void report_result(int result)
     printf("Test failed!\n");
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/test_html5_pointerlockerror.c
+++ b/tests/test_html5_pointerlockerror.c
@@ -11,7 +11,7 @@ void report_result(int result)
     printf("Test failed!\n");
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/test_preallocated_heap.cpp
+++ b/tests/test_preallocated_heap.cpp
@@ -11,7 +11,6 @@ int main()
 	printf("ptr2: %p\n", ptr2);
 	assert(ptr2 == 0);
 #ifdef REPORT_RESULT
-	int result = 1;
-	REPORT_RESULT();
+	REPORT_RESULT(1);
 #endif
 }

--- a/tests/test_sdl_mousewheel.c
+++ b/tests/test_sdl_mousewheel.c
@@ -11,7 +11,7 @@ void report_result(int result)
     printf("Test failed!\n");
   }
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -19,7 +19,7 @@ report_result(int result)
         printf("Test failed!\n");
     }
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     exit(result);
 }

--- a/tests/test_webgl_context_attributes_glfw.c
+++ b/tests/test_webgl_context_attributes_glfw.c
@@ -45,7 +45,7 @@ int main() {
   
     glfwTerminate();
   
-    REPORT_RESULT();
+    REPORT_RESULT(result);
   
     return 0;
 

--- a/tests/test_webgl_context_attributes_glut.c
+++ b/tests/test_webgl_context_attributes_glut.c
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
     
     draw();
     
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     
     return 0;
 }

--- a/tests/test_webgl_context_attributes_sdl.c
+++ b/tests/test_webgl_context_attributes_sdl.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
     
     draw();
         
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     
     return 0;
 }

--- a/tests/test_wget.c
+++ b/tests/test_wget.c
@@ -20,6 +20,6 @@ int main()
             result = 1;
         fclose(f);
     }
-    REPORT_RESULT();
+    REPORT_RESULT(result);
     return 0;
 }

--- a/tests/test_wget_data.c
+++ b/tests/test_wget_data.c
@@ -21,7 +21,6 @@ int main()
     assert(error);
 
     printf("ok!\n");
-    int result = 1;
-    REPORT_RESULT();
+    REPORT_RESULT(1);
     return 0;
 }

--- a/tests/unistd/access.c
+++ b/tests/unistd/access.c
@@ -57,8 +57,7 @@ int main() {
 #endif
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 
   return 0;

--- a/tests/unistd/close.c
+++ b/tests/unistd/close.c
@@ -36,8 +36,7 @@ int main() {
   errno = 0;
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return 0;
 }

--- a/tests/unistd/unlink.c
+++ b/tests/unistd/unlink.c
@@ -170,8 +170,7 @@ int main() {
   test();
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
   return EXIT_SUCCESS;
 }

--- a/tests/uuid/test.c
+++ b/tests/uuid/test.c
@@ -58,12 +58,9 @@ int main() {
     assert(uuid_is_null(uuid) == 1);
 
     // The following lets the browser test exit cleanly.
-    int result = 1;
-    #if defined(__EMSCRIPTEN__)
-        #ifdef REPORT_RESULT
-            REPORT_RESULT();
-        #endif
-    #endif
+#ifdef REPORT_RESULT
+    REPORT_RESULT(1);
+#endif
     exit(0);
 }
 

--- a/tests/webgl2.cpp
+++ b/tests/webgl2.cpp
@@ -45,7 +45,7 @@ int main()
   }
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/webgl2_backwards_compatibility_emulation.cpp
+++ b/tests/webgl2_backwards_compatibility_emulation.cpp
@@ -31,7 +31,7 @@ int main()
   emscripten_webgl_destroy_context(context);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/webgl2_garbage_free_entrypoints.cpp
+++ b/tests/webgl2_garbage_free_entrypoints.cpp
@@ -97,8 +97,7 @@ int main(int argc, char *argv[])
 
   printf("Test passed!\n");
 #ifdef REPORT_RESULT
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 #endif
 
   return 0;

--- a/tests/webgl2_objects.cpp
+++ b/tests/webgl2_objects.cpp
@@ -36,7 +36,7 @@ int main()
   {
     printf("Skipped: WebGL 2 is not supported.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     return 0;
   }
@@ -85,7 +85,7 @@ int main()
   assert(sampler2 == sampler);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/webgl2_ubos.cpp
+++ b/tests/webgl2_ubos.cpp
@@ -35,7 +35,7 @@ int main()
   {
     printf("Skipped: WebGL 2 is not supported.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     return 0;
   }
@@ -166,7 +166,7 @@ int main()
   }
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/webgl_color_buffer_readpixels.cpp
+++ b/tests/webgl_color_buffer_readpixels.cpp
@@ -69,7 +69,6 @@ int main()
   assert(glGetError() == 0 && "glReadPixels of FBO with floating point color renderbuffer in GL_RGBA+GL_FLOAT format failed");
 
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/webgl_create_context.cpp
+++ b/tests/webgl_create_context.cpp
@@ -36,10 +36,9 @@ GLint GetInt(GLenum param)
 }
 
 void final(void*) {
-  #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
-  #endif
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
 }
 
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;

--- a/tests/webgl_create_context2.cpp
+++ b/tests/webgl_create_context2.cpp
@@ -15,7 +15,6 @@ int main()
   assert(res == EMSCRIPTEN_RESULT_SUCCESS);
   assert(emscripten_webgl_get_current_context() == context);
 #ifdef REPORT_RESULT
-  int result = 0;
-  REPORT_RESULT();
+  REPORT_RESULT(0);
 #endif
 }

--- a/tests/webgl_destroy_context.cpp
+++ b/tests/webgl_destroy_context.cpp
@@ -12,7 +12,7 @@ void report_result()
 {
   printf("Test finished with result %d\n", result);
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
 }
 

--- a/tests/webgl_shader_source_length.cpp
+++ b/tests/webgl_shader_source_length.cpp
@@ -33,7 +33,7 @@ int main()
   {
     printf("Skipped: WebGL is not supported.\n");
 #ifdef REPORT_RESULT
-    REPORT_RESULT();
+    REPORT_RESULT(result);
 #endif
     return 0;
   }
@@ -64,7 +64,7 @@ int main()
   assert(res == EMSCRIPTEN_RESULT_SUCCESS);
 
 #ifdef REPORT_RESULT
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 #endif
   return 0;
 }

--- a/tests/webgl_with_closure.cpp
+++ b/tests/webgl_with_closure.cpp
@@ -81,7 +81,7 @@ int main()
 #ifdef REPORT_RESULT
         // We did not have WebGL 2, but were able to init WebGL 1? In that case, gracefully skip this test with the current browser not supporting this one.
         int result = context ? 0 : 12365;
-        REPORT_RESULT();
+        REPORT_RESULT(result);
 #endif
         return 0;
     }
@@ -178,8 +178,7 @@ int main()
     GL_CALL( glBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 ) );  
 
 #ifdef REPORT_RESULT
-    int result = 0;
-    REPORT_RESULT();
+    REPORT_RESULT(0);
 #endif
 
   return 0;

--- a/tests/webidl/test.cpp
+++ b/tests/webidl/test.cpp
@@ -19,8 +19,7 @@ int main() {
     var got = sme.getVal();
     assert(got === 84, "got: " + got);
   });
-  int result = 1;
-  REPORT_RESULT();
+  REPORT_RESULT(1);
 }
 #endif
 

--- a/tests/worker_api_2_main.cpp
+++ b/tests/worker_api_2_main.cpp
@@ -34,8 +34,7 @@ void c3(char *data, int size, void *arg) { // tests calls different in different
   }
   if (c3_7 && c3_7) { // note: racey, responses from 2 workers here
     emscripten_destroy_worker(w1);
-    int result = 11;
-    REPORT_RESULT();
+    REPORT_RESULT(11);
     emscripten_force_exit(0);
   }
 }

--- a/tests/worker_api_3_main.cpp
+++ b/tests/worker_api_3_main.cpp
@@ -29,7 +29,7 @@ void c1(char *data, int size, void *arg) {
     int result = 1;  // Final call occurred.
     for (int i = 0; i < 4; ++i)
       if (sawCalls[i]) result++;
-    REPORT_RESULT();
+    REPORT_RESULT(result);
   }
 }
 

--- a/tests/worker_api_main.cpp
+++ b/tests/worker_api_main.cpp
@@ -10,7 +10,7 @@ void c1(char *data, int size, void *arg) {
   printf("c1: %d,%d\n", x[0], x[1]);
 
   int result = x[1] % x[0];
-  REPORT_RESULT();
+  REPORT_RESULT(result);
 }
 
 int main() {


### PR DESCRIPTION
Refactor `int result; REPORT_RESULT();` to form `REPORT_RESULT(result);` to make it easier to be refactored to be thread-safe later.