### PR TITLE
fix_relative_file_loads_node_js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2713,6 +2713,8 @@ def generate_html(target, options, js_target, target_basename,
           } else if (Module['memoryInitializerPrefixURL']) {
             memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
           }
+          // If URL to memory initializer is relative, treat it relative with respect to Module['scriptDirectory'], if that is present.
+          if (Module['scriptDirectory'] && !/^(?:[a-z]+:)?[\/\\\\]\/?/i.test(memoryInitializer)) memoryInitializer = Module['scriptDirectory'] + memoryInitializer;
           Module['memoryInitializerRequestURL'] = memoryInitializer;
           var meminitXHR = Module['memoryInitializerRequest'] = new XMLHttpRequest();
           meminitXHR.open('GET', memoryInitializer, true);

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -115,6 +115,7 @@ var Fetch = {
       // of these are passed, then the default URL 'pthread-main.js' relative to the main html file is loaded.
       if (typeof Module['locateFile'] === 'function') fetchJs = Module['locateFile'](fetchJs);
       else if (Module['pthreadMainPrefixURL']) fetchJs = Module['pthreadMainPrefixURL'] + fetchJs;
+      fetchJs = joinUrl(Module['scriptDirectory'], fetchJs);
       Fetch.worker = new Worker(fetchJs);
       Fetch.worker.onmessage = function(e) {
         out('fetch-worker sent a message: ' + e.filename + ':' + e.lineno + ': ' + e.message);

--- a/src/library_debugger_toolkit.js
+++ b/src/library_debugger_toolkit.js
@@ -451,6 +451,7 @@ var CyberDWARFHeapPrinter = function(cdFileLocation) {
     } else if (Module['cdInitializerPrefixURL']) {
       cdFileLocation = Module['cdInitializerPrefixURL'] + cdFileLocation;
     }
+    cdFileLocation = joinUrl(Module['scriptDirectory'], cdFileLocation);
     if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
       var data = Module['read'](cdFileLocation);
       install_cyberdwarf(data);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -260,6 +260,7 @@ var LibraryPThread = {
       else if (Module['pthreadMainPrefixURL']) pthreadMainJs = Module['pthreadMainPrefixURL'] + pthreadMainJs;
 
       for (var i = 0; i < numWorkers; ++i) {
+        pthreadMainJs = joinUrl(Module['scriptDirectory'], pthreadMainJs);
         var worker = new Worker(pthreadMainJs);
 
         (function(worker) {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -45,7 +45,9 @@ if (memoryInitializer) {
     } else if (Module['memoryInitializerPrefixURL']) {
       memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
     }
+    memoryInitializer = joinUrl(Module['scriptDirectory'], memoryInitializer);
   }
+
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
     var data = Module['readBinary'](memoryInitializer);
     HEAPU8.set(data, GLOBAL_BASE);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -844,6 +844,18 @@ function stackTrace() {
   return demangleAll(js);
 }
 
+function isAbsolutePath(path) {
+  return isDataURI(path) || /^(?:[a-z]+:)?[\/\\]\/?/i.test(path);
+}
+
+// Joins relative URL 'b' to URL 'a'. 'a' may be empty, in which case 'b' is returned.
+// If 'b' is an absolute URL, then 'a' is ignored and 'b' is returned as-is as well.
+function joinUrl(a, b) {
+#if ASSERTIONS
+  if (a && !a.endsWith('/')) throw 'First parameter to joinUrl() should end in /!';
+#endif
+  return (a && !isAbsolutePath(b)) ? a + b : b;
+}
 // Memory management
 
 var PAGE_SIZE = 16384;
@@ -2031,6 +2043,9 @@ function integrateWasmJS() {
       asmjsCodeFile = Module['locateFile'](asmjsCodeFile);
     }
   }
+  wasmTextFile = joinUrl(Module['scriptDirectory'], wasmTextFile);
+  wasmBinaryFile = joinUrl(Module['scriptDirectory'], wasmBinaryFile);
+  asmjsCodeFile = joinUrl(Module['scriptDirectory'], asmjsCodeFile);
 
   // utilities
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -94,6 +94,8 @@ if (ENVIRONMENT_IS_NODE) {
 
   // Expose functionality in the same simple way that the shells work
   // Note that we pollute the global namespace here, otherwise we break in node
+  if (!Module['scriptDirectory']) Module['scriptDirectory'] = __dirname + '/';
+
   var nodeFS;
   var nodePath;
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -738,6 +738,7 @@ ret += '''%s
   var REMOTE_METADATA_NAME = typeof Module['locateFile'] === 'function' ?
                              Module['locateFile']('%(metadata_file)s') :
                              ((Module['filePackagePrefixURL'] || '') + '%(metadata_file)s');
+  REMOTE_METADATA_NAME = joinUrl(Module['scriptDirectory'], REMOTE_METADATA_NAME);
   var xhr = new XMLHttpRequest();
   xhr.onreadystatechange = function() {
    if (xhr.readyState === 4 && xhr.status === 200) {


### PR DESCRIPTION
Add Module['scriptDirectory'] to fix loading files that should be relative to main .js file on Node.js.

Intended to replace #5368 to fix #4542.