### PR TITLE
Multithreading 3/N: Thread-safe test harness

### DIFF
--- a/tests/gauge_available_memory.cpp
+++ b/tests/gauge_available_memory.cpp
@@ -13,9 +13,10 @@ int main()
 	// Keep allocating in ~powers of two until we fail, then print out how much we got.
 	uint64_t availableMemory = 0;
 	uint64_t i = 0x80000000ULL;
-	while(i > 0)
+	while(i > 512) // Leak almost all available memory, but not the last bytes, because REPORT_RESULT() needs to malloc() a bit in order to proxy from pthread to main thread.
 	{
 		void *ptr = leak_alloc(i);
+		printf("Alloc %llu: %p\n", i, ptr);
 		if (ptr) availableMemory += i;
 		else i >>= 1;
 	}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -831,8 +831,14 @@ class BrowserCore(RunnerCore):
     }, result, sync);
   }
 
-  #define REPORT_RESULT(result) _ReportResult((result), 0)
-  #define REPORT_RESULT_SYNC(result) _ReportResult((result), 1)
+  #if __EMSCRIPTEN_PTHREADS__
+    #include <emscripten/threading.h>
+    #define REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 0)
+    #define REPORT_RESULT_SYNC(result) emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 1)
+  #else
+    #define REPORT_RESULT(result) _ReportResult((result), 0)
+    #define REPORT_RESULT_SYNC(result) _ReportResult((result), 1)
+  #endif
 
   #endif // ~__REPORT_RESULT_DEFINED__
 


### PR DESCRIPTION
Run REPORT_RESULT() synchronously on the main thread, because `Module['pageThrewException']` and `window.close()` are only available on the main browser thread.