### PR TITLE
Initial upgrade to WebVR 1.1

### DIFF
--- a/site/source/docs/api_reference/index.rst
+++ b/site/source/docs/api_reference/index.rst
@@ -33,7 +33,10 @@ This section lists Emscripten's public API, organised by header file. At a very 
 - :ref:`trace-h`:
 	A tracing API for doing memory usage analysis.
 
-- :ref:`api-reference-advanced-apis`: 
+- :ref:`vr-h`:
+	API for using WebVR from native code.
+
+- :ref:`api-reference-advanced-apis`:
 	APIs for advanced users/core developers.
 
 
@@ -49,6 +52,7 @@ This section lists Emscripten's public API, organised by header file. At a very 
    val.h
    bind.h
    trace.h
+   vr.h
    advanced-apis
 
 

--- a/site/source/docs/api_reference/vr.h.rst
+++ b/site/source/docs/api_reference/vr.h.rst
@@ -10,6 +10,20 @@ The C APIs in `vr.h <https://github.com/kripken/emscripten/blob/master/system/in
 	:local:
 	:depth: 1
 
+.. _test-example-code-vr-api:
+
+Test/Example code
+-----------------
+
+The vr test code demonstrates how to use this API:
+
+	- `test_vr.c <https://github.com/kripken/emscripten/blob/master/tests/test_vr.c>`_
+
+.. _functions-vr-api:
+
+Functions
+---------
+
 Initialization
 ==============
 
@@ -19,11 +33,11 @@ Initialization
 	<https://w3c.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute>`_
 	and when completed, set the return of :c:func:`emscripten_vr_ready` to be `true`.
 
-.. tip:: This call succeeding is not sufficient for use of the rest of the API. Please
-	make sure to wait until the return value of :c:func:`emscripten_vr_ready` is true.
-
 	:returns: `1` on success, `0` if the browsers WebVR support is insufficient.
 	:rtype: int
+
+.. tip:: This call succeeding is not sufficient for use of the rest of the API. Please
+	make sure to wait until the return value of :c:func:`emscripten_vr_ready` is true.
 
 .. c:function:: int emscripten_vr_ready()
 
@@ -68,13 +82,13 @@ called the return value of :c:func:`emscripten_vr_ready` to be `true`.
 	:returns: Number of displays connected.
 	:rtype: int
 
-.. c:function: VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex)
+.. c:function:: VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex)
 
 	:param int displayIndex: index of display (inclusive 0 to exclusive :c:func:`emscripten_vr_count_displays`).
 	:returns: handle for a VR display.
 	:rtype: VRDisplayHandle
 
-.. c:function: char* emscripten_vr_get_display_name(VRDisplayHandle handle)
+.. c:function:: char* emscripten_vr_get_display_name(VRDisplayHandle handle)
 
 	Get a user-readable name which identifies the VR display.
 
@@ -82,14 +96,14 @@ called the return value of :c:func:`emscripten_vr_ready` to be `true`.
 	:returns: name of the VR display or `0 (NULL)` if the handle is invalid.
 	:rtype: char*
 
-.. c:function: bool emscripten_vr_get_display_connected(VRDisplayHandle handle)
+.. c:function:: bool emscripten_vr_get_display_connected(VRDisplayHandle handle)
 
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:returns: `true` if the display is connected, `false` otherwise or when
 		the handle is invalid.
 	:rtype: bool
 
-.. c:function: bool emscripten_vr_get_display_presenting(VRDisplayHandle handle)
+.. c:function:: bool emscripten_vr_get_display_presenting(VRDisplayHandle handle)
 
 	See also :c:func:`emscripten_vr_request_present`.
 
@@ -98,14 +112,14 @@ called the return value of :c:func:`emscripten_vr_ready` to be `true`.
 		or when the handle is invalid.
 	:rtype: bool
 
-.. c:function: int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps)
+.. c:function:: int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps)
 
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:param VRDisplayCapabilities displayCaps: receives capabilities of the VR display.
 	:returns: |display-function-return-doc|
 	:rtype: bool
 
-.. c:function: int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams)
+.. c:function:: int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams)
 
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:param VREye whichEye: which eye to query parameters for.
@@ -116,7 +130,7 @@ called the return value of :c:func:`emscripten_vr_ready` to be `true`.
 Render Loop
 ===========
 
-In contrast to the usual emscripten main loop (see :ref:`_emscripten-h-browser-execution-environment`),
+In contrast to the usual emscripten main loop (see :ref:`emscripten-h-browser-execution-environment`),
 VR displays require their own rendering loop which is independent from the main loop. The rendering
 loop can be set per display and will act like a main loop with timing mode ``EM_TIMING_RAF`` until the
 display is requested to present, as of which it will run at the VR display's refresh rate.
@@ -125,11 +139,11 @@ display is requested to present, as of which it will run at the VR display's ref
 
 	Set a C function as the per frame rendering callback of a VR display.
 
-.. tip:: There can be only *one* render loop function per VR display. To change the render loop function, first :c:func:`cancel <emscripten_vr_cancel_display_render_loop>` the current loop, and then call this function to set another.
-
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|: id of the display to set the render loop for.
 	:param em_vr_callback_func callback: C function to set as per frame rendering callback.
 	:rtype: |display-function-return-doc|
+
+.. tip:: There can be only *one* render loop function per VR display. To change the render loop function, first :c:func:`cancel <emscripten_vr_cancel_display_render_loop>` the current loop, and then call this function to set another.
 
 .. c:function:: void emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_callback_func callback, void* arg)
 
@@ -176,9 +190,9 @@ display is requested to present, as of which it will run at the VR display's ref
 	If the request is successful `callback` will be called with `userData` and the render
 	loop will continue rendering at the refresh rate of the VR display.
 
-	Must be called from a user callback (see :ref:`HTML5 API <_html5-h>`_).
+	Must be called from a user callback (see :ref:`HTML5 API <html5-h>`).
 
-	See the :ref:`specification of VRDisplay.requestPresent <https://w3c.github.io/webvr/spec/1.1/#dom-vrdisplay-requestpresent>` for detailed information.
+	See the specification of `VRDisplay.requestPresent <https://w3c.github.io/webvr/spec/1.1/#dom-vrdisplay-requestpresent>`_ for detailed information.
 
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:param VRLayerInit layers: array of layers which will be rendered to.
@@ -193,6 +207,164 @@ display is requested to present, as of which it will run at the VR display's ref
 
 	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:rtype: |display-function-return-doc|
+
+.. _defines-vr-api:
+
+Defines
+-------
+
+.. c:macro:: VR_EYE_LEFT
+	VR_EYE_RIGHT
+
+	Eye values for use with :c:func:`emscripten_vr_get_eye_parameters`.
+
+.. _vr-pose-defines-vr-api:
+
+.. c:macro:: VR_POSE_POSITION
+	VR_POSE_LINEAR_VELOCITY
+	VR_POSE_LINEAR_ACCELERATION
+	VR_POSE_ORIENTATION
+	VR_POSE_ANGULAR_VELOCITY
+	VR_POSE_ANGULAR_ACCELERATION
+
+	Flags which describe which properties of a :c:type:`VRPose` are valid.
+
+.. c:macro:: VR_LAYER_DEFAULT_LEFT_BOUNDS
+	VR_LAYER_DEFAULT_RIGHT_BOUNDS
+
+	Default values to pass to :c:type:`VRLayerInit`.
+
+.. _types-vr-api:
+
+Types
+-----
+
+.. c:type:: VRDisplayCapabilities
+
+	Structure passed to :c:func:`emscripten_vr_get_display_capabilities`, maps to the WebVR `VRDisplayCapabilities <https://w3c.github.io/webvr/spec/1.1/#interface-vrdisplaycapabilities>`__ interface.
+
+	.. c:member:: int32_t hasPosition
+
+	.. c:member:: int32_t hasExternalDisplay
+
+	.. c:member:: int32_t canPresent
+
+	.. c:member:: unsigned long maxLayers
+
+
+.. c:type:: VRLayerInit
+
+	Structure passed to :c:func:`emscripten_vr_request_present`, maps to the WebVR `VRLayerInit <https://w3c.github.io/webvr/spec/1.1/#interface-vrlayerinit>`__ interface.
+
+	.. c:member:: const char* source
+
+		Id of the source canvas which will be used to present to the VR display.
+
+		`0 (NULL)` is used to refer to ``Module.canvas``.
+
+	.. c:member:: float[4] leftBounds
+
+		Texture bounds of the left eye on the target canvas. Initialize with :c:macro:`VR_LAYER_DEFAULT_LEFT_BOUNDS` for default.
+
+	.. c:member:: float[4] rightBounds
+
+		Texture bounds of the right eye on the target canvas. Initialize with :c:macro:`VR_LAYER_DEFAULT_RIGHT_BOUNDS` for default.
+
+
+.. c:type:: VRPose
+
+	Substructure of :c:type:`VRFrameData`, maps to the WebVR
+	`VRPose <https://w3c.github.io/webvr/spec/1.1/#interface-vrpose>`__ interface.
+
+	VR Displays do not necessarily report all of the pose values (mobile VR devices usually
+	only report orientation, but not position for example). To check which values are valid,
+	the :c:member:`poseFlags <poseFlags>` member provides a bitmask of
+	:ref:`VR_POSE_* <vr-pose-defines-vr-api>` which has a bit set for every valid value.
+
+	.. c:member:: VRVector3 position
+
+		Position, valid only if ``poseFlags & VR_POSE_POSITION == 0``.
+
+	.. c:member:: VRVector3 linearVelocity
+
+		Linear velocity, valid only if ``poseFlags & VR_POSE_LINEAR_VELOCITY == 0``.
+
+	.. c:member:: VRVector3 linearAcceleration
+
+		Linear acceleration, valid only if ``poseFlags & VR_POSE_LINEAR_ACCELERATION == 0``.
+
+	.. c:member:: VRQuaternion orientation
+
+		Orientation quaternion, valid only if ``poseFlags & VR_POSE_ORIENTATION == 0``.
+
+	.. c:member:: VRVector3 angularVelocity
+
+		Angular velocity, valid only if ``poseFlags & VR_POSE_ANGULAR_VELOCITY == 0``.
+
+	.. c:member:: VRVector3 angularAcceleration
+
+		Angular acceleration, valid only if ``poseFlags & VR_POSE_ANGULAR_ACCELERATION == 0``.
+
+	.. c:member:: int poseFlags
+
+		Bitmask of :ref:`VR_POSE_* <vr-pose-defines-vr-api>` which determines whether the corresponding pose attributes are valid
+
+
+.. c:type:: VRFrameData
+
+	Structure passed to :c:func:`emscripten_vr_get_frame_data`, maps to the WebVR
+	`VRFrameData <https://w3c.github.io/webvr/spec/1.1/#interface-vrframedata>`__ interface.
+
+	.. c:member:: double timestamp
+
+	.. c:member:: float[16] leftProjectionMatrix
+
+	.. c:member:: float[16] leftViewMatrix
+
+	.. c:member:: float[16] rightProjectionMatrix
+
+	.. c:member:: float[16] rightViewMatrix
+
+	.. c:member:: VRPose pose
+
+
+.. c:type:: VREyeParameters
+
+	Structure passed to :c:func:`emscripten_vr_get_eye_parameters`, maps to the WebVR
+	`VREyeParameters <https://w3c.github.io/webvr/spec/1.1/#interface-vreyeparameters>`__ interface.
+
+	.. c:member:: VRVector3 offset
+
+	.. c:member:: unsigned long renderWidth
+
+	.. c:member:: unsigned long renderHeight
+
+Math
+====
+
+.. c:type:: VRVector3
+
+	A 3-dimensional vector.
+
+	.. c:member:: float x
+
+	.. c:member:: float y
+
+	.. c:member:: float z
+
+
+.. c:type:: VRQuaternion
+
+	A quaternion.
+
+	.. c:member:: float x
+
+	.. c:member:: float y
+
+	.. c:member:: float z
+
+	.. c:member:: float w
+
 
 
 .. COMMENT (not rendered): Following values are common to many functions, and currently only updated in one place (here).

