### PR TITLE
In pthread_create test, ensure the desired number of threads are created

### DIFF
--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -83,20 +83,23 @@ int main()
 		CreateThread(i);
 
 	// Join all threads and create more.
-	for(int i = 0; i < NUM_THREADS; ++i)
-	{
-		if (thread[i])
+        while (numThreadsToCreate > 0)
+        {
+		for(int i = 0; i < NUM_THREADS; ++i)
 		{
-			int status;
-			int rc = pthread_join(thread[i], (void**)&status);
-			assert(rc == 0);
-			EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
-			assert(status == N);
-			thread[i] = 0;
-			if (numThreadsToCreate > 0)
+			if (thread[i])
 			{
-				--numThreadsToCreate;
-				CreateThread(i);
+				int status;
+				int rc = pthread_join(thread[i], (void**)&status);
+				assert(rc == 0);
+				EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
+				assert(status == N);
+				thread[i] = 0;
+				if (numThreadsToCreate > 0)
+				{
+					--numThreadsToCreate;
+					CreateThread(i);
+				}
 			}
 		}
 	}

--- a/tests/pthread/test_pthread_printf.cpp
+++ b/tests/pthread/test_pthread_printf.cpp
@@ -12,8 +12,6 @@ void *ThreadMain(void *arg)
 	return 0;
 }
 
-int numThreadsToCreate = 1000;
-
 int main()
 {
 	pthread_t thread;


### PR DESCRIPTION
It appears that the intention of this test was to keep creating threads until
numThreadsToCreate reaches 0 but that didn't happen because it only iterated
once through the pool of threads. This PR keeps going until we create all of
them.