### PR TITLE
Add missing library targets to embuilder

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -63,6 +63,31 @@ and set up the location to the native optimizer in ~/.emscripten
 '''
   sys.exit(0)
 
+C_BARE = '''
+        int main() {}
+      '''
+C_WITH_STDLIB = '''
+        #include <string.h>
+        int main() {
+          return int(strchr("str", 'c'));
+        }
+      '''
+C_WITH_MALLOC = '''
+        #include <string.h>
+        #include <stdlib.h>
+        int main() {
+          return int(malloc(10)) + int(strchr("str", 'c'));
+        }
+      '''
+CXX_WITH_STDLIB = '''
+        #include <iostream>
+        int main() {
+          std::cout << "hello";
+          return 0;
+        }
+      '''
+
+
 temp_files = shared.configuration.get_temp_files()
 
 def build(src, result_libs, args=[]):
@@ -76,68 +101,50 @@ def build(src, result_libs, args=[]):
     for lib in result_libs:
       assert os.path.exists(shared.Cache.get_path(lib)), 'not seeing that requested library %s has been built because file %s does not exist' % (lib, shared.Cache.get_path(lib))
 
+
 def build_port(port_name, lib_name, params):
-  build('''
-    int main() {}
-  ''', [os.path.join('ports-builds', port_name, lib_name)] if lib_name else None, params)
+  build(C_BARE, [os.path.join('ports-builds', port_name, lib_name)] if lib_name else None, params)
+
+
+SYSTEM_TASKS = ['libc', 'libc-mt', 'dlmalloc', 'dlmalloc_threadsafe', 'pthreads', 'libcxx', 'libcxx_noexcept', 'libcxxabi']
+USER_TASKS = ['gl', 'binaryen', 'bullet', 'freetype', 'libpng', 'ogg', 'sdl2', 'sdl2-image', 'sdl2-ttf', 'sdl2-net', 'vorbis', 'zlib']
 
 operation = sys.argv[1]
 
 if operation == 'build':
+  auto_tasks = False
   tasks = sys.argv[2:]
+  if 'SYSTEM' in tasks:
+    tasks = SYSTEM_TASKS
+    auto_tasks = True
   if 'ALL' in tasks:
-    tasks = ['libc', 'libc-mt', 'dlmalloc', 'dlmalloc_threadsafe', 'pthreads', 'libcxx', 'libcxx_noexcept', 'libcxxabi', 'gl', 'binaryen', 'bullet', 'freetype', 'libpng', 'ogg', 'sdl2', 'sdl2-image', 'sdl2-ttf', 'sdl2-net', 'vorbis', 'zlib']
+    tasks = SYSTEM_TASKS + USER_TASKS
+    auto_tasks = True
+  if auto_tasks:
     if shared.Settings.WASM_BACKEND:
       skip_tasks = {'libc-mt', 'dlmalloc_threadsafe', 'pthreads'}
       print('Skipping building of %s, because WebAssembly does not support pthreads.' % ', '.join(skip_tasks))
       tasks = [x for x in tasks if x not in skip_tasks]
-    if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER'):
-      print 'Skipping building of native-optimizer since environment variable EMSCRIPTEN_NATIVE_OPTIMIZER is present and set to point to a prebuilt native optimizer path.'
-    elif hasattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER'):
-      print 'Skipping building of native-optimizer since .emscripten config file has set EMSCRIPTEN_NATIVE_OPTIMIZER to point to a prebuilt native optimizer path.'
     else:
-      tasks += ['native_optimizer']
+      if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER'):
+        print 'Skipping building of native-optimizer since environment variable EMSCRIPTEN_NATIVE_OPTIMIZER is present and set to point to a prebuilt native optimizer path.'
+      elif hasattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER'):
+        print 'Skipping building of native-optimizer since .emscripten config file has set EMSCRIPTEN_NATIVE_OPTIMIZER to point to a prebuilt native optimizer path.'
+      else:
+        tasks += ['native_optimizer']
+    print 'Building targets: %s' % ' '.join (tasks)
   for what in tasks:
     shared.logging.info('building and verifying ' + what)
     if what in ('libc', 'dlmalloc'):
-      build('''
-        #include <string.h>
-        #include <stdlib.h>
-        int main() {
-          return int(malloc(10)) + int(strchr("str", 'c'));
-        }
-      ''', ['libc.bc', 'dlmalloc.bc'])
+      build(C_WITH_MALLOC, ['libc.bc', 'dlmalloc.bc'])
     elif what in 'wasm-libc':
-      build('''
-        #include <string.h>
-        int main() {
-          return int(strchr("str", 'c'));
-        }
-      ''', ['wasm-libc.bc'], ['-s', 'WASM=1'])
+      build(C_WITH_STDLIB, ['wasm-libc.bc'], ['-s', 'WASM=1'])
     elif what in ('libc-mt', 'pthreads', 'dlmalloc_threadsafe'):
-      build('''
-        #include <string.h>
-        #include <stdlib.h>
-        int main() {
-          return int(malloc(10)) + int(strchr("str", 'c'));
-        }
-      ''', ['libc-mt.bc', 'dlmalloc_threadsafe.bc', 'pthreads.bc'], ['-s', 'USE_PTHREADS=1'])
+      build(C_WITH_MALLOC, ['libc-mt.bc', 'dlmalloc_threadsafe.bc', 'pthreads.bc'], ['-s', 'USE_PTHREADS=1'])
     elif what == 'libcxx':
-      build('''
-        #include <iostream>
-        int main() {
-          std::cout << "hello";
-          return 0;
-        }
-      ''', ['libcxx.a'])
+      build(CXX_WITH_STDLIB, ['libcxx.a'])
     elif what == 'libcxx_noexcept':
-      build('''
-        #include <iostream>
-        int main() {
-          std::cout << "hello";
-          return 0;
-        }
-      ''', ['libcxx_noexcept.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=1'])
+      build(CXX_WITH_STDLIB, ['libcxx_noexcept.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=1'])
     elif what == 'libcxxabi':
       build('''
         struct X { int x; virtual void a() {} };
@@ -156,14 +163,10 @@ if operation == 'build':
         }
       ''', ['gl.bc'])
     elif what == 'native_optimizer':
-      build('''
-        int main() {}
-      ''', ['optimizer.2.exe'], ['-O2'])
+      build(C_BARE, ['optimizer.2.exe'], ['-O2'])
     elif what == 'wasm_compiler_rt':
       if shared.Settings.WASM_BACKEND:
-        build('''
-          int main() {}
-        ''', ['wasm_compiler_rt.a'], ['-s', 'WASM=1'])
+        build(C_BARE, ['wasm_compiler_rt.a'], ['-s', 'WASM=1'])
       else:
         shared.logging.warning('wasm_compiler_rt not built when using JSBackend')
     elif what == 'zlib':

--- a/system/include/emscripten/dom_pk_codes.h
+++ b/system/include/emscripten/dom_pk_codes.h
@@ -168,8 +168,14 @@ in Emscripten root directory to regenerate this file. */
 #define DOM_PK_LAUNCH_MEDIA_PLAYER  0xE06D /* "LaunchMediaPlayer"  */
 #define DOM_PK_MEDIA_SELECT         0xE06D /* "MediaSelect"        */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* Maps the EmscriptenKeyboardEvent::code field from emscripten/html5.h to one of the DOM_PK codes above. */
 DOM_PK_CODE_TYPE emscripten_compute_dom_pk_code(const char *keyCodeString);
 
 /* Returns the string representation of the given key code ID. Useful for debug printing. */
 const char *emscripten_dom_pk_code_to_string(DOM_PK_CODE_TYPE code);
+#ifdef __cplusplus
+}
+#endif

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -288,11 +288,17 @@ for s in input_strings:
   h_file.write('#define ' + pad_to_length(s[2], longest_dom_pk_code_length()) + ' 0x%04X /* "%s */' % (s[0], pad_to_length(s[1] + '"', longest_key_code_length()+1)) + '\n')
 
 h_file.write('''
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* Maps the EmscriptenKeyboardEvent::code field from emscripten/html5.h to one of the DOM_PK codes above. */
 DOM_PK_CODE_TYPE emscripten_compute_dom_pk_code(const char *keyCodeString);
 
 /* Returns the string representation of the given key code ID. Useful for debug printing. */
 const char *emscripten_dom_pk_code_to_string(DOM_PK_CODE_TYPE code);
+#ifdef __cplusplus
+}
+#endif
 ''')
 
 c_file.write('''


### PR DESCRIPTION
Also: 
* Refactor embuilder's source definitions and target lists
* Fix the dom_pk_codes header generator to declare its functions `extern "C"`

Fixes #5638 