### PR TITLE
Resolve symlinks in em* wrapper scripts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -308,3 +308,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Michael Siebert <michael.siebert2k@gmail.com>
 * Jonathan Hale <squareys@googlemail.com>
 * Etienne Brateau <etienne.brateau@gmail.com>
+* Zhiming Wang <zmwangx@gmail.com>

--- a/em++
+++ b/em++
@@ -18,4 +18,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emcc.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))

--- a/em++.py
+++ b/em++.py
@@ -14,4 +14,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emcc.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))

--- a/emar
+++ b/emar
@@ -15,4 +15,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emar.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emar.py')] + sys.argv[1:]))

--- a/emcc
+++ b/emcc
@@ -15,4 +15,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emcc.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))

--- a/emcmake
+++ b/emcmake
@@ -14,4 +14,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emcmake.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcmake.py')] + sys.argv[1:]))

--- a/emconfigure
+++ b/emconfigure
@@ -14,4 +14,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emconfigure.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emconfigure.py')] + sys.argv[1:]))

--- a/emmake
+++ b/emmake
@@ -17,4 +17,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emmake.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emmake.py')] + sys.argv[1:]))

--- a/emrun
+++ b/emrun
@@ -11,4 +11,4 @@ if sys.version_info.major == 2:
 else:
   import os, subprocess
   if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(__file__), 'emrun.py')] + sys.argv[1:]))
+    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emrun.py')] + sys.argv[1:]))


### PR DESCRIPTION
When wrapper scripts `em*` in `PATH` are symlinks to the actual scripts installed alongside `em*.py` (e.g. in the case of a Homebrew installation), we need to resolve symlinks in order to find `em*.py`.