--- a/site/source/docs/api_reference/vr.h.rst
+++ b/site/source/docs/api_reference/vr.h.rst
@@ -1,0 +1,49 @@
+.. _vr-h:
+
+====
+vr.h
+====
+
+The C APIs in `vr.h <https://github.com/kripken/emscripten/blob/master/system/include/emscripten/vr.h>`_ provide basic interfaces for interacting with WebVR from Emscripten.
+
+.. contents:: Table of Contents
+	:local:
+	:depth: 1
+
+
+
+Render loop
+===========
+
+In contrast to the usual emscripten main loop (see :ref:`_emscripten-h-browser-execution-environment`),
+VR displays require their own rendering loop which is independent from the main loop. The rendering
+loop can be set per display and will act like a main loop with timing mode ``EM_TIMING_RAF`` until the
+display is requested to present, as of which it will run at the VR display's refresh rate.
+
+.. c:function:: void emscripten_vr_set_display_render_loop(WebVRDeviceId deviceId, em_vr_callback_func callback)
+
+	Set a C function as the per frame rendering callback of a VR display.
+
+.. tip:: There can be only *one* render loop function per VR display. To change the render loop function, first :c:func:`cancel <emscripten_vr_cancel_display_render_loop>` the current loop, and then call this function to set another.
+
+	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
+	:param em_vr_callback_func callback: C function to set as per frame rendering callback.
+	:rtype: void
+
+.. c:function:: void emscripten_vr_set_display_render_loop_arg(WebVRDeviceId deviceId, em_vr_callback_func callback, void* arg)
+
+	Set a C function as the per frame rendering callback of a VR display.
+
+	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
+	:param em_vr_callback_arg_func callback: C function to set as per frame rendering callback. The function signature must have a ``void*`` parameter for passing the ``arg`` value.
+	:param void* arg: User-defined data passed to the render loop function, untouched by the API itself.
+	:rtype: void
+
+.. c:function:: void emscripten_vr_cancel_display_render_loop(WebVRDeviceId deviceId)
+
+	Cancels the render loop of a VR display should there be one running for it.
+
+	See also :c:func:`emscripten_vr_set_display_render_loop` and :c:func:`emscripten_vr_set_display_render_loop_arg` for information about setting and using the render loop.
+
+	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
+	:rtype: void

--- a/site/source/docs/api_reference/vr.h.rst
+++ b/site/source/docs/api_reference/vr.h.rst
@@ -10,9 +10,110 @@ The C APIs in `vr.h <https://github.com/kripken/emscripten/blob/master/system/in
 	:local:
 	:depth: 1
 
+Initialization
+==============
 
+.. c:function:: int emscripten_vr_init()
 
-Render loop
+	Initialize the emscripten VR API. This will `navigator.getVRDisplays()
+	<https://w3c.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute>`_
+	and when completed, set the return of :c:func:`emscripten_vr_ready` to be `true`.
+
+.. tip:: This call succeeding is not sufficient for use of the rest of the API. Please
+	make sure to wait until the return value of :c:func:`emscripten_vr_ready` is true.
+
+	:returns: `1` on success, `0` if the browsers WebVR support is insufficient.
+	:rtype: int
+
+.. c:function:: int emscripten_vr_ready()
+
+	Check whether the VR API has finished initializing VR displays.
+	See also :c:func:`emscripten_vr_init`.
+
+	This function may return `1` event if WebVR is not supported in the
+	running browser.
+
+	:returns: `1` if ready, `0` otherwise.
+	:rtype: int
+
+API Queries
+===========
+
+All of the following functions require :c:func:`emscripten_vr_init` to have been
+called but do not require VR displays and can therefore be called before the return
+value of :c:func:`emscripten_vr_ready` is `true`.
+
+.. c:function:: int emscripten_vr_version_minor()
+
+	Minor version of the WebVR API currently supported by the browser.
+
+	:returns: minor version of WebVR, or `-1` if not supported or API not initialized.
+	:rtype: int
+
+.. c:function:: int emscripten_vr_version_major()
+
+	Major version of the WebVR API currently supported by the browser.
+
+	:returns: major version of WebVR, or `-1` if not supported or API not initialized.
+	:rtype: int
+
+Display Functions
+=================
+
+All of the following functions require :c:func:`emscripten_vr_init` to have been
+called the return value of :c:func:`emscripten_vr_ready` to be `true`.
+
+.. c:function:: int emscripten_vr_count_displays()
+
+	:returns: Number of displays connected.
+	:rtype: int
+
+.. c:function: VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex)
+
+	:param int displayIndex: index of display (inclusive 0 to exclusive :c:func:`emscripten_vr_count_displays`).
+	:returns: handle for a VR display.
+	:rtype: VRDisplayHandle
+
+.. c:function: char* emscripten_vr_get_display_name(VRDisplayHandle handle)
+
+	Get a user-readable name which identifies the VR display.
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:returns: name of the VR display or `0 (NULL)` if the handle is invalid.
+	:rtype: char*
+
+.. c:function: bool emscripten_vr_get_display_connected(VRDisplayHandle handle)
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:returns: `true` if the display is connected, `false` otherwise or when
+		the handle is invalid.
+	:rtype: bool
+
+.. c:function: bool emscripten_vr_get_display_presenting(VRDisplayHandle handle)
+
+	See also :c:func:`emscripten_vr_request_present`.
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:returns: `true` if the display is currently presenting, `false` otherwise
+		or when the handle is invalid.
+	:rtype: bool
+
+.. c:function: int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps)
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:param VRDisplayCapabilities displayCaps: receives capabilities of the VR display.
+	:returns: |display-function-return-doc|
+	:rtype: bool
+
+.. c:function: int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams)
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:param VREye whichEye: which eye to query parameters for.
+	:param VREyeParameters eyeParam: receives the parameters for requested eye.
+	:returns: |display-function-return-doc|
+	:rtype: bool
+
+Render Loop
 ===========
 
 In contrast to the usual emscripten main loop (see :ref:`_emscripten-h-browser-execution-environment`),
@@ -20,30 +121,86 @@ VR displays require their own rendering loop which is independent from the main 
 loop can be set per display and will act like a main loop with timing mode ``EM_TIMING_RAF`` until the
 display is requested to present, as of which it will run at the VR display's refresh rate.
 
-.. c:function:: void emscripten_vr_set_display_render_loop(WebVRDeviceId deviceId, em_vr_callback_func callback)
+.. c:function:: void emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback)
 
 	Set a C function as the per frame rendering callback of a VR display.
 
 .. tip:: There can be only *one* render loop function per VR display. To change the render loop function, first :c:func:`cancel <emscripten_vr_cancel_display_render_loop>` the current loop, and then call this function to set another.
 
-	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|: id of the display to set the render loop for.
 	:param em_vr_callback_func callback: C function to set as per frame rendering callback.
-	:rtype: void
+	:rtype: |display-function-return-doc|
 
-.. c:function:: void emscripten_vr_set_display_render_loop_arg(WebVRDeviceId deviceId, em_vr_callback_func callback, void* arg)
+.. c:function:: void emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_callback_func callback, void* arg)
 
 	Set a C function as the per frame rendering callback of a VR display.
 
-	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
 	:param em_vr_callback_arg_func callback: C function to set as per frame rendering callback. The function signature must have a ``void*`` parameter for passing the ``arg`` value.
 	:param void* arg: User-defined data passed to the render loop function, untouched by the API itself.
-	:rtype: void
+	:rtype: |display-function-return-doc|
 
-.. c:function:: void emscripten_vr_cancel_display_render_loop(WebVRDeviceId deviceId)
+.. c:function:: void emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle: |display-handle-parameter-doc|)
 
 	Cancels the render loop of a VR display should there be one running for it.
 
-	See also :c:func:`emscripten_vr_set_display_render_loop` and :c:func:`emscripten_vr_set_display_render_loop_arg` for information about setting and using the render loop.
+	|render-loop-info|
 
-	:param WebVRDeviceId deviceId: id of the display to set the render loop for.
-	:rtype: void
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:rtype: |display-function-return-doc|
+
+.. c:function:: int emscripten_vr_get_frame_data(VRDisplayHandle handle)
+
+	Get view matrix, projection matrix, timestamp and head pose for current frame.
+	Only valid when called from within a render loop callback.
+
+	|render-loop-info|
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:rtype: |display-function-return-doc|
+
+.. c:function:: int emscripten_vr_submit_frame(VRDisplayHandle handle)
+
+	Submit the current state of canvases passed via VRLayerInit to
+	:c:func:`emscripten_vr_request_present` to be rendered to the VR display.
+	Only valid when called from within a render loop callback.
+
+	|render-loop-info|
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:rtype: |display-function-return-doc|
+
+.. c:function:: int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount, em_vr_arg_callback_func callback, void* userData)
+
+	Request present for the VR display using canvases specified in the `layerInit` array.
+	If the request is successful `callback` will be called with `userData` and the render
+	loop will continue rendering at the refresh rate of the VR display.
+
+	Must be called from a user callback (see :ref:`HTML5 API <_html5-h>`_).
+
+	See the :ref:`specification of VRDisplay.requestPresent <https://w3c.github.io/webvr/spec/1.1/#dom-vrdisplay-requestpresent>` for detailed information.
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:param VRLayerInit layers: array of layers which will be rendered to.
+	:param int layerCount: number of layers in `layers`.
+	:param em_vr_arg_callback_func callback: optional function that will be called when the requst has succeeded.
+	:param void* userData: optional data to pass to the callback when the request succeeds. Is not modified by the API.
+	:rtype: |display-function-return-doc|
+
+.. c:function:: int emscripten_vr_exit_present(VRDisplayHandle handle)
+
+	Request present exit.
+
+	:param VRDisplayHandle handle: |display-handle-parameter-doc|
+	:rtype: |display-function-return-doc|
+
+
+.. COMMENT (not rendered): Following values are common to many functions, and currently only updated in one place (here).
+.. COMMENT (not rendered): These can be properly replaced if required either wholesale or on an individual basis.
+
+.. |display-handle-parameter-doc| replace:: a display handle.
+
+.. |display-function-return-doc| replace:: `1` on success, `0` if handle was invalid.
+
+.. |render-loop-info| replace:: See also :c:func:`emscripten_vr_set_display_render_loop` and :c:func:`emscripten_vr_set_display_render_loop_arg` for information about setting and using the render loop.
+

