### PR TITLE
Python 3 compatibility: Use except-as syntax

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -912,7 +912,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
         assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
         assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
-      except Exception, e:
+      except Exception as e:
         logging.error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
         raise e
 

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -45,7 +45,7 @@ def run():
 
   try:
     shared.Building.configure(sys.argv[1:])
-  except CalledProcessError, e:
+  except CalledProcessError as e:
     sys.exit(e.returncode)
 
 if __name__ == '__main__':

--- a/emmake.py
+++ b/emmake.py
@@ -40,7 +40,7 @@ def run():
 
   try:
     shared.Building.make(sys.argv[1:])
-  except CalledProcessError, e:
+  except CalledProcessError as e:
     sys.exit(e.returncode)
 
 if __name__ == '__main__':

--- a/emscripten.py
+++ b/emscripten.py
@@ -145,7 +145,7 @@ def parse_backend_output(backend_output, DEBUG):
   try:
     #if DEBUG: print >> sys.stderr, "METAraw", metadata_raw
     metadata = json.loads(metadata_raw)
-  except Exception, e:
+  except Exception as e:
     logging.error('emscript: failure to parse metadata output from compiler backend. raw output is: \n' + metadata_raw)
     raise e
 
@@ -2024,7 +2024,7 @@ def create_s2wasm_args(temp_s):
 def load_metadata(metadata_raw):
   try:
     metadata_json = json.loads(metadata_raw)
-  except Exception, e:
+  except Exception as e:
     logging.error('emscript: failure to parse metadata output from s2wasm. raw output is: \n' + metadata_raw)
     raise e
 

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -73,7 +73,7 @@ class Cache(object):
     tempfiles.try_delete(self.dirname)
     try:
       open(self.dirname + '__last_clear', 'w').write('last clear: ' + time.asctime() + '\n')
-    except Exception, e:
+    except Exception as e:
       print('failed to save last clear time: ', e, file=sys.stderr)
     self.filelock = None
     tempfiles.try_delete(self.filelock_name)

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -247,7 +247,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
     proc = subprocess.Popen(shared.NODE_JS + [temp_file], stdout=out_file_handle, stderr=err_file_handle)
     try:
       shared.jsrun.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
-    except Exception, e:
+    except Exception as e:
       if 'Timed out' not in str(e): raise e
       shared.logging.debug('ctors timed out\n')
       return (0, 0, 0, 0)

--- a/tools/emmaken.py
+++ b/tools/emmaken.py
@@ -225,7 +225,7 @@ try:
   print("Running:", call, ' '.join(newargs), file=sys.stderr)
 
   subprocess.call([call] + newargs)
-except Exception, e:
+except Exception as e:
   print('Error in emmaken.py. (Is the config file %s set up properly?) Error:' % EM_CONFIG, e)
   raise
 

--- a/tools/emprofile.py
+++ b/tools/emprofile.py
@@ -47,7 +47,7 @@ def create_profiling_graph():
       lines[-1] = lines[-1][:-1]
       json_data = '[' + '\n'.join(lines) + ']'
       all_results += json.loads(json_data)
-    except Exception, e:
+    except Exception as e:
       print(str(e), file=sys.stderr)
       print('Failed to parse JSON file "' + f + '"!', file=sys.stderr)
       sys.exit(1)

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -889,7 +889,7 @@ if __name__ == '__main__':
     elif line.startswith('// EMTERPRET_INFO '):
       try:
         func, curr, absolute_targets = json.loads(line[len('// EMTERPRET_INFO '):])
-      except Exception, e:
+      except Exception as e:
         print('failed to parse code from', line, file=sys.stderr)
         raise e
       assert len(curr) % 4 == 0, len(curr)

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -82,9 +82,9 @@ def read_b2g_response(print_errors_to_console = True):
     if semicolon+1+payload_len > len(read_queue):
       try:
         read_queue += b2g_socket.recv(4096)
-      except socket.timeout, e: 
+      except socket.timeout as e: 
         pass # We simulate blocking sockets with looping over reads that time out, since on Windows, the user cannot press Ctrl-C to break on blocking sockets.
-      except Exception, e:
+      except Exception as e:
         if e[0] == 57: # Socket is not connected
           print('Error! Failed to receive data from the device: socket is not connected!')
           sys.exit(1)
@@ -180,7 +180,7 @@ def adb_devices():
     devices = devices.strip().split('\n')[1:]
     devices = map(lambda x: x.strip().split('\t'), devices)
     return devices
-  except Exception, e:
+  except Exception as e:
     return []
 
 def b2g_get_prefs_filename():
@@ -237,7 +237,7 @@ def get_packaged_app_manifest(target_app_path):
     try:
       z = zipfile.ZipFile(target_app_path, "r")
       bytes = z.read('manifest.webapp')
