### PR TITLE
em_asm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -681,7 +681,7 @@ def trim_asm_const_body(body):
   orig = None
   while orig != body:
     orig = body
-    if len(body) > 1 and body[0] == '"' and body[-1] == '"': body = body[1:-1].strip()
+    if len(body) > 1 and body[0] == '"' and body[-1] == '"': body = body[1:-1].replace('\\"', '"').strip()
     if len(body) > 1 and body[0] == '{' and body[-1] == '}' and parentheses_match(body, 0, -1): body = body[1:-1].strip()
     if len(body) > 1 and body[0] == '(' and body[-1] == ')' and parentheses_match(body, 0, -1): body = body[1:-1].strip()
   return body

--- a/site/source/api_items.py
+++ b/site/source/api_items.py
@@ -86,7 +86,7 @@ def get_mapped_items():
 	mapped_wiki_inline_code['em_str_callback_func']=':c:type:`em_str_callback_func`'
 	mapped_wiki_inline_code['EMSCRIPTEN_EVENT_TOUCHSTART']=':c:macro:`EMSCRIPTEN_EVENT_TOUCHSTART`'
 	mapped_wiki_inline_code['emscripten_set_keypress_callback()']=':c:func:`emscripten_set_keypress_callback`'
-	mapped_wiki_inline_code['EM_ASM_']=':c:macro:`EM_ASM_`'
+	mapped_wiki_inline_code['EM_ASM']=':c:macro:`EM_ASM`'
 	mapped_wiki_inline_code['emscripten_set_orientationchange_callback()']=':c:func:`emscripten_set_orientationchange_callback`'
 	mapped_wiki_inline_code['HEAPF32']=':js:data:`HEAPF32`'
 	mapped_wiki_inline_code['EMSCRIPTEN_EVENT_VISIBILITYCHANGE']=':c:macro:`EMSCRIPTEN_EVENT_VISIBILITYCHANGE`'

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -32,7 +32,6 @@ Defines
 		alert(‘bai’)); )
    
 	.. note:: 
-		- Double-quotes (") cannot be used in the inline assembly/JavaScript. Single-quotes (‘) can be used, as shown above.
 		- Newlines (\\n, \\r etc.) are supported in the inline JavaScript. Note that any platform-specific issues with line endings in normal JavaScript also apply to inline JavaScript declared using ``EM_ASM``.
 		- You can’t access C variables with :c:macro:`EM_ASM`, nor receive a value back. Instead use :c:macro:`EM_ASM_ARGS`, :c:macro:`EM_ASM_INT`, or :c:macro:`EM_ASM_DOUBLE`.
 		- As of ``1.30.4``, ``EM_ASM`` contents appear as normal JS, outside of the compiled code. Previously we had them as a string that was ``eval``ed. The newer approach avoids the overhead of ``eval``, and also allows for better optimization of ``EM_ASM`` contents by things like closure compiler, as their contents are now visible. Note that this means that closure compiler will optimize them as if they were written together with the rest of the codebase, which is a change from before - you may need to use safety quotes in some places (``a['b']`` instead of ``a.b``).

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -28,41 +28,31 @@ Defines
 	
 	This allows you to declare JavaScript in your C code "inline", which is then executed when your compiled code is run in the browser. For example, the following C code would display two alerts if it was compiled with Emscripten and run in the browser: ::
 
-		EM_ASM( alert(‘hai’)); 
-		alert(‘bai’)); )
-   
-	.. note:: 
-		- Newlines (\\n, \\r etc.) are supported in the inline JavaScript. Note that any platform-specific issues with line endings in normal JavaScript also apply to inline JavaScript declared using ``EM_ASM``.
-		- You can’t access C variables with :c:macro:`EM_ASM`, nor receive a value back. Instead use :c:macro:`EM_ASM_ARGS`, :c:macro:`EM_ASM_INT`, or :c:macro:`EM_ASM_DOUBLE`.
-		- As of ``1.30.4``, ``EM_ASM`` contents appear as normal JS, outside of the compiled code. Previously we had them as a string that was ``eval``ed. The newer approach avoids the overhead of ``eval``, and also allows for better optimization of ``EM_ASM`` contents by things like closure compiler, as their contents are now visible. Note that this means that closure compiler will optimize them as if they were written together with the rest of the codebase, which is a change from before - you may need to use safety quotes in some places (``a['b']`` instead of ``a.b``).
-   
-	
-.. c:macro:: EM_ASM_(code, ...)
-	EM_ASM_ARGS(code, ...) 
-	EM_ASM_INT(code, ...)
-	EM_ASM_DOUBLE(code, ...)
-	EM_ASM_INT_V(code) 
-	EM_ASM_DOUBLE_V(code) 
-	
-	Input-output versions of EM_ASM.
- 	
-	:c:macro:`EM_ASM_` (an extra "_" is added) or :c:macro:`EM_ASM_ARGS` allow values (``int`` or ``double``) to be sent into the code.
+		EM_ASM(alert('hai'); alert('bai'));
 