--- a/site/source/docs/compiling/Running-html-files-with-emrun.rst
+++ b/site/source/docs/compiling/Running-html-files-with-emrun.rst
@@ -144,7 +144,7 @@ When running web pages via ``emrun`` using Firefox, you may want to set one or m
   ; Don't bring up the modal "Start in Safe Mode" dialog after browser is killed, since
   ; that is an expected path for --kill_start and --kill_exit options.
   browser.sessionstore.max_resumed_crashes;-1
-  toolkip.startup.max_resumed_crashes;-1
+  toolkit.startup.max_resumed_crashes;-1
 
   ; Don't fail on long-running scripts, but have emrun instead control execution termination.
   dom.max_script_run_time;0

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -12,7 +12,7 @@ var LibraryWebVR = {
 
     initialized: false,
     ready: false,
-    version: [0, 0],
+    version: [-1, -1],
     devices: [],
 
     init: function() {
@@ -60,10 +60,6 @@ var LibraryWebVR = {
 
   emscripten_vr_version_minor: function() {
     return WebVR.version[1];
-  },
-
-  emscripten_vr_supported: function() {
-    return WebVR.version == null ? 1 : 0;
   },
 
   emscripten_vr_ready: function() {
@@ -140,13 +136,6 @@ var LibraryWebVR = {
   emscripten_vr_display_presenting: function(displayHandle) {
     var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display || !display.isPresenting) return 0;
-    return 1;
-  },
-
-  emscripten_vr_reset_pose: function(displayHandle) {
-    var display = WebVR.dereferenceDisplayHandle(displayHandle);
-    if (!display) return 0;
-    display.resetPose();
     return 1;
   },
 
@@ -234,19 +223,20 @@ var LibraryWebVR = {
     layerInit = new Array(layerCount);
     for (var i = 0; i < layerCount; ++i) {
         sourceStrPtr = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.source, 'void*') }}};
-        sourceStr = UTF8ToString(sourceStrPtr);
 
         var source = null;
-        if(sourceStr == '#canvas') {
-            /* Default emscripten canvas */
+        if(sourceStrPtr == 0) {
             source = Module['canvas'];
-        } else if (sourceStr && sourceStr.length > 0) {
-            /* Other canvas id */
-            source = document.getElementById(sourceStr);
-        }
+        } else {
+            sourceStr = UTF8ToString(sourceStrPtr);
 
-        if (!source) {
-            return 0;
+            if (sourceStr && sourceStr.length > 0) {
+                source = document.getElementById(sourceStr);
+            }
+
+            if (!source) {
+                return 0;
+            }
         }
 
         leftBounds = new Float32Array(4);

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -131,6 +131,18 @@ var LibraryWebVR = {
     return 1;
   },
 
+  emscripten_vr_display_connected: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display || !display.isConnected) return 0;
+    return 1;
+  },
+
+  emscripten_vr_display_presenting: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display || !display.isPresenting) return 0;
+    return 1;
+  },
+
   emscripten_vr_reset_pose: function(displayHandle) {
     var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display) return 0;

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -274,6 +274,14 @@ var LibraryWebVR = {
     return 1;
   },
 
+  emscripten_vr_exit_present: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display) return 0;
+
+    display.exitPresent();
+    return 1;
+  },
+
   emscripten_vr_get_frame_data: function(displayHandle, frameDataPtr) {
     var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display || !display.mainLoop || !frameDataPtr) return 0;

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -30,17 +30,16 @@ var LibraryWebVR = {
       WebVR.version = [1, 1];
 
       navigator.getVRDisplays().then(function(displays) {
-          WebVR.ready = true;
-          WebVR.displays = displays;
-        }
-      );
+        WebVR.ready = true;
+        WebVR.displays = displays;
+      });
 
       return 1;
     },
 
     dereferenceDisplayHandle: function(displayHandle) {
-        /* Display handles start as 1 as 0 will be interpreted as false or null-handle
-        * on errors */
+      /* Display handles start as 1 as 0 will be interpreted as false or null-handle
+       * on errors */
       if (displayHandle < 1 || displayHandle > WebVR.displays.length) {
         console.log("library_vr dereferenceDisplayHandle invalid display handle at: " + stackTrace());
         return null;
@@ -76,7 +75,7 @@ var LibraryWebVR = {
     }
 
     /* As displayHandle == 0 will be interpreted as NULL handle for errors,
-    * the handle is index + 1. */
+     * the handle is index + 1. */
     return displayIndex + 1;
   },
 
@@ -162,7 +161,7 @@ var LibraryWebVR = {
         display.requestAnimationFrame(display.mainLoop.runner);
       },
       runner: function() {
-        if(ABORT) return;
+        if (ABORT) return;
 
         /* Prevent scheduler being called twice when loop is changed */
         display.mainLoop.running = true;
@@ -222,43 +221,43 @@ var LibraryWebVR = {
 
     layerInit = new Array(layerCount);
     for (var i = 0; i < layerCount; ++i) {
-        sourceStrPtr = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.source, 'void*') }}};
+      sourceStrPtr = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.source, 'void*') }}};
 
-        var source = null;
-        if(sourceStrPtr == 0) {
-            source = Module['canvas'];
-        } else {
-            sourceStr = UTF8ToString(sourceStrPtr);
+      var source = null;
+      if (sourceStrPtr == 0) {
+        source = Module['canvas'];
+      } else {
+        sourceStr = UTF8ToString(sourceStrPtr);
 
-            if (sourceStr && sourceStr.length > 0) {
-                source = document.getElementById(sourceStr);
-            }
-
-            if (!source) {
-                return 0;
-            }
+        if (sourceStr && sourceStr.length > 0) {
+          source = document.getElementById(sourceStr);
         }
 
-        leftBounds = new Float32Array(4);
-        rightBounds = new Float32Array(4);
-        var ptr = layerInitPtr;
-        for (var j = 0; j < 4; ++j) {
-            leftBounds[j] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.leftBounds + '+ 4*j', 'float') }}};
-            rightBounds[j] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.rightBounds + '+ 4*j', 'float') }}};
-            ptr += 4;
+        if (!source) {
+          return 0;
         }
+      }
 
-        layerInit[i] = {
-            source: source,
-            leftBounds: leftBounds,
-            rightBounds: rightBounds
-        };
-        layerInitPtr += {{{ C_STRUCTS.VRLayerInit.__size__ }}};
+      leftBounds = new Float32Array(4);
+      rightBounds = new Float32Array(4);
+      var ptr = layerInitPtr;
+      for (var j = 0; j < 4; ++j) {
+        leftBounds[j] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.leftBounds + '+ 4*j', 'float') }}};
+        rightBounds[j] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.rightBounds + '+ 4*j', 'float') }}};
+        ptr += 4;
+      }
+
+      layerInit[i] = {
+        source: source,
+        leftBounds: leftBounds,
+        rightBounds: rightBounds
+      };
+      layerInitPtr += {{{ C_STRUCTS.VRLayerInit.__size__ }}};
     }
 
     display.requestPresent(layerInit).then(function() {
-        if(!func) return;
-        Runtime.dynCall('vi', func, [userData]);
+      if (!func) return;
+      Runtime.dynCall('vi', func, [userData]);
     });
 
     return 1;
@@ -276,7 +275,7 @@ var LibraryWebVR = {
     var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display || !display.mainLoop || !frameDataPtr) return 0;
 