-    except Exception, e:
+    except Exception as e:
       print("Error: Failed to read FFOS packaged app manifest file 'manifest.webapp' in zip file '" + target_app_path + "'! Error: " + str(e))
       sys.exit(1)
       return None
@@ -562,7 +562,7 @@ def main():
     b2g_socket.settimeout(0.5)
   try:
     b2g_socket.connect((HOST, PORT))
-  except Exception, e:
+  except Exception as e:
     if e[0] == 61 or e[0] == 107 or e[0] == 111: # 61 == Connection refused and 107+111 == Transport endpoint is not connected
       if (HOST == 'localhost' or HOST == '127.0.0.1') and not connect_to_simulator:
         cmd = [ADB, 'forward', 'tcp:'+str(PORT), 'localfilesystem:/data/local/debugger-socket']
@@ -572,7 +572,7 @@ def main():
         sys.exit(1)
       try:
         retcode = subprocess.check_call(cmd)
-      except Exception, e:
+      except Exception as e:
         print('Error! Failed to execute adb: ' + str(e))
         print("Check that the device is connected properly, call 'adb devices' to list the detected devices.")
         sys.exit(1)
@@ -584,7 +584,7 @@ def main():
       try:
         b2g_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         b2g_socket.connect((HOST, PORT))
-      except Exception, e:
+      except Exception as e:
         print('Error! Failed to connect to B2G device debugger socket at address ' + HOST + ':' + str(PORT) + '!')
         sys.exit(1)
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -154,7 +154,7 @@ for arg in sys.argv[2:]:
   elif arg.startswith('--crunch'):
     try:
       from shared import CRUNCH
-    except Exception, e:
+    except Exception as e:
       print('could not import CRUNCH (make sure it is defined properly in ' + shared.hint_config_file_location() + ')', file=sys.stderr)
       raise e
     crunch = arg.split('=', 1)[1] if '=' in arg else '128'

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -176,7 +176,7 @@ def get_native_optimizer():
         return shared.Cache.get(name, create_optimizer_cmake, extension='exe')
       else:
         return shared.Cache.get(name, create_optimizer, extension='exe')
-    except NativeOptimizerCreationException, e:
+    except NativeOptimizerCreationException as e:
       shared.logging.debug('failed to build native optimizer')
       handle_build_errors(outs, errs)
       open(FAIL_MARKER, 'w').write(':(')
@@ -574,7 +574,7 @@ if __name__ == '__main__':
       extra_info = None
     out = run(sys.argv[1], sys.argv[2:], extra_info=extra_info)
     shutil.copyfile(out, sys.argv[1] + '.jsopt.js')
-  except Exception, e:
+  except Exception as e:
     ToolchainProfiler.record_process_exit(1)
     raise e
   ToolchainProfiler.record_process_exit(0)

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -56,7 +56,7 @@ def check_engine(engine):
     logging.debug('Checking JS engine %s' % engine)
     if 'hello, world!' in run_js(os.path.join(__rootpath__, 'src', 'hello_world.js'), engine, skip_check=True):
       WORKING_ENGINES[engine_path] = True
-  except Exception, e:
+  except Exception as e:
     logging.info('Checking JS engine %s failed. Check your config file. Details: %s' % (str(engine), str(e)))
     WORKING_ENGINES[engine_path] = False
   return WORKING_ENGINES[engine_path]
@@ -101,7 +101,7 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
         stdout=stdout,
         stderr=stderr,
         cwd=cwd)
-  except Exception, e:
+  except Exception as e:
     # the failure may be because the engine is not present. show the proper
     # error in that case
     if not skip_check:
@@ -120,7 +120,7 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
       'Execution',
       full_output=full_output,
       throw_on_failure=False)
-  except Exception, e:
+  except Exception as e:
     # the failure may be because the engine does not work. show the proper
     # error in that case
     if not skip_check:

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -19,7 +19,7 @@ def convert_line_endings_in_file(filename, from_eol, to_eol):
 def check_line_endings(filename, expect_only_specific_line_endings=None, print_errors=True, print_info=False):
   try:
     data = open(filename, 'rb').read()
-  except Exception, e:
+  except Exception as e:
     if print_errors: print("Unable to read file '" + filename + "'! " + str(e), file=sys.stderr)
     return 1
   if len(data) == 0:

--- a/tools/ll-strip.py
+++ b/tools/ll-strip.py
@@ -12,7 +12,7 @@ try:
   range_from = int(sys.argv[2])
   range_to = int(sys.argv[3])
   if range_from >= range_to:
