### PR TITLE
Support node env override in Electron renderer process

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2231,7 +2231,9 @@ function integrateWasmJS(Module) {
 
   function getBinaryPromise() {
     // if we don't have the binary yet, and have the Fetch api, use that
-    if (!Module['wasmBinary'] && typeof fetch === 'function') {
+    // if Module overridded its environment to Node in Electron's renderer process, do not use fetch
+    var electronNodeContext = Module["ENVIRONMENT"] === "NODE" && typeof(window) !== 'undefined' && !!window.process;
+    if (!Module['wasmBinary'] && typeof fetch === 'function' && !electronNodeContext) {
       return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";


### PR DESCRIPTION
It might not be legit approach to solve issues and possibly I am lack of way to correctly setting it - feel freely close PR if so.

This PR try to resolve usecases in Electron (https://electron.atom.io/) 's renderer process. Electron's renderer process is basically web browser instance but have node.js integration, so it is possible global context to have `window.fetch` and node.js both. In those process, setting up `ENVIRONMENT` to `NODE` is not sufficient to load wasm binary without fetch, as current detection logic falls back to use `fetch` as soon as it is available.

Instead, adds one additional condition to check - if given process is Electron (where `window` have node.js `require` and `fetch` both) but explicitly overridden to use `NODE`, skips to `fetch`. Otherwise it'll work as same as browser context.