-    if(!display.frameData) {
+    if (!display.frameData) {
       display.frameData = new VRFrameData();
     }
     display.getFrameData(display.frameData);
@@ -289,52 +288,52 @@ var LibraryWebVR = {
     {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.timestamp, 'display.frameData.timestamp', 'double') }}};
 
     if (display.frameData.pose.position !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.x, 'display.frameData.pose.position[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.y, 'display.frameData.pose.position[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.z, 'display.frameData.pose.position[2]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.x, 'display.frameData.pose.position[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.y, 'display.frameData.pose.position[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.z, 'display.frameData.pose.position[2]', 'float') }}};
 
-        poseFlags |= WebVR.POSE_POSITION;
+      poseFlags |= WebVR.POSE_POSITION;
     }
 
     if (display.frameData.pose.linearVelocity !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.x, 'display.frameData.pose.linearVelocity[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.y, 'display.frameData.pose.linearVelocity[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.z, 'display.frameData.pose.linearVelocity[2]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.x, 'display.frameData.pose.linearVelocity[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.y, 'display.frameData.pose.linearVelocity[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.z, 'display.frameData.pose.linearVelocity[2]', 'float') }}};
 
-        poseFlags |= WebVR.POSE_LINEAR_VELOCITY;
+      poseFlags |= WebVR.POSE_LINEAR_VELOCITY;
     }
 
     if (display.frameData.pose.linearAcceleration !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.x, 'display.frameData.pose.linearAcceleration[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.y, 'display.frameData.pose.linearAcceleration[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.z, 'display.frameData.pose.linearAcceleration[2]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.x, 'display.frameData.pose.linearAcceleration[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.y, 'display.frameData.pose.linearAcceleration[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.z, 'display.frameData.pose.linearAcceleration[2]', 'float') }}};
 
-        poseFlags |= WebVR.POSE_LINEAR_ACCELERATION;
+      poseFlags |= WebVR.POSE_LINEAR_ACCELERATION;
     }
 
     if (display.frameData.pose.orientation !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.x, 'display.frameData.pose.orientation[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.y, 'display.frameData.pose.orientation[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.z, 'display.frameData.pose.orientation[2]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.w, 'display.frameData.pose.orientation[3]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.x, 'display.frameData.pose.orientation[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.y, 'display.frameData.pose.orientation[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.z, 'display.frameData.pose.orientation[2]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.w, 'display.frameData.pose.orientation[3]', 'float') }}};
 
         poseFlags |= WebVR.POSE_ORIENTATION;
     }
 
     if (display.frameData.pose.angularVelocity !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.x, 'display.frameData.pose.angularVelocity[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.y, 'display.frameData.pose.angularVelocity[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.z, 'display.frameData.pose.angularVelocity[2]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.x, 'display.frameData.pose.angularVelocity[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.y, 'display.frameData.pose.angularVelocity[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.z, 'display.frameData.pose.angularVelocity[2]', 'float') }}};
 
-        poseFlags |= WebVR.POSE_ANGULAR_VELOCITY;
+      poseFlags |= WebVR.POSE_ANGULAR_VELOCITY;
     }
 
     if (display.frameData.pose.angularAcceleration !== null) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.x, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.y, 'display.frameData.pose.angularAcceleration[1]', 'float') }}};
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.z, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.x, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.y, 'display.frameData.pose.angularAcceleration[1]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.z, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
 
-        poseFlags |= WebVR.POSE_ANGULAR_ACCELERATION;
+      poseFlags |= WebVR.POSE_ANGULAR_ACCELERATION;
     }
 
     {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.poseFlags, 'poseFlags', 'i32') }}};
@@ -342,19 +341,19 @@ var LibraryWebVR = {
     /* Matrices */
 
     for (var i = 0; i < 16; ++i) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftProjectionMatrix + ' + i*4', 'display.frameData.leftProjectionMatrix[i]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftProjectionMatrix + ' + i*4', 'display.frameData.leftProjectionMatrix[i]', 'float') }}};
     }
 
     for (var i = 0; i < 16; ++i) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftViewMatrix + ' + i*4', 'display.frameData.leftViewMatrix[i]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftViewMatrix + ' + i*4', 'display.frameData.leftViewMatrix[i]', 'float') }}};
     }
 
     for (var i = 0; i < 16; ++i) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightProjectionMatrix + ' + i*4', 'display.frameData.rightProjectionMatrix[i]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightProjectionMatrix + ' + i*4', 'display.frameData.rightProjectionMatrix[i]', 'float') }}};
     }
 
     for (var i = 0; i < 16; ++i) {
-        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightViewMatrix + ' + i*4', 'display.frameData.rightViewMatrix[i]', 'float') }}};
+      {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightViewMatrix + ' + i*4', 'display.frameData.rightViewMatrix[i]', 'float') }}};
     }
 
     return 1;

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -1,21 +1,19 @@
 var LibraryWebVR = {
   $WebVR: {
-    DEVICE_TYPE_UNKNOWN: 0,
-    DEVICE_TYPE_HMD: 1,
-    DEVICE_TYPE_SENSOR: 2,
+    EYE_LEFT: {{{ cDefine('VR_EYE_LEFT') }}},
+    EYE_RIGHT: {{{ cDefine('VR_EYE_RIGHT') }}},
 
-    EYE_LEFT: 0,
-    EYE_RIGHT: 1,
+    POSE_POSITION: {{{ cDefine('VR_POSE_POSITION') }}},
+    POSE_LINEAR_VELOCITY: {{{ cDefine('VR_POSE_LINEAR_VELOCITY') }}},
+    POSE_LINEAR_ACCELERATION: {{{ cDefine('VR_POSE_LINEAR_ACCELERATION') }}},
+    POSE_ORIENTATION: {{{ cDefine('VR_POSE_ORIENTATION') }}},
+    POSE_ANGULAR_VELOCITY: {{{ cDefine('VR_POSE_ANGULAR_VELOCITY') }}},
+    POSE_ANGULAR_ACCELERATION: {{{ cDefine('VR_POSE_ANGULAR_ACCELERATION') }}},
 
     initialized: false,
     ready: false,
+    version: [0, 0],
     devices: [],
-    deviceHardwareIds: {},
-    nextHardwareDeviceId: 1,
-    getDevicesPromise: null,
-
-    selectedHMD: null,
-    selectedHMDId: 0,
 
     init: function() {
       if (WebVR.initialized) return;
@@ -25,220 +23,131 @@ var LibraryWebVR = {
       if (!navigator.getVRDisplays) {
         /* WebVR 1.1 required, but not supported. */
         WebVR.ready = true;
-        WebVR.devices = [];
-        return;
+        WebVR.displays = [];
+        return 0;
       }
 
-      navigator.getVRDisplays().then(function(disps) {
+      WebVR.version = [1, 1];
+
+      navigator.getVRDisplays().then(function(displays) {
           WebVR.ready = true;
-          WebVR.displays = disps;
+          WebVR.displays = displays;
         }
       );
+
+      return 1;
     },
 
-    getDeviceByID: function(deviceId) {
-      if (deviceId < 1 || deviceId > WebVR.devices.length) {
-        console.log("library_vr getDeviceByID invalid device id at: " + stackTrace());
+    dereferenceDisplayHandle: function(displayHandle) {
+        /* Display handles start as 1 as 0 will be interpreted as false or null-handle
+        * on errors */
+      if (displayHandle < 1 || displayHandle > WebVR.displays.length) {
+        console.log("library_vr dereferenceDisplayHandle invalid display handle at: " + stackTrace());
         return null;
       }
 
-      return WebVR.devices[deviceId-1];
+      return WebVR.displays[displayHandle-1];
     }
   },
 
   emscripten_vr_init: function() {
-    WebVR.init();
+    return WebVR.init();
+  },
+
+  emscripten_vr_version_major: function() {
+    return WebVR.version[0];
+  },
+
+  emscripten_vr_version_minor: function() {
+    return WebVR.version[1];
+  },
+
+  emscripten_vr_supported: function() {
+    return WebVR.version == null ? 1 : 0;
   },
 
   emscripten_vr_ready: function() {
     return WebVR.ready ? 1 : 0;
   },
 
-  emscripten_vr_count_devices: function() {
-    return WebVR.devices.length;
+  emscripten_vr_count_displays: function() {
+    return WebVR.displays.length;
   },
 
-  emscripten_vr_get_device_id: function(deviceIndex) {
-    if (deviceIndex < 0 || deviceIndex >= WebVR.devices.length) {
+  emscripten_vr_get_display_handle: function(displayIndex) {
+    if (displayIndex < 0 || displayIndex >= WebVR.displays.length) {
       return -1;
     }
 
-    // we're doing to treat the device ID the same as the index + 1
-    return deviceIndex + 1;
+    /* As displayHandle == 0 will be interpreted as NULL handle for errors,
+    * the handle is index + 1. */
+    return displayIndex + 1;
   },
 
-  emscripten_vr_get_device_hwid: function(deviceId) {
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return -1;
+  emscripten_vr_get_display_name: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
 
-    if (!WebVR.deviceHardwareIds[dev.hardwareUnitId]) {
-      WebVR.deviceHardwareIds[dev.hardwareUnitId] = WebVR.nextHardwareDeviceId++;
-    }
-    return WebVR.deviceHardwareIds[dev.hardwareUnitId];
+    var buffer, displayName;
+    displayName = display ? display.displayName : "";
+    var len = lengthBytesUTF8(displayName);
+    buffer = _malloc(len + 1);
+    stringToUTF8(displayName, buffer, len + 1);
+
+    return buffer;
   },
 
-  emscripten_vr_get_device_name: function(deviceId) {
-    var dev = WebVR.getDeviceByID(deviceId);
-    var buffer, devName;
-    devName = dev ? dev.deviceName : "";
-    var len = lengthBytesUTF8(devName);
-    buf = _malloc(len + 1);
-    stringToUTF8(devName, buf, len + 1);
-    return buf;
-  },
+  emscripten_vr_get_display_capabilities: function(displayHandle, capsPtr) {
+    if (!capsPtr) return 0;
 
-  emscripten_vr_get_device_type: function(deviceId) {
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return -1;
-
-    if (dev instanceof HMDVRDevice) {
-      return WebVR.DEVICE_TYPE_HMD;
-    }
-    if (dev instanceof PositionSensorVRDevice) {
-      return WebVR.DEVICE_TYPE_SENSOR;
-    }
-    return WebVR.DEVICE_TYPE_UNKNOWN;
-  },
-
-  emscripten_vr_select_hmd_device: function(deviceId) {
-    if (deviceId == 0) {
-      WebVR.selectedHMD = null;
-      WebVR.selectedHMDId = 0;
-      return 1;
-    }
-
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev || !(dev instanceof HMDVRDevice)) {
-      console.log("Trying to call emscripten_vr_select_hmd_device on invalid or non-HMD device ID!");
-      return 0;
-    }
-    WebVR.selectedHMD = dev;
-    WebVR.selectedHMDId = deviceId;
-    return 1;
-  },
-
-  emscripten_vr_get_selected_hmd_device: function() {
-    return WebVR.selectedHMDId;
-  },
-
-  emscripten_vr_hmd_get_eye_parameters: function(deviceId, whichEye, eyeParamsPtr) {
-    if (!eyeParamsPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var params = dev.getEyeParameters(whichEye == WebVR.EYE_LEFT ? "left" : "right");
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.upDegrees, 'params.minimumFieldOfView.upDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.downDegrees, 'params.minimumFieldOfView.downDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.leftDegrees, 'params.minimumFieldOfView.leftDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.minimumFieldOfView.rightDegrees, 'params.minimumFieldOfView.rightDegrees', 'double') }}};
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.upDegrees, 'params.maximumFieldOfView.upDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.downDegrees, 'params.maximumFieldOfView.downDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.leftDegrees, 'params.maximumFieldOfView.leftDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.maximumFieldOfView.rightDegrees, 'params.maximumFieldOfView.rightDegrees', 'double') }}};
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.upDegrees, 'params.recommendedFieldOfView.upDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.downDegrees, 'params.recommendedFieldOfView.downDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.leftDegrees, 'params.recommendedFieldOfView.leftDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.recommendedFieldOfView.rightDegrees, 'params.recommendedFieldOfView.rightDegrees', 'double') }}};
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.x, 'params.eyeTranslation.x', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.y, 'params.eyeTranslation.y', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.z, 'params.eyeTranslation.z', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.eyeTranslation.w, 'params.eyeTranslation.w', 'double') }}};
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.upDegrees, 'params.currentFieldOfView.upDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.downDegrees, 'params.currentFieldOfView.downDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.leftDegrees, 'params.currentFieldOfView.leftDegrees', 'double') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.currentFieldOfView.rightDegrees, 'params.currentFieldOfView.rightDegrees', 'double') }}};
-
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.x, 'params.renderRect.x', 'i32') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.y, 'params.renderRect.y', 'i32') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.width, 'params.renderRect.width', 'i32') }}};
-    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.WebVREyeParameters.renderRect.height, 'params.renderRect.height', 'i32') }}};
-
-    return 1;
-
-  },
-
-  emscripten_vr_hmd_set_fov: function(deviceId, leftFovPtr, rightFovPtr, zNear, zFar) {
-    if (!leftFovPtr || !rightFovPtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var leftFov = {
-      upDegrees: {{{ makeGetValue('leftFovPtr', C_STRUCTS.WebVRFieldOfView.upDegrees, 'double') }}},
-      downDegrees: {{{ makeGetValue('leftFovPtr', C_STRUCTS.WebVRFieldOfView.downDegrees, 'double') }}},
-      leftDegrees: {{{ makeGetValue('leftFovPtr', C_STRUCTS.WebVRFieldOfView.leftDegrees, 'double') }}},
-      rightDegrees: {{{ makeGetValue('leftFovPtr', C_STRUCTS.WebVRFieldOfView.rightDegrees, 'double') }}}
-    };
-    var rightFov = {
-      upDegrees: {{{ makeGetValue('rightFovPtr', C_STRUCTS.WebVRFieldOfView.upDegrees, 'double') }}},
-      downDegrees: {{{ makeGetValue('rightFovPtr', C_STRUCTS.WebVRFieldOfView.downDegrees, 'double') }}},
-      leftDegrees: {{{ makeGetValue('rightFovPtr', C_STRUCTS.WebVRFieldOfView.leftDegrees, 'double') }}},
-      rightDegrees: {{{ makeGetValue('rightFovPtr', C_STRUCTS.WebVRFieldOfView.rightDegrees, 'double') }}}
-    };
-    dev.setFieldOfView(leftFov, rightFov, zNear, zFar);
-    return 1;
-  },
-
-  emscripten_vr_sensor_get_state: function(deviceId, immediate, statePtr) {
-    if (!statePtr) return 0;
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    var state = immediate ? dev.getImmediateState : dev.getState();
-
-    {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.timeStamp, 'state.timeStamp', 'double') }}};
-
-    {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.hasPosition, 'state.hasPosition ? 1 : 0', 'i32') }}};
-    if (state.hasPosition) {
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.position.x, 'state.position.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.position.y, 'state.position.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.position.z, 'state.position.z', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearVelocity.x, 'state.linearVelocity.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearVelocity.y, 'state.linearVelocity.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearVelocity.z, 'state.linearVelocity.z', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearAcceleration.x, 'state.linearAcceleration.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearAcceleration.y, 'state.linearAcceleration.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.linearAcceleration.z, 'state.linearAcceleration.z', 'double') }}};
-    }
-
-    {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.hasOrientation, 'state.hasOrientation ? 1 : 0', 'i32') }}};
-    if (state.hasOrientation) {
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.orientation.x, 'state.orientation.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.orientation.y, 'state.orientation.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.orientation.z, 'state.orientation.z', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.orientation.w, 'state.orientation.w', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularVelocity.x, 'state.angularVelocity.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularVelocity.y, 'state.angularVelocity.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularVelocity.z, 'state.angularVelocity.z', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularVelocity.w, 'state.angularVelocity.w', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularAcceleration.x, 'state.angularAcceleration.x', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularAcceleration.y, 'state.angularAcceleration.y', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularAcceleration.z, 'state.angularAcceleration.z', 'double') }}};
-      {{{ makeSetValue('statePtr', C_STRUCTS.WebVRPositionState.angularAcceleration.w, 'state.angularAcceleration.w', 'double') }}};
-    }
-
-    return 1;
-  },
-
-  emscripten_vr_sensor_zero: function(deviceId) {
-    var dev = WebVR.getDeviceByID(deviceId);
-    if (!dev) return 0;
-    dev.resetSensor();
-    return 1;
-  },
-
-  emscripten_vr_set_display_render_loop: function(deviceId, func, arg) {
-    var display = WebVR.getDeviceByID(deviceId);
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display) return 0;
 
