### PR TITLE
Use WebAssembly.compileStreaming API if available

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2230,9 +2230,6 @@ function integrateWasmJS() {
   }
 
   function getBinaryPromise() {
-    //if (!Module['wasmbinary'] && typeof WebAssembly.instantiateStreaming === 'function') {
-    //  return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-    //}
     // if we don't have the binary yet, and have the Fetch api, use that
     // in some environments, like Electron's render process, Fetch api may be present, but have a different context than expected, let's only use it on the Web
     if (!Module['wasmBinary'] && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) && typeof fetch === 'function') {
@@ -2340,7 +2337,6 @@ function integrateWasmJS() {
     }
     // Prefer streaming instantiation if available.
     if (!Module['wasmBinary'] && typeof WebAssembly.instantiateStreaming === 'function') {
-      console.log("Fetching");
       WebAssembly.instantiateStreaming(fetch(wasmBinaryFile, { credentials: 'same-origin' }), info)
           .then(receiveInstantiatedSource).catch(
               function(reason) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2338,18 +2338,17 @@ function integrateWasmJS() {
     // Prefer streaming instantiation if available.
     if (!Module['wasmBinary'] && typeof WebAssembly.instantiateStreaming === 'function') {
       WebAssembly.instantiateStreaming(fetch(wasmBinaryFile, { credentials: 'same-origin' }), info)
-          .then(receiveInstantiatedSource).catch(
-              function(reason) {
-                // We expect the most common failure cause to be a bad MIME type for the binary,
-                // in which case falling back to ArrayBuffer instantiation should work.
-                Module['printErr']('wasm streaming compile failed: ' + reason);
-                Module['printErr']('falling back to ArrayBuffer instantiation');
-                instantiateArrayBuffer(receiveInstantiatedSource);
-              }
-      );
-      return {};
+        .then(receiveInstantiatedSource)
+        .catch(function(reason) {
+          // We expect the most common failure cause to be a bad MIME type for the binary,
+          // in which case falling back to ArrayBuffer instantiation should work.
+          Module['printErr']('wasm streaming compile failed: ' + reason);
+          Module['printErr']('falling back to ArrayBuffer instantiation');
+          instantiateArrayBuffer(receiveInstantiatedSource);
+        });
+    } else {
+      instantiateArrayBuffer(receiveInstantiatedSource);
     }
-    instantiateArrayBuffer(receiveInstantiatedSource);
     return {}; // no exports yet; we'll fill them in later
 #else
     var instance;

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -748,7 +748,6 @@ def server_func(dir, q):
       pass
 
   SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
-  print SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map
   os.chdir(dir)
   httpd = BaseHTTPServer.HTTPServer(('localhost', 8888), TestServerHandler)
   httpd.serve_forever() # test runner will kill us

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -746,6 +746,9 @@ def server_func(dir, q):
     def log_request(code=0, size=0):
       # don't log; too noisy
       pass
+
+  SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
+  print SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map
   os.chdir(dir)
   httpd = BaseHTTPServer.HTTPServer(('localhost', 8888), TestServerHandler)
   httpd.serve_forever() # test runner will kill us


### PR DESCRIPTION
This API is a post-MVP addition
(http://webassembly.org/docs/web/#additional-web-embedding-api) that does
streaming compilation (i.e compiles the wasm binary as it downloads), resulting
in faster instantiation in the non-cached case.