### PR TITLE
Only use Fetch API in browser

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2231,7 +2231,8 @@ function integrateWasmJS(Module) {
 
   function getBinaryPromise() {
     // if we don't have the binary yet, and have the Fetch api, use that
-    if (!Module['wasmBinary'] && typeof fetch === 'function') {
+    // in some environments, like Electron's render process, Fetch api may be present, but have a different context than expected, let's only use it on the Web
+    if (!Module['wasmBinary'] && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) && typeof fetch === 'function') {
       return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";


### PR DESCRIPTION
`fetch()` can be present in some environments like Electron's renderer process, but is not useful outside browser environment

This is an alternative, simpler approach to #5577