### PR TITLE
Multithreading 5/N: emscripten_async_load_script is not available in pthreads.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -470,6 +470,7 @@ var Runtime = {
   funcWrappers: {},
 
   getFuncWrapper: function(func, sig) {
+    if (!func) return; // on null pointer, return undefined
     assert(sig);
     if (!Runtime.funcWrappers[sig]) {
       Runtime.funcWrappers[sig] = {};


### PR DESCRIPTION
Mark `emscripten_async_load_script` not available in pthreads. Define .getFuncWrapper() to return null if passed function does not exist.

This is one of the few functions in `src/library_browser.js` that is not easily available to be called from a pthread, because of the need to backproxy event handlers. Others will be able to be proxied fine. For now, make this function yell if attempted to be called from a pthread.