### PR TITLE
Re-enable dylink tests with V8

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2284,10 +2284,6 @@ The current type of b is: 9
   def can_dlfcn(self):
     if Settings.ALLOW_MEMORY_GROWTH == 1: return self.skip('no dlfcn with memory growth yet')
     if self.is_wasm_backend(): return self.skip('no shared modules in wasm backend')
-    # V8 doesn't support mismatch between table import decl initial size and imported table runtime size.
-    # See https://bugs.chromium.org/p/v8/issues/detail?id=5795
-    if self.is_wasm():
-      self.banned_js_engines = [V8_ENGINE, NODE_JS]
     return True
 
   def prep_dlfcn_lib(self):


### PR DESCRIPTION
The bugs with shared tables have been fixed.