### PR TITLE
default_lang_is_utf8

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -632,7 +632,7 @@ LibraryManager.library = {
       ENV['PATH'] = '/';
       ENV['PWD'] = '/';
       ENV['HOME'] = '/home/web_user';
-      ENV['LANG'] = 'C';
+      ENV['LANG'] = 'C.UTF-8';
       ENV['_'] = Module['thisProgram'];
       // Allocate memory.
       poolPtr = allocate(TOTAL_ENV_SIZE, 'i8', ALLOC_STATIC);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7117,6 +7117,9 @@ Success!
   def test_locale(self):
     self.do_run_from_file(path_from_root('tests', 'test_locale.c'), path_from_root('tests', 'test_locale.out'))
 
+  def test_vswprintf_utf8(self):
+    self.do_run_from_file(path_from_root('tests', 'vswprintf_utf8.c'), path_from_root('tests', 'vswprintf_utf8.out'))
+
   def test_async(self):
     self.banned_js_engines = [SPIDERMONKEY_ENGINE, V8_ENGINE] # needs setTimeout which only node has
 

--- a/tests/vswprintf_utf8.c
+++ b/tests/vswprintf_utf8.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <locale.h>
+#include <errno.h>
+#include <assert.h>
+
+void test_vswprintf(const wchar_t *format, ...)
+{
+  wchar_t buffer[256];
+  va_list args;
+  va_start(args, format);
+  int n = vswprintf(buffer, 256, format, args);
+  fputws(buffer, stdout);
+  va_end(args);
+  wprintf(L"number of characters in above string: %d. errno: %d\n", n, errno);
+  assert(n == 24);
+  assert(errno == 0);
+}
+
+int main ()
+{
+  setlocale(LC_ALL, "");
+  test_vswprintf(L"This is a character: %lc.\n", 0xF6 /* Unicode Character 'LATIN SMALL LETTER O WITH DIAERESIS' (U+00F6): http://www.fileformat.info/info/unicode/char/00f6/index.htm */);
+  return 0;
+}

--- a/tests/vswprintf_utf8.out
+++ b/tests/vswprintf_utf8.out
@@ -1,0 +1,2 @@
+This is a character: ö.
+number of characters in above string: 24. errno: 0


### PR DESCRIPTION
Change initial startup value of LANG environment variable from "C" to "C.UTF-8", and add a test that setlocale(LC_ALL, "") accesses it. The test passes when building a native application with GCC on Linux and MinGW toolchain on Windows, so looks like a good default.

This fixes #5474.