### PR TITLE
Fix js lib exports

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -238,14 +238,22 @@ function JSify(data, functionsOnly) {
         Functions.implementedFunctions[finalName] = sig;
         asmLibraryFunctions.push(contentText);
         contentText = ' ';
-        EXPORTED_FUNCTIONS[finalName] = 1;
         Functions.libraryFunctions[finalName] = 2;
       }
-      // Normal exports are done in emscripten.py, after the asm module is ready. Here
-      // we also export all library methods when EXPORT_ALL, that would not be
-      // exported by the normal path.
-      if (EXPORT_ALL && !(finalName in EXPORTED_FUNCTIONS) && !noExport) {
+      // asm module exports are done in emscripten.py, after the asm module is ready. Here
+      // we also export library methods as necessary.
+      if ((EXPORT_ALL || (finalName in EXPORTED_FUNCTIONS)) && !noExport) {
         contentText += '\nModule["' + finalName + '"] = ' + finalName + ';';
+      }
+      if (!LibraryManager.library[ident + '__asm']) {
+        // If we are not an asm library func, and we have a dep that is, then we need to call
+        // into the asm module to reach that dep. so it must be exported from the asm module.
+        // We set EXPORTED_FUNCTIONS here to tell emscripten.py to do that.
+        deps.forEach(function(dep) {
+          if (LibraryManager.library[dep + '__asm']) {
+            EXPORTED_FUNCTIONS['_' + dep] = 0;
+          }
+        });
       }
       return depsText + contentText;
     }

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -239,6 +239,7 @@ function JSify(data, functionsOnly) {
         asmLibraryFunctions.push(contentText);
         contentText = ' ';
         Functions.libraryFunctions[finalName] = 2;
+        noExport = true; // if it needs to be exported, that will happen in emscripten.py
       }
       // asm module exports are done in emscripten.py, after the asm module is ready. Here
       // we also export library methods as necessary.


### PR DESCRIPTION
After reading the code more carefully, I think #5471 was a step in the right direction but still not quite right. Basically, jsifier is in charge of exporting js library functions, and emscripten.py of exporting asm module (compiled code) functions. So we can't only do EXPORT_ALL in jsifier, it would miss exporting of library functions. It's true that probably no one ever used this ;) aside from dynamic linking, which uses EXPORT_ALL anyhow. Still, it's better to not break that, so this PR does that, and adds tests.

Second, the real issue is actually not on the line with EXPORT_ALL. The actual bug was that we added all asm library functions to EXPORTED_FUNCTIONS. That's not necessary, and this PR makes us only add asm library funcs if they are needed from outside the asm module. That makes us export even fewer things than after that first improvement.

Still running tests, but looks good so far. @nazar-pc, maybe you can take a look at this, and also confirm that doesn't do anything worse than after your PR?