-    raise "error"
+    raise Exception("error")
   file = open(sys.argv[1])
 except:
   print_usage()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -46,7 +46,7 @@ class WindowsPopen(object):
       # Call the process with fixed streams.
       self.process = subprocess.Popen(args, bufsize, executable, self.stdin_, self.stdout_, self.stderr_, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags)
       self.pid = self.process.pid
-    except Exception, e:
+    except Exception as e:
       logging.error('\nsubprocess.Popen(args=%s) failed! Exception %s\n' % (' '.join(args), str(e)))
       raise e
 
@@ -262,7 +262,7 @@ This command will now exit. When you are done editing those paths, re-run it.
 try:
   config_text = open(CONFIG_FILE, 'r').read() if CONFIG_FILE else EM_CONFIG
   exec(config_text)
-except Exception, e:
+except Exception as e:
   logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
   sys.exit(1)
 
@@ -346,7 +346,7 @@ def check_clang_version():
 def check_llvm_version():
   try:
     check_clang_version()
-  except Exception, e:
+  except Exception as e:
     logging.critical('Could not verify LLVM version: %s' % str(e))
 
 # look for emscripten-version.txt files under or alongside the llvm source dir
@@ -371,7 +371,7 @@ def get_llc_targets():
     llc_version_info = Popen([LLVM_COMPILER, '--version'], stdout=PIPE).communicate()[0]
     pre, targets = llc_version_info.split('Registered Targets:')
     return targets
-  except Exception, e:
+  except Exception as e:
     return '(no targets could be identified: ' + str(e) + ')'
 
 def has_asm_js_target(targets):
@@ -427,7 +427,7 @@ def check_fastcomp():
           logging.error('Make sure to rebuild llvm and clang after updating repos')
 
     return True
-  except Exception, e:
+  except Exception as e:
     logging.warning('could not check fastcomp: %s' % str(e))
     return True
 
@@ -442,7 +442,7 @@ def check_node_version():
       return True
     logging.warning('node version appears too old (seeing "%s", expected "%s")' % (actual, 'v' + ('.'.join(map(str, EXPECTED_NODE_VERSION)))))
     return False
-  except Exception, e:
+  except Exception as e:
     logging.warning('cannot check node version: %s',  e)
     return False
 
@@ -488,13 +488,13 @@ try:
     EMSCRIPTEN_VERSION_MAJOR = parts[0]
     EMSCRIPTEN_VERSION_MINOR = parts[1]
     EMSCRIPTEN_VERSION_TINY = parts[2]
-  except Exception, e:
+  except Exception as e:
     logging.warning('emscripten version ' + EMSCRIPTEN_VERSION + ' lacks standard parts')
     EMSCRIPTEN_VERSION_MAJOR = 0
     EMSCRIPTEN_VERSION_MINOR = 0
     EMSCRIPTEN_VERSION_TINY = 0
     raise e
-except Exception, e:
+except Exception as e:
   logging.error('cannot find emscripten version ' + str(e))
   EMSCRIPTEN_VERSION = 'unknown'
 
@@ -525,7 +525,7 @@ def check_sanity(force=False):
               reason = 'system change: %s vs %s' % (generate_sanity(), sanity_data)
             else:
               if not force: return # all is well
-        except Exception, e:
+        except Exception as e:
           reason = 'unknown: ' + str(e)
     if reason:
       logging.warning('(Emscripten: %s, clearing cache)' % reason)
@@ -581,7 +581,7 @@ def check_sanity(force=False):
       f.write(generate_sanity())
       f.close()
 
-  except Exception, e:
+  except Exception as e:
     # Any error here is not worth failing on
     print('WARNING: sanity check failed to run', e)
   finally:
@@ -756,7 +756,7 @@ FILE_PACKAGER = path_from_root('tools', 'file_packager.py')
 def safe_ensure_dirs(dirname):
   try:
     os.makedirs(dirname)
-  except os.error, e:
+  except os.error as e:
     # Ignore error for already existing dirname
     if e.errno != errno.EEXIST:
       raise e
@@ -852,7 +852,7 @@ class Configuration(object):
       try:
         self.EMSCRIPTEN_TEMP_DIR = self.CANONICAL_TEMP_DIR
         safe_ensure_dirs(self.EMSCRIPTEN_TEMP_DIR)
-      except Exception, e:
+      except Exception as e:
         logging.error(str(e) + 'Could not create canonical temp dir. Check definition of TEMP_DIR in ' + hint_config_file_location())
 
   def get_temp_files(self):
@@ -883,7 +883,7 @@ try:
 except:
   try:
     JS_ENGINES = [JS_ENGINE]
-  except Exception, e:
+  except Exception as e:
     print('ERROR: %s does not seem to have JS_ENGINES or JS_ENGINE set up' % EM_CONFIG)
     raise
 
