### PR TITLE
OpenAL: don't overflow an array on alGetSourcei(AL_BUFFER).

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1059,7 +1059,7 @@ var LibraryOpenAL = {
       {{{ makeSetValue('value', '0', 'src.loop', 'i32') }}};
       break;
     case 0x1009 /* AL_BUFFER */:
-      if (!src.queue.length) {
+      if (src.queue.length <= src.buffersPlayed) {
         {{{ makeSetValue('value', '0', '0', 'i32') }}};
       } else {
         // Find the first unprocessed buffer.


### PR DESCRIPTION
This happens if you have a source with a completely processed buffer queue;
the query will dereference index src.buffersPlayed, which is equal to the
src.queue.length.