### PR TITLE
Less dependency installations on Travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For travis
-FROM ubuntu:16.04
+FROM buildpack-deps:xenial
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND noninteractive
 RUN mkdir -p /root/emscripten/
@@ -7,7 +7,7 @@ COPY . /root/emscripten/
 
 RUN cd /root/ \
  && apt-get update \
- && apt-get install -y python python-pip wget git cmake build-essential software-properties-common \
+ && apt-get install -y python python-pip cmake build-essential software-properties-common \
  && pip install --upgrade pip \
  && pip install lit \
  && add-apt-repository ppa:webupd8team/java \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,9 @@ COPY . /root/emscripten/
 
 RUN cd /root/ \
  && apt-get update \
- && apt-get install -y python python-pip cmake build-essential software-properties-common \
+ && apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless \
  && pip install --upgrade pip \
  && pip install lit \
- && add-apt-repository ppa:webupd8team/java \
- && apt-get update \
- && echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
- && echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections \
- && apt-get install -y oracle-java9-installer \
  && wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
  && tar -xf emsdk-portable.tar.gz \
  && pushd emsdk-portable \


### PR DESCRIPTION
...by a shorter script.

Current: 

```
The following NEW packages will be installed:
  apt-utils binutils build-essential bzip2 ca-certificates cmake cmake-data
  cpp cpp-5 cron dbus dh-python distro-info-data dpkg-dev fakeroot file g++
  g++-5 gcc gcc-5 gir1.2-glib-2.0 git git-man ifupdown iproute2
  isc-dhcp-client isc-dhcp-common iso-codes krb5-locales less
  libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl
  libapt-inst2.0 libarchive13 libasan2 libasn1-8-heimdal libatm1 libatomic1
  libbsd0 libc-dev-bin libc6-dev libcap-ng0 libcc1-0 libcilkrts5 libcurl3
  libcurl3-gnutls libdbus-1-3 libdbus-glib-1-2 libdns-export162 libdpkg-perl
  libedit2 liberror-perl libexpat1 libexpat1-dev libfakeroot libffi6
  libfile-fcntllock-perl libgcc-5-dev libgdbm3 libgirepository-1.0-1
  libglib2.0-0 libglib2.0-data libgmp10 libgnutls30 libgomp1 libgssapi-krb5-2
  libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libicu55 libidn11
  libisc-export160 libisl15 libitm1 libjsoncpp1 libk5crypto3 libkeyutils1
  libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2 liblsan0
  liblzo2-2 libmagic1 libmnl0 libmpc3 libmpdec2 libmpfr4 libmpx0 libnettle6
  libp11-kit0 libperl5.22 libpopt0 libpython-all-dev libpython-dev
  libpython-stdlib libpython2.7 libpython2.7-dev libpython2.7-minimal
  libpython2.7-stdlib libpython3-stdlib libpython3.5-minimal
  libpython3.5-stdlib libquadmath0 libroken18-heimdal librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libsqlite3-0 libssl1.0.0
  libstdc++-5-dev libtasn1-6 libtsan0 libubsan0 libwind0-heimdal libx11-6
  libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxml2 libxmuu1 libxtables11
  linux-libc-dev lsb-release make manpages manpages-dev mime-support netbase
  openssh-client openssl patch perl perl-modules-5.22 python python-all
  python-all-dev python-apt-common python-dev python-minimal python-pip
  python-pip-whl python-pkg-resources python-setuptools python-wheel python2.7
  python2.7-dev python2.7-minimal python3 python3-apt python3-dbus python3-gi
  python3-minimal python3-pycurl python3-software-properties python3.5
  python3.5-minimal rename rsync sgml-base shared-mime-info
  software-properties-common ucf unattended-upgrades wget xauth xdg-user-dirs
  xml-core xz-utils
0 upgraded, 176 newly installed, 0 to remove and 0 not upgraded.
Need to get 117 MB of archives.

(... messages including downloading and unpacking logs ...)

337920K ...                                                  100% 91.2M=9.6s

2017-10-17 00:27:03 (34.4 MB/s) - 'jdk-9_linux-x64_bin.tar.gz' saved [346271941/346271941]
```

This PR:

```
The following NEW packages will be installed:
  build-essential ca-certificates-java cmake cmake-data java-common
  libarchive13 libjsoncpp1 libnspr4 libnss3 libnss3-nssdb libpcsclite1
  libpython-all-dev libpython-dev libpython2.7 libpython2.7-dev libxtst6
  openjdk-9-jre-headless python-all python-all-dev python-dev python-pip
  python-pip-whl python-pkg-resources python-setuptools python-wheel
  python2.7-dev
0 upgraded, 26 newly installed, 0 to remove and 1 not upgraded.
Need to get 219 MB of archives.
```