### PR TITLE
Multithreading 12/N: Async Emscripten Browser API in pthreads

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -733,6 +733,8 @@ var LibraryBrowser = {
   },
 
   emscripten_async_wget__deps: ['$PATH'],
+  emscripten_async_wget__proxy: 'sync',
+  emscripten_async_wget__sig: 'viiii',
   emscripten_async_wget: function(url, file, onload, onerror) {
     Module['noExitRuntime'] = true;
 
@@ -770,6 +772,8 @@ var LibraryBrowser = {
     );
   },
 
+  emscripten_async_wget_data__proxy: 'sync',
+  emscripten_async_wget_data__sig: 'viiii',
   emscripten_async_wget_data: function(url, arg, onload, onerror) {
     Browser.asyncLoad(Pointer_stringify(url), function(byteArray) {
       var buffer = _malloc(byteArray.length);
@@ -781,6 +785,8 @@ var LibraryBrowser = {
     }, true /* no need for run dependency, this is async but will not do any prepare etc. step */ );
   },
 
+  emscripten_async_wget2__proxy: 'sync',
+  emscripten_async_wget2__sig: 'iiiiiiiii',
   emscripten_async_wget2: function(url, file, request, param, arg, onload, onerror, onprogress) {
     Module['noExitRuntime'] = true;
 
@@ -860,6 +866,8 @@ var LibraryBrowser = {
     return handle;
   },
 
+  emscripten_async_wget2_data__proxy: 'sync',
+  emscripten_async_wget2_data__sig: 'iiiiiiiii',
   emscripten_async_wget2_data: function(url, request, param, arg, free, onload, onerror, onprogress) {
     var _url = Pointer_stringify(url);
     var _request = Pointer_stringify(request);
@@ -922,6 +930,8 @@ var LibraryBrowser = {
     return handle;
   },
 
+  emscripten_async_wget2_abort__proxy: 'sync',
+  emscripten_async_wget2_abort__sig: 'vi',
   emscripten_async_wget2_abort: function(handle) {
     var http = Browser.wgetRequests[handle];
     if (http) {
@@ -930,6 +940,8 @@ var LibraryBrowser = {
   },
 
   emscripten_run_preload_plugins__deps: ['$PATH'],
+  emscripten_run_preload_plugins__proxy: 'sync',
+  emscripten_run_preload_plugins__sig: 'iiii',
   emscripten_run_preload_plugins: function(file, onload, onerror) {
     Module['noExitRuntime'] = true;
 
@@ -951,6 +963,8 @@ var LibraryBrowser = {
     return 0;
   },
 
+  emscripten_run_preload_plugins_data__proxy: 'sync',
+  emscripten_run_preload_plugins_data__sig: 'viiiiii',
   emscripten_run_preload_plugins_data: function(data, size, suffix, arg, onload, onerror) {
     Module['noExitRuntime'] = true;
 
@@ -1260,10 +1274,14 @@ var LibraryBrowser = {
     Module['exit'](status);
   },
 
+  emscripten_get_device_pixel_ratio__proxy: 'sync',
+  emscripten_get_device_pixel_ratio__sig: 'd',
   emscripten_get_device_pixel_ratio: function() {
     return window.devicePixelRatio || 1.0;
   },
 
+  emscripten_hide_mouse__proxy: 'sync',
+  emscripten_hide_mouse__sig: 'v',
   emscripten_hide_mouse: function() {
     var styleSheet = document.styleSheets[0];
     var rules = styleSheet.cssRules;
@@ -1276,10 +1294,14 @@ var LibraryBrowser = {
     styleSheet.insertRule('canvas.emscripten { border: 1px solid black; cursor: none; }', 0);
   },
 
+  emscripten_set_canvas_size__proxy: 'sync',
+  emscripten_set_canvas_size__sig: 'vii',
   emscripten_set_canvas_size: function(width, height) {
     Browser.setCanvasSize(width, height);
   },
   
+  emscripten_get_canvas_size__proxy: 'sync',
+  emscripten_get_canvas_size__sig: 'viii',
   emscripten_get_canvas_size: function(width, height, isFullscreen) {
     var canvas = Module['canvas'];
     {{{ makeSetValue('width', '0', 'canvas.width', 'i32') }}};
@@ -1287,6 +1309,9 @@ var LibraryBrowser = {
     {{{ makeSetValue('isFullscreen', '0', 'Browser.isFullscreen ? 1 : 0', 'i32') }}};
   },
 
+  // To avoid creating worker parent->child chains, always proxies to execute on the main thread.
+  emscripten_create_worker__proxy: 'sync',
+  emscripten_create_worker__sig: 'ii',
   emscripten_create_worker: function(url) {
     url = Pointer_stringify(url);
     var id = Browser.workers.length;
@@ -1327,6 +1352,8 @@ var LibraryBrowser = {
     return id;
   },
 
+  emscripten_destroy_worker__proxy: 'sync',
+  emscripten_destroy_worker__sig: 'vi',
   emscripten_destroy_worker: function(id) {
     var info = Browser.workers[id];
     info.worker.terminate();
@@ -1334,6 +1361,8 @@ var LibraryBrowser = {
     Browser.workers[id] = null;
   },
 
+  emscripten_call_worker__proxy: 'sync',
+  emscripten_call_worker__sig: 'viiiiii',
   emscripten_call_worker: function(id, funcName, data, size, callback, arg) {
     Module['noExitRuntime'] = true; // should we only do this if there is a callback?
 
@@ -1360,6 +1389,8 @@ var LibraryBrowser = {
     }
   },
 
+  emscripten_worker_respond_provisionally__proxy: 'sync',
+  emscripten_worker_respond_provisionally__sig: 'vii',
   emscripten_worker_respond_provisionally: function(data, size) {
     if (workerResponded) throw 'already responded with final response!';
     var transferObject = {
@@ -1374,6 +1405,8 @@ var LibraryBrowser = {
     }
   },
 
+  emscripten_worker_respond__proxy: 'sync',
+  emscripten_worker_respond__sig: 'vii',
   emscripten_worker_respond: function(data, size) {
     if (workerResponded) throw 'already responded with final response!';
     workerResponded = true;
@@ -1389,6 +1422,8 @@ var LibraryBrowser = {
     }
   },
 
+  emscripten_get_worker_queue_size__proxy: 'sync',
+  emscripten_get_worker_queue_size__sig: 'i',
   emscripten_get_worker_queue_size: function(id) {
     var info = Browser.workers[id];
     if (!info) return -1;
@@ -1396,6 +1431,8 @@ var LibraryBrowser = {
   },
 
   emscripten_get_preloaded_image_data__deps: ['$PATH'],
+  emscripten_get_preloaded_image_data__proxy: 'sync',
+  emscripten_get_preloaded_image_data__sig: 'iiii',
   emscripten_get_preloaded_image_data: function(path, w, h) {
     if (typeof path === "number") {
       path = Pointer_stringify(path);
@@ -1420,6 +1457,8 @@ var LibraryBrowser = {
   },
 
   emscripten_get_preloaded_image_data_from_FILE__deps: ['emscripten_get_preloaded_image_data'],
+  emscripten_get_preloaded_image_data_from_FILE__proxy: 'sync',
+  emscripten_get_preloaded_image_data_from_FILE__sig: 'iiii',
   emscripten_get_preloaded_image_data_from_FILE: function(file, w, h) {
     var fd = Module['_fileno'](file);
     var stream = FS.getStream(fd);


### PR DESCRIPTION
Enable Emscripten Browser APIs `emscripten_async_wget*()`, `emsripten preload_plugins*()`, `emscripten_worker*()` and a couple of others to be called from pthreads.