-    assert(!display.mainLoop || !display.mainLoop.scheduler, 'emscripten_vr_set_device_main_loop: there can only be one render loop function per VRDisplay: call emscripten_vr_cancel_render_loop to cancel the previous one before setting a new one with different parameters.');
+    var caps = display.capabilities;
+
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasPosition, 'caps.hasPosition ? 1 : 0', 'i32') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasExternalDisplay, 'caps.hasExternalDisplay ? 1 : 0', 'i32') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.canPresent, 'caps.canPresent ? 1 : 0', 'i32') }}};
+
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.maxLayers, 'caps.maxLayers', 'i64') }}};
+
+    return 1;
+  },
+
+  emscripten_vr_get_eye_parameters: function(displayHandle, whichEye, eyeParamsPtr) {
+    if (!eyeParamsPtr) return 0;
+
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display) return 0;
+
+    var params = display.getEyeParameters(whichEye == WebVR.EYE_LEFT ? "left" : "right");
+
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.VREyeParameters.offset.x, 'params.offset[0]', 'float') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.VREyeParameters.offset.y, 'params.offset[1]', 'float') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.VREyeParameters.offset.z, 'params.offset[2]', 'float') }}};
+
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.VREyeParameters.renderWidth, 'params.renderWidth', 'i64') }}};
+    {{{ makeSetValue('eyeParamsPtr', C_STRUCTS.VREyeParameters.renderHeight, 'params.renderHeight', 'i64') }}};
+
+    return 1;
+  },
+
+  emscripten_vr_reset_pose: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display) return 0;
+    display.resetPose();
+    return 1;
+  },
+
+  emscripten_vr_set_display_render_loop: function(displayHandle, func, arg) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display) return 0;
+
+    assert(!display.mainLoop || !display.mainLoop.scheduler, "emscripten_vr_set_device_main_loop: there can only be one render loop function per VRDisplay: call emscripten_vr_cancel_render_loop to cancel the previous one before setting a new one with different parameters.");
 
     var displayIterationFunc;
     if (typeof arg !== 'undefined') {
-      var argArray = [arg];
       displayIterationFunc = function() {
-        Runtime.dynCall('vi', func, argArray);
+        Runtime.dynCall('vi', func, [arg]);
       };
     } else {
       displayIterationFunc = function() {
@@ -247,11 +156,15 @@ var LibraryWebVR = {
     }
 
     display.mainLoop = {
-      sheduler: function() {
+      running: !display.mainLoop ? false : display.mainLoop.running,
+      scheduler: function() {
         display.requestAnimationFrame(display.mainLoop.runner);
       },
       runner: function() {
         if(ABORT) return;
+
+        /* Prevent scheduler being called twice when loop is changed */
+        display.mainLoop.running = true;
 
 #if USES_GL_EMULATION
         GL.newRenderingFrameStarted();
@@ -263,7 +176,7 @@ var LibraryWebVR = {
           if (e instanceof ExitStatus) {
             return;
           } else {
-            if (e && typeof e === 'object' && e.stack) Module.printErr('exception thrown: ' + [e, e.stack]);
+            if (e && typeof e === 'object' && e.stack) Module.printErr('exception thrown in render loop of VR display ' + displayHandle.toString() + ': ' + [e, e.stack]);
             throw e;
           }
         }
@@ -272,27 +185,178 @@ var LibraryWebVR = {
         checkStackCookie();
 #endif
 
-        display.mainLoop.sheduler();
+        if (!display.mainLoop.scheduler) {
+          display.mainLoop.running = false;
+        } else {
+          display.mainLoop.scheduler();
+        }
       },
       pause: function() {
-        display.mainLoop.sheduler = null;
+        display.mainLoop.scheduler = null;
       }
     };
 
-    display.requestAnimationFrame(display.mainLoop.runner);
+    if (!display.mainLoop.running) {
+      display.mainLoop.scheduler();
+    } // otherwise called by display.mainLoop.runner()
+    return 1;
   },
 
   emscripten_vr_set_display_render_loop_arg__deps: ['emscripten_vr_set_display_render_loop'],
-  emscripten_vr_set_display_render_loop_arg: function(deviceId, func, arg) {
-    _emscripten_vr_set_display_main_loop(func, arg);
+  emscripten_vr_set_display_render_loop_arg: function(displayHandle, func, arg) {
+    return _emscripten_vr_set_display_render_loop(displayHandle, func, arg);
   },
 
-  emscripten_vr_cancel_display_render_loop: function(deviceId) {
-    var display = WebVR.getDeviceByID(deviceId);
+  emscripten_vr_cancel_display_render_loop: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
     if (!display || !display.mainLoop) return 0;
 
     display.mainLoop.pause();
+    return 1;
+  },
+
+  emscripten_vr_request_present: function(displayHandle, layerInitPtr, layerCount) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display) return 0;
+
+    layerInit = new Array(layerCount);
+    for (var i = 0; i < layerCount; ++i) {
+        sourceStrPtr = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.source, 'void*') }}};
+        sourceStr = UTF8ToString(sourceStrPtr);
+
+        console.log("Source: " + sourceStr);
+        var source = null;
+        if(sourceStr == '#canvas') {
+            /* Default emscripten canvas */
+            source = Module['canvas'];
+        } else if (sourceStr && sourceStr.length > 0 && sourceStr[0] == '#') {
+            /* Other canvas id */
+            source = document.getElementById(sourceStr);
+        }
+
+        if (!source) {
+            return 0;
+        }
+
+        leftBounds = new Float32Array(4);
+        rightBounds = new Float32Array(4);
+        var ptr = layerInitPtr;
+        for (var j = 0; j < 4; ++j) {
+            leftBounds[i] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.leftBounds, 'float') }}};
+            rightBounds[i] = {{{ makeGetValue('layerInitPtr', C_STRUCTS.VRLayerInit.rightBounds, 'float') }}};
+            ptr += 4;
+        }
+
+        layerInit[i] = {
+            source: source,
+            leftBounds: leftBounds,
+            rightBounds: rightBounds
+        };
+        layerInitPtr += {{{ C_STRUCTS.VRLayerInit.__size__ }}};
+    }
+
+    display.requestPresent(layerInit).then;
+
+    return 1;
+  },
+
+  emscripten_vr_get_frame_data: function(displayHandle, frameDataPtr) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display || !display.mainLoop || !frameDataPtr) return 0;
+
+    if(!display.frameData) {
+      display.frameData = new VRFrameData();
+    }
+    display.getFrameData(display.frameData);
+
+    /* Pose */
+
+    /* Used to expose to C which attributes are valid (!== null) */
+    var poseFlags = 0;
+
+    {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.timestamp, 'display.frameData.timestamp', 'double') }}};
+
+    if (display.frameData.pose.position !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.x, 'display.frameData.pose.position[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.y, 'display.frameData.pose.position[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.position.z, 'display.frameData.pose.position[2]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_POSITION;
+    }
+
+    if (display.frameData.pose.linearVelocity !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.x, 'display.frameData.pose.linearVelocity[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.y, 'display.frameData.pose.linearVelocity[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearVelocity.z, 'display.frameData.pose.linearVelocity[2]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_LINEAR_VELOCITY;
+    }
+
+    if (display.frameData.pose.linearAcceleration !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.x, 'display.frameData.pose.linearAcceleration[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.y, 'display.frameData.pose.linearAcceleration[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.linearAcceleration.z, 'display.frameData.pose.linearAcceleration[2]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_LINEAR_ACCELERATION;
+    }
+
+    if (display.frameData.pose.orientation !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.x, 'display.frameData.pose.orientation[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.y, 'display.frameData.pose.orientation[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.z, 'display.frameData.pose.orientation[2]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.orientation.w, 'display.frameData.pose.orientation[3]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_ORIENTATION;
+    }
+
+    if (display.frameData.pose.angularVelocity !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.x, 'display.frameData.pose.angularVelocity[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.y, 'display.frameData.pose.angularVelocity[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularVelocity.z, 'display.frameData.pose.angularVelocity[2]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_ANGULAR_VELOCITY;
+    }
+
+    if (display.frameData.pose.angularAcceleration !== null) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.x, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.y, 'display.frameData.pose.angularAcceleration[1]', 'float') }}};
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.angularAcceleration.z, 'display.frameData.pose.angularAcceleration[0]', 'float') }}};
+
+        poseFlags |= WebVR.POSE_ANGULAR_ACCELERATION;
+    }
+
+    {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.pose.poseFlags, 'poseFlags', 'i32') }}};
+
+    /* Matrices */
+
+    for (var i = 0; i < 16; ++i) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftProjectionMatrix + ' + i*4', 'display.frameData.leftProjectionMatrix[i]', 'float') }}};
+    }
+
+    for (var i = 0; i < 16; ++i) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.leftViewMatrix + ' + i*4', 'display.frameData.leftViewMatrix[i]', 'float') }}};
+    }
+
+    for (var i = 0; i < 16; ++i) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightProjectionMatrix + ' + i*4', 'display.frameData.leftProjectionMatrix[i]', 'float') }}};
+    }
+
+    for (var i = 0; i < 16; ++i) {
+        {{{ makeSetValue('frameDataPtr', C_STRUCTS.VRFrameData.rightViewMatrix + ' + i*4', 'display.frameData.leftViewMatrix[i]', 'float') }}};
+    }
+
+    return 1;
+  },
+
+  emscripten_vr_submit_frame: function(displayHandle) {
+    var display = WebVR.dereferenceDisplayHandle(displayHandle);
+    if (!display || !display.mainLoop) return 0;
+
+    display.submitFrame();
+
+    return 1;
   }
