### PR TITLE
Multithreading 7/N: Add support to calling SDL 1.x from pthreads

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1307,6 +1307,8 @@ var LibrarySDL = {
     },
   },
 
+  SDL_Linked_Version__proxy: 'sync',
+  SDL_Linked_Version__sig: 'i',
   SDL_Linked_Version: function() {
     if (SDL.version === null) {
       SDL.version = _malloc({{{ C_STRUCTS.SDL_version.__size__ }}});
@@ -1317,6 +1319,8 @@ var LibrarySDL = {
     return SDL.version;
   },
 
+  SDL_Init__proxy: 'sync',
+  SDL_Init__sig: 'ii',
   SDL_Init: function(initFlags) {
     SDL.startTime = Date.now();
     SDL.initFlags = initFlags;
@@ -1370,6 +1374,8 @@ var LibrarySDL = {
   },
 
   SDL_WasInit__deps: ['SDL_Init'],
+  SDL_WasInit__proxy: 'sync',
+  SDL_WasInit__sig: 'i',
   SDL_WasInit: function() {
     if (SDL.startTime === null) {
       _SDL_Init();
@@ -1377,6 +1383,8 @@ var LibrarySDL = {
     return 1;
   },
 
+  SDL_GetVideoInfo__proxy: 'sync',
+  SDL_GetVideoInfo__sig: 'i',
   SDL_GetVideoInfo: function() {
     // %struct.SDL_VideoInfo = type { i32, i32, %struct.SDL_PixelFormat*, i32, i32 } - 5 fields of quantum size
     var ret = _malloc(5*Runtime.QUANTUM_SIZE);
@@ -1403,6 +1411,8 @@ var LibrarySDL = {
     return _SDL_VideoDriverName(buf, max_size);
   },
 
+  SDL_VideoDriverName__proxy: 'sync',
+  SDL_VideoDriverName__sig: 'iii',
   SDL_VideoDriverName: function(buf, max_size) {
     if (SDL.startTime === null) {
       return 0; //return NULL
@@ -1429,6 +1439,8 @@ var LibrarySDL = {
   },
 
   SDL_SetVideoMode__deps: ['$GL'],
+  SDL_SetVideoMode__proxy: 'sync',
+  SDL_SetVideoMode__sig: 'iiiii',
   SDL_SetVideoMode: function(width, height, depth, flags) {
     ['touchstart', 'touchend', 'touchmove', 'mousedown', 'mouseup', 'mousemove', 'DOMMouseScroll', 'mousewheel', 'wheel', 'mouseout'].forEach(function(event) {
       Module['canvas'].addEventListener(event, SDL.receiveEvent, true);
@@ -1474,10 +1486,14 @@ var LibrarySDL = {
     return SDL.screen;
   },
 
+  SDL_GetVideoSurface__proxy: 'sync',
+  SDL_GetVideoSurface__sig: 'i',
   SDL_GetVideoSurface: function() {
     return SDL.screen;
   },
 
+  SDL_AudioQuit__proxy: 'sync',
+  SDL_AudioQuit__sig: 'v',
   SDL_AudioQuit: function() {
     for (var i = 0; i < SDL.numChannels; ++i) {
       if (SDL.channels[i].audio) {
@@ -1504,6 +1520,8 @@ var LibrarySDL = {
   },
 
   // Copy data from the canvas backing to a C++-accessible storage
+  SDL_LockSurface__proxy: 'sync',
+  SDL_LockSurface__sig: 'ii',
   SDL_LockSurface: function(surf) {
     var surfData = SDL.surfaces[surf];
 
@@ -1572,6 +1590,8 @@ var LibrarySDL = {
   },
 
   // Copy data from the C++-accessible storage to the canvas backing
+  SDL_UnlockSurface__proxy: 'sync',
+  SDL_UnlockSurface__sig: 'vi',
   SDL_UnlockSurface: function(surf) {
     assert(!SDL.GL); // in GL mode we do not keep around 2D canvases and contexts
 
@@ -1704,6 +1724,8 @@ var LibrarySDL = {
   },
 #endif
 
+  SDL_WM_SetCaption__proxy: 'sync',
+  SDL_WM_SetCaption__sig: 'vii',
   SDL_WM_SetCaption: function(title, icon) {
     if (title && typeof Module['setWindowTitle'] !== 'undefined') {
       Module['setWindowTitle'](Pointer_stringify(title));
@@ -1715,6 +1737,8 @@ var LibrarySDL = {
     // TODO
   },
 
+  SDL_GetKeyboardState__proxy: 'sync',
+  SDL_GetKeyboardState__sig: 'ii',
   SDL_GetKeyboardState: function(numKeys) {
     if (numKeys) {
       {{{ makeSetValue('numKeys', 0, 0x10000, 'i32') }}};
@@ -1727,6 +1751,8 @@ var LibrarySDL = {
     return _SDL_GetKeyboardState();
   },
   
+  SDL_GetKeyName__proxy: 'sync',
+  SDL_GetKeyName__sig: 'ii',
   SDL_GetKeyName: function(key) {
     if (!SDL.keyName) {
       SDL.keyName = allocate(intArrayFromString('unknown key'), 'i8', ALLOC_NORMAL);
@@ -1734,16 +1760,22 @@ var LibrarySDL = {
     return SDL.keyName;
   },
 
+  SDL_GetModState__proxy: 'sync',
+  SDL_GetModState__sig: 'i',
   SDL_GetModState: function() {
     return SDL.modState;
   },
 
+  SDL_GetMouseState__proxy: 'sync',
+  SDL_GetMouseState__sig: 'iii',
   SDL_GetMouseState: function(x, y) {
     if (x) {{{ makeSetValue('x', '0', 'Browser.mouseX', 'i32') }}};
     if (y) {{{ makeSetValue('y', '0', 'Browser.mouseY', 'i32') }}};
     return SDL.buttonState;
   },
 
+  SDL_WarpMouse__proxy: 'sync',
+  SDL_WarpMouse__sig: 'vii',
   SDL_WarpMouse: function(x, y) {
     return; // TODO: implement this in a non-buggy way. Need to keep relative mouse movements correct after calling this
     var rect = Module["canvas"].getBoundingClientRect();
@@ -1754,6 +1786,8 @@ var LibrarySDL = {
     });
   },
 
+  SDL_ShowCursor__proxy: 'sync',
+  SDL_ShowCursor__sig: 'ii',
   SDL_ShowCursor: function(toggle) {
     switch (toggle) {
       case 0: // SDL_DISABLE
@@ -1777,6 +1811,8 @@ var LibrarySDL = {
     }
   },
 
+  SDL_GetError__proxy: 'sync',
+  SDL_GetError__sig: 'i',
   SDL_GetError: function() {
     if (!SDL.errorMessage) {
       SDL.errorMessage = allocate(intArrayFromString("unknown SDL-emscripten error"), 'i8', ALLOC_NORMAL);
@@ -1789,10 +1825,14 @@ var LibrarySDL = {
   SDL_malloc: 'malloc',
   SDL_free: 'free',
 
+  SDL_CreateRGBSurface__proxy: 'sync',
+  SDL_CreateRGBSurface__sig: 'iiiiiiiii',
   SDL_CreateRGBSurface: function(flags, width, height, depth, rmask, gmask, bmask, amask) {
     return SDL.makeSurface(width, height, flags, false, 'CreateRGBSurface', rmask, gmask, bmask, amask);
   },
 
+  SDL_CreateRGBSurfaceFrom__proxy: 'sync',
+  SDL_CreateRGBSurfaceFrom__sig: 'iiiiiiiiii',
   SDL_CreateRGBSurfaceFrom: function(pixels, width, height, depth, pitch, rmask, gmask, bmask, amask) {
     var surf = SDL.makeSurface(width, height, 0, false, 'CreateRGBSurfaceFrom', rmask, gmask, bmask, amask);
 
@@ -1821,6 +1861,8 @@ var LibrarySDL = {
     return surf;
   },
 
+  SDL_ConvertSurface__proxy: 'sync',
+  SDL_ConvertSurface__sig: 'iiii',
   SDL_ConvertSurface: function(surf, format, flags) {
     if  (format) {
       SDL.checkPixelFormat(format);
@@ -1841,14 +1883,20 @@ var LibrarySDL = {
     return _SDL_ConvertSurface(surf);
   },
 
+  SDL_FreeSurface__proxy: 'sync',
+  SDL_FreeSurface__sig: 'vi',
   SDL_FreeSurface: function(surf) {
     if (surf) SDL.freeSurface(surf);
   },
 
+  SDL_UpperBlit__proxy: 'sync',
+  SDL_UpperBlit__sig: 'iiiii',
   SDL_UpperBlit: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, false);
   },
 
+  SDL_UpperBlitScaled__proxy: 'sync',
+  SDL_UpperBlitScaled__sig: 'iiiii',
   SDL_UpperBlitScaled: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, true);
   },
@@ -1856,6 +1904,8 @@ var LibrarySDL = {
   SDL_LowerBlit: 'SDL_UpperBlit',
   SDL_LowerBlitScaled: 'SDL_UpperBlitScaled',
 
+  SDL_GetClipRect__proxy: 'sync',
+  SDL_GetClipRect__sig: 'vii',
   SDL_GetClipRect: function(surf, rect) {
     assert(rect);
 
@@ -1864,6 +1914,8 @@ var LibrarySDL = {
     SDL.updateRect(rect, r);
   },
 
+  SDL_SetClipRect__proxy: 'sync',
+  SDL_SetClipRect__sig: 'vii',
   SDL_SetClipRect: function(surf, rect) {
     var surfData = SDL.surfaces[surf];
 
@@ -1874,6 +1926,8 @@ var LibrarySDL = {
     }
   },
 
+  SDL_FillRect__proxy: 'sync',
+  SDL_FillRect__sig: 'iiii',
   SDL_FillRect: function(surf, rect, color) {
     var surfData = SDL.surfaces[surf];
     assert(!surfData.locked); // but we could unlock and re-lock if we must..
@@ -1902,10 +1956,14 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_BlitSurface__proxy: 'sync',
+  SDL_BlitSurface__sig: 'iiiii',
   SDL_BlitSurface: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, false);
   },
 
+  SDL_BlitScaled__proxy: 'sync',
+  SDL_BlitScaled__sig: 'iiiii',
   SDL_BlitScaled: function(src, srcrect, dst, dstrect) {
     return SDL.blitSurface(src, srcrect, dst, dstrect, true);
   },
@@ -1945,6 +2003,8 @@ var LibrarySDL = {
     return ret;
   },
 
+  SDL_SetAlpha__proxy: 'sync',
+  SDL_SetAlpha__sig: 'iiii',
   SDL_SetAlpha: function(surf, flag, alpha) {
     var surfData = SDL.surfaces[surf];
     surfData.alpha = alpha;
@@ -1962,14 +2022,20 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_GetTicks__proxy: 'sync',
+  SDL_GetTicks__sig: 'i',
   SDL_GetTicks: function() {
     return (Date.now() - SDL.startTime)|0;
   },
 
+  SDL_PollEvent__proxy: 'sync',
+  SDL_PollEvent__sig: 'ii',
   SDL_PollEvent: function(ptr) {
     return SDL.pollEvent(ptr);
   },
 
+  SDL_PushEvent__proxy: 'sync',
+  SDL_PushEvent__sig: 'ii',
   SDL_PushEvent: function(ptr) {
     var copy = _malloc({{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
     _memcpy(copy, ptr, {{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
@@ -1977,6 +2043,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_PeepEvents__proxy: 'sync',
+  SDL_PeepEvents__sig: 'iiiiii',
   SDL_PeepEvents: function(events, requestedEventCount, action, from, to) {
     switch(action) {
       case 2: { // SDL_GETEVENT
@@ -2007,6 +2075,8 @@ var LibrarySDL = {
     }
   },
 
+  SDL_PumpEvents__proxy: 'sync',
+  SDL_PumpEvents__sig: 'v',
   SDL_PumpEvents: function(){
     SDL.events.forEach(function(event) {
       SDL.handleEvent(event);
@@ -2015,6 +2085,8 @@ var LibrarySDL = {
   
   // An Emscripten-specific extension to SDL: Some browser APIs require that they are called from within an event handler function.
   // Allow recording a callback that will be called for each received event.
+  emscripten_SDL_SetEventHandler__proxy: 'sync',
+  emscripten_SDL_SetEventHandler__sig: 'vii',
   emscripten_SDL_SetEventHandler: function(handler, userdata) {
     SDL.eventHandler = handler;
     SDL.eventHandlerContext = userdata;
@@ -2023,6 +2095,8 @@ var LibrarySDL = {
     if (!SDL.eventHandlerTemp) SDL.eventHandlerTemp = _malloc({{{ C_STRUCTS.SDL_KeyboardEvent.__size__ }}});
   },
 
+  SDL_SetColors__proxy: 'sync',
+  SDL_SetColors__sig: 'iiiii',
   SDL_SetColors: function(surf, colors, firstColor, nColors) {
     var surfData = SDL.surfaces[surf];
 
@@ -2052,18 +2126,24 @@ var LibrarySDL = {
     return _SDL_SetColors(surf, colors, firstColor, nColors);
   },
 
+  SDL_MapRGB__proxy: 'sync',
+  SDL_MapRGB__sig: 'iiiii',
   SDL_MapRGB: function(fmt, r, g, b) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
     return r&0xff|(g&0xff)<<8|(b&0xff)<<16|0xff000000;
   },
 
+  SDL_MapRGBA__proxy: 'sync',
+  SDL_MapRGBA__sig: 'iiiiii',
   SDL_MapRGBA: function(fmt, r, g, b, a) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
     return r&0xff|(g&0xff)<<8|(b&0xff)<<16|(a&0xff)<<24;
   },
 
+  SDL_GetRGB__proxy: 'sync',
+  SDL_GetRGB__sig: 'viiiii',
   SDL_GetRGB: function(pixel, fmt, r, g, b) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2078,6 +2158,8 @@ var LibrarySDL = {
     }
   },
 
+  SDL_GetRGBA__proxy: 'sync',
+  SDL_GetRGBA__sig: 'viiiiii',
   SDL_GetRGBA: function(pixel, fmt, r, g, b, a) {
     SDL.checkPixelFormat(fmt);
     // We assume the machine is little-endian.
@@ -2095,6 +2177,8 @@ var LibrarySDL = {
     }
   },
 
+  SDL_GetAppState__proxy: 'sync',
+  SDL_GetAppState__sig: 'i',
   SDL_GetAppState: function() {
     var state = 0;
 
@@ -2111,6 +2195,8 @@ var LibrarySDL = {
 
   SDL_WM_GrabInput: function() {},
   
+  SDL_WM_ToggleFullScreen__proxy: 'sync',
+  SDL_WM_ToggleFullScreen__sig: 'ii',
   SDL_WM_ToggleFullScreen: function(surf) {
     if (Browser.isFullscreen) {
       Module['canvas'].exitFullscreen();
@@ -2131,6 +2217,8 @@ var LibrarySDL = {
   },
 
   IMG_Load_RW__deps: ['SDL_LockSurface', 'SDL_FreeRW'],
+  IMG_Load_RW__proxy: 'sync',
+  IMG_Load_RW__sig: 'iii',
   IMG_Load_RW: function(rwopsID, freeSrc) {
     try {
       // stb_image integration support
@@ -2279,7 +2367,10 @@ var LibrarySDL = {
   },
   SDL_LoadBMP: 'IMG_Load',
   SDL_LoadBMP_RW: 'IMG_Load_RW',
+
   IMG_Load__deps: ['IMG_Load_RW', 'SDL_RWFromFile'],
+  IMG_Load__proxy: 'sync',
+  IMG_Load__sig: 'ii',
   IMG_Load: function(filename){
     var rwops = _SDL_RWFromFile(filename);
     var result = _IMG_Load_RW(rwops, 1);
@@ -2295,6 +2386,8 @@ var LibrarySDL = {
 #if EMTERPRETIFY_ASYNC
   SDL_OpenAudio__deps: ['$EmterpreterAsync'],
 #endif
+  SDL_OpenAudio__proxy: 'sync',
+  SDL_OpenAudio__sig: 'iii',
   SDL_OpenAudio: function(desired, obtained) {
     try {
       SDL.audio = {
@@ -2500,6 +2593,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_PauseAudio__proxy: 'sync',
+  SDL_PauseAudio__sig: 'vi',
   SDL_PauseAudio: function(pauseOn) {
     if (!SDL.audio) {
       return;
@@ -2519,6 +2614,8 @@ var LibrarySDL = {
   },
 
   SDL_CloseAudio__deps: ['SDL_PauseAudio', 'free'],
+  SDL_CloseAudio__proxy: 'sync',
+  SDL_CloseAudio__sig: 'v',
   SDL_CloseAudio: function() {
     if (SDL.audio) {
 #if EMTERPRETIFY_ASYNC
@@ -2548,9 +2645,13 @@ var LibrarySDL = {
   SDL_CondWait: function() {},
   SDL_DestroyCond: function() {},
 
+  SDL_StartTextInput__proxy: 'sync',
+  SDL_StartTextInput__sig: 'v',
   SDL_StartTextInput: function() {
     SDL.textInput = true;
   },
+  SDL_StopTextInput__proxy: 'sync',
+  SDL_StopTextInput__sig: 'v',
   SDL_StopTextInput: function() {
     SDL.textInput = false;
   },
@@ -2563,6 +2664,8 @@ var LibrarySDL = {
   },
   Mix_Quit: function(){},
 
+  Mix_OpenAudio__proxy: 'sync',
+  Mix_OpenAudio__sig: 'iiiii',
   Mix_OpenAudio: function(frequency, format, channels, chunksize) {
     SDL.openAudioContext();
     SDL.allocateChannels(32);
@@ -2576,15 +2679,21 @@ var LibrarySDL = {
 
   Mix_CloseAudio: 'SDL_CloseAudio',
 
+  Mix_AllocateChannels__proxy: 'sync',
+  Mix_AllocateChannels__sig: 'ii',
   Mix_AllocateChannels: function(num) {
     SDL.allocateChannels(num);
     return num;
   },
 
+  Mix_ChannelFinished__proxy: 'sync',
+  Mix_ChannelFinished__sig: 'vi',
   Mix_ChannelFinished: function(func) {
     SDL.channelFinished = func;
   },
 
+  Mix_Volume__proxy: 'sync',
+  Mix_Volume__sig: 'iii',
   Mix_Volume: function(channel, volume) {
     if (channel == -1) {
       for (var i = 0; i < SDL.numChannels-1; i++) {
@@ -2596,6 +2705,8 @@ var LibrarySDL = {
   },
 
   // Note: Mix_SetPanning requires WebAudio (file loaded from memory).
+  Mix_SetPanning__proxy: 'sync',
+  Mix_SetPanning__sig: 'iiii',
   Mix_SetPanning: function(channel, left, right) {
     // SDL API uses [0-255], while PannerNode has an (x, y, z) position.
 
@@ -2609,6 +2720,8 @@ var LibrarySDL = {
     return 1;
   },
 
+  Mix_LoadWAV_RW__proxy: 'sync',
+  Mix_LoadWAV_RW__sig: 'iii',
   Mix_LoadWAV_RW: function(rwopsID, freesrc) {
     var rwops = SDL.rwops[rwopsID];
 
@@ -2714,6 +2827,8 @@ var LibrarySDL = {
   },
 
   Mix_LoadWAV__deps: ['Mix_LoadWAV_RW', 'SDL_RWFromFile', 'SDL_FreeRW'],
+  Mix_LoadWAV__proxy: 'sync',
+  Mix_LoadWAV__sig: 'ii',
   Mix_LoadWAV: function(filename) {
     var rwops = _SDL_RWFromFile(filename);
     var result = _Mix_LoadWAV_RW(rwops);
@@ -2721,6 +2836,8 @@ var LibrarySDL = {
     return result;
   },
 
+  Mix_QuickLoad_RAW__proxy: 'sync',
+  Mix_QuickLoad_RAW__sig: 'iii',
   Mix_QuickLoad_RAW: function(mem, len) {
     var audio;
     var webAudio;
@@ -2753,12 +2870,18 @@ var LibrarySDL = {
     return id;
   },
 
+  Mix_FreeChunk__proxy: 'sync',
+  Mix_FreeChunk__sig: 'vi',
   Mix_FreeChunk: function(id) {
     SDL.audios[id] = null;
   },
+  Mix_ReserveChannels__proxy: 'sync',
+  Mix_ReserveChannels__sig: 'ii',
   Mix_ReserveChannels: function(num) {
     SDL.channelMinimumNumber = num;
   },
+  Mix_PlayChannel__proxy: 'sync',
+  Mix_PlayChannel__sig: 'iiii',
   Mix_PlayChannel: function(channel, id, loops) {
     // TODO: handle fixed amount of N loops. Currently loops either 0 or infinite times.
 
@@ -2816,6 +2939,8 @@ var LibrarySDL = {
     return 0; // MIX_NO_FADING, TODO
   },
 
+  Mix_HaltChannel__proxy: 'sync',
+  Mix_HaltChannel__sig: 'ii',
   Mix_HaltChannel: function(channel) {
     function halt(channel) {
       var info = SDL.channels[channel];
@@ -2836,6 +2961,8 @@ var LibrarySDL = {
   },
 
   Mix_HookMusicFinished__deps: ['Mix_HaltMusic'],
+  Mix_HookMusicFinished__proxy: 'sync',
+  Mix_HookMusicFinished__sig: 'vi',
   Mix_HookMusicFinished: function(func) {
     SDL.hookMusicFinished = func;
     if (SDL.music.audio) { // ensure the callback will be called, if a music is already playing
@@ -2843,12 +2970,16 @@ var LibrarySDL = {
     }
   },
 
+  Mix_VolumeMusic__proxy: 'sync',
+  Mix_VolumeMusic__sig: 'ii',
   Mix_VolumeMusic: function(volume) {
     return SDL.setGetVolume(SDL.music, volume);
   },
 
   Mix_LoadMUS_RW: 'Mix_LoadWAV_RW',
   Mix_LoadMUS__deps: ['Mix_LoadMUS_RW', 'SDL_RWFromFile', 'SDL_FreeRW'],
+  Mix_LoadMUS__proxy: 'sync',
+  Mix_LoadMUS__sig: 'ii',
   Mix_LoadMUS: function(filename) {
     var rwops = _SDL_RWFromFile(filename);
     var result = _Mix_LoadMUS_RW(rwops);
@@ -2859,6 +2990,8 @@ var LibrarySDL = {
   Mix_FreeMusic: 'Mix_FreeChunk',
 
   Mix_PlayMusic__deps: ['Mix_HaltMusic'],
+  Mix_PlayMusic__proxy: 'sync',
+  Mix_PlayMusic__sig: 'iii',
   Mix_PlayMusic: function(id, loops) {
     // Pause old music if it exists.
     if (SDL.music.audio) {
@@ -2886,18 +3019,22 @@ var LibrarySDL = {
     return 0;
   },
 
+  Mix_PauseMusic__proxy: 'sync',
+  Mix_PauseMusic__sig: 'v',
   Mix_PauseMusic: function() {
     var audio = SDL.music.audio;
     if (audio) audio.pause();
-    return 0;
   },
 
+  Mix_ResumeMusic__proxy: 'sync',
+  Mix_ResumeMusic__sig: 'v',
   Mix_ResumeMusic: function() {
     var audio = SDL.music.audio;
     if (audio) audio.play();
-    return 0;
   },
 
+  Mix_HaltMusic__proxy: 'sync',
+  Mix_HaltMusic__sig: 'i',
   Mix_HaltMusic: function() {
     var audio = SDL.music.audio;
     if (audio) {
@@ -2916,12 +3053,16 @@ var LibrarySDL = {
 
   Mix_FadeOutMusic: 'Mix_HaltMusic', // XXX ignore fading out effect
 
+  Mix_PlayingMusic__proxy: 'sync',
+  Mix_PlayingMusic__sig: 'i',
   Mix_PlayingMusic: function() {
     return (SDL.music.audio && !SDL.music.audio.paused) ? 1 : 0;
   },
 
   // http://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_38.html#SEC38
   // "Note: Does not check if the channel has been paused."
+  Mix_Playing__proxy: 'sync',
+  Mix_Playing__sig: 'ii',
   Mix_Playing: function(channel) {
     if (channel === -1) {
       var count = 0;
@@ -2937,6 +3078,8 @@ var LibrarySDL = {
     return 0;
   },
   
+  Mix_Pause__proxy: 'sync',
+  Mix_Pause__sig: 'vi',
   Mix_Pause: function(channel) {
     if (channel === -1) {
       for (var i = 0; i<SDL.channels.length;i++) {
@@ -2953,6 +3096,8 @@ var LibrarySDL = {
   },
   
   // http://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_39.html#SEC39
+  Mix_Paused__proxy: 'sync',
+  Mix_Paused__sig: 'ii',
   Mix_Paused: function(channel) {
     if (channel === -1) {
       var pausedCount = 0;
@@ -2968,11 +3113,15 @@ var LibrarySDL = {
     return 0;
   },
 
+  Mix_PausedMusic__proxy: 'sync',
+  Mix_PausedMusic__sig: 'i',
   Mix_PausedMusic: function() {
     return (SDL.music.audio && SDL.music.audio.paused) ? 1 : 0;
   },
 
   // http://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_33.html#SEC33
+  Mix_Resume__proxy: 'sync',
+  Mix_Resume__sig: 'vi',
   Mix_Resume: function(channel) {
     if (channel === -1) {
       for (var i = 0; i<SDL.channels.length;i++) {
@@ -2986,12 +3135,16 @@ var LibrarySDL = {
 
   // SDL TTF
 
+  TTF_Init__proxy: 'sync',
+  TTF_Init__sig: 'i',
   TTF_Init: function() {
     var canvas = document.createElement('canvas');
     SDL.ttfContext = canvas.getContext('2d');
     return 0;
   },
 
+  TTF_OpenFont__proxy: 'sync',
+  TTF_OpenFont__sig: 'iii',
   TTF_OpenFont: function(filename, size) {
     filename = PATH.normalize(Pointer_stringify(filename));
     var id = SDL.fonts.length;
@@ -3002,10 +3155,14 @@ var LibrarySDL = {
     return id;
   },
 
+  TTF_CloseFont__proxy: 'sync',
+  TTF_CloseFont__sig: 'vi',
   TTF_CloseFont: function(font) {
     SDL.fonts[font] = null;
   },
 
+  TTF_RenderText_Solid__proxy: 'sync',
+  TTF_RenderText_Solid__sig: 'iiii',
   TTF_RenderText_Solid: function(font, text, color) {
     // XXX the font and color are ignored
     text = Pointer_stringify(text) || ' '; // if given an empty string, still return a valid surface
@@ -3032,6 +3189,8 @@ var LibrarySDL = {
   TTF_RenderUTF8_Solid: 'TTF_RenderText_Solid',
   TTF_SizeUTF8: 'TTF_SizeText',
 
+  TTF_SizeText__proxy: 'sync',
+  TTF_SizeText__sig: 'iiiii',
   TTF_SizeText: function(font, text, w, h) {
     var fontData = SDL.fonts[font];
     if (w) {
@@ -3043,6 +3202,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  TTF_GlyphMetrics__proxy: 'sync',
+  TTF_GlyphMetrics__sig: 'iiiiiiii',
   TTF_GlyphMetrics: function(font, ch, minx, maxx, miny, maxy, advance) {
     var fontData = SDL.fonts[font];
     var width = SDL.estimateTextWidth(fontData,  String.fromCharCode(ch));
@@ -3064,16 +3225,22 @@ var LibrarySDL = {
     }
   },
 
+  TTF_FontAscent__proxy: 'sync',
+  TTF_FontAscent__sig: 'ii',
   TTF_FontAscent: function(font) {
     var fontData = SDL.fonts[font];
     return (fontData.size*0.98)|0; // XXX
   },
 
+  TTF_FontDescent__proxy: 'sync',
+  TTF_FontDescent__sig: 'ii',
   TTF_FontDescent: function(font) {
     var fontData = SDL.fonts[font];
     return (fontData.size*0.02)|0; // XXX
   },
 
+  TTF_FontHeight__proxy: 'sync',
+  TTF_FontHeight__sig: 'ii',
   TTF_FontHeight: function(font) {
     var fontData = SDL.fonts[font];
     return fontData.size;
@@ -3205,6 +3372,8 @@ var LibrarySDL = {
 
   // GL
 
+  SDL_GL_SetAttribute__proxy: 'sync',
+  SDL_GL_SetAttribute__sig: 'iii',
   SDL_GL_SetAttribute: function(attr, value) {
     if (!(attr in SDL.glAttributes)) {
       abort('Unknown SDL GL attribute (' + attr + '). Please check if your SDL version is supported.');
@@ -3213,6 +3382,8 @@ var LibrarySDL = {
     SDL.glAttributes[attr] = value;
   },
 
+  SDL_GL_GetAttribute__proxy: 'sync',
+  SDL_GL_GetAttribute__sig: 'iii',
   SDL_GL_GetAttribute: function(attr, value) {
     if (!(attr in SDL.glAttributes)) {
       abort('Unknown SDL GL attribute (' + attr + '). Please check if your SDL version is supported.');
@@ -3228,12 +3399,16 @@ var LibrarySDL = {
     return _emscripten_GetProcAddress(name_);
   },
 
+  SDL_GL_SwapBuffers__proxy: 'sync',
+  SDL_GL_SwapBuffers__sig: 'v',
   SDL_GL_SwapBuffers: function() {
     if (Browser.doSwapBuffers) Browser.doSwapBuffers(); // in workers, this is used to send out a buffered frame
   },
 
   // SDL 2
 
+  SDL_GL_ExtensionSupported__proxy: 'sync',
+  SDL_GL_ExtensionSupported__sig: 'ii',
   SDL_GL_ExtensionSupported: function(extension) {
     return Module.ctx.getExtension(extension) | 0;
   },
@@ -3242,6 +3417,8 @@ var LibrarySDL = {
 
   SDL_DestroyRenderer: function(renderer) {},
 
+  SDL_GetWindowFlags__proxy: 'sync',
+  SDL_GetWindowFlags__sig: 'iii',
   SDL_GetWindowFlags: function(x, y) {
     if (Browser.isFullscreen) {
        return 1;
@@ -3256,6 +3433,8 @@ var LibrarySDL = {
 
   SDL_GL_DeleteContext: function(context) {},
 
+  SDL_GL_GetSwapInterval__proxy: 'sync',
+  SDL_GL_GetSwapInterval__sig: 'ii',
   SDL_GL_GetSwapInterval: function(state) {
     if (Browser.mainLoop.timingMode == 1/*EM_TIMING_RAF*/) return Browser.mainLoop.timingValue;
     else return 0;
@@ -3266,10 +3445,14 @@ var LibrarySDL = {
     _emscripten_set_main_loop_timing(1/*EM_TIMING_RAF*/, state);
   },
 
+  SDL_SetWindowTitle__proxy: 'sync',
+  SDL_SetWindowTitle__sig: 'vii',
   SDL_SetWindowTitle: function(window, title) {
     if (title) document.title = Pointer_stringify(title);
   },
 
+  SDL_GetWindowSize__proxy: 'sync',
+  SDL_GetWindowSize__sig: 'viii',
   SDL_GetWindowSize: function(window, width, height){
     var w = Module['canvas'].width;
     var h = Module['canvas'].height;
@@ -3279,6 +3462,8 @@ var LibrarySDL = {
 
   SDL_LogSetOutputFunction: function(callback, userdata) {},
 
+  SDL_SetWindowFullscreen__proxy: 'sync',
+  SDL_SetWindowFullscreen__sig: 'iii',
   SDL_SetWindowFullscreen: function(window, fullscreen) {
     if (Browser.isFullscreen) {
       Module['canvas'].exitFullscreen();
@@ -3308,6 +3493,8 @@ var LibrarySDL = {
 
   // Joysticks
 
+  SDL_NumJoysticks__proxy: 'sync',
+  SDL_NumJoysticks__sig: 'i',
   SDL_NumJoysticks: function() {
     var count = 0;
     var gamepads = SDL.getGamepads();
@@ -3318,6 +3505,8 @@ var LibrarySDL = {
     return count;
   },
 
+  SDL_JoystickName__proxy: 'sync',
+  SDL_JoystickName__sig: 'ii',
   SDL_JoystickName: function(deviceIndex) {
     var gamepad = SDL.getGamepad(deviceIndex);
     if (gamepad) {
@@ -3330,6 +3519,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_JoystickOpen__proxy: 'sync',
+  SDL_JoystickOpen__sig: 'ii',
   SDL_JoystickOpen: function(deviceIndex) {
     var gamepad = SDL.getGamepad(deviceIndex);
     if (gamepad) {
@@ -3341,6 +3532,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_JoystickOpened__proxy: 'sync',
+  SDL_JoystickOpened__sig: 'ii',
   SDL_JoystickOpened: function(deviceIndex) {
     return SDL.lastJoystickState.hasOwnProperty(deviceIndex+1) ? 1 : 0;
   },
@@ -3350,6 +3543,8 @@ var LibrarySDL = {
     return joystick - 1;
   },
 
+  SDL_JoystickNumAxes__proxy: 'sync',
+  SDL_JoystickNumAxes__sig: 'ii',
   SDL_JoystickNumAxes: function(joystick) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad) {
@@ -3362,6 +3557,8 @@ var LibrarySDL = {
 
   SDL_JoystickNumHats: function(joystick) { return 0; },
 
+  SDL_JoystickNumButtons__proxy: 'sync',
+  SDL_JoystickNumButtons__sig: 'ii',
   SDL_JoystickNumButtons: function(joystick) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad) {
@@ -3370,10 +3567,14 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_JoystickUpdate__proxy: 'sync',
+  SDL_JoystickUpdate__sig: 'v',
   SDL_JoystickUpdate: function() {
     SDL.queryJoysticks();
   },
 
+  SDL_JoystickEventState__proxy: 'sync',
+  SDL_JoystickEventState__sig: 'ii',
   SDL_JoystickEventState: function(state) {
     if (state < 0) {
       // SDL_QUERY: Return current state.
@@ -3382,6 +3583,8 @@ var LibrarySDL = {
     return SDL.joystickEventState = state;
   },
 
+  SDL_JoystickGetAxis__proxy: 'sync',
+  SDL_JoystickGetAxis__sig: 'iii',
   SDL_JoystickGetAxis: function(joystick, axis) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad && gamepad.axes.length > axis) {
@@ -3394,6 +3597,8 @@ var LibrarySDL = {
 
   SDL_JoystickGetBall: function(joystick, ball, dxptr, dyptr) { return -1; },
 
+  SDL_JoystickGetButton__proxy: 'sync',
+  SDL_JoystickGetButton__sig: 'iii',
   SDL_JoystickGetButton: function(joystick, button) {
     var gamepad = SDL.getGamepad(joystick - 1);
     if (gamepad && gamepad.buttons.length > button) {
@@ -3402,6 +3607,8 @@ var LibrarySDL = {
     return 0;
   },
 
+  SDL_JoystickClose__proxy: 'sync',
+  SDL_JoystickClose__sig: 'vi',
   SDL_JoystickClose: function(joystick) {
     delete SDL.lastJoystickState[joystick];
   },
@@ -3410,6 +3617,8 @@ var LibrarySDL = {
 
   SDL_InitSubSystem: function(flags) { return 0 },
 
+  SDL_RWFromConstMem__proxy: 'sync',
+  SDL_RWFromConstMem__sig: 'iii',
   SDL_RWFromConstMem: function(mem, size) {
     var id = SDL.rwops.length; // TODO: recycle ids when they are null
     SDL.rwops.push({ bytes: mem, count: size });
@@ -3417,6 +3626,8 @@ var LibrarySDL = {
   },
   SDL_RWFromMem: 'SDL_RWFromConstMem',
 
+  SDL_RWFromFile__proxy: 'sync',
+  SDL_RWFromFile__sig: 'iii',
   SDL_RWFromFile: function(_name, mode) {
     var id = SDL.rwops.length; // TODO: recycle ids when they are null
     var name = Pointer_stringify(_name)
@@ -3424,6 +3635,8 @@ var LibrarySDL = {
     return id;
   },
   
+  SDL_FreeRW__proxy: 'sync',
+  SDL_FreeRW__sig: 'vi',
   SDL_FreeRW: function(rwopsID) {
     SDL.rwops[rwopsID] = null;
     while (SDL.rwops.length > 0 && SDL.rwops[SDL.rwops.length-1] === null) {
@@ -3439,22 +3652,29 @@ var LibrarySDL = {
   SDL_GetAudioDriver__deps: ['SDL_GetCurrentAudioDriver'],
   SDL_GetAudioDriver: function(index) { return _SDL_GetCurrentAudioDriver() },
 
+  SDL_EnableUNICODE__proxy: 'sync',
+  SDL_EnableUNICODE__sig: 'ii',
   SDL_EnableUNICODE: function(on) {
     var ret = SDL.unicode || 0;
     SDL.unicode = on;
     return ret;
   },
 
+  SDL_AddTimer__proxy: 'sync',
+  SDL_AddTimer__sig: 'iiii',
   SDL_AddTimer: function(interval, callback, param) {
     return window.setTimeout(function() {
       Module['dynCall_iii'](callback, interval, param);
     }, interval);
   },
+  SDL_RemoveTimer__proxy: 'sync',
+  SDL_RemoveTimer__sig: 'ii',
   SDL_RemoveTimer: function(id) {
     window.clearTimeout(id);
     return true;
   },
 
+  // TODO:
   SDL_CreateThread: function() {
     throw 'SDL threads cannot be supported in the web platform because they assume shared state. See emscripten_create_worker etc. for a message-passing concurrency model that does let you run code in another thread.'
   },


### PR DESCRIPTION
Adds support for calling SDL API from pthreads by synchronously proxying to main thread. This makes pthreads "see" the JavaScript state of SDL held in the main browser thread, so that multiple threads all act like they have one coherent state of SDL data structures. That allows one thread to call `SDL_Init`, and it will be in effect for all other threads as well.