### PR TITLE
librt_is_implicit

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2281,6 +2281,7 @@ class Building(object):
       'glut': 'library_glut.js',
       'm': '',
       'openal': 'library_openal.js',
+      'rt': '',
       'pthread': '',
       'X11': 'library_xlib.js',
       'SDL': 'library_sdl.js',


### PR DESCRIPTION
Make -lrt linker command line directive not issue a warning, the rt specific symbols (https://docs.oracle.com/cd/E86824_01/html/E54772/librt-3lib.html) are linked in automatically with musl, some of these when compiling with pthreads enabled.