### PR TITLE
Multithreading 1/N: JS scripts via Blob URLs

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -321,7 +321,12 @@ var LibraryPThread = {
         // Ask the new worker to load up the Emscripten-compiled page. This is a heavy operation.
         worker.postMessage({
             cmd: 'load',
-            url: currentScriptUrl,
+            // If the application main .js file was loaded from a Blob, then it is not possible
+            // to access the URL of the current script that could be passed to a Web Worker so that
+            // it could load up the same file. In that case, developer must either deliver the Blob
+            // object in Module['mainScriptUrlOrBlob'], or a URL to it, so that pthread Workers can
+            // independently load up the same main application file.
+            urlOrBlob: Module['mainScriptUrlOrBlob'] || currentScriptUrl,
             buffer: HEAPU8.buffer,
             tempDoublePtr: tempDoublePtr,
             TOTAL_MEMORY: TOTAL_MEMORY,

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -56,7 +56,13 @@ this.onmessage = function(e) {
     DYNAMICTOP_PTR = e.data.DYNAMICTOP_PTR;
 
     PthreadWorkerInit = e.data.PthreadWorkerInit;
-    importScripts(e.data.url);
+    if (typeof e.data.urlOrBlob === 'string') {
+      importScripts(e.data.urlOrBlob);
+    } else {
+      var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+      importScripts(objectUrl);
+      URL.revokeObjectURL(objectUrl);
+    }
     if (typeof FS !== 'undefined') FS.createStandardStreams();
     postMessage({ cmd: 'loaded' });
   } else if (e.data.cmd === 'objectTransfer') {

--- a/tests/pthread/hello_thread.c
+++ b/tests/pthread/hello_thread.c
@@ -1,0 +1,18 @@
+#include <pthread.h>
+#include <emscripten.h>
+
+void *thread_main(void *arg)
+{
+	EM_ASM(Module.print('hello from thread!'));
+#ifdef REPORT_RESULT
+	REPORT_RESULT(1);
+#endif
+	return 0;
+}
+
+int main()
+{
+	pthread_t thread;
+	pthread_create(&thread, NULL, thread_main, NULL);
+	EM_ASM(Module['noExitRuntime']=true);
+}

--- a/tests/pthread/main_js_as_blob_loader.html
+++ b/tests/pthread/main_js_as_blob_loader.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      textarea.emscripten { font-family: monospace; width: 80%; }
+      div.emscripten { text-align: center; }
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; background-color: black; }
+
+      .spinner {
+        height: 50px;
+        width: 50px;
+        margin: 0px auto;
+        -webkit-animation: rotation .8s linear infinite;
+        -moz-animation: rotation .8s linear infinite;
+        -o-animation: rotation .8s linear infinite;
+        animation: rotation 0.8s linear infinite;
+        border-left: 10px solid rgb(0,150,240);
+        border-right: 10px solid rgb(0,150,240);
+        border-bottom: 10px solid rgb(0,150,240);
+        border-top: 10px solid rgb(100,0,200);
+        border-radius: 100%;
+        background-color: rgb(200,100,250);
+      }
+      @-webkit-keyframes rotation {
+        from {-webkit-transform: rotate(0deg);}
+        to {-webkit-transform: rotate(360deg);}
+      }
+      @-moz-keyframes rotation {
+        from {-moz-transform: rotate(0deg);}
+        to {-moz-transform: rotate(360deg);}
+      }
+      @-o-keyframes rotation {
+        from {-o-transform: rotate(0deg);}
+        to {-o-transform: rotate(360deg);}
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+    </style>
+  </head>
+  <body>
+    <hr/>
+    <figure style="overflow:visible;" id="spinner"><div class="spinner"></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
+    <div class="emscripten" id="status">Downloading...</div>
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>  
+    </div>
+    <div class="emscripten_border">
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <hr/>
+    <div class="emscripten">
+      <input type="checkbox" id="resize">Resize canvas
+      <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
+      &nbsp;&nbsp;&nbsp;
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
+                                                                                document.getElementById('resize').checked)">
+    </div>
+    
+    <hr/>
+    <textarea class="emscripten" id="output" rows="8"></textarea>
+    <hr>
+    <script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          if (0) { // XXX disabled for safety typeof dump == 'function') {
+            dump(text + '\n'); // fast, straight to the real console
+          } else {
+            console.error(text);
+          }
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Date.now() < 30) return; // if this is a progress update, skip it if too soon
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function() {
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) Module.printErr('[post-exception status] ' + text);
+        };
+      };
+    </script>
+    
+    <script>
+
+function download(url, responseType) {
+  return new Promise(function(resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'blob';
+    xhr.onload = function() {
+      resolve(xhr.response);
+    };
+    xhr.send(null);
+  });
+}
+
+function addToDom(scriptCodeBlob) {
+  return new Promise(function(resolve, reject) {
+    var script = document.createElement('script');
+    var objectUrl = URL.createObjectURL(scriptCodeBlob);
+    script.src = objectUrl;
+    script.onload = function() {
+      Module['mainScriptUrlOrBlob'] = scriptCodeBlob;
+      URL.revokeObjectURL(objectUrl);
+      resolve();
+    }
+    document.body.appendChild(script);
+  });
+}
+
+download('hello_thread_with_blob_url.js').then(addToDom);
+
+    </script>
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3624,3 +3624,7 @@ window.close = function() {
   # Tests the Emscripten HTML5 API emscripten_set_canvas_element_size() and emscripten_get_canvas_element_size() functionality in singlethreaded programs.
   def test_emscripten_set_canvas_element_size(self):
     self.btest('emscripten_set_canvas_element_size.c', expected='1')
+
+  # Tests the absolute minimum pthread-enabled application.
+  def test_hello_thread(self):
+    self.btest(path_from_root('tests', 'pthread', 'hello_thread.c'), expected='1', args=['-s', 'USE_PTHREADS=1'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3628,3 +3628,12 @@ window.close = function() {
   # Tests the absolute minimum pthread-enabled application.
   def test_hello_thread(self):
     self.btest(path_from_root('tests', 'pthread', 'hello_thread.c'), expected='1', args=['-s', 'USE_PTHREADS=1'])
+
+  # Tests that it is possible to load the main .js file of the application manually via a Blob URL, and still use pthreads.
+  def test_load_js_from_blob_with_pthreads(self):
+    src = os.path.join(self.get_dir(), 'src.c')
+    open(src, 'w').write(self.with_report_result(open(path_from_root('tests', 'pthread', 'hello_thread.c')).read()))
+
+    Popen([PYTHON, EMCC, 'src.c', '-s', 'USE_PTHREADS=1', '-o', 'hello_thread_with_blob_url.js']).communicate()
+    shutil.copyfile(path_from_root('tests', 'pthread', 'main_js_as_blob_loader.html'), os.path.join(self.get_dir(), 'hello_thread_with_blob_url.html'))
+    self.run_browser('hello_thread_with_blob_url.html', 'hello from thread!', '/report_result?1')


### PR DESCRIPTION
Users sometimes add the main .js files via Blob URLs into the DOM. For example, Unreal Engine 4 has the following flow to implement IndexedDB based caching of downloads: (condensed greatly to remove error handling to show the guts)

```javascript
function addScriptToDom(blob) {
  return new Promise(function(resolve, reject) {
    var script = document.createElement('script');
    var objectUrl = URL.createObjectURL(blob);
    script.src = objectUrl;
    script.onload = function() {
      URL.revokeObjectURL(objectUrl);
      resolve();
    }
    document.body.appendChild(script);
  });
}

function fetchOrDownloadAndStore(db, url, responseType) {
  return new Promise(function(resolve, reject) {
    fetchFromIndexedDB(db, url)
    .then(function(data) { return resolve(data); })
    .catch(function(error) {
      return download(url, responseType).then(function(data) {
        storeToIndexedDB(db, url, data).then(function() { return resolve(data); })
      })
    });
  });
}

var mainJsDownload = fetchOrDownloadAndStore(db, Module.locateFile('UE4Game.js'), 'blob').then(function(data) {
    return addScriptToDom(data).then(function() {
      addRunDependency('wait-for-compiled-code');
    });
  });
```

This is practically the same machinery as our `-s PRECISE_F32=2` and `-s USE_PTHREADS=2` support is, but for the main .js file, as opposed to the asm.js/wasm files.

The above flow however creates trouble when used with asm.js multithreading, because in that case, `document.currentScript.src` refers to the URL of the blob, such as `blob://UUID`, and that blob is constrained to the scope of the main browser thread. That is, if I `URL.createObjectURL()` on the main thread, and pass the received URL to a worker, then that worker cannot use that URL to load the script, but will receive a not found error. Because of that, it is necessary to pass the actual Blob over to the Worker so that it can be accessed via `importScripts`. I have been unable to come up with a better mechanism than allow such html files to explicitly assist the pthread creation routine with a `Module['mainScriptUrlOrBlob']` field.