### PR TITLE
Test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ env:
 - TEST_TARGET="asm3.test_p*"
 - TEST_TARGET="ALL.test_q* ALL.test_r* ALL.test_s*"
 - TEST_TARGET="ALL.test_t* ALL.test_u* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*"
-- TEST_TARGET=binaryen0
-- TEST_TARGET=binaryen1
-- TEST_TARGET=binaryen2
-- TEST_TARGET=binaryen3
-- TEST_TARGET=binaryens
-- TEST_TARGET=binaryenz
 - TEST_TARGET=other
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ env:
 - TEST_TARGET="asm2nn.test_p* asm3.test_p*"
 - TEST_TARGET="ALL.test_q* ALL.test_r* ALL.test_s*"
 - TEST_TARGET="ALL.test_t* ALL.test_u* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*"
+- TEST_TARGET=binaryen0
+- TEST_TARGET=binaryen1
+- TEST_TARGET=binaryen2
+- TEST_TARGET=binaryen3
+- TEST_TARGET=binaryens
+- TEST_TARGET=binaryenz
 - TEST_TARGET=other
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ env:
 - TEST_TARGET=ALL.test_c*
 - TEST_TARGET="default.test_d* asm1.test_d* asm2.test_d* asm2f.test_d* asm2g.test_d*"
 - TEST_TARGET=asm2i.test_d*
-- TEST_TARGET="asm2nn.test_d* asm3.test_d*"
+- TEST_TARGET="asm3.test_d*"
 - TEST_TARGET=ALL.test_e*
 - TEST_TARGET=ALL.test_f*
 - TEST_TARGET="ALL.test_g* ALL.test_h* ALL.test_i*"
 - TEST_TARGET="ALL.test_j* ALL.test_k* ALL.test_l* ALL.test_m* ALL.test_n* ALL.test_o*"
 - TEST_TARGET="default.test_p* asm1.test_p* asm2.test_p* asm2f.test_p* asm2g.test_p*"
 - TEST_TARGET=asm2i.test_p*
-- TEST_TARGET="asm2nn.test_p* asm3.test_p*"
+- TEST_TARGET="asm3.test_p*"
 - TEST_TARGET="ALL.test_q* ALL.test_r* ALL.test_s*"
 - TEST_TARGET="ALL.test_t* ALL.test_u* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*"
 - TEST_TARGET=binaryen0

--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -17,7 +17,6 @@ assert not os.environ.get('EM_SAVE_DIR'), 'Need separate directories to avoid th
 # run slower ones first, to optimize total time
 optimal_order = [
   'asm2i',
-  'asm2nn',
   'asm3',
   'asm2',
   'asm2g',

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -108,8 +108,7 @@ test_modes = [
   'asm3',
   'asm2f',
   'asm2g',
-  'asm2i',
-  'asm2nn'
+  'asm2i'
 ]
 nondefault_test_modes = [
   'binaryen0',


### PR DESCRIPTION
Remove legacy asm2nn test mode (non-native optimizer, no longer important) and add travis binaryen tests.