+
 };
 
 autoAddDeps(LibraryWebVR, '$WebVR');

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1392,49 +1392,74 @@
         }
     },
     // ===========================================
-    // emscripten WebVR library
+    // emscripten VR library
     // ===========================================
     {
         "file": "emscripten/vr.h",
-        "defines": [],
+        "defines": [
+            "VR_EYE_LEFT",
+            "VR_EYE_RIGHT",
+
+            "VR_POSE_POSITION",
+            "VR_POSE_LINEAR_VELOCITY",
+            "VR_POSE_LINEAR_ACCELERATION",
+            "VR_POSE_ORIENTATION",
+            "VR_POSE_ANGULAR_VELOCITY",
+            "VR_POSE_ANGULAR_ACCELERATION"
+        ],
         "structs": {
-            "WebVRFieldOfView": [
-              "upDegrees",
-              "rightDegrees",
-              "downDegrees",
-              "leftDegrees"
+            "VRVector3": [
+              "x",
+              "y",
+              "z"
             ],
-            "WebVRPoint": [
+            "VRQuaternion": [
               "x",
               "y",
               "z",
               "w"
-	    ],
-            "WebVRIntRect": [
-              "x",
-              "y",
-              "width",
-              "height"
             ],
-	    "WebVRPositionState": [
-	      "timeStamp",
-	      "hasPosition",
-	      { "position": [ "x", "y", "z", "w" ] },
-	      { "linearVelocity": [ "x", "y", "z", "w" ] },
-	      { "linearAcceleration": [ "x", "y", "z", "w" ] },
-	      "hasOrientation",
-	      { "orientation": [ "x", "y", "z", "w" ] },
-	      { "angularVelocity": [ "x", "y", "z", "w" ] },
-	      { "angularAcceleration": [ "x", "y", "z", "w" ] }
-	    ],
-        "WebVREyeParameters": [
-          { "minimumFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
-          { "maximumFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
-          { "recommendedFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
-          { "eyeTranslation": [ "x", "y", "z", "w" ] },
-          { "currentFieldOfView": [ "upDegrees", "rightDegrees", "downDegrees", "leftDegrees" ] },
-          { "renderRect": [ "x", "y", "width", "height"] }
-	    ]
+            "VRPose": [
+                { "position": [ "x", "y", "z" ] },
+                { "linearVelocity": [ "x", "y", "z" ] },
+                { "linearAcceleration": [ "x", "y", "z" ] },
+                { "orientation": [ "x", "y", "z", "w" ] },
+                { "angularVelocity": [ "x", "y", "z" ] },
+                { "angularAcceleration": [ "x", "y", "z" ] },
+                "poseFlags"
+            ],
+            "VRFrameData": [
+                "leftProjectionMatrix",
+                "leftViewMatrix",
+                "rightProjectionMatrix",
+                "rightViewMatrix",
+                { "pose": [
+                    { "position": [ "x", "y", "z" ] },
+                    { "linearVelocity": [ "x", "y", "z" ] },
+                    { "linearAcceleration": [ "x", "y", "z" ] },
+                    { "orientation": [ "x", "y", "z", "w" ] },
+                    { "angularVelocity": [ "x", "y", "z" ] },
+                    { "angularAcceleration": [ "x", "y", "z" ] },
+                    "poseFlags"
+                ] },
+                "timestamp"
+            ],
+            "VREyeParameters": [
+                { "offset": [ "x", "y", "z" ] },
+                "renderWidth",
+                "renderHeight"
+            ],
+            "VRDisplayCapabilities": [
+                "hasPosition",
+                "hasExternalDisplay",
+                "canPresent",
+                "maxLayers"
+            ],
+            "VRLayerInit": [
+                "source",
+                "leftBounds",
+                "rightBounds"
+            ]
         }
     },
     {

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -9,6 +9,13 @@
 /*
  * This file provides some basic interfaces for interacting with WebVR from Emscripten.
  *
+ * Documentation for the public APIs defined in this file must be updated in:
+ *    site/source/docs/api_reference/vr.h.rst
+ * A prebuilt local version of the documentation is available at:
+ *    site/build/text/docs/api_reference/emscripten.h.txt
+ * You can also build docs locally as HTML or other formats in site/
+ * An online HTML version (which may be of a different version of Emscripten)
+ *    is up at http://kripken.github.io/emscripten-site/docs/api_reference/vr.h.html
  */
 
 #ifdef __cplusplus

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -22,6 +22,19 @@
 extern "C" {
 #endif
 
+/**
+ * Version of the emscripten vr API, assembled as follows:
+ * WebVR Version Major * 10000 + WebVR Version Minor * 100 + API version [0-99]
+ *
+ * The first two can be used to determine the for which WebVR version the API
+ * has been built while the last can be used to determine which functions are
+ * available with the current build.
+ *
+ * E.g. emscripten vr API version 1.1.0 implements some initial features for
+ * WebVR 1.1 and its version define will have the value 10100
+ */
+#define EMSCRIPTEN_VR_API_VERSION 10100
+
 typedef int32_t VRDisplayHandle;
 
 typedef void (*em_vr_callback_func)(void);
@@ -51,7 +64,7 @@ typedef struct VRDisplayCapabilities {
 } VRDisplayCapabilities;
 
 #define VR_LAYER_DEFAULT_LEFT_BOUNDS {0.0f, 0.0f, 0.5f, 1.0f}
-#define VR_LAYER_DEFAULT_RIGHT_BOUNDS {0.0f, 0.5f, 1.0f, 1.0f}
+#define VR_LAYER_DEFAULT_RIGHT_BOUNDS {0.5f, 0.0f, 0.5f, 1.0f}
 typedef struct VRLayerInit {
     const char* source;
 
@@ -116,12 +129,13 @@ extern int emscripten_vr_count_displays(void);
 extern VRDisplayHandle emscripten_vr_get_display_handle(int deviceIndex);
 
 extern int emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback);
-extern int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func, void* arg);
+extern int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func callback, void* arg);
 extern void emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
 
-extern int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount);
+extern int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount, em_vr_arg_callback_func callback, void* userData);
 extern int emscripten_vr_get_frame_data(VRDisplayHandle handle, VRFrameData* frameData);
 extern int emscripten_vr_submit_frame(VRDisplayHandle handle);
+extern int emscripten_vr_exit_present(VRDisplayHandle handle);
 
 extern char *emscripten_vr_get_display_name(VRDisplayHandle handle);
 extern int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams);

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -18,6 +18,9 @@ extern "C" {
 typedef int32_t WebVRDeviceId;
 typedef int32_t WebVRHardwareUnitId;
 
+typedef void (*em_vr_callback_func)(void);
+typedef void (*em_vr_arg_callback_func)(void*);
+
 typedef enum {
     WebVREyeLeft = 0,
     WebVREyeRight = 1
@@ -71,6 +74,10 @@ typedef struct WebVREyeParameters {
 
 extern void emscripten_vr_init();
 extern int emscripten_vr_ready();
+
+extern void emscripten_vr_set_display_render_loop(WebVRDeviceId deviceId, em_vr_callback_func callback);
+extern void emscripten_vr_set_display_render_loop_arg(WebVRDeviceId deviceId, em_vr_arg_callback_func, void *arg);
+extern void emscripten_vr_cancel_display_render_loop(WebVRDeviceId deviceId);
 
 extern int emscripten_vr_count_devices();
 extern WebVRDeviceId emscripten_vr_get_device_id(int deviceIndex);

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -22,93 +22,112 @@
 extern "C" {
 #endif
 
-typedef int32_t WebVRDeviceId;
-typedef int32_t WebVRHardwareUnitId;
+typedef int32_t VRDisplayHandle;
 
 typedef void (*em_vr_callback_func)(void);
 typedef void (*em_vr_arg_callback_func)(void*);
 
-typedef enum {
-    WebVREyeLeft = 0,
-    WebVREyeRight = 1
-} WebVREye;
+#define VR_EYE_LEFT 0
+#define VR_EYE_RIGHT 1
 
 typedef enum {
-    WebVRUnknownDevice = 0,
-    WebVRHMDDevice = 1,
-    WebVRPositionSensorDevice = 2
-} WebVRDeviceType;
+    VREyeLeft = VR_EYE_LEFT,
+    VREyeRight = VR_EYE_RIGHT
+} VREye;
 
-typedef struct WebVRFieldOfView {
-    double upDegrees;
-    double rightDegrees;
-    double downDegrees;
-    double leftDegrees;
-} WebVRFieldOfView;
+typedef struct VRVector3 {
+    float x, y, z;
+} VRVector3;
 
-typedef struct WebVRPoint {
-    double x, y, z, w;
-} WebVRPoint;
+typedef struct VRQuaternion {
+    float x, y, z, w;
+} VRQuaternion;
 
-typedef struct WebVRIntRect {
-    int32_t x, y;
-    uint32_t width, height;
-} WebVRIntRect;
+typedef struct VRDisplayCapabilities {
+    int32_t hasPosition;
+    int32_t hasExternalDisplay;
+    int32_t canPresent;
+    unsigned long maxLayers;
+} VRDisplayCapabilities;
 
-typedef struct WebVRPositionState {
-    double timeStamp;
+#define VR_LAYER_DEFAULT_LEFT_BOUNDS {0.0f, 0.0f, 0.5f, 1.0f}
+#define VR_LAYER_DEFAULT_RIGHT_BOUNDS {0.0f, 0.5f, 1.0f, 1.0f}
+typedef struct VRLayerInit {
+    const char* source;
 
-    int hasPosition;
-    WebVRPoint position;
-    WebVRPoint linearVelocity;
-    WebVRPoint linearAcceleration;
+    float leftBounds[4];
+    float rightBounds[4];
+} VRLayerInit;
 
-    int hasOrientation;
-    WebVRPoint orientation;
-    WebVRPoint angularVelocity;
-    WebVRPoint angularAcceleration;
-} WebVRPositionState;
+/* Defines for VRPose::poseFlags */
+#define VR_POSE_POSITION 0x1
+#define VR_POSE_LINEAR_VELOCITY 0x2
+#define VR_POSE_LINEAR_ACCELERATION 0x4
+#define VR_POSE_ORIENTATION 0x8
+#define VR_POSE_ANGULAR_VELOCITY 0x10
+#define VR_POSE_ANGULAR_ACCELERATION 0x20
 
-typedef struct WebVREyeParameters {
-    WebVRFieldOfView minimumFieldOfView;
-    WebVRFieldOfView maximumFieldOfView;
-    WebVRFieldOfView recommendedFieldOfView;
-    WebVRPoint eyeTranslation;
+typedef struct VRPose {
+    /** Position, valid only if `poseFlags & VR_POSE_POSITION == 0` */
+    VRVector3 position;
+    /** Linear velocity, valid only if `poseFlags & VR_POSE_LINEAR_VELOCITY == 0` */
+    VRVector3 linearVelocity;
+    /** Linear acceleration, valid only if `poseFlags & VR_POSE_LINEAR_ACCELERATION == 0` */
+    VRVector3 linearAcceleration;
 
-    WebVRFieldOfView currentFieldOfView;
-    WebVRIntRect renderRect;
-} WebVREyeParameters;
+    /** Orientation quaternion, valid only if `poseFlags & VR_POSE_ORIENTATION == 0` */
+    VRQuaternion orientation;
+    /** Angular velocity, valid only if `poseFlags & VR_POSE_ANGULAR_VELOCITY == 0` */
+    VRVector3 angularVelocity;
+    /** Angular acceleration, valid only if `poseFlags & VR_POSE_ANGULAR_ACCELERATION == 0` */
+    VRVector3 angularAcceleration;
 
-extern void emscripten_vr_init();
-extern int emscripten_vr_ready();
+    /** Bitmask of VR_POSE_* which determines whether the corresponding pose
+     * attributes are valid */
+    int poseFlags;
+} VRPose;
 
-extern void emscripten_vr_set_display_render_loop(WebVRDeviceId deviceId, em_vr_callback_func callback);
-extern void emscripten_vr_set_display_render_loop_arg(WebVRDeviceId deviceId, em_vr_arg_callback_func, void *arg);
-extern void emscripten_vr_cancel_display_render_loop(WebVRDeviceId deviceId);
+typedef struct VREyeParameters {
+    VRVector3 offset;
 
-extern int emscripten_vr_count_devices();
-extern WebVRDeviceId emscripten_vr_get_device_id(int deviceIndex);
-extern WebVRDeviceType emscripten_vr_get_device_type(WebVRDeviceId deviceId);
-extern WebVRHardwareUnitId emscripten_vr_get_device_hwid(WebVRDeviceId deviceId);
-extern char *emscripten_vr_get_device_name(WebVRDeviceId deviceId);
+    unsigned long renderWidth;
+    unsigned long renderHeight;
+} VREyeParameters;
 
-// select the given device as the fullscreen HMD device
-extern int emscripten_vr_select_hmd_device(WebVRDeviceId deviceId);
-extern WebVRDeviceId emscripten_vr_get_selected_hmd_device();
+typedef struct VRFrameData {
+    double timestamp;
 
-// For HMD devices.
-// All of these return 1 on success, <= 0 on failure.
-extern int emscripten_vr_hmd_get_eye_parameters(WebVRDeviceId deviceId, WebVREye whichEye, WebVREyeParameters *eyeParams);
-extern int emscripten_vr_hmd_set_fov(WebVRDeviceId deviceId,
-                                     const WebVRFieldOfView *leftFov,
-                                     const WebVRFieldOfView *rightFov,
-                                     double zNear, double zFar);
+    float leftProjectionMatrix[16];
+    float leftViewMatrix[16];
 
+    float rightProjectionMatrix[16];
+    float rightViewMatrix[16];
 
-// for Position devices
-// All of these return 1 on success, <= 0 on failure.
-extern int emscripten_vr_sensor_get_state(WebVRDeviceId deviceId, bool immediate, WebVRPositionState *state);
-extern int emscripten_vr_sensor_zero(WebVRDeviceId deviceId);
+    VRPose pose;
+} VRFrameData;
+
+extern int emscripten_vr_init(void);
+extern int emscripten_vr_ready(void);
+
+extern int emscripten_vr_version_major(void);
+extern int emscripten_vr_version_minor(void);
+
+extern int emscripten_vr_count_displays(void);
+extern VRDisplayHandle emscripten_vr_get_display_handle(int deviceIndex);
+
+extern int emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback);
+extern int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func, void* arg);
+extern void emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
+
+extern int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount);
+extern int emscripten_vr_get_frame_data(VRDisplayHandle handle, VRFrameData* frameData);
+extern int emscripten_vr_submit_frame(VRDisplayHandle handle);
+
+extern char *emscripten_vr_get_display_name(VRDisplayHandle handle);
+extern int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams);
+extern int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps);
+
+extern int emscripten_vr_reset_pose(VRDisplayHandle handle);
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -126,6 +126,8 @@ extern int emscripten_vr_submit_frame(VRDisplayHandle handle);
 extern char *emscripten_vr_get_display_name(VRDisplayHandle handle);
 extern int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams);
 extern int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps);
