### PR TITLE
deprecate_emscripten_set_get_canvas_size

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1925,6 +1925,26 @@ var LibraryJSEvents = {
     return Module['ctx'].isContextLost();
   },
 
+  emscripten_set_canvas_element_size: function(target, width, height) {
+    if (target) target = JSEvents.findEventTarget(target);
+    else target = Module['canvas'];
+    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+
+    target.width = width;
+    target.height = height;
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_get_canvas_element_size: function(target, width, height) {
+    if (target) target = JSEvents.findEventTarget(target);
+    else target = Module['canvas'];
+    if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
+
+    {{{ makeSetValue('width', '0', 'target.width', 'i32') }}};
+    {{{ makeSetValue('height', '0', 'target.height', 'i32') }}};
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
   emscripten_set_element_css_size: function(target, width, height) {
     if (!target) {
       target = Module['canvas'];

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -132,8 +132,8 @@ extern void emscripten_force_exit(int status);
 double emscripten_get_device_pixel_ratio(void);
 
 void emscripten_hide_mouse(void);
-void emscripten_set_canvas_size(int width, int height);
-void emscripten_get_canvas_size(int *width, int *height, int *isFullscreen);
+void emscripten_set_canvas_size(int width, int height) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_set_canvas_element_size() instead")));
+void emscripten_get_canvas_size(int *width, int *height, int *isFullscreen) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_get_canvas_element_size() and emscripten_get_fullscreen_status() instead")));
 
 #if __EMSCRIPTEN__
 double emscripten_get_now(void);

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -438,6 +438,9 @@ extern EM_BOOL emscripten_is_webgl_context_lost(const char *target);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_commit_frame();
 
+extern EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target, int width, int height);
+extern EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, int *width, int *height);
+
 extern EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
 extern EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
 

--- a/tests/emscripten_set_canvas_element_size.c
+++ b/tests/emscripten_set_canvas_element_size.c
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+
+// Tests the operation of emscripten_set_canvas_element_size() and emscripten_get_canvas_element_size()
+
+int main(int argc, char **argv)
+{
+  // For testing purposes, rename the canvas on the page to some arbitrary ID.
+  EM_ASM(document.getElementById('canvas').id = 'myCanvasId');
+
+  // Accessing #canvas should resize Module['canvas']
+  EMSCRIPTEN_RESULT r = emscripten_set_canvas_element_size("#canvas", 100, 200);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+
+  int w, h;
+  r = emscripten_get_canvas_element_size("#canvas", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 100);
+  assert(h == 200);
+  w = h = 0;
+
+  // Check that we see the change via 'NULL'
+  r = emscripten_get_canvas_element_size(NULL, &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 100);
+  assert(h == 200);
+  w = h = 0;
+
+  // Check that we see the change via 'mycanvasId'
+  r = emscripten_get_canvas_element_size("myCanvasId", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 100);
+  assert(h == 200);
+
+  // The following line will not work with OffscreenCanvas, that is covered in another test
+  int jsAgreesWithSize = EM_ASM_INT_V({return Module['canvas'].width == 100 && Module['canvas'].height == 200});
+  assert(jsAgreesWithSize);
+
+  // Accessing NULL should also resize Module['canvas']
+  r = emscripten_set_canvas_element_size(NULL, 101, 201);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+
+  // Check that we see the change on the canvas (via the established #canvas)
+  r = emscripten_get_canvas_element_size("#canvas", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 101);
+  assert(h == 201);
+  w = h = 0;
+
+  // Check that we see the change via 'NULL'
+  r = emscripten_get_canvas_element_size(NULL, &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 101);
+  assert(h == 201);
+  w = h = 0;
+
+  // Check that we see the change via 'mycanvasId'
+  r = emscripten_get_canvas_element_size("myCanvasId", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 101);
+  assert(h == 201);
+
+  // Accessing by specific ID should resize canvas by that ID
+  r = emscripten_set_canvas_element_size("myCanvasId", 102, 202);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+
+  // Check that we see the change on the canvas (via the established #canvas)
+  r = emscripten_get_canvas_element_size("#canvas", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 102);
+  assert(h == 202);
+
+  // Check that we see the change on the canvas (via the established #canvas)
+  r = emscripten_get_canvas_element_size("#canvas", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 102);
+  assert(h == 202);
+  w = h = 0;
+
+  // Check that we see the change via 'NULL'
+  r = emscripten_get_canvas_element_size(NULL, &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 102);
+  assert(h == 202);
+  w = h = 0;
+
+  // Check that we see the change via 'mycanvasId'
+  r = emscripten_get_canvas_element_size("myCanvasId", &w, &h);
+  assert(r == EMSCRIPTEN_RESULT_SUCCESS);
+  assert(w == 102);
+  assert(h == 202);
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(1);
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3616,3 +3616,7 @@ window.close = function() {
     ]:
       print "Testing with: ", args
       self.btest('pthread/test_pthread_locale.c', expected='1', args=args)
+
+  # Tests the Emscripten HTML5 API emscripten_set_canvas_element_size() and emscripten_get_canvas_element_size() functionality in singlethreaded programs.
+  def test_emscripten_set_canvas_element_size(self):
+    self.btest('emscripten_set_canvas_element_size.c', expected='1')


### PR DESCRIPTION
Deprecate `emscripten_set/get_canvas_size()` in favor of `emscripten_set/get_canvas_element_size()` which are slimmer to the point and allow specifying the target canvas element to resize, instead of relying on a singleton `Module['canvas']`.