### PR TITLE
Add EMTERPRETIFY_SYNCLIST to specify sync functions for EMTERPRETIFY_ADVISE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -65,7 +65,7 @@ LIB_PREFIXES = ('', 'lib')
 JS_CONTAINING_SUFFIXES = ('js', 'html')
 EXECUTABLE_SUFFIXES = JS_CONTAINING_SUFFIXES + ('wasm',)
 
-DEFERRED_REPONSE_FILES = ('EMTERPRETIFY_BLACKLIST', 'EMTERPRETIFY_WHITELIST')
+DEFERRED_REPONSE_FILES = ('EMTERPRETIFY_BLACKLIST', 'EMTERPRETIFY_WHITELIST', 'EMTERPRETIFY_SYNCLIST')
 
 # Mapping of emcc opt levels to llvm opt levels. We use llvm opt level 3 in emcc opt
 # levels 2 and 3 (emcc 3 is unsafe opts, so unsuitable for the only level to get
@@ -2202,7 +2202,7 @@ def emterpretify(js_target, optimizer, options):
             final + '.em.js',
             json.dumps(shared.Settings.EMTERPRETIFY_BLACKLIST),
             json.dumps(shared.Settings.EMTERPRETIFY_WHITELIST),
-            '',
+            json.dumps(shared.Settings.EMTERPRETIFY_SYNCLIST),
             str(shared.Settings.SWAPPABLE_ASM_MODULE),
            ]
     if shared.Settings.EMTERPRETIFY_ASYNC:

--- a/site/source/docs/porting/emterpreter.rst
+++ b/site/source/docs/porting/emterpreter.rst
@@ -85,6 +85,12 @@ Building with ``EMTERPRETIFY_ADVISE`` will process the project and perform a sta
 
 The analysis is pessimistic, in that it checks what *could* possibly be called, but might not in practice. For example, function pointers are hard to figure out: Even though the analysis takes into account the **type** of function pointer, if you call a ``void (int)`` method by a function pointer, then the analysis must assume that any ``void (int)`` method (that ever has its address taken, i.e., *could* be called via a function pointer) could be called there. For example, on Doom it suggests that 31% (!) of all methods should be interpreted, while in practice only 1% need to be (as is easy to verify by reading the code).
 
+If you have written custom synchronous functions, use ``EMTERPRETIFY_SYNCLIST`` to specify them and ``EMTERPRETIFY_ADVISE`` will include them in its analysis along with the standard synchronous functions.
+
+::
+
+    -s EMTERPRETIFY_SYNCLIST='["_custom_func_a","_custom_func_b"]'
+
 Dynamic Tools
 ~~~~~~~~~~~~~
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -646,6 +646,8 @@ var EMTERPRETIFY_ADVISE = 0; // Performs a static analysis to suggest which func
                              // appears they can be on the stack when a sync function is called in the EMTERPRETIFY_ASYNC option.
                              // After showing the suggested list, compilation will halt. You can apply the provided list as an
                              // emcc argument when compiling later.
+var EMTERPRETIFY_SYNCLIST = []; // If you have additional custom synchronous functions, add them to this list and the advise mode
+                                // will include them in its analysis.
 
 var SPLIT_MEMORY = 0; // If > 0, we split memory into chunks, of the size given in this parameter.
                       //  * TOTAL_MEMORY becomes the maximum amount of memory, as chunks are allocated on

--- a/tests/emterpreter_advise_synclist.c
+++ b/tests/emterpreter_advise_synclist.c
@@ -1,0 +1,27 @@
+int test = 0;
+
+void l() { test++; }
+
+void k() { test++; }
+
+void j() { test++; }
+
+void i() { test++; }
+
+void h() { test++; }
+
+void g() { l(); test++; }
+
+void f() { k(); test++; }
+
+void e() { i(); j(); test++; }
+
+void d() { test++; }
+
+void c() { g(); h(); test++; }
+
+void b() { f(); g(); test++; }
+
+void a() { d(); e(); f(); test++; }
+
+int main() { a(); b(); b(); }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5378,6 +5378,9 @@ function _main() {
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise_funcptr.cpp'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1'], stdout=PIPE).stdout
     self.assertContained('-s EMTERPRETIFY_WHITELIST=\'["__Z4posti", "__Z5post2i", "__Z6middlev", "__Z7sleeperv", "__Z8recurserv", "_main"]\'', out)
 
+    out = run_process([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise_synclist.c'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1', '-s', 'EMTERPRETIFY_SYNCLIST=["_j","_k"]'], stdout=PIPE).stdout
+    self.assertContained('-s EMTERPRETIFY_WHITELIST=\'["_a", "_b", "_e", "_f", "_main"]\'', out)
+
   def test_link_with_a_static(self):
     for args in [[], ['-O2']]:
       print(args)

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -720,6 +720,13 @@ if __name__ == '__main__':
       WHITELIST = json.loads(temp)
 
       if len(sys.argv) >= 6:
+        temp = sys.argv[5]
+        if temp[0] == '"':
+          # response file
+          assert temp[1] == '@'
+          temp = open(temp[2:-1]).read()
+        SYNC_FUNCS.update(json.loads(temp))
+
         if len(sys.argv) >= 7:
           SWAPPABLE = int(sys.argv[6])
 


### PR DESCRIPTION
Fixes #5105.

Uses the disused argument to emterpretify.py which long ago had been used by the yield list.