### PR TITLE
Fix driver to use sourcemaps with wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1214,6 +1214,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.OPT_LEVEL = options.opt_level
       shared.Settings.DEBUG_LEVEL = options.debug_level
       shared.Settings.PROFILING_FUNCS = options.profiling_funcs
+      shared.Settings.SOURCE_MAP_BASE = options.source_map_base
 
       ## Compile source code to bitcode
 
@@ -1522,9 +1523,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # we also received wast and wasm at this stage
         temp_basename = unsuffixed(final)
         wast_temp = temp_basename + '.wast'
+        wasm_temp = temp_basename + '.wasm'
         shutil.move(wast_temp, wasm_text_target)
-        shutil.move(temp_basename + '.wasm', wasm_binary_target)
+        shutil.move(wasm_temp, wasm_binary_target)
         open(wasm_text_target + '.mappedGlobals', 'w').write('{}') # no need for mapped globals for now, but perhaps some day
+        if options.debug_level >= 4:
+          shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
 
       if shared.Settings.CYBERDWARF:
         cd_target = final + '.cd'
@@ -2263,7 +2267,7 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
         if options.debug_level >= 4:
           cmd += ['--source-map=' + wasm_binary_target + '.map']
           if options.source_map_base:
-            cmd += ['--source-map-url=' + options.source_map_base + wasm_binary_target + '.map']
+            cmd += ['--source-map-url=' + options.source_map_base + os.path.basename(wasm_binary_target) + '.map']
       logging.debug('wasm-as (text => binary): ' + ' '.join(cmd))
       subprocess.check_call(cmd)
     if import_mem_init:

--- a/emcc.py
+++ b/emcc.py
@@ -1214,7 +1214,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.OPT_LEVEL = options.opt_level
       shared.Settings.DEBUG_LEVEL = options.debug_level
       shared.Settings.PROFILING_FUNCS = options.profiling_funcs
-      shared.Settings.SOURCE_MAP_BASE = options.source_map_base
+      shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
       ## Compile source code to bitcode
 
@@ -1259,6 +1259,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if options.debug_level == 4 or not (final_suffix in JS_CONTAINING_SUFFIXES and options.js_opts):
           newargs.append('-g') # preserve LLVM debug info
           options.debug_level = 4
+          shared.Settings.DEBUG_LEVEL = 4
 
       # Bitcode args generation code
       def get_bitcode_args(input_files):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1770,6 +1770,7 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
     assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
     basename = shared.unsuffixed(outfile.name)
     wast = basename + '.wast'
+    wasm = basename + '.wasm'
     s2wasm_args = create_s2wasm_args(temp_s)
     if DEBUG:
       logging.debug('emscript: binaryen s2wasm: ' + ' '.join(s2wasm_args))
@@ -1778,9 +1779,15 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
     shared.check_call(s2wasm_args, stdout=open(wast, 'w'))
     # Also convert wasm text to binary
     wasm_as_args = [os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-as'),
-                    wast, '-o', basename + '.wasm']
+                    wast, '-o', wasm]
     if settings['DEBUG_LEVEL'] >= 2 or settings['PROFILING_FUNCS']:
       wasm_as_args += ['-g']
+      if settings['DEBUG_LEVEL'] >= 4:
+        wasm_as_args += ['--source-map=' + wasm + '.map']
+        if not settings['SOURCE_MAP_BASE']:
+          logging.warn("Wasm source map won't be usable in a browser without --source-map-base")
+        else:
+          wasm_as_args += ['--source-map-url=' + settings['SOURCE_MAP_BASE'] + os.path.basename(settings['WASM_BINARY_FILE']) + '.map']
     logging.debug('  emscript: binaryen wasm-as: ' + ' '.join(wasm_as_args))
     shared.check_call(wasm_as_args)
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -860,3 +860,4 @@ var ASMFS = 0; // If set to 1, uses the multithreaded filesystem that is impleme
 var WASM_TEXT_FILE = ''; // name of the file containing wasm text, if relevant
 var WASM_BINARY_FILE = ''; // name of the file containing wasm binary, if relevant
 var ASMJS_CODE_FILE = ''; // name of the file containing asm.js, if relevant
+var SOURCE_MAP_BASE = ''; // Base URL the source mapfile, if relevant

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6842,7 +6842,7 @@ Module.printErr = Module['printErr'] = function(){};
 
   @no_emterpreter
   def test_source_map(self):
-    if NODE_JS not in JS_ENGINES: return self.skip('sourcemapper requires Node to run')
+    #if NODE_JS not in JS_ENGINES: return self.skip('sourcemapper requires Node to run')
     if '-g' not in Building.COMPILER_TEST_OPTS: Building.COMPILER_TEST_OPTS.append('-g')
 
     src = '''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6946,7 +6946,7 @@ Module.printErr = Module['printErr'] = function(){};
   def test_exception_source_map(self):
     if self.is_wasm(): return self.skip('wasmifying destroys debug info and stack tracability')
     if '-g4' not in Building.COMPILER_TEST_OPTS: Building.COMPILER_TEST_OPTS.append('-g4')
-    if NODE_JS not in JS_ENGINES: return self.skip('sourcemapper requires Node to run')
+    if not jsrun.check_engine(NODE_JS): return self.skip('sourcemapper requires Node to run')
 
     src = '''
       #include <stdio.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6842,7 +6842,7 @@ Module.printErr = Module['printErr'] = function(){};
 
   @no_emterpreter
   def test_source_map(self):
-    #if NODE_JS not in JS_ENGINES: return self.skip('sourcemapper requires Node to run')
+    if not jsrun.check_engine(NODE_JS): return self.skip('sourcemapper requires Node to run')
     if '-g' not in Building.COMPILER_TEST_OPTS: Building.COMPILER_TEST_OPTS.append('-g')
 
     src = '''


### PR DESCRIPTION
Fix emcc to output source maps when debug level >= 4 with the wasm backend as well as asm2wasm.