-	.. note:: The C preprocessor does not have a full understanding of JavaScript tokens, of course. An issue you might see is that it is not aware of nesting due to ``{`` or ``[``, it is only aware of ``,`` and ``(``. As a result, if you have a JavaScript array ``[1,2,3]`` then you might get an error, but can fix things with parentheses: ``([1,2,3])``.
+	Arguments can be passed inside the JavaScript code block, where they arrive as variables ``$0``, ``$1`` etc. These arguments can either be of type ``int32_t`` or ``double``. ::
 
-	If you also want a return value, :c:macro:`EM_ASM_INT` receives arguments (of ``int`` or ``double`` type) and returns an ``int``; :c:macro:`EM_ASM_DOUBLE` does the same and returns a ``double``.
-	
-	Arguments arrive as ``$0``, ``$1`` etc. The output value should be returned: ::
-
-		int x = EM_ASM_INT({
+		EM_ASM({
 		  console.log('I received: ' + [$0, $1]);
-		  return $0 + $1;
-		}, calc(), otherCalc());
+		}, 100, 35.5);
 
 	Note the ``{`` and ``}``.
-	
-	If you just want to receive an output value (``int`` or ``double``) but not pass any values, you can use :c:macro:`EM_ASM_INT_V` or :c:macro:`EM_ASM_DOUBLE_V`, respectively.
 
+	.. note:: 
+		- As of Emscripten ``1.30.4``, the contents of ``EM_ASM`` code blocks appear inside the normal JS file, and as result, Closure compiler and other JavaScript minifiers will be able to operate on them. You may need to use safety quotes in some places (``a['b']`` instead of ``a.b``) to avoid minification fro occurring.
+		- The C preprocessor does not have an understanding of JavaScript tokens, and as a result, if the ``code`` block contains a comma character ``,``, it may be necessary to wrap the code block inside parentheses. For example, code ``EM_ASM(return [1,2,3].length);`` will not compile, but ``EM_ASM((return [1,2,3].length));`` does.
+
+
+.. c:macro:: EM_ASM_INT(code, ...)
+	EM_ASM_DOUBLE(code, ...)
+	
+	These two functions behave like EM_ASM, but in addition they also return a value back to C code. The output value is passed back with a ``return`` statement: ::
+
+		int x = EM_ASM_INT({
+		  return $0 + 42;
+		}, 100);
+
+		int y = EM_ASM_INT(return TOTAL_MEMORY);
 
 
 Calling JavaScript From C/C++

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -46,7 +46,7 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
   }
 
   // POSTs the given binary data represented as a (typed) array data back to the emrun-based web server.
-  // To use from C code, call e.g. EM_ASM_({emrun_file_dump("file.dat", HEAPU8.subarray($0, $0 + $1));}, my_data_pointer, my_data_pointer_byte_length);
+  // To use from C code, call e.g. EM_ASM({emrun_file_dump("file.dat", HEAPU8.subarray($0, $0 + $1));}, my_data_pointer, my_data_pointer_byte_length);
   function emrun_file_dump(filename, data) {
     var http = new XMLHttpRequest();
     Module['print']('Dumping out file "' + filename + '" with ' + data.length + ' bytes of data.');

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -39,11 +39,24 @@ double emscripten_asm_const_double(const char* code, ...);
 
 void emscripten_asm_const(const char* code);
 
-#define EM_ASM(...) emscripten_asm_const(#__VA_ARGS__)
+// Note: If the code block in the EM_ASM() family of functions below contains a comma,
+// then wrap the whole code block inside parentheses (). See tests/core/test_em_asm_2.cpp
+// for example code snippets.
+
+// Runs the given JavaScript code, and returns nothing back
+#define EM_ASM_VOID(code, ...) ((void)emscripten_asm_const_int(#code, ##__VA_ARGS__))
+
+// Runs the given JavaScript code, and returns an integer back. EM_ASM is a
+// convenient alias to EM_ASM_INT for brevity.
+#define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
+#define EM_ASM(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
+
+// Runs the given JavaScript code, and returns a double back
+#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code, ##__VA_ARGS__)
+
+// Old forms for compatibility, no need to use these.
 #define EM_ASM_(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
 #define EM_ASM_ARGS(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
-#define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
-#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code, __VA_ARGS__)
 #define EM_ASM_INT_V(code) emscripten_asm_const_int(#code)
 #define EM_ASM_DOUBLE_V(code) emscripten_asm_const_double(#code)
 

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -43,18 +43,18 @@ void emscripten_asm_const(const char* code);
 // then wrap the whole code block inside parentheses (). See tests/core/test_em_asm_2.cpp
 // for example code snippets.
 
-// Runs the given JavaScript code, and returns nothing back
-#define EM_ASM_VOID(code, ...) ((void)emscripten_asm_const_int(#code, ##__VA_ARGS__))
+// Runs the given JavaScript code, and returns nothing back.
+#define EM_ASM(code, ...) ((void)emscripten_asm_const_int(#code, ##__VA_ARGS__))
 
-// Runs the given JavaScript code, and returns an integer back. EM_ASM is a
-// convenient alias to EM_ASM_INT for brevity.
+// Runs the given JavaScript code, and returns an integer back.
 #define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
-#define EM_ASM(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
 
-// Runs the given JavaScript code, and returns a double back
+// Runs the given JavaScript code, and returns a double back.
 #define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code, ##__VA_ARGS__)
 
 // Old forms for compatibility, no need to use these.
+// Replace EM_ASM_, EM_ASM_ARGS and EM_ASM_INT_V with EM_ASM_INT,
+// and EM_ASM_DOUBLE_V with EM_ASM_DOUBLE.
 #define EM_ASM_(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
 #define EM_ASM_ARGS(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
 #define EM_ASM_INT_V(code) emscripten_asm_const_int(#code)

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -37,7 +37,7 @@ void emscripten_proxy_fetch(emscripten_fetch_t *fetch)
 	__emscripten_fetch_queue *queue = _emscripten_get_fetch_queue();
 //	TODO handle case when queue->numQueuedItems >= queue->queueSize
 	queue->queuedOperations[queue->numQueuedItems++] = fetch;
-	EM_ASM_INT( { console.log('Queued fetch to fetch-worker to process. There are now ' + $0 + ' operations in the queue.') }, 
+	EM_ASM(console.log('Queued fetch to fetch-worker to process. There are now ' + $0 + ' operations in the queue.'),
 		queue->numQueuedItems);
 	// TODO: mutex unlock
 }
@@ -61,7 +61,7 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 	const bool isMainBrowserThread = emscripten_is_main_browser_thread() != 0;
 	if (isMainBrowserThread && synchronous && (performXhr || readFromIndexedDB || writeToIndexedDB))
 	{
-		EM_ASM_INT( { Module['printErr']('emscripten_fetch("' + Pointer_stringify($0) + '") failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.') }, 
+		EM_ASM(Module['printErr']('emscripten_fetch("' + Pointer_stringify($0) + '") failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.'), 
 			url);
 		return 0;
 	}
@@ -105,7 +105,7 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 	if (proxyState == 2) return EMSCRIPTEN_RESULT_SUCCESS; // already finished.
 	if (proxyState != 1) return EMSCRIPTEN_RESULT_INVALID_PARAM; // the fetch should be ongoing?
 // #ifdef FETCH_DEBUG
-	EM_ASM({ console.log('fetch: emscripten_fetch_wait..') });
+	EM_ASM(console.log('fetch: emscripten_fetch_wait..'));
 // #endif
 	// TODO: timeoutMsecs is currently ignored. Return EMSCRIPTEN_RESULT_TIMED_OUT on timeout.
 	while(proxyState == 1/*sent to proxy worker*/)
@@ -114,13 +114,13 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 		proxyState = emscripten_atomic_load_u32(&fetch->__proxyState);
 	}
 // #ifdef FETCH_DEBUG
-	EM_ASM({ console.log('fetch: emscripten_fetch_wait done..') });
+	EM_ASM(console.log('fetch: emscripten_fetch_wait done..'));
 // #endif
 
 	if (proxyState == 2) return EMSCRIPTEN_RESULT_SUCCESS;
 	else return EMSCRIPTEN_RESULT_FAILED;
 #else
-	EM_ASM({ console.error('fetch: emscripten_fetch_wait is not available when building without pthreads!') });
+	EM_ASM(console.error('fetch: emscripten_fetch_wait is not available when building without pthreads!'));
 	return EMSCRIPTEN_RESULT_FAILED;
 #endif
 }

--- a/system/lib/gl.c
+++ b/system/lib/gl.c
@@ -1728,7 +1728,7 @@ void* emscripten_GetProcAddress(const char *name_) {
   else if (!strcmp(name, "glCopyTexSubImage2D")) return emscripten_glCopyTexSubImage2D;
   else if (!strcmp(name, "glDrawBuffers")) return emscripten_glDrawBuffers;
 
-  EM_ASM_({
+  EM_ASM({
     Module.printErr('bad name in getProcAddress: ' + [Pointer_stringify($0), Pointer_stringify($1)]);
   }, name_, name);
   return 0;

--- a/system/lib/gl.c
+++ b/system/lib/gl.c
@@ -1728,9 +1728,7 @@ void* emscripten_GetProcAddress(const char *name_) {
   else if (!strcmp(name, "glCopyTexSubImage2D")) return emscripten_glCopyTexSubImage2D;
   else if (!strcmp(name, "glDrawBuffers")) return emscripten_glDrawBuffers;
 
-  EM_ASM({
-    Module.printErr('bad name in getProcAddress: ' + [Pointer_stringify($0), Pointer_stringify($1)]);
-  }, name_, name);
+  EM_ASM(Module.printErr('bad name in getProcAddress: ' + [Pointer_stringify($0), Pointer_stringify($1)]), name_, name);
   return 0;
 }
 

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -111,7 +111,7 @@ void __pthread_testcancel()
 	struct pthread *self = pthread_self();
 	if (self->canceldisable) return;
 	if (_pthread_isduecanceled(self)) {
-		EM_ASM( throw 'Canceled!'; );
+		EM_ASM(throw 'Canceled!');
 	}
 }
 

--- a/system/lib/split_malloc.cpp
+++ b/system/lib/split_malloc.cpp
@@ -71,7 +71,7 @@ struct Space {
       start = split_memory*index;
     } else {
       // small area in existing chunk 0
-      start = EM_ASM_INT_V({ return (HEAP32[DYNAMICTOP_PTR>>2]+3)&-4; });
+      start = EM_ASM_INT({ return (HEAP32[DYNAMICTOP_PTR>>2]+3)&-4; });
       assert(start < split_memory);
     }
     int size = (split_memory*(index+1)) - start;
@@ -92,7 +92,7 @@ struct Space {
     allocated = false;
     destroy_mspace((void*)(split_memory*index));
     if (index > 0) {
-      EM_ASM_({ freeSplitChunk($0) }, index);
+      EM_ASM({ freeSplitChunk($0) }, index);
     }
   }
 };
@@ -100,9 +100,9 @@ struct Space {
 static Space spaces[MAX_SPACES];
 
 static void init() {
-  total_memory = EM_ASM_INT_V({ return TOTAL_MEMORY; });
-  split_memory = EM_ASM_INT_V({ return SPLIT_MEMORY; });
-  num_spaces = EM_ASM_INT_V({ return HEAPU8s.length; });
+  total_memory = EM_ASM_INT({ return TOTAL_MEMORY; });
+  split_memory = EM_ASM_INT({ return SPLIT_MEMORY; });
+  num_spaces = EM_ASM_INT({ return HEAPU8s.length; });
   if (num_spaces >= MAX_SPACES) abort();
   for (int i = 0; i < num_spaces; i++) {
     spaces[i].init(i);
@@ -130,7 +130,7 @@ static void* get_memory(size_t size, bool malloc=true, size_t alignment=-1, bool
   if (size >= split_memory) {
     static bool warned = false;
     if (!warned) {
-      EM_ASM_({
+      EM_ASM({
         Module.print("trying to get " + $0 + ", a size >= than SPLIT_MEMORY (" + $1 + "), increase SPLIT_MEMORY if you want that to work");
       }, size, split_memory);
       warned = true;
@@ -168,7 +168,7 @@ static void* get_memory(size_t size, bool malloc=true, size_t alignment=-1, bool
     if (next == start) break;
   }
   // we cycled, so none of them can allocate
-  int returnNull = EM_ASM_INT_V({
+  int returnNull = EM_ASM_INT({
     if (!ABORTING_MALLOC && !ALLOW_MEMORY_GROWTH) return 1; // malloc can return 0, and we cannot grow
     if (!ALLOW_MEMORY_GROWTH) {
       abortOnCannotGrowMemory();

--- a/tests/binaryen_async.c
+++ b/tests/binaryen_async.c
@@ -4,7 +4,7 @@
 
 int main() {
   printf("hello, world!\n");
-  int result = EM_ASM_INT_V({
+  int result = EM_ASM_INT({
     return Module.sawAsyncCompilation | 0;
   });
   REPORT_RESULT(result);

--- a/tests/core/test_dlmalloc_partial_2.c
+++ b/tests/core/test_dlmalloc_partial_2.c
@@ -4,7 +4,7 @@
 void *malloc(size_t size) { return (void *)123; }
 int main() {
   void *x = malloc(10);
-  EM_ASM_({ Module.print("got 0x" + $0.toString(16)) }, x);
+  EM_ASM({ Module.print("got 0x" + $0.toString(16)) }, x);
   free(0);
   EM_ASM({ Module.print("freed a fake") });
   return 1;

--- a/tests/core/test_em_asm_2.cpp
+++ b/tests/core/test_em_asm_2.cpp
@@ -1,0 +1,123 @@
+#include <emscripten.h>
+
+int main()
+{
+  printf("EM_ASM: Simple expression without trailing semicolon\n");
+  EM_ASM(console.log('1. expression without trailing semicolon'));
+  EM_ASM("console.log('2. expression without trailing semicolon')");
+  EM_ASM({"console.log('3. expression without trailing semicolon')"});
+  EM_ASM({console.log('4. expression without trailing semicolon')});
+  EM_ASM("{console.log('5. expression without trailing semicolon')}");
+
+  printf("\nEM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses\n");
+  EM_ASM((console.log('1. expression without trailing semicolon, in parentheses')));
+  EM_ASM(("console.log('2. expression without trailing semicolon, in parentheses')"));
+  EM_ASM(({"console.log('3. expression without trailing semicolon, in parentheses')"}));
+  EM_ASM(({console.log('4. expression without trailing semicolon, in parentheses')}));
+  EM_ASM(("{console.log('5. expression without trailing semicolon, in parentheses')}"));
+
+  printf("\nEM_ASM: Two statements, separated with a semicolon\n");
+  EM_ASM(console.log('1. two'); console.log('1. statements'););
+  EM_ASM("console.log('2. two'); console.log('2. statements 2');");
+  EM_ASM({"console.log('3. two'); console.log('3. statements 3');"});
+  EM_ASM({console.log('4. two'); console.log('4. statements 4');});
+  EM_ASM("{console.log('5. two'); console.log('5. statements 5');}");
+
+  printf("\nEM_ASM: Pass an integer\n");
+  EM_ASM(console.log('1. int ' + $0), 42);
+  EM_ASM("console.log('2. int ' + $0)", 43);
+  EM_ASM({"console.log('3. int ' + $0)"}, 44);
+  EM_ASM({console.log('4. int ' + $0)}, 45);
+  EM_ASM("{console.log('5. int ' + $0)}", 46);
+
+  printf("\nEM_ASM: Evaluate an anonymous function\n");
+  EM_ASM((function() {console.log('1. evaluating anonymous function ' + $0)})(), 42);
+  EM_ASM("(function() {console.log('2. evaluating anonymous function ' + $0)})()", 42);
+  EM_ASM({"(function() {console.log('3. evaluating anonymous function ' + $0)})()"}, 42);
+  EM_ASM({(function() {console.log('4. evaluating anonymous function ' + $0)})()}, 42);
+  EM_ASM("{(function() {console.log('5. evaluating anonymous function ' + $0)})()}", 42);
+
+  printf("\nEM_ASM: Pass an integer and a double\n");
+  EM_ASM(console.log('1. int and double ' + $0 + ' ' + $1), 42, 43.5);
+  EM_ASM("console.log('2. int and double ' + $0 + ' ' + $1)", 42, 43.5);
+  EM_ASM({"console.log('3. int and double ' + $0 + ' ' + $1)"}, 42, 43.5);
+  EM_ASM({console.log('4. int and double ' + $0 + ' ' + $1)}, 42, 43.5);
+  EM_ASM("{console.log('5. int and double ' + $0 + ' ' + $1)}", 42, 43.5);
+
+  printf("\nEM_ASM_VOID: Pass an integer and a double\n");
+  EM_ASM_VOID(console.log('1. int and double in void ' + $0 + ' ' + $1), 42, 43.5);
+  EM_ASM_VOID("console.log('2. int and double in void ' + $0 + ' ' + $1)", 42, 43.5);
+  EM_ASM_VOID({"console.log('3. int and double in void ' + $0 + ' ' + $1)"}, 42, 43.5);
+  EM_ASM_VOID({console.log('4. int and double in void ' + $0 + ' ' + $1)}, 42, 43.5);
+  EM_ASM_VOID("{console.log('5. int and double in void ' + $0 + ' ' + $1)}", 42, 43.5);
+
+  int i;
+
+  printf("\nEM_ASM: Pass an integer, return an integer back\n");
+  i = EM_ASM(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
+  i = EM_ASM("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
+  i = EM_ASM({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
+  i = EM_ASM({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
+  i = EM_ASM("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
+
+  printf("\nEM_ASM: Pass an integer, return an integer back, wrap code block in extra parentheses\n");
+  i = EM_ASM((console.log('1. got int, extra parentheses ' + $0); return 3.5;), 42); printf("1. returned int, extra parentheses %d\n", i);
+  i = EM_ASM(("console.log('2. got int, extra parentheses ' + $0); return 4.5;"), 42); printf("2. returned int, extra parentheses %d\n", i);
+  i = EM_ASM(({"console.log('3. got int, extra parentheses ' + $0); return 5.5;"}), 42); printf("3. returned int, extra parentheses %d\n", i);
+  i = EM_ASM(({console.log('4. got int, extra parentheses ' + $0); return 6.5;}), 42); printf("4. returned int, extra parentheses %d\n", i);
+  i = EM_ASM(("{console.log('5. got int, extra parentheses ' + $0); return 7.5;}"), 42); printf("5. returned int, extra parentheses %d\n", i);
+
+  printf("\nEM_ASM: More imaginable ways for user to wrap in extra parentheses\n");
+  i = EM_ASM({("console.log('1. got int, extra extra parentheses ' + $0); return 5.5;")}, 42); printf("1. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM({(console.log('2. got int, extra extra parentheses ' + $0); return 6.5;)}, 42); printf("2. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM(((((((((((console.log('3. got int, extra extra extra parentheses ' + $0); return 6.5;)))))))))), 42); printf("3. returned int, extra extra extra parentheses %d\n", i);
+
+  printf("\nEM_ASM_INT: Return an integer back.\n");
+  i = EM_ASM_INT(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
+  i = EM_ASM_INT("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
+  i = EM_ASM_INT({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
+  i = EM_ASM_INT({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
+  i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
+
+  printf("\nEM_ASM: Return an integer in a single brief statement.\n");
+  i = EM_ASM(return TOTAL_MEMORY); printf("1. returned statement %d\n", i);
+  i = EM_ASM("return TOTAL_MEMORY+1"); printf("2. returned statement %d\n", i);
+  i = EM_ASM({"return TOTAL_MEMORY+2"}); printf("3. returned statement %d\n", i);
+  i = EM_ASM({return TOTAL_MEMORY+3}); printf("4. returned statement %d\n", i);
+  i = EM_ASM("return TOTAL_MEMORY+4"); printf("5. returned statement %d\n", i);
+
+  // Note that expressions do not evaluate to return values, but the "return" keyword is needed. That is, the following line would return undefined and store i <- 0.
+  // i = EM_ASM(TOTAL_MEMORY); printf("returned statement %d\n", i);
+
+  double d;
+
+  printf("\nEM_ASM_DOUBLE: Pass no parameters, return a double.\n");
+  d = EM_ASM_DOUBLE(console.log('1. returning double'); return 3.5;); printf("1. got double %f\n", d);
+  d = EM_ASM_DOUBLE("console.log('2. returning double'); return 4.5;"); printf("2. got double %f\n", d);
+  d = EM_ASM_DOUBLE({"console.log('3. returning double'); return 5.5;"}); printf("3. got double %f\n", d);
+  d = EM_ASM_DOUBLE({console.log('4. returning double'); return 6.5;}); printf("4. got double %f\n", d);
+  d = EM_ASM_DOUBLE("{console.log('5. returning double'); return 7.5;}"); printf("5. got double %f\n", d);
+
+  printf("\nEM_ASM_DOUBLE: Pass an integer, return a double.\n");
+  d = EM_ASM_DOUBLE(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned double %f\n", d);
+
+  printf("\nEM_ASM_DOUBLE: Pass a double and an integer, return a double.\n");
+  d = EM_ASM_DOUBLE(console.log('1. got double and int ' + $0 + ' ' + $1); return 3.5;, 5.5, 42); printf("1. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("console.log('2. got double and int ' + $0 + ' ' + $1); return 4.5;", 5.5, 42); printf("2. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({"console.log('3. got double and int ' + $0 + ' ' + $1); return 5.5;"}, 5.5, 42); printf("3. returned double %f\n", d);
+  d = EM_ASM_DOUBLE({console.log('4. got double and int ' + $0 + ' ' + $1); return 6.5;}, 5.5, 42); printf("4. returned double %f\n", d);
+  d = EM_ASM_DOUBLE("{console.log('5. got double and int ' + $0 + ' ' + $1); return 7.5;}", 5.5, 42); printf("5. returned double %f\n", d);
+
+  printf("\nEM_ASM: A comma character (,) inside the code block may need extra parentheses\n");
+// i = EM_ASM(console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b, 10); printf("1. returned %d\n", i); // This would not compile: use of undeclared identifier 'b'
+  i = EM_ASM((console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b), 10); printf("1. returned %d\n", i); // However by wrapping the code block inside parentheses, it will be ok
+  i = EM_ASM("console.log('2. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b", 10); printf("2. returned %d\n", i);
+  i = EM_ASM({"console.log('3. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b"}, 10); printf("3. returned %d\n", i);
+// i = EM_ASM({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}, 10); printf("4. returned %d\n", i); // This would also not compile: use of undeclared identifier 'b'
+  i = EM_ASM(({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}), 10); printf("4. returned %d\n", i); // Again by wrapping the code block inside parentheses, it will work
+  i = EM_ASM("{console.log('5. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}", 10); printf("5. returned %d\n", i);
+}

--- a/tests/core/test_em_asm_2.cpp
+++ b/tests/core/test_em_asm_2.cpp
@@ -9,6 +9,22 @@ int main()
   EM_ASM({console.log('4. expression without trailing semicolon')});
   EM_ASM("{console.log('5. expression without trailing semicolon')}");
 
+  printf("\nEM_ASM: Double quotes\n");
+  EM_ASM(console.log("1. string in double quotes"));
+  EM_ASM("console.log(\"2. string in double quotes\")");
+  EM_ASM({"console.log(\"3. string in double quotes\")"});
+  EM_ASM({console.log("4. string in double quotes")});
+  EM_ASM("{console.log(\"5. string in double quotes\")}");
+
+  printf("\nEM_ASM: Double quotes inside a string\n");
+  EM_ASM(console.log('1. this is \"double\" \"quotes\"'));
+  EM_ASM(console.log('2. this is "double" "quotes" without escaping'));
+  EM_ASM("console.log('3. this is \"double\" \"quotes\"')");
+  EM_ASM({"console.log('4. this is \"double\" \"quotes\"')"});
+  EM_ASM({console.log('5. this is \"double\" \"quotes\"')});
+  EM_ASM({console.log('6. this is "double" "quotes" without esacping')});
+  EM_ASM("{console.log('7. this is \"double\" \"quotes\"')}");
+
   printf("\nEM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses\n");
   EM_ASM((console.log('1. expression without trailing semicolon, in parentheses')));
   EM_ASM(("console.log('2. expression without trailing semicolon, in parentheses')"));

--- a/tests/core/test_em_asm_2.cpp
+++ b/tests/core/test_em_asm_2.cpp
@@ -1,4 +1,5 @@
 #include <emscripten.h>
+#include <stdio.h>
 
 int main()
 {
@@ -24,6 +25,13 @@ int main()
   EM_ASM({console.log('5. this is \"double\" \"quotes\"')});
   EM_ASM({console.log('6. this is "double" "quotes" without esacping')});
   EM_ASM("{console.log('7. this is \"double\" \"quotes\"')}");
+
+  printf("\nEM_ASM: Pass a string\n");
+  EM_ASM(console.log('1. hello ' + UTF8ToString($0)), "world!");
+  EM_ASM("console.log('2. hello ' + UTF8ToString($0))", "world!");
+  EM_ASM({"console.log('3. hello ' + UTF8ToString($0))"}, "world!");
+  EM_ASM({console.log('4. hello ' + UTF8ToString($0))}, "world!");
+  EM_ASM("{console.log('5. hello ' + UTF8ToString($0))}", "world!");
 
   printf("\nEM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses\n");
   EM_ASM((console.log('1. expression without trailing semicolon, in parentheses')));

--- a/tests/core/test_em_asm_2.cpp
+++ b/tests/core/test_em_asm_2.cpp
@@ -60,33 +60,26 @@ int main()
   EM_ASM({console.log('4. int and double ' + $0 + ' ' + $1)}, 42, 43.5);
   EM_ASM("{console.log('5. int and double ' + $0 + ' ' + $1)}", 42, 43.5);
 
-  printf("\nEM_ASM_VOID: Pass an integer and a double\n");
-  EM_ASM_VOID(console.log('1. int and double in void ' + $0 + ' ' + $1), 42, 43.5);
-  EM_ASM_VOID("console.log('2. int and double in void ' + $0 + ' ' + $1)", 42, 43.5);
-  EM_ASM_VOID({"console.log('3. int and double in void ' + $0 + ' ' + $1)"}, 42, 43.5);
-  EM_ASM_VOID({console.log('4. int and double in void ' + $0 + ' ' + $1)}, 42, 43.5);
-  EM_ASM_VOID("{console.log('5. int and double in void ' + $0 + ' ' + $1)}", 42, 43.5);
-
   int i;
 
-  printf("\nEM_ASM: Pass an integer, return an integer back\n");
-  i = EM_ASM(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
-  i = EM_ASM("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
-  i = EM_ASM({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
-  i = EM_ASM({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
-  i = EM_ASM("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
+  printf("\nEM_ASM_INT: Pass an integer, return an integer back\n");
+  i = EM_ASM_INT(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
+  i = EM_ASM_INT("console.log('2. got int ' + $0); return 4.5;", 42); printf("2. returned int %d\n", i);
+  i = EM_ASM_INT({"console.log('3. got int ' + $0); return 5.5;"}, 42); printf("3. returned int %d\n", i);
+  i = EM_ASM_INT({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
+  i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
 
-  printf("\nEM_ASM: Pass an integer, return an integer back, wrap code block in extra parentheses\n");
-  i = EM_ASM((console.log('1. got int, extra parentheses ' + $0); return 3.5;), 42); printf("1. returned int, extra parentheses %d\n", i);
-  i = EM_ASM(("console.log('2. got int, extra parentheses ' + $0); return 4.5;"), 42); printf("2. returned int, extra parentheses %d\n", i);
-  i = EM_ASM(({"console.log('3. got int, extra parentheses ' + $0); return 5.5;"}), 42); printf("3. returned int, extra parentheses %d\n", i);
-  i = EM_ASM(({console.log('4. got int, extra parentheses ' + $0); return 6.5;}), 42); printf("4. returned int, extra parentheses %d\n", i);
-  i = EM_ASM(("{console.log('5. got int, extra parentheses ' + $0); return 7.5;}"), 42); printf("5. returned int, extra parentheses %d\n", i);
+  printf("\nEM_ASM_INT: Pass an integer, return an integer back, wrap code block in extra parentheses\n");
+  i = EM_ASM_INT((console.log('1. got int, extra parentheses ' + $0); return 3.5;), 42); printf("1. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(("console.log('2. got int, extra parentheses ' + $0); return 4.5;"), 42); printf("2. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(({"console.log('3. got int, extra parentheses ' + $0); return 5.5;"}), 42); printf("3. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(({console.log('4. got int, extra parentheses ' + $0); return 6.5;}), 42); printf("4. returned int, extra parentheses %d\n", i);
+  i = EM_ASM_INT(("{console.log('5. got int, extra parentheses ' + $0); return 7.5;}"), 42); printf("5. returned int, extra parentheses %d\n", i);
 
-  printf("\nEM_ASM: More imaginable ways for user to wrap in extra parentheses\n");
-  i = EM_ASM({("console.log('1. got int, extra extra parentheses ' + $0); return 5.5;")}, 42); printf("1. returned int, extra extra parentheses %d\n", i);
-  i = EM_ASM({(console.log('2. got int, extra extra parentheses ' + $0); return 6.5;)}, 42); printf("2. returned int, extra extra parentheses %d\n", i);
-  i = EM_ASM(((((((((((console.log('3. got int, extra extra extra parentheses ' + $0); return 6.5;)))))))))), 42); printf("3. returned int, extra extra extra parentheses %d\n", i);
+  printf("\nEM_ASM_INT: More imaginable ways for user to wrap in extra parentheses\n");
+  i = EM_ASM_INT({("console.log('1. got int, extra extra parentheses ' + $0); return 5.5;")}, 42); printf("1. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM_INT({(console.log('2. got int, extra extra parentheses ' + $0); return 6.5;)}, 42); printf("2. returned int, extra extra parentheses %d\n", i);
+  i = EM_ASM_INT(((((((((((console.log('3. got int, extra extra extra parentheses ' + $0); return 6.5;)))))))))), 42); printf("3. returned int, extra extra extra parentheses %d\n", i);
 
   printf("\nEM_ASM_INT: Return an integer back.\n");
   i = EM_ASM_INT(console.log('1. got int ' + $0); return 3.5;, 42); printf("1. returned int %d\n", i);
@@ -95,15 +88,15 @@ int main()
   i = EM_ASM_INT({console.log('4. got int ' + $0); return 6.5;}, 42); printf("4. returned int %d\n", i);
   i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
 
-  printf("\nEM_ASM: Return an integer in a single brief statement.\n");
-  i = EM_ASM(return TOTAL_MEMORY); printf("1. returned statement %d\n", i);
-  i = EM_ASM("return TOTAL_MEMORY+1"); printf("2. returned statement %d\n", i);
-  i = EM_ASM({"return TOTAL_MEMORY+2"}); printf("3. returned statement %d\n", i);
-  i = EM_ASM({return TOTAL_MEMORY+3}); printf("4. returned statement %d\n", i);
-  i = EM_ASM("return TOTAL_MEMORY+4"); printf("5. returned statement %d\n", i);
+  printf("\nEM_ASM_INT: Return an integer in a single brief statement.\n");
+  i = EM_ASM_INT(return TOTAL_MEMORY); printf("1. returned statement %d\n", i);
+  i = EM_ASM_INT("return TOTAL_MEMORY+1"); printf("2. returned statement %d\n", i);
+  i = EM_ASM_INT({"return TOTAL_MEMORY+2"}); printf("3. returned statement %d\n", i);
+  i = EM_ASM_INT({return TOTAL_MEMORY+3}); printf("4. returned statement %d\n", i);
+  i = EM_ASM_INT("return TOTAL_MEMORY+4"); printf("5. returned statement %d\n", i);
 
   // Note that expressions do not evaluate to return values, but the "return" keyword is needed. That is, the following line would return undefined and store i <- 0.
-  // i = EM_ASM(TOTAL_MEMORY); printf("returned statement %d\n", i);
+  // i = EM_ASM_INT(TOTAL_MEMORY); printf("returned statement %d\n", i);
 
   double d;
 
@@ -128,12 +121,12 @@ int main()
   d = EM_ASM_DOUBLE({console.log('4. got double and int ' + $0 + ' ' + $1); return 6.5;}, 5.5, 42); printf("4. returned double %f\n", d);
   d = EM_ASM_DOUBLE("{console.log('5. got double and int ' + $0 + ' ' + $1); return 7.5;}", 5.5, 42); printf("5. returned double %f\n", d);
 
-  printf("\nEM_ASM: A comma character (,) inside the code block may need extra parentheses\n");
-// i = EM_ASM(console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b, 10); printf("1. returned %d\n", i); // This would not compile: use of undeclared identifier 'b'
-  i = EM_ASM((console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b), 10); printf("1. returned %d\n", i); // However by wrapping the code block inside parentheses, it will be ok
-  i = EM_ASM("console.log('2. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b", 10); printf("2. returned %d\n", i);
-  i = EM_ASM({"console.log('3. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b"}, 10); printf("3. returned %d\n", i);
-// i = EM_ASM({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}, 10); printf("4. returned %d\n", i); // This would also not compile: use of undeclared identifier 'b'
-  i = EM_ASM(({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}), 10); printf("4. returned %d\n", i); // Again by wrapping the code block inside parentheses, it will work
-  i = EM_ASM("{console.log('5. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}", 10); printf("5. returned %d\n", i);
+  printf("\nEM_ASM_INT: A comma character (,) inside the code block may need extra parentheses\n");
+// i = EM_ASM_INT(console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b, 10); printf("1. returned %d\n", i); // This would not compile: use of undeclared identifier 'b'
+  i = EM_ASM_INT((console.log('1. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b), 10); printf("1. returned %d\n", i); // However by wrapping the code block inside parentheses, it will be ok
+  i = EM_ASM_INT("console.log('2. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b", 10); printf("2. returned %d\n", i);
+  i = EM_ASM_INT({"console.log('3. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b"}, 10); printf("3. returned %d\n", i);
+// i = EM_ASM_INT({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}, 10); printf("4. returned %d\n", i); // This would also not compile: use of undeclared identifier 'b'
+  i = EM_ASM_INT(({console.log('4. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}), 10); printf("4. returned %d\n", i); // Again by wrapping the code block inside parentheses, it will work
+  i = EM_ASM_INT("{console.log('5. comma in em_asm'); var foo = { a: 5, b: $0 }; return foo.a + foo.b}", 10); printf("5. returned %d\n", i);
 }

--- a/tests/core/test_em_asm_2.out
+++ b/tests/core/test_em_asm_2.out
@@ -61,14 +61,7 @@ EM_ASM: Pass an integer and a double
 4. int and double 42 43.5
 5. int and double 42 43.5
 
-EM_ASM_VOID: Pass an integer and a double
-1. int and double in void 42 43.5
-2. int and double in void 42 43.5
-3. int and double in void 42 43.5
-4. int and double in void 42 43.5
-5. int and double in void 42 43.5
-
-EM_ASM: Pass an integer, return an integer back
+EM_ASM_INT: Pass an integer, return an integer back
 1. got int 42
 1. returned int 3
 2. got int 42
@@ -80,7 +73,7 @@ EM_ASM: Pass an integer, return an integer back
 5. got int 42
 5. returned int 7
 
-EM_ASM: Pass an integer, return an integer back, wrap code block in extra parentheses
+EM_ASM_INT: Pass an integer, return an integer back, wrap code block in extra parentheses
 1. got int, extra parentheses 42
 1. returned int, extra parentheses 3
 2. got int, extra parentheses 42
@@ -92,7 +85,7 @@ EM_ASM: Pass an integer, return an integer back, wrap code block in extra parent
 5. got int, extra parentheses 42
 5. returned int, extra parentheses 7
 
-EM_ASM: More imaginable ways for user to wrap in extra parentheses
+EM_ASM_INT: More imaginable ways for user to wrap in extra parentheses
 1. got int, extra extra parentheses 42
 1. returned int, extra extra parentheses 5
 2. got int, extra extra parentheses 42
@@ -112,7 +105,7 @@ EM_ASM_INT: Return an integer back.
 5. got int 42
 5. returned int 7
 
-EM_ASM: Return an integer in a single brief statement.
+EM_ASM_INT: Return an integer in a single brief statement.
 1. returned statement 16777216
 2. returned statement 16777217
 3. returned statement 16777218
@@ -155,7 +148,7 @@ EM_ASM_DOUBLE: Pass a double and an integer, return a double.
 5. got double and int 5.5 42
 5. returned double 7.500000
 
-EM_ASM: A comma character (,) inside the code block may need extra parentheses
+EM_ASM_INT: A comma character (,) inside the code block may need extra parentheses
 1. comma in em_asm
 1. returned 15
 2. comma in em_asm

--- a/tests/core/test_em_asm_2.out
+++ b/tests/core/test_em_asm_2.out
@@ -21,6 +21,13 @@ EM_ASM: Double quotes inside a string
 6. this is "double" "quotes" without esacping
 7. this is "double" "quotes"
 
+EM_ASM: Pass a string
+1. hello world!
+2. hello world!
+3. hello world!
+4. hello world!
+5. hello world!
+
 EM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses
 1. expression without trailing semicolon, in parentheses
 2. expression without trailing semicolon, in parentheses

--- a/tests/core/test_em_asm_2.out
+++ b/tests/core/test_em_asm_2.out
@@ -1,0 +1,152 @@
+EM_ASM: Simple expression without trailing semicolon
+1. expression without trailing semicolon
+2. expression without trailing semicolon
+3. expression without trailing semicolon
+4. expression without trailing semicolon
+5. expression without trailing semicolon
+
+EM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses
+1. expression without trailing semicolon, in parentheses
+2. expression without trailing semicolon, in parentheses
+3. expression without trailing semicolon, in parentheses
+4. expression without trailing semicolon, in parentheses
+5. expression without trailing semicolon, in parentheses
+
+EM_ASM: Two statements, separated with a semicolon
+1. two
+1. statements
+2. two
+2. statements 2
+3. two
+3. statements 3
+4. two
+4. statements 4
+5. two
+5. statements 5
+
+EM_ASM: Pass an integer
+1. int 42
+2. int 43
+3. int 44
+4. int 45
+5. int 46
+
+EM_ASM: Evaluate an anonymous function
+1. evaluating anonymous function 42
+2. evaluating anonymous function 42
+3. evaluating anonymous function 42
+4. evaluating anonymous function 42
+5. evaluating anonymous function 42
+
+EM_ASM: Pass an integer and a double
+1. int and double 42 43.5
+2. int and double 42 43.5
+3. int and double 42 43.5
+4. int and double 42 43.5
+5. int and double 42 43.5
+
+EM_ASM_VOID: Pass an integer and a double
+1. int and double in void 42 43.5
+2. int and double in void 42 43.5
+3. int and double in void 42 43.5
+4. int and double in void 42 43.5
+5. int and double in void 42 43.5
+
+EM_ASM: Pass an integer, return an integer back
+1. got int 42
+1. returned int 3
+2. got int 42
+2. returned int 4
+3. got int 42
+3. returned int 5
+4. got int 42
+4. returned int 6
+5. got int 42
+5. returned int 7
+
+EM_ASM: Pass an integer, return an integer back, wrap code block in extra parentheses
+1. got int, extra parentheses 42
+1. returned int, extra parentheses 3
+2. got int, extra parentheses 42
+2. returned int, extra parentheses 4
+3. got int, extra parentheses 42
+3. returned int, extra parentheses 5
+4. got int, extra parentheses 42
+4. returned int, extra parentheses 6
+5. got int, extra parentheses 42
+5. returned int, extra parentheses 7
+
+EM_ASM: More imaginable ways for user to wrap in extra parentheses
+1. got int, extra extra parentheses 42
+1. returned int, extra extra parentheses 5
+2. got int, extra extra parentheses 42
+2. returned int, extra extra parentheses 6
+3. got int, extra extra extra parentheses 42
+3. returned int, extra extra extra parentheses 6
+
+EM_ASM_INT: Return an integer back.
+1. got int 42
+1. returned int 3
+2. got int 42
+2. returned int 4
+3. got int 42
+3. returned int 5
+4. got int 42
+4. returned int 6
+5. got int 42
+5. returned int 7
+
+EM_ASM: Return an integer in a single brief statement.
+1. returned statement 16777216
+2. returned statement 16777217
+3. returned statement 16777218
+4. returned statement 16777219
+5. returned statement 16777220
+
+EM_ASM_DOUBLE: Pass no parameters, return a double.
+1. returning double
+1. got double 3.500000
+2. returning double
+2. got double 4.500000
+3. returning double
+3. got double 5.500000
+4. returning double
+4. got double 6.500000
+5. returning double
+5. got double 7.500000
+
+EM_ASM_DOUBLE: Pass an integer, return a double.
+1. got int 42
+1. returned double 3.500000
+2. got int 42
+2. returned double 4.500000
+3. got int 42
+3. returned double 5.500000
+4. got int 42
+4. returned double 6.500000
+5. got int 42
+5. returned double 7.500000
+
+EM_ASM_DOUBLE: Pass a double and an integer, return a double.
+1. got double and int 5.5 42
+1. returned double 3.500000
+2. got double and int 5.5 42
+2. returned double 4.500000
+3. got double and int 5.5 42
+3. returned double 5.500000
+4. got double and int 5.5 42
+4. returned double 6.500000
+5. got double and int 5.5 42
+5. returned double 7.500000
+
+EM_ASM: A comma character (,) inside the code block may need extra parentheses
+1. comma in em_asm
+1. returned 15
+2. comma in em_asm
+2. returned 15
+3. comma in em_asm
+3. returned 15
+4. comma in em_asm
+4. returned 15
+5. comma in em_asm
+5. returned 15

--- a/tests/core/test_em_asm_2.out
+++ b/tests/core/test_em_asm_2.out
@@ -5,6 +5,22 @@ EM_ASM: Simple expression without trailing semicolon
 4. expression without trailing semicolon
 5. expression without trailing semicolon
 
+EM_ASM: Double quotes
+1. string in double quotes
+2. string in double quotes
+3. string in double quotes
+4. string in double quotes
+5. string in double quotes
+
+EM_ASM: Double quotes inside a string
+1. this is "double" "quotes"
+2. this is "double" "quotes" without escaping
+3. this is "double" "quotes"
+4. this is "double" "quotes"
+5. this is "double" "quotes"
+6. this is "double" "quotes" without esacping
+7. this is "double" "quotes"
+
 EM_ASM: Simple expression without trailing semicolon, wrap code block in extra parentheses
 1. expression without trailing semicolon, in parentheses
 2. expression without trailing semicolon, in parentheses

--- a/tests/core/test_memorygrowth_3.c
+++ b/tests/core/test_memorygrowth_3.c
@@ -6,7 +6,7 @@
 #include "emscripten.h"
 
 int get_TOTAL_MEMORY() {
-  return EM_ASM_INT_V({ return TOTAL_MEMORY });
+  return EM_ASM_INT({ return TOTAL_MEMORY });
 }
 
 typedef void* voidStar;

--- a/tests/core/test_runtime_stacksave.c
+++ b/tests/core/test_runtime_stacksave.c
@@ -2,8 +2,8 @@
 #include <assert.h>
 
 int main() {
-  int x = EM_ASM_INT_V({ return Runtime.stackSave(); });
-  int y = EM_ASM_INT_V({ return Runtime.stackSave(); });
+  int x = EM_ASM_INT({ return Runtime.stackSave(); });
+  int y = EM_ASM_INT({ return Runtime.stackSave(); });
   EM_ASM_INT({ Module.print($0); }, &x);
   EM_ASM_INT({ Module.print($0); }, &y);
   assert(x == y);

--- a/tests/emscripten_api_browser.cpp
+++ b/tests/emscripten_api_browser.cpp
@@ -94,7 +94,7 @@ int main() {
   printf("frist! %d\n", last);
 
   double ratio = emscripten_get_device_pixel_ratio();
-  double ratio2 = EM_ASM_DOUBLE_V({
+  double ratio2 = EM_ASM_DOUBLE({
     return window.devicePixelRatio || 1.0;
   });
 

--- a/tests/emscripten_set_canvas_element_size.c
+++ b/tests/emscripten_set_canvas_element_size.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
   assert(h == 200);
 
   // The following line will not work with OffscreenCanvas, that is covered in another test
-  int jsAgreesWithSize = EM_ASM_INT_V({return Module['canvas'].width == 100 && Module['canvas'].height == 200});
+  int jsAgreesWithSize = EM_ASM_INT({return Module['canvas'].width == 100 && Module['canvas'].height == 200});
   assert(jsAgreesWithSize);
 
   // Accessing NULL should also resize Module['canvas']

--- a/tests/emterpreter_advise_funcptr.cpp
+++ b/tests/emterpreter_advise_funcptr.cpp
@@ -3,11 +3,11 @@
 #include <assert.h>
 
 void print1(const char *c, int x) {
-  EM_ASM_({ Module.print([$0, $1]) }, c, x);
+  EM_ASM({ Module.print([$0, $1]) }, c, x);
 }
 
 void print2(const char *c, int x, int y) {
-  EM_ASM_({ Module.print([$0, $1, $2]) }, c, x, y);
+  EM_ASM({ Module.print([$0, $1, $2]) }, c, x, y);
 }
 
 typedef void (*func_v)();

--- a/tests/emterpreter_async_sleep2_safeheap.cpp
+++ b/tests/emterpreter_async_sleep2_safeheap.cpp
@@ -10,7 +10,7 @@ void fix() {
 }
 
 void EMSCRIPTEN_KEEPALIVE callback() {
-  EM_ASM_({
+  EM_ASM({
     Module.print('callback...');
     Module['dynCall_v']($0);
     Module.print('callback fixed.');

--- a/tests/emterpreter_async_virtual_2.cpp
+++ b/tests/emterpreter_async_virtual_2.cpp
@@ -22,12 +22,12 @@ public:
 
 bool device_CON::Read(unsigned char * data,unsigned short * size) {
     printf("device_CON::Read (this = %i) Sleep--> \n", (int)this);
-    EM_ASM_ARGS({
+    EM_ASM({
       Module.the_this = $0;
       Module.print('first this ' + Module.the_this);
     }, this);
     emscripten_sleep(1000);
-    EM_ASM_ARGS({
+    EM_ASM({
       Module.print('second this ' + $0);
       assert(Module.the_this === $0, 'this must be unchanged');
     }, this);

--- a/tests/gles2_uniform_arrays.cpp
+++ b/tests/gles2_uniform_arrays.cpp
@@ -98,7 +98,7 @@ void RunTest(int testVariant)
 
     glDrawArrays(GL_TRIANGLES, 0, 6);
 
-    int in_worker = EM_ASM_INT_V({
+    int in_worker = EM_ASM_INT({
       return typeof importScripts !== 'undefined'
     });
 

--- a/tests/in_flight_memfile_request.c
+++ b/tests/in_flight_memfile_request.c
@@ -2,7 +2,7 @@
 #include <emscripten.h>
 
 int main() {
-  int result = EM_ASM_INT_V({
+  int result = EM_ASM_INT({
     return !!Module['memoryInitializerRequest'];
   });
   printf("memory init request: %d\n", result);

--- a/tests/interop/test_add_function.cpp
+++ b/tests/interop/test_add_function.cpp
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
   printf("fp: %d\n", fp);
   void (*f)(int) = reinterpret_cast<void (*)(int)>(fp);
   f(7);
-  EM_ASM_(Module['Runtime']['removeFunction']($0), f);
+  EM_ASM(Module['Runtime']['removeFunction']($0), f);
   printf("ok\n");
   return 0;
 }

--- a/tests/mallinfo.cpp
+++ b/tests/mallinfo.cpp
@@ -24,14 +24,14 @@ extern "C" {
 
 unsigned int getTotalMemory()
 {
-	return EM_ASM_INT_V(return TOTAL_MEMORY);
+	return EM_ASM_INT(return TOTAL_MEMORY);
 }
 
 unsigned int getFreeMemory()
 {
 	s_mallinfo i = mallinfo();
 	unsigned int totalMemory = getTotalMemory();
-	unsigned int dynamicTop = EM_ASM_INT_V(return HEAPU32[DYNAMICTOP_PTR>>2]);
+	unsigned int dynamicTop = EM_ASM_INT(return HEAPU32[DYNAMICTOP_PTR>>2]);
 	return totalMemory - dynamicTop + i.fordblks;
 }
 

--- a/tests/manual_download_data.cpp
+++ b/tests/manual_download_data.cpp
@@ -12,7 +12,7 @@ int main()
 	assert(!strcmp(str, "Hello!"));
 	printf("OK\n");
 #ifdef REPORT_RESULT
-	int result = EM_ASM_INT_V({return Module.manuallyDownloadedData;});
+	int result = EM_ASM_INT({return Module.manuallyDownloadedData;});
 	REPORT_RESULT(result);
 #endif
 }

--- a/tests/manual_wasm_instantiate.cpp
+++ b/tests/manual_wasm_instantiate.cpp
@@ -5,7 +5,7 @@ int main()
 {
 	printf("OK\n");
 #ifdef REPORT_RESULT
-	int result = EM_ASM_INT_V({return Module.testWasmInstantiationSucceeded;});
+	int result = EM_ASM_INT({return Module.testWasmInstantiationSucceeded;});
 	REPORT_RESULT(result);
 #endif
 }

--- a/tests/mem_init.cpp
+++ b/tests/mem_init.cpp
@@ -6,9 +6,9 @@ extern "C" {
 int noted = 1;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM_({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ Module.print([$0, $1]) }, n, noted);
   noted = noted | n;
-  EM_ASM_({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
   if (noted == 3) {
     REPORT_RESULT(noted);
   }

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -34,7 +34,7 @@ void *ThreadMain(void *arg)
 	assert(globalDouble == 5.0);
 	assert(globalU64 == 5);
 	struct Test *t = (struct Test*)arg;
-	EM_ASM_INT( { Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'); }, t->threadId, t->op);
+	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
 
 	for(int i = 0; i < 99999; ++i)
 		for(int j = 0; j < N; ++j)
@@ -75,7 +75,7 @@ void *ThreadMain(void *arg)
 				break;
 			}
 		}
-	EM_ASM_INT( { Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'); }, t->threadId, t->op);
+	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
 	pthread_exit(0);
 }
 
@@ -99,7 +99,7 @@ void RunTest(int test)
 		default: memset(sharedData, 0, sizeof(sharedData)); break;
 	}
 
-	EM_ASM_INT( { Module['print']('Main: Starting test ' + $0); }, test);
+	EM_ASM(Module['print']('Main: Starting test ' + $0), test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -120,7 +120,7 @@ void RunTest(int test)
 	}
 
 	int val = sharedData[0];
-	EM_ASM_INT( { Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1); }, test, val);
+	EM_ASM(Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
 	if (test != 6)
 	{
 		for(int i = 1; i < N; ++i)

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -46,7 +46,7 @@ void *ThreadMain(void *arg)
 	assert(globalDouble == 5.0);
 	assert(globalU64 == 5);
 	struct Test *t = (struct Test*)arg;
-	EM_ASM_INT( { Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'); }, t->threadId, t->op);
+	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
 
 	for(int i = 0; i < 99999; ++i)
 		for(int j = 0; j < N; ++j)
@@ -86,7 +86,7 @@ void *ThreadMain(void *arg)
 				break;
 			}
 		}
-	EM_ASM_INT( { Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'); }, t->threadId, t->op);
+	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
 	pthread_exit(0);
 }
 
@@ -110,7 +110,7 @@ void RunTest(int test)
 		default: memset(sharedData, 0, sizeof(sharedData)); break;
 	}
 
-	EM_ASM_INT( { Module['print']('Main: Starting test ' + $0); }, test);
+	EM_ASM(Module['print']('Main: Starting test ' + $0), test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -131,7 +131,7 @@ void RunTest(int test)
 	}
 
 	int val = sharedData[0];
-	EM_ASM_INT( { Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1); }, test, val);
+	EM_ASM(Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
 	if (test != 6)
 	{
 		for(int i = 1; i < N; ++i)

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -11,7 +11,7 @@
 volatile int res = 43;
 static void cleanup_handler(void *arg)
 {
-  EM_ASM_INT( { Module['print']('Called clean-up handler with arg ' + $0); }, arg);
+  EM_ASM(Module['print']('Called clean-up handler with arg ' + $0), arg);
   int a = (int)arg;
   res -= a;
 }
@@ -19,7 +19,7 @@ static void cleanup_handler(void *arg)
 static void *thread_start(void *arg)
 {
   pthread_cleanup_push(cleanup_handler, (void*)42);
-  EM_ASM(Module['print']('Thread started!'););
+  EM_ASM(Module['print']('Thread started!'));
   for(;;)
   {
     pthread_testcancel();

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -15,7 +15,7 @@ static void cleanup_handler1(void *arg)
 {
    cleanupState <<= 2;
    cleanupState *= (int)arg; // Perform non-commutative arithmetic to a global var that encodes the cleanup stack order ops.
-   EM_ASM_INT( { console.log('Called clean-up handler 1 with arg ' + $0); }, arg);
+   EM_ASM(console.log('Called clean-up handler 1 with arg ' + $0), arg);
 //   printf("Called clean-up handler 1 with arg %d\n", (int)arg);
 }
 
@@ -23,7 +23,7 @@ static void cleanup_handler2(void *arg)
 {
    cleanupState <<= 3;
    cleanupState *= (int)arg; // Perform non-commutative arithmetic to a global var that encodes the cleanup stack order ops.
-   EM_ASM_INT( { console.log('Called clean-up handler 2 with arg ' + $0); }, arg);
+   EM_ASM(console.log('Called clean-up handler 2 with arg ' + $0), arg);
 //   printf("Called clean-up handler 2 with arg %d\n", (int)arg);
 }
 
@@ -93,7 +93,7 @@ int main()
 //   s = pthread_cancel(thr[3]);
 //   assert(s == 0);
    pthread_cleanup_pop(1);
-   EM_ASM_INT( { console.log('Cleanup state variable: ' + $0); }, cleanupState);
+   EM_ASM(console.log('Cleanup state variable: ' + $0), cleanupState);
 
 #ifdef REPORT_RESULT
    REPORT_RESULT(cleanupState);

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -30,11 +30,11 @@ void *inc_count(void *t)
       pthread_cond_signal(&count_threshold_cv);
  //     printf("inc_count(): thread %ld, count = %d  Threshold reached.\n", 
  //            my_id, count);
-      EM_ASM_INT( { Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', Threshold reached.'); }, my_id, count);
+      EM_ASM(Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', Threshold reached.'), my_id, count);
       }
 //    printf("inc_count(): thread %ld, count = %d, unlocking mutex\n", 
 //	   my_id, count);
-    EM_ASM_INT( { Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', unlocking mutex.'); }, my_id, count);
+    EM_ASM(Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', unlocking mutex.'), my_id, count);
     pthread_mutex_unlock(&count_mutex);
 
     /* Do some "work" so threads can alternate on mutex lock */
@@ -48,7 +48,7 @@ void *watch_count(void *t)
   long my_id = (long)t;
 
 //  printf("Starting watch_count(): thread %ld\n", my_id);
-  EM_ASM_INT( { Module['print']('Starting watch_count(): thread ' + $0); }, my_id);
+  EM_ASM(Module['print']('Starting watch_count(): thread ' + $0), my_id);
 
   /*
   Lock mutex and wait for signal.  Note that the pthread_cond_wait 
@@ -61,10 +61,10 @@ void *watch_count(void *t)
   while (count<COUNT_LIMIT) {
     pthread_cond_wait(&count_threshold_cv, &count_mutex);
 //    printf("watch_count(): thread %ld Condition signal received.\n", my_id);
-    EM_ASM_INT( { Module['print']('watch_count(): thread ' + $0 + ' Condition signal received.'); }, my_id);
+    EM_ASM(Module['print']('watch_count(): thread ' + $0 + ' Condition signal received.'), my_id);
     count += 125;
 //    printf("watch_count(): thread %ld count now = %d.\n", my_id, count);
-    EM_ASM_INT( { Module['print']('watch_count(): thread ' + $0 + ', count now = ' + $1); }, my_id, count);
+    EM_ASM(Module['print']('watch_count(): thread ' + $0 + ', count now = ' + $1), my_id, count);
     }
   pthread_mutex_unlock(&count_mutex);
   pthread_exit(NULL);

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -23,7 +23,7 @@ void *ThreadMain(void *arg)
 
 #define N 100
 
-	EM_ASM_INT( { Module['printErr']('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.') }, idx, N, param);
+	EM_ASM(Module['printErr']('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
 
 	unsigned int n[N];
 	for(unsigned int i = 0; i < N; ++i)
@@ -44,9 +44,9 @@ void *ThreadMain(void *arg)
 	int numGood = 0;
 	for(unsigned int i = 0; i < N; ++i)
 		if (n[i] == i) ++numGood;
-		else EM_ASM_INT( { Module['printErr']('n['+$0+']='+$1); }, i, n[i]);
+		else EM_ASM(Module['printErr']('n['+$0+']='+$1), i, n[i]);
 
-	EM_ASM_INT( { Module['print']('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'); }, idx, param, numGood);
+	EM_ASM(Module['print']('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
 	pthread_exit((void*)numGood);
 }
 
@@ -61,7 +61,7 @@ void CreateThread(int i)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	static int counter = 1;
 	global_shared_data[i] = (counter++ * 12141231) & 0x7FFFFFFF; // Arbitrary random'ish data for perturbing the sort for this thread task.
-//	EM_ASM_INT( { Module['print']('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'); }, i, global_shared_data[i]);
+//	EM_ASM(Module['print']('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'), i, global_shared_data[i]);
 	int rc = pthread_create(&thread[i], &attr, ThreadMain, (void*)i);
 	assert(rc == 0);
 	pthread_attr_destroy(&attr);
@@ -90,7 +90,7 @@ int main()
 			int status;
 			int rc = pthread_join(thread[i], (void**)&status);
 			assert(rc == 0);
-			EM_ASM_INT( { Module['printErr']('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2); }, i, global_shared_data[i], (int)status);
+			EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
 			assert(status == N);
 			thread[i] = 0;
 			if (numThreadsToCreate > 0)

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -8,7 +8,7 @@ volatile int result = 0;
 
 static void *thread2_start(void *arg)
 {
-  EM_ASM(Module['print']('thread2_start!'););
+  EM_ASM(Module['print']('thread2_start!'));
   ++result;
 
   pthread_exit(0);
@@ -16,7 +16,7 @@ static void *thread2_start(void *arg)
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(Module['print']('thread1_start!'););
+  EM_ASM(Module['print']('thread1_start!'));
   pthread_t thr;
   pthread_create(&thr, NULL, thread2_start, 0);
   pthread_join(thr, 0);

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -7,7 +7,7 @@
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(Module['print']('thread1_start!'););
+  EM_ASM(Module['print']('thread1_start!'));
 
   FILE *handle = fopen("file1.txt", "r");
   assert(handle);

--- a/tests/pthread/test_pthread_join.cpp
+++ b/tests/pthread/test_pthread_join.cpp
@@ -18,9 +18,9 @@ int fib(int n)
 static void *thread_start(void *arg)
 {
   int n = (int)arg;
-  EM_ASM_INT( { Module['print']('Thread: Computing fib('+$0+')...'); }, n);
+  EM_ASM(Module['print']('Thread: Computing fib('+$0+')...'), n);
   int fibn = fib(n);
-  EM_ASM_INT( { Module['print']('Thread: Computation done. fib('+$0+') = '+$1+'.'); }, n, fibn);
+  EM_ASM(Module['print']('Thread: Computation done. fib('+$0+') = '+$1+'.'), n, fibn);
   pthread_exit((void*)fibn);
 }
 
@@ -42,14 +42,14 @@ int main()
   pthread_t thr;
 
   int n = 20;
-  EM_ASM_INT( { Module['print']('Main: Spawning thread to compute fib('+$0+')...'); }, n);
+  EM_ASM(Module['print']('Main: Spawning thread to compute fib('+$0+')...'), n);
   int s = pthread_create(&thr, NULL, thread_start, (void*)n);
   assert(s == 0);
-  EM_ASM(Module['print']('Main: Waiting for thread to join.'););
+  EM_ASM(Module['print']('Main: Waiting for thread to join.'));
   int result = 0;
   s = pthread_join(thr, (void**)&result);
   assert(s == 0);
-  EM_ASM_INT( { Module['print']('Main: Thread joined with result: '+$0+'.'); }, result);
+  EM_ASM(Module['print']('Main: Thread joined with result: '+$0+'.'), result);
 #ifdef REPORT_RESULT
   REPORT_RESULT(result);
 #endif

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -72,7 +72,7 @@ int main()
   // Finally test that the thread is not doing any work and it is dead.
   assert(sharedVar == 0);
   assert(emscripten_atomic_load_u32((void*)&sharedVar) == 0);
-  EM_ASM_INT( { Module['print']('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'); }, sharedVar);
+  EM_ASM(Module['print']('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'), sharedVar);
 #ifdef REPORT_RESULT
   REPORT_RESULT(sharedVar);
 #endif

--- a/tests/pthread/test_pthread_malloc.cpp
+++ b/tests/pthread/test_pthread_malloc.cpp
@@ -22,14 +22,14 @@ static void *thread_start(void *arg)
     int k = *mem[i];
     if (k != n+i)
     {
-      EM_ASM_INT( { console.error('Memory corrupted! mem[i]: ' + $0 + ', i: ' + $1 + ', n: ' + $2); }, k, i, n);
+      EM_ASM(console.error('Memory corrupted! mem[i]: ' + $0 + ', i: ' + $1 + ', n: ' + $2), k, i, n);
       pthread_exit((void*)1);
     }
 
     assert(*mem[i] == n+i);
     free(mem[i]);
   }
-  EM_ASM_INT( { console.log('Worker with task number ' + $0 + ' finished.'); }, n);
+  EM_ASM(console.log('Worker with task number ' + $0 + ' finished.'), n);
   pthread_exit(0);
 }
 

--- a/tests/pthread/test_pthread_mandelbrot.cpp
+++ b/tests/pthread/test_pthread_mandelbrot.cpp
@@ -340,7 +340,7 @@ double prevT = 0;
 
 void register_tasks()
 {
-    numTasks = EM_ASM_INT_V(return (typeof document !== 'undefined' && document.getElementById('num_threads')) ? parseInt(document.getElementById('num_threads').value) : 1);
+    numTasks = EM_ASM_INT(return (typeof document !== 'undefined' && document.getElementById('num_threads')) ? parseInt(document.getElementById('num_threads').value) : 1);
 
 #ifdef SINGLETHREADED
   // Single-threaded
@@ -359,7 +359,7 @@ void register_tasks()
 #else
   emscripten_atomic_fence();
 
-  numTasks = EM_ASM_INT_V(return (typeof document !== 'undefined' && document.getElementById('num_threads')) ? parseInt(document.getElementById('num_threads').value) : 1);
+  numTasks = EM_ASM_INT(return (typeof document !== 'undefined' && document.getElementById('num_threads')) ? parseInt(document.getElementById('num_threads').value) : 1);
   if (numTasks < 1) numTasks = 1;
   if (numTasks > emscripten_num_logical_cores()) numTasks = emscripten_num_logical_cores();
 
@@ -475,7 +475,7 @@ void main_tick()
   }
 #endif
 
-  int new_use_sse = EM_ASM_INT_V(return (typeof document !== 'undefined' && document.getElementById('use_sse')) ? document.getElementById('use_sse').checked : false);
+  int new_use_sse = EM_ASM_INT(return (typeof document !== 'undefined' && document.getElementById('use_sse')) ? document.getElementById('use_sse').checked : false);
 
   if (numItersDoneOnCanvas >= minItersBeforeDisplaying || new_use_sse != use_sse)
   {
@@ -491,7 +491,7 @@ void main_tick()
   }
   use_sse = new_use_sse;
 
-  numItersPerFrame = EM_ASM_INT_V({
+  numItersPerFrame = EM_ASM_INT({
     if (typeof location !== 'undefined') {
       var updatesPerFrame = (new RegExp("[\\?&]updates=([^&#]*)")).exec(location.href);
       if (updatesPerFrame) return updatesPerFrame[1];
@@ -565,7 +565,7 @@ void main_tick()
 
 int main(int argc, char** argv)
 {
-  ENVIRONMENT_IS_WEB = EM_ASM_INT_V(return ENVIRONMENT_IS_WEB);
+  ENVIRONMENT_IS_WEB = EM_ASM_INT(return ENVIRONMENT_IS_WEB);
 
 #ifndef NO_SDL
   if (ENVIRONMENT_IS_WEB) {
@@ -601,7 +601,7 @@ int main(int argc, char** argv)
   if (ENVIRONMENT_IS_WEB) {
     emscripten_set_main_loop(main_tick, 0, 0);
   } else {
-    int numTotalFrames = EM_ASM_INT_V(return (typeof Module !== 'undefined' && Module.arguments && Module.arguments.length >= 2) ? parseInt(Module.arguments[1]) : 1000);
+    int numTotalFrames = EM_ASM_INT(return (typeof Module !== 'undefined' && Module.arguments && Module.arguments.length >= 2) ? parseInt(Module.arguments[1]) : 1000);
     printf("Rendering %d frames of Mandelbrot. Invoke \"node|js mandelbrot.js numItersPerFrame numFrames\" to configure.\n", numTotalFrames);
     double t0 = emscripten_get_now();
     for(int i = 0; i < numTotalFrames; ++i) {

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -77,9 +77,9 @@ void WaitToJoin()
 	if (!threadsRunning)
 	{
 		if (counter == numThreadsToCreateTotal)
-			EM_ASM_INT( { console.log('All threads finished. Counter = ' + $0 + ' as expected.'); }, counter);
+			EM_ASM(console.log('All threads finished. Counter = ' + $0 + ' as expected.'), counter);
 		else
-			EM_ASM_INT( { console.error('All threads finished, but counter = ' + $0 + ' != ' + $1 + '!'); }, counter, numThreadsToCreateTotal);
+			EM_ASM(console.error('All threads finished, but counter = ' + $0 + ' != ' + $1 + '!'), counter, numThreadsToCreateTotal);
 #ifdef REPORT_RESULT
 		REPORT_RESULT(counter);
 #endif

--- a/tests/pthread/test_pthread_sbrk.cpp
+++ b/tests/pthread/test_pthread_sbrk.cpp
@@ -49,7 +49,7 @@ static void *thread_start(void *arg)
       {
         ++return_code; // Failed! (but run to completion so that the barriers will all properly proceed without hanging)
         if (!reported_once) {
-          EM_ASM_INT( { console.error('Memory corrupted! mem[i]: ' + $0 + ' != ' + $1 + ', i: ' + $2 + ', j: ' + $3); }, allocated_buffers[i][j], id, i, j);
+          EM_ASM(console.error('Memory corrupted! mem[i]: ' + $0 + ' != ' + $1 + ', i: ' + $2 + ', j: ' + $3), allocated_buffers[i][j], id, i, j);
           reported_once = 1; // Avoid print flood that makes debugging hard.
         }
       }

--- a/tests/pthread/test_pthread_thread_local_storage.cpp
+++ b/tests/pthread/test_pthread_thread_local_storage.cpp
@@ -20,7 +20,7 @@ void *ThreadMain(void *arg)
 		for(int i = 0; i < NUM_KEYS; ++i)
 		{
 			local_keys[i] = (uintptr_t)pthread_getspecific(keys[i]);
-//			EM_ASM_INT( { Module['printErr']('Thread ' + $0 + ': Read value ' + $1 + ' from TLS for key at index ' + $2); }, pthread_self(), (int)local_keys[i], i);
+//			EM_ASM(Module['printErr']('Thread ' + $0 + ': Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
 		}
 
 		for(int i = 0; i < NUM_KEYS; ++i)
@@ -33,7 +33,7 @@ void *ThreadMain(void *arg)
 	for(int i = 0; i < NUM_KEYS; ++i)
 	{
 		local_keys[i] = (uintptr_t)pthread_getspecific(keys[i]);
-//		EM_ASM_INT( { Module['printErr']('Thread ' + $0 + ' final verify: Read value ' + $1 + ' from TLS for key at index ' + $2); }, pthread_self(), (int)local_keys[i], i);
+//		EM_ASM(Module['printErr']('Thread ' + $0 + ' final verify: Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
 		if (local_keys[i] != NUM_ITERS)
 			pthread_exit((void*)1);
 	}
@@ -74,7 +74,7 @@ int main()
 				int status;
 				int rc = pthread_join(thread[i], (void**)&status);
 				assert(rc == 0);
-				EM_ASM_INT( { Module['printErr']('Main: Joined thread idx ' + $0 + ' with status ' + $1); }, i, (int)status);
+				EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' with status ' + $1), i, (int)status);
 				assert(status == 0);
 				thread[i] = 0;
 				if (numThreadsToCreate > 0)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -821,7 +821,7 @@ class BrowserCore(RunnerCore):
 
   static void _ReportResult(int result, int sync)
   {
-    EM_ASM_({
+    EM_ASM({
       var xhr = new XMLHttpRequest();
       var result = $0;
       if (Module['pageThrewException']) result = 12345;

--- a/tests/runtime_misuse.cpp
+++ b/tests/runtime_misuse.cpp
@@ -6,10 +6,10 @@ extern "C" {
 int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM_({ Module.noted = $0 }, (int)&noted);
-  EM_ASM_({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ Module.noted = $0 }, (int)&noted);
+  EM_ASM({ Module.print([$0, $1]) }, n, noted);
   noted += n;
-  EM_ASM_({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
   return (char*)"silly-string";
 }
 

--- a/tests/runtime_misuse_2.cpp
+++ b/tests/runtime_misuse_2.cpp
@@ -6,15 +6,15 @@ extern "C" {
 int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM_({ Module.noted = $0 }, (int)&noted);
-  EM_ASM_({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ Module.noted = $0 }, (int)&noted);
+  EM_ASM({ Module.print([$0, $1]) }, n, noted);
   noted += n;
-  EM_ASM_({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
   return (char*)"silly-string";
 }
 
 void free(void*) { // free is valid to call even after the runtime closes, so useful as a hack here for this test
-  EM_ASM_({ Module.print(['reporting', $0]) }, noted);
+  EM_ASM({ Module.print(['reporting', $0]) }, noted);
 }
 
 }

--- a/tests/sdl2_canvas_write.cpp
+++ b/tests/sdl2_canvas_write.cpp
@@ -28,7 +28,7 @@ void draw(SDL_Window *window, SDL_Surface *surface) {
 }
 
 int verify(void) {
-    int res = EM_ASM_INT_V({
+    int res = EM_ASM_INT({
         var ctx = Module['canvas'].getContext('2d');
         var data = ctx.getImageData(0, 0, 256, 256).data;
         var idx = 0;

--- a/tests/sdl2_custom_cursor.c
+++ b/tests/sdl2_custom_cursor.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 
     SDL_SetCursor(cursor);
 
-    int cursor_updated = EM_ASM_INT_V(
+    int cursor_updated = EM_ASM_INT(
         return Module['canvas'].style['cursor'].startsWith("url(");
     );
 

--- a/tests/sdl2_unwasteful.cpp
+++ b/tests/sdl2_unwasteful.cpp
@@ -27,7 +27,7 @@ static void main_loop(void)
             Module.print('set values');
         });
     } else if (runs > 1) {
-        EM_ASM_ARGS({
+        EM_ASM({
             assert(Module.the_ctx === Module.SDL2.ctx, 'ctx');
             assert(Module.the_image === Module.SDL2.image, 'image');
             Module.print('check ok ' + $0);

--- a/tests/sdl_stb_image_cleanup.c
+++ b/tests/sdl_stb_image_cleanup.c
@@ -17,7 +17,7 @@ int main() {
     loadImage("screenshot.jpg");
   }
 
-  int result = EM_ASM_INT_V({
+  int result = EM_ASM_INT({
     return Math.trunc(emscriptenMemoryProfiler.totalMemoryAllocated / 1024 / 1024);
   });
 

--- a/tests/sdl_togglefullscreen.c
+++ b/tests/sdl_togglefullscreen.c
@@ -76,7 +76,7 @@ static void render() {
 
 static void mainloop() {
   render();
-  int isInFullscreen = EM_ASM_INT_V(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
+  int isInFullscreen = EM_ASM_INT(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
 
   switch (state) {
   case STATE_INITIAL:

--- a/tests/sdl_wm_togglefullscreen.c
+++ b/tests/sdl_wm_togglefullscreen.c
@@ -27,7 +27,7 @@ void mainloop() {
   if (finished) return;
 
   SDL_Event event;
-  int isInFullscreen = EM_ASM_INT_V(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
+  int isInFullscreen = EM_ASM_INT(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
   if (isInFullscreen && !wasFullscreen) {
     printf("Successfully transitioned to fullscreen mode!\n");
     wasFullscreen = isInFullscreen;

--- a/tests/stack_overflow.cpp
+++ b/tests/stack_overflow.cpp
@@ -4,7 +4,7 @@
 
 void __attribute__((noinline)) InteropString(char *staticBuffer)
 {
-	char *string = (char*)EM_ASM_INT_V({
+	char *string = (char*)EM_ASM_INT({
 		var str = "hello, this is a string! ";
 		for(var i = 0; i < 15; ++i)
 			str = str + str;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2430,7 +2430,7 @@ open(filename, 'w').write(replaced)
 #include <emscripten.h>
 
 int main() {
-  int result = EM_ASM_INT_V({
+  int result = EM_ASM_INT({
     return Module['memoryInitializerRequest'].status;
   });
   printf("memory init request: %d\n", result);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6036,7 +6036,7 @@ def process(filename):
       }
 
       int main() {
-        int x = EM_ASM_INT_V({ return Module._other_function() });
+        int x = EM_ASM_INT({ return Module._other_function() });
         emscripten_run_script_string(""); // Add a reference to a symbol that exists in src/deps_info.json to uncover issue #2836 in the test suite.
         printf("waka %d!\n", x);
         return 0;
@@ -6069,7 +6069,7 @@ def process(filename):
       }
 
       int main() {
-        int x = EM_ASM_INT_V({ return Module._exported_func_from_response_file_4999() });
+        int x = EM_ASM_INT({ return Module._exported_func_from_response_file_4999() });
         emscripten_run_script_string(""); // Add a reference to a symbol that exists in src/deps_info.json to uncover issue #2836 in the test suite.
         printf("waka %d!\n", x);
         return 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1603,6 +1603,10 @@ int main(int argc, char **argv) {
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm')
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm', force_c=True)
 
+  def test_em_asm_2(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_2')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_2', force_c=True)
+
   def test_em_asm_unicode(self):
     self.do_run(r'''
 #include <emscripten.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6133,7 +6133,7 @@ def process(filename):
     }
 
     int main() {
-      EM_ASM_INT({
+      EM_ASM({
         Runtime.getFuncWrapper($0, 'vi')(0);
         Runtime.getFuncWrapper($1, 'vii')(0, 0);
       }, func1, func2);

--- a/tests/test_glfw_fullscreen.c
+++ b/tests/test_glfw_fullscreen.c
@@ -22,7 +22,7 @@ void error_callback(int error, const char* description) {
 }
 
 void windowSizeCallback(GLFWwindow* window, int width, int height) {
-  int isInFullscreen = EM_ASM_INT_V(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
+  int isInFullscreen = EM_ASM_INT(return !!(document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement));
   if (isInFullscreen && !wasFullscreen) {
     printf("Successfully transitioned to fullscreen mode!\n");
     wasFullscreen = isInFullscreen;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6519,7 +6519,7 @@ Resolved: "/" => "/"
 #include <stdlib.h>
 int main() {
   int x = 5;
-  EM_ASM_({
+  EM_ASM({
     var allocs = [];
     allocs.push([]);
     allocs.push([]);
@@ -6590,7 +6590,7 @@ int alloc_where_is_it() {
   return x / split_memory;
 }
 int main() {
-  split_memory = EM_ASM_INT_V({
+  split_memory = EM_ASM_INT({
     return SPLIT_MEMORY;
   });
   int counter = 0;
@@ -6629,7 +6629,7 @@ int where(int x) {
   return x / split_memory;
 }
 int main() {
-  split_memory = EM_ASM_INT_V({
+  split_memory = EM_ASM_INT({
     return SPLIT_MEMORY;
   });
   int sbrk_0 = (int)sbrk(0);
@@ -7014,7 +7014,7 @@ int main() {
 #include <emscripten.h>
 
 int main() {
-  EM_ASM_ARGS({
+  EM_ASM({
     Module.print('inputs: ' + $0 + ', ' + $1 + '.');
   }, int64_t(0x12345678ABCDEF1FLL));
 }

--- a/tests/utf32.cpp
+++ b/tests/utf32.cpp
@@ -16,7 +16,7 @@ int main() {
 	if (sizeof(wchar_t) == 4) {
 		utf32 *memory = new utf32[wstr.length()+1];
 
-		EM_ASM_INT({
+		EM_ASM({
 			var str = Module.UTF32ToString($0);
 			Module.print(str);
 			var numBytesWritten = Module.stringToUTF32(str, $1, $2);
@@ -31,7 +31,7 @@ int main() {
 				break;
 		}
 
-		EM_ASM_INT({
+		EM_ASM({
 			var str = Module.UTF32ToString($0);
 			Module.print(str);
 			var numBytesWritten = Module.stringToUTF32(str, $1, $2);
@@ -43,7 +43,7 @@ int main() {
 	} else { // sizeof(wchar_t) == 2, and we're building with -fshort-wchar.
 		utf16 *memory = new utf16[2*wstr.length()+1];
 
-		EM_ASM_INT({
+		EM_ASM({
 			var str = Module.UTF16ToString($0);
 			Module.print(str);
 			var numBytesWritten = Module.stringToUTF16(str, $1, $2);
@@ -58,7 +58,7 @@ int main() {
 				break;
 		}
 
-		EM_ASM_INT({
+		EM_ASM({
 			var str = Module.UTF16ToString($0);
 			Module.print(str);
 			var numBytesWritten = Module.stringToUTF16(str, $1, $2);

--- a/tests/utf8.cpp
+++ b/tests/utf8.cpp
@@ -9,7 +9,7 @@
 int main() {
   const char asciiString[] = "Hello world!";
   char asciiString2[128] = {};
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.AsciiToString($0);
     Module.print(str);
     Module.stringToAscii(str, $1);
@@ -17,7 +17,7 @@ int main() {
   assert(!strcmp(asciiString, asciiString2));
 
   char asciiString3[128] = {};
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.UTF8ToString($0);
     Module.print(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
@@ -27,7 +27,7 @@ int main() {
 
   const char utf8String[] = u8"Hyv\u00E4\u00E4 p\u00E4iv\u00E4\u00E4! T\u00F6\u00F6\u00F6\u00F6t! abc\u2603\u20AC\U0002007C123 --- abc\u2603\u20AC\U0002007C123."; // U+2603 is snowman, U+20AC is the Euro sign, U+2007C is a Chinese Han character that looks like three raindrops.
   char utf8String2[128] = {};
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.UTF8ToString($0);
     Module.print(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
@@ -40,7 +40,7 @@ int main() {
   assert(!strcmp(utf8String, utf8String2));
 
   // Test that text gets properly cut off if output buffer is too small.
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.UTF8ToString($0);
     Module.print(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
@@ -49,7 +49,7 @@ int main() {
   assert(strlen(utf8String2) == 9);
 
   // Zero-length string.
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.UTF8ToString($0);
     Module.print(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
@@ -59,7 +59,7 @@ int main() {
 
   // No bytes output.
   utf8String2[0] = 'X';
-  EM_ASM_INT({
+  EM_ASM({
     var str = Module.UTF8ToString($0);
     Module.print(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);

--- a/tests/wasm/trap-f2i.cpp
+++ b/tests/wasm/trap-f2i.cpp
@@ -2,7 +2,7 @@
 
 int main() {
   volatile double d = 17179870521;
-  EM_ASM_({
+  EM_ASM({
     Module.print('|' + $0 + '|')
   }, int(d));
 }

--- a/tests/wasm/trap-idiv.cpp
+++ b/tests/wasm/trap-idiv.cpp
@@ -3,7 +3,7 @@
 int main() {
   volatile int i = 1;
   volatile int j = 0;
-  EM_ASM_({
+  EM_ASM({
     Module.print('|' + $0 + '|')
   }, i / j);
 }

--- a/tests/webgl_create_context.cpp
+++ b/tests/webgl_create_context.cpp
@@ -133,7 +133,7 @@ int main()
       GetInt(GL_RED_BITS), GetInt(GL_GREEN_BITS), GetInt(GL_BLUE_BITS), GetInt(GL_ALPHA_BITS),
       numDepthBits, numStencilBits, numSamples);
     
-    if (!depth && stencil && numDepthBits && numStencilBits && EM_ASM_INT_V(navigator.userAgent.toLowerCase().indexOf('firefox')) > -1)
+    if (!depth && stencil && numDepthBits && numStencilBits && EM_ASM_INT(navigator.userAgent.toLowerCase().indexOf('firefox')) > -1)
     {
       numDepthBits = 0;
       printf("Applying workaround to ignore Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=982477\n");

--- a/tests/webgl_destroy_context.cpp
+++ b/tests/webgl_destroy_context.cpp
@@ -45,14 +45,14 @@ int main()
   emscripten_set_webglcontextlost_callback(0, 0, 0, context_lost);
   emscripten_set_webglcontextrestored_callback(0, 0, 0, context_restored);
   // When we force a context loss, we should get an event, i.e. context_lost_desired() should get called.
-  EM_ASM_INT({
+  EM_ASM({
       // The GL object is accessed here in a closure unsafe manner, so this test should not be run with closure enabled.
       Module['firstGLContextExt'] = GL.contexts[$0].GLctx.getExtension('WEBGL_lose_context');
     }, context);
 
   emscripten_webgl_destroy_context(context);
 
-  EM_ASM_INT({
+  EM_ASM({
       Module['firstGLContextExt'].loseContext();
     }, context);
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -257,7 +257,7 @@ mid_c += ['''
 // Not using size_t for array indices as the values used by the javascript code are signed.
 void array_bounds_check(const int array_size, const int array_idx) {
   if (array_idx < 0 || array_idx >= array_size) {
-    EM_ASM_INT({
+    EM_ASM({
       throw 'Array index ' + $0 + ' out of bounds: [0,' + $1 + ')';
     }, array_idx, array_size);
   }


### PR DESCRIPTION
Improve testing of `EM_ASM` code blocks, and handling of inputs that would have become non-evaluating strings in the body of an `ASM_CONST`. Revise the core set of `EM_ASM` functions to be `EM_ASM_VOID`, `EM_ASM_INT` and `EM_ASM_DOUBLE`, as well as `EM_ASM` which is a convenient alias to `EM_ASM_INT`. Deprecate `EM_ASM_`, `EM_ASM_ARGS`, `EM_ASM_INT_V` and `EM_ASM_DOUBLE_V` as redundant. This closes #5480.