### PR TITLE
Implement requestHeaders and requestData processing in fetch library

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -325,3 +325,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Daniel Wirtz <dcode@dcode.io>
 * Kibeom Kim <kk1674@nyu.edu>
 * Axel Forsman <axelsfor@gmail.com>
+* Alexander Bich <quyse0@gmail.com>

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -93,8 +93,10 @@ typedef struct emscripten_fetch_attr_t
 
 	// If non-zero, specifies a pointer to the data that is to be passed as the body (payload) of the request
 	// that is being performed. Leave as zero if no request body needs to be sent.
-	// The memory pointed to by this field is provided by the user, and needs to be valid only until the call to
-	// emscripten_fetch() returns.
+	// The memory pointed to by this field is provided by the user, and needs to be valid throughout the
+	// duration of the fetch operation. If passing a non-zero pointer into this field, make sure to implement
+	// the onsuccess and onerror handlers to be notified when the fetch finishes to know when this memory
+	// block can be freed. Do not pass a pointer to memory on the stack or other temporary area here.
 	const char *requestData;
 
 	// Specifies the length of the buffer pointed by 'requestData'. Leave as 0 if no request body needs to be sent.
@@ -171,9 +173,6 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 // Closes a finished or an executing fetch operation and frees up all memory. If the fetch operation was still executing, the
 // onerror() handler will be called in the calling thread before this function returns.
 EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
-
-// For internal use only. Frees all memory related to fetch operation.
-void emscripten_fetch_free(emscripten_fetch_t *fetch);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -172,6 +172,9 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 // onerror() handler will be called in the calling thread before this function returns.
 EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
 
+// For internal use only. Frees all memory related to fetch operation.
+void emscripten_fetch_free(emscripten_fetch_t *fetch);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implementation for actual sending of `requestHeaders` and `requestData` fields from `emscripten_fetch_attr_t` structure in the `fetch` library.

The patch so far is very simple, I just needed this feature for my current project.