### PR TITLE
Change an assertion to an error when the emterpreter data is missing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -315,5 +315,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jiajie Hu <jiajie.hu@intel.com> (copyright owned by Intel Corporation)
 * Kamil Klimek <naresh@tlen.pl>
 * José Carlos Pujol <josecpujol(at)gmail.com>
+* Dannii Willis <curiousdannii@gmail.com>
 
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -991,7 +991,9 @@ __ATPRERUN__.push(function() {
 
     js += ['''
   var bytecodeFile = Module['emterpreterFile'];
-  assert(bytecodeFile instanceof ArrayBuffer, 'bad or missing emterpreter file. if you compiled to JS (and not HTML) make sure you set Module["emterpreterFile"]');
+  if (!(bytecodeFile instanceof ArrayBuffer)) {
+    throw "bad or missing emterpreter file. If you compiled to JS (and not HTML) make sure you set Module['emterpreterFile']";
+  }
   var codeSize = %d;
   HEAPU8.set(new Uint8Array(bytecodeFile).subarray(0, codeSize), eb);
   assert(HEAPU8[eb] === %d);


### PR DESCRIPTION
When the emterpreter data is missing there is an assertion, but this disappears at higher optimisation levels. Change it to throw an error so that the check is always there, rather than a more cryptic error down the line when the variable is used.

Uncovered as part of #5330.