@@ -946,7 +946,7 @@ def check_vanilla():
         logging.debug('regenerating vanilla check since other llvm')
         temp_cache.get('is_vanilla', get_vanilla_file, extension='.txt', force=True)
         is_vanilla = check_vanilla()
-    except Exception, e:
+    except Exception as e:
       logging.debug('failed to use vanilla file, will re-check: ' + str(e))
       is_vanilla = check_vanilla()
     temp_cache = None
@@ -1279,7 +1279,7 @@ def extract_archive_contents(f):
       'dir': temp_dir,
       'files': contents
     }
-  except Exception, e:
+  except Exception as e:
     print('extract archive contents('+str(f)+') failed with error: ' + str(e), file=sys.stderr)
   finally:
     os.chdir(cwd)
@@ -1365,7 +1365,7 @@ class Building(object):
             Building.multiprocessing_pool.terminate()
             Building.multiprocessing_pool.join()
             Building.multiprocessing_pool = None
-          except OSError, e:
+          except OSError as e:
             # Mute the "WindowsError: [Error 5] Access is denied" errors, raise all others through
             if not (sys.platform.startswith('win') and isinstance(e, WindowsError) and e.winerror == 5): raise
         atexit.register(close_multiprocessing_pool)
@@ -1533,7 +1533,7 @@ class Building(object):
       if EM_BUILD_VERBOSE_LEVEL >= 3: print('configure: ' + str(args), file=sys.stderr)
       process = Popen(args, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else stdout, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else stderr, env=env)
       process.communicate()
-    except Exception, e:
+    except Exception as e:
       logging.error('Exception thrown when invoking Popen in configure with args: "%s"!' % ' '.join(args))
       raise
     if 'EMMAKEN_JUST_CONFIGURE' in env: del env['EMMAKEN_JUST_CONFIGURE']
@@ -1565,7 +1565,7 @@ class Building(object):
       if EM_BUILD_VERBOSE_LEVEL >= 3: print('make: ' + str(args), file=sys.stderr)
       process = Popen(args, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else stdout, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else stderr, env=env, shell=WINDOWS)
       process.communicate()
-    except Exception, e:
+    except Exception as e:
       logging.error('Exception thrown when invoking Popen in make with args: "%s"!' % ' '.join(args))
       raise
     if process.returncode is not 0:
@@ -1610,7 +1610,7 @@ class Building(object):
       try:
         Building.configure(configure + configure_args, env=env, stdout=open(os.path.join(project_dir, 'configure_'), 'w') if EM_BUILD_VERBOSE_LEVEL < 2 else None,
                                                                 stderr=open(os.path.join(project_dir, 'configure_err'), 'w') if EM_BUILD_VERBOSE_LEVEL < 1 else None)
-      except subprocess.CalledProcessError, e:
+      except subprocess.CalledProcessError as e:
         pass # Ignore exit code != 0
     def open_make_out(i, mode='r'):
       return open(os.path.join(project_dir, 'make_' + str(i)), mode)
@@ -1627,7 +1627,7 @@ class Building(object):
           try:
             Building.make(make + make_args, stdout=make_out if EM_BUILD_VERBOSE_LEVEL < 2 else None,
                                             stderr=make_err if EM_BUILD_VERBOSE_LEVEL < 1 else None, env=env)
-          except subprocess.CalledProcessError, e:
+          except subprocess.CalledProcessError as e:
             pass # Ignore exit code != 0
       try:
         if cache is not None:
@@ -1636,7 +1636,7 @@ class Building(object):
             basename = os.path.basename(f)
             cache[cache_name].append((basename, open(f, 'rb').read()))
         break
-      except Exception, e:
+      except Exception as e:
         if i > 0:
           if EM_BUILD_VERBOSE_LEVEL == 0:
             # Due to the ugly hack above our best guess is to output the first run
@@ -2233,7 +2233,7 @@ class Building(object):
                  b[6] == '>' and ord(b[7]) == 10
       Building._is_ar_cache[filename] = sigcheck
       return sigcheck
-    except Exception, e:
+    except Exception as e:
       logging.debug('Building.is_ar failed to test whether file \'%s\' is a llvm archive file! Failed on exception: %s' % (filename, e))
       return False
 

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -23,7 +23,7 @@ def validate_asmjs_jsfile(filename, muteOutput):
     return False
   try:
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
-  except Exception, e:
+  except Exception as e:
     print('Executing command ' + str(cmd) + ' failed due to an exception: ' + str(e) + '!', file=sys.stderr)
     return False
   (stdout, stderr) = process.communicate()


### PR DESCRIPTION
```python
# Python 2 only
except Exception, e:
  pass

# Python 2 and 3
except Exception as e:
  pass
```

This again requires [Python 2.6+](https://www.python.org/dev/peps/pep-3110/#compatibility).