+extern bool emscripten_vr_display_connected(VRDisplayHandle handle);
+extern bool emscripten_vr_display_presenting(VRDisplayHandle handle);
 
 extern int emscripten_vr_reset_pose(VRDisplayHandle handle);
 

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -126,11 +126,11 @@ extern int emscripten_vr_version_major(void);
 extern int emscripten_vr_version_minor(void);
 
 extern int emscripten_vr_count_displays(void);
-extern VRDisplayHandle emscripten_vr_get_display_handle(int deviceIndex);
+extern VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex);
 
 extern int emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback);
 extern int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func callback, void* arg);
-extern void emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
+extern int emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
 
 extern int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount, em_vr_arg_callback_func callback, void* userData);
 extern int emscripten_vr_get_frame_data(VRDisplayHandle handle, VRFrameData* frameData);
@@ -142,8 +142,6 @@ extern int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichE
 extern int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps);
 extern bool emscripten_vr_display_connected(VRDisplayHandle handle);
 extern bool emscripten_vr_display_presenting(VRDisplayHandle handle);
-
-extern int emscripten_vr_reset_pose(VRDisplayHandle handle);
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -5,11 +5,9 @@
 #include <emscripten.h>
 #include <emscripten/vr.h>
 
-static int gDevCount = -1;
-static int gPosDev = -1;
-static int gHmdDev = -1;
+static int gDisplay = -1;
 
-static bool renderLoopCalled = false;
+static int renderLoopCalled = 0;
 static bool renderLoopArgCalled = false;
 static void* renderLoopArgArg = NULL;
 
@@ -23,23 +21,157 @@ void report_result(int result) {
 #ifdef REPORT_RESULT
     REPORT_RESULT();
 #endif
-    exit(result);
 }
 
+static void printMatrix(float* m) {
+    printf("{%f, %f, %f, %f,\n"
+           " %f, %f, %f, %f,\n"
+           " %f, %f, %f, %f,\n"
+           " %f, %f, %f, %f}\n",
+           m[0],  m[1],  m[2],  m[3],
+           m[4],  m[5],  m[6],  m[7],
+           m[8],  m[9],  m[10], m[11],
+           m[12], m[13], m[14], m[15]);
+}
+
+/* Render loop with an argument, set in `renderLoop()` */
 static void renderLoopArg(void* arg) {
+    emscripten_vr_cancel_display_render_loop(gDisplay);
+
     renderLoopArgCalled = true;
     renderLoopArgArg = arg;
 
-    emscripten_vr_cancel_display_render_loop(gHmdDev);
+    printf("Render loop with argument was called.\n");
+
+    return;
 }
 
+/* Render loop without argument, set in `mainLoop()` */
 static void renderLoop() {
-    renderLoopCalled = true;
+    renderLoopCalled++;
+    if(renderLoopCalled == 1) {
+        /* First iteration */
+        VRLayerInit init = {
+            "#canvas",
+            VR_LAYER_DEFAULT_LEFT_BOUNDS,
+            VR_LAYER_DEFAULT_RIGHT_BOUNDS
+        };
+        if (!emscripten_vr_request_present(gDisplay, &init, 1)) {
+            printf("Request present with default canvas failed.\n");
+            report_result(1);
+            return;
+        }
 
-    emscripten_vr_cancel_display_render_loop(gHmdDev);
-    emscripten_vr_set_display_render_loop_arg(gHmdDev, renderLoopArg, (void*) 42);
+        VRFrameData data;
+        if (!emscripten_vr_get_frame_data(gDisplay, &data)) {
+            printf("Could not get frame data. (first iteration)\n");
+            report_result(1);
+            return;
+        }
+        if(!emscripten_vr_submit_frame(gDisplay)) {
+            printf("Error: Failed to submit frame to VR display %d (first iteration)\n", gDisplay);
+            report_result(1);
+            return;
+        }
+        return;
+    } else if (renderLoopCalled > 2) {
+        printf("Error: Unexpected render loop iteration\n");
+        report_result(1);
+        return; // only two iterations should run code
+    }
+
+    /* Second iteration */
+
+    emscripten_vr_cancel_display_render_loop(gDisplay);
+
+    VRFrameData data;
+    if (!emscripten_vr_get_frame_data(gDisplay, &data)) {
+        printf("Could not get frame data.\n");
+        report_result(1);
+    }
+
+    /* Print list of properties which are reported as valid */
+    printf("The following properties are valid:\n[");
+    if(data.pose.poseFlags & VR_POSE_POSITION) {
+        printf("position, ");
+    }
+    if(data.pose.poseFlags & VR_POSE_LINEAR_VELOCITY) {
+        printf("linear vel, ");
+    }
+    if(data.pose.poseFlags & VR_POSE_LINEAR_ACCELERATION) {
+        printf("linear accel, ");
+    }
+    if(data.pose.poseFlags & VR_POSE_ORIENTATION) {
+        printf("orientation, ");
+    }
+    if(data.pose.poseFlags & VR_POSE_ANGULAR_VELOCITY) {
+        printf("angular vel, ");
+    }
+    if(data.pose.poseFlags & VR_POSE_ANGULAR_ACCELERATION) {
+        printf("angular accel");
+    }
+    printf("]\n");
+
+    /* Print all values (independent of validity) */
+    printf("Position: \t\t%f %f %f\n",
+            data.pose.position.x,
+            data.pose.position.y,
+            data.pose.position.z);
+
+    printf("Linear Velocity: \t%f %f %f\n",
+            data.pose.linearVelocity.x,
+            data.pose.linearVelocity.y,
+            data.pose.linearVelocity.z);
+
+    printf("Linear Acceleration: \t%f %f %f\n",
+            data.pose.linearAcceleration.x,
+            data.pose.linearAcceleration.y,
+            data.pose.linearAcceleration.z);
+
+    printf("Orientation: \t\t%f %f %f %f\n",
+            data.pose.orientation.x,
+            data.pose.orientation.y,
+            data.pose.orientation.z,
+            data.pose.orientation.w);
+
+    printf("Angular Velocity: \t%f %f %f\n",
+            data.pose.angularVelocity.x,
+            data.pose.angularVelocity.y,
+            data.pose.angularVelocity.z);
+
+    printf("Angular Acceleration: \t%f %f %f\n",
+            data.pose.angularAcceleration.x,
+            data.pose.angularAcceleration.y,
+            data.pose.angularAcceleration.z);
+
+    printf("Left Projection Matrix:\n");
+    printMatrix(data.leftProjectionMatrix);
+
+    printf("Right Projection Matrix:\n");
+    printMatrix(data.rightProjectionMatrix);
+
+    printf("Left View Matrix:\n");
+    printMatrix(data.leftViewMatrix);
+
+    printf("Right View Matrix:\n");
+    printMatrix(data.rightViewMatrix);
+
+    if(!emscripten_vr_submit_frame(gDisplay)) {
+        printf("Error: Failed to submit frame to VR display %d (second iteration)\n", gDisplay);
+        report_result(1);
+    }
+
+    printf("Submitted frame.\n");
+
+    if (!emscripten_vr_set_display_render_loop_arg(gDisplay, renderLoopArg, (void*) 42)) {
+        printf("Error: Failed to dereference handle while settings display render loop of device %d\n", gDisplay);
+        report_result(1);
+    }
+
+    printf("Set main loop with argument to be called next.\n");
 }
 
+/* emscripten main loop */
 static void mainloop() {
     static int loopcount = 0;
 
@@ -48,63 +180,63 @@ static void mainloop() {
         return;
     }
 
-    if (gDevCount == -1) {
-        gDevCount = emscripten_vr_count_devices();
-        if (gDevCount == 0) {
-            printf("No VR devices found!\n");
+    if(gDisplay == -1) {
+        int numDisplays = emscripten_vr_count_displays();
+        if (numDisplays == 0) {
+            printf("No VR displays found!\n");
             report_result(0);
             return;
         }
-        printf("%d VR devices found\n", gDevCount);
 
+        printf("%d VR displays found\n", numDisplays);
 
-        int hwid = -1;
+        int id = -1;
         char *devName;
-        for (int i = 0; i < gDevCount; ++i) {
-            WebVRDeviceId devid = emscripten_vr_get_device_id(i);
-            if (hwid == -1 || hwid == emscripten_vr_get_device_hwid(devid)) {
-                hwid = emscripten_vr_get_device_hwid(devid);
-                devName = emscripten_vr_get_device_name(devid);
+        for (int i = 0; i < numDisplays; ++i) {
+            VRDisplayHandle handle = emscripten_vr_get_display_handle(i);
+            if (gDisplay == -1) {
+                /* Save first found display for more testing */
+                gDisplay = handle;
+                devName = emscripten_vr_get_display_name(handle);
+                printf("Using VRDisplay '%s' (displayId '%d')\n", devName, gDisplay);
 
-                if (emscripten_vr_get_device_type(devid) == WebVRHMDDevice) {
-                    gHmdDev = devid;
-                    printf("Using WebVRHMDDevice '%s' (deviceId '%d'; hardwareUnitId '%d'.)\n", devName, gHmdDev,  hwid);
-                } else if (emscripten_vr_get_device_type(devid) == WebVRPositionSensorDevice) {
-                    gPosDev = devid;
-                    printf("Using WebVRPositionSensorDevice '%s' (deviceId '%d'; hardwareUnitId '%d').\n", devName, gPosDev,  hwid);
+                VRDisplayCapabilities caps;
+                if(!emscripten_vr_get_display_capabilities(handle, &caps)) {
+                    printf("Error: Failed to get display capabilities\n");
+                    report_result(1);
+                    return;
                 }
+                printf("Display Capabilities:\n"
+                       "{hasPosition: %d, hasExternalDisplay: %d, canPreset: %d, maxLayers: %lu}\n",
+                       caps.hasPosition, caps.hasExternalDisplay, caps.canPresent, caps.maxLayers);
             }
         }
 
-        if (gHmdDev == -1 || gPosDev == -1) {
-            printf("Couln't find both a HMD and position device\n");
-            // this is a failure because it's weird
+        if (gDisplay == -1) {
+            printf("Couln't find a VR display even though at least one was found.\n");
             report_result(1);
             return;
         }
 
-        WebVREyeParameters leftParams, rightParams;
-        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeLeft, &leftParams);
-        emscripten_vr_hmd_get_eye_parameters(gHmdDev, WebVREyeRight, &rightParams);
+        VREyeParameters leftParams, rightParams;
+        emscripten_vr_get_eye_parameters(gDisplay, VREyeLeft, &leftParams);
+        emscripten_vr_get_eye_parameters(gDisplay, VREyeRight, &rightParams);
 
-        WebVRFieldOfView leftFov = leftParams.currentFieldOfView, rightFov = rightParams.currentFieldOfView;
-        printf("Left FOV: %f %f %f %f\n", leftFov.upDegrees, leftFov.downDegrees, leftFov.rightDegrees, leftFov.leftDegrees);
-        printf("Right FOV: %f %f %f %f\n", rightFov.upDegrees, rightFov.downDegrees, rightFov.rightDegrees, rightFov.leftDegrees);
+        VREyeParameters* p = &leftParams;
+        printf("Left eye params: {offset: [%f, %f, %f], renderWidth: %lu, renderHeight: %lu}\n", p->offset.x, p->offset.y, p->offset.z, p->renderWidth, p->renderHeight);
 
-        emscripten_vr_set_display_render_loop(gHmdDev, renderLoop);
+        p = &rightParams;
+        printf("Right eye params: {offset: [%f, %f, %f], renderWidth: %lu, renderHeight: %lu}\n", p->offset.x, p->offset.y, p->offset.z, p->renderWidth, p->renderHeight);
+
+        if (!emscripten_vr_set_display_render_loop(gDisplay, renderLoop)) {
+            printf("Error: Failed to dereference handle while settings display render loop of device %d\n", gDisplay);
+            report_result(1);
+        }
     }
 
-    WebVRPositionState state;
-    emscripten_vr_sensor_get_state(gPosDev, false, &state);
-    printf("Timestamp: %f, hasPosition: %s , hasOrientation: %s\n", state.timeStamp,
-           state.hasPosition ? "true" : "false", state.hasOrientation ? "true" : "false");
-    printf("State: orientation: [%f %f %f %f] position: [%f %f %f]\n",
-           state.orientation.x, state.orientation.y, state.orientation.z, state.orientation.w,
-           state.position.x, state.position.y, state.position.z);
-
     if (loopcount++ > 10) {
-        if (!renderLoopCalled) {
-            printf("Render loop was never called\n");
+        if (renderLoopCalled != 2) {
+            printf("Render loop was not called twice (expected 2, was %d)\n", renderLoopCalled);
             report_result(1);
         }
         if (!renderLoopArgCalled) {
@@ -120,7 +252,14 @@ static void mainloop() {
 }
 
 int main(int argc, char **argv) {
-    emscripten_vr_init();
+    if (!emscripten_vr_init()) {
+        printf("Skipping: Browser does not support WebVR\n");
+        return 0;
+    }
+
+    printf("Browser is running WebVR version %d.%d\n",
+           emscripten_vr_version_major(),
+           emscripten_vr_version_minor());
 
     /* 2fps -- no rAF */
     emscripten_set_main_loop(mainloop, 2, 0);

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -41,6 +41,8 @@ static void renderLoopArg(void* arg) {
     renderLoopArgCalled = true;
     renderLoopArgArg = arg;
 
+    emscripten_vr_exit_present(gDisplay);
+
     printf("Render loop with argument was called.\n");
 
     return;

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -228,7 +228,7 @@ static void mainloop() {
                     return;
                 }
                 printf("Display Capabilities:\n"
-                       "{hasPosition: %d, hasExternalDisplay: %d, canPreset: %d, maxLayers: %lu}\n",
+                       "{hasPosition: %d, hasExternalDisplay: %d, canPresent: %d, maxLayers: %lu}\n",
                        caps.hasPosition, caps.hasExternalDisplay, caps.canPresent, caps.maxLayers);
             }
         }

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -62,6 +62,14 @@ static void renderLoop() {
             return;
         }
 
+        if(emscripten_vr_display_presenting(gDisplay)) {
+            /* request present needs to be called from a user gesture callback and
+             * should have failed to make the display present. */
+            printf("Error: Expected display not to be presenting.\n");
+            report_result(1);
+            return;
+        }
+
         VRFrameData data;
         if (!emscripten_vr_get_frame_data(gDisplay, &data)) {
             printf("Could not get frame data. (first iteration)\n");
@@ -202,7 +210,12 @@ static void mainloop() {
 
                 VRDisplayCapabilities caps;
                 if(!emscripten_vr_get_display_capabilities(handle, &caps)) {
-                    printf("Error: Failed to get display capabilities\n");
+                    printf("Error: failed to get display capabilities.\n");
+                    report_result(1);
+                    return;
+                }
+                if(!emscripten_vr_display_connected(gDisplay)) {
+                    printf("Error: expected display to be connected.\n");
                     report_result(1);
                     return;
                 }

--- a/tests/test_vr.c
+++ b/tests/test_vr.c
@@ -46,6 +46,12 @@ static void renderLoopArg(void* arg) {
     return;
 }
 
+static void requestPresentCallback(void* userData) {
+    // Will likely never happen as the callback is not called
+    // from a user-gesture in this test.
+    printf("Request present callback called.\n");
+}
+
 /* Render loop without argument, set in `mainLoop()` */
 static void renderLoop() {
     renderLoopCalled++;
@@ -56,7 +62,7 @@ static void renderLoop() {
             VR_LAYER_DEFAULT_LEFT_BOUNDS,
             VR_LAYER_DEFAULT_RIGHT_BOUNDS
         };
-        if (!emscripten_vr_request_present(gDisplay, &init, 1)) {
+        if (!emscripten_vr_request_present(gDisplay, &init, 1, requestPresentCallback, NULL)) {
             printf("Request present with default canvas failed.\n");
             report_result(1);
             return;


### PR DESCRIPTION
**Hi everybody!**

This is the pullrequest for my work on #5028. Probably also closes #4309 and partially #4589.

I am already using this in an [example](https://github.com/mosra/magnum-examples/pull/33) for the [Magnum C++11/C++14 and OpenGL graphics engine](https://github.com/mosra/magnum) -- if you are interested, thanks to @mosra, you can view an online [preview version](http://magnum.graphics/showcase/webvr/) (requires WebGL 2).

As discussed in #5028, WebVR has changes quite a bit since the initial emscripten-vr API was written and therefore this is basically a big rewrite. I wrapped all essential features plus a couple of others which may come in handy. This does not wrap *all* WebVR functionality.

Looking forward to your reviews!

**Cheers, Jonathan.**

PS:

@kripken or @juj : One of you may want to cherry-pick c8aca03ba81a556a975fcd7a05042e04c7123ff2 right away, it fixes a minor typo in the firefox config for testing.

@promethe42 and @Noxalus: Any feedback on the API is welcome! I would also appreciate you trying the above example with your hardware: there seems to be an issue where the switch to VR (after requestPresent succeeds) seems to take quite a while on Oculus+Firefox while with [Threejs examples](https://threejs.org/examples/?q=webvr#webvr_cubes) it does not.

### Current State

All done, some smaller API questions to discuss (see below).

### Some Random Notes

 * All structures are named `VR*` to match the WebVR structure names.
 * Rather than "device", "display" is used to refer to a HMD to match the WebVR specification.
 * The "main loop" of WebVR displays is named *render loop*
 * All functions that take a `VRDisplayHandle` should return `int`, as they return `0` if the handle (index into an array) is invalid.