### PR TITLE
Precise the version of python in emrun

### DIFF
--- a/emrun
+++ b/emrun
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # emrun: Implements machinery that allows running a .html page as if it was a standard executable file.
 # Usage: emrun <options> filename.html <args to program>


### PR DESCRIPTION
In some linux distribution, python3 is the default version.