### PR TITLE
Make loop less confusing

### DIFF
--- a/src/library_path.js
+++ b/src/library_path.js
@@ -26,7 +26,7 @@ mergeInto(LibraryManager.library, {
       }
       // if the path is allowed to go above the root, restore leading ..s
       if (allowAboveRoot) {
-        for (; up--; up) {
+        for (; up; up--) {
           parts.unshift('..');
         }
       }


### PR DESCRIPTION
Writing decrement in the same place as check for truthfulness is confusing to read, also `up` is not used anywhere further in the function, so it doesn't need to apply decrement in place.

Also this confuses Closure Compiler:
```
... (JSC_USELESS_CODE)
Suspicious code. This code lacks side-effects. Is there a bug?
...
```