### PR TITLE
cleanup_test_modularize_noise

### DIFF
--- a/tests/browser_test_hello_world.c
+++ b/tests/browser_test_hello_world.c
@@ -15,8 +15,8 @@ int main() {
   });
   printf("hello, world!\n");
   EM_ASM({
-    assert(Module.prints.length === 1, 'bad length');
-    assert(Module.prints[0] == 'hello, world!', 'bad contents: ' + Module.prints[0]);
+    if (Module.prints.length !== 1) throw 'bad length ' + Module.prints.length;
+    if (Module.prints[0] !== 'hello, world!') throw 'bad contents: ' + Module.prints[0];
   });
   REPORT_RESULT(0);
   return 0;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2955,7 +2955,7 @@ window.close = function() {
           var helloOutside = HelloWorld({ noInitialRun: true }).then(function(hello) {
             setTimeout(function() {
               hello._main();
-              assert(hello === helloOutside); // as we are async, helloOutside must have been set
+              if (hello !== helloOutside) throw 'helloOutside has not been set!'; // as we are async, helloOutside must have been set
             });
           });
         '''),


### PR DESCRIPTION
Don't use assert() in browser.test_modularize test, which is not visible in all test code. Fixes a noisy 'assert is undefined' print during the test.

```
JavaScript error: http://localhost:8888/a.html, line 8: ReferenceError: assert is not defined
```

though that was not affecting the test run it seems.