### PR TITLE
Updated pre-js and post-js documentation

### DIFF
--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -285,12 +285,12 @@ Options that are modified or new in *emcc* are listed below:
        or above, or "--js-opts 1").
 
 "--pre-js <file>"
-   Specify a file whose contents are added before the generated code.
+   Specify a file whose contents are added before the generated bit code.
    This is done *before* optimization, so it will be minified properly
    if the *Closure Compiler* is run.
 
 "--post-js <file>"
-   Specify a file whose contents are added after the generated code.
+   Specify a file whose contents are added after the generated bit code.
    This is done *before* optimization, so it will be minified properly
    if the *Closure Compiler* is run.
 


### PR DESCRIPTION
Pre-js and post-js are inserted before and after the generated bit code, not generated code overall. Sadly, there is no documentation for where -s MODULARIZE is generated so I didn't update that.