### PR TITLE
Python 3 compatibility: Convert maps/filters to lists

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1307,7 +1307,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # -E preprocessor-only support
       if '-E' in newargs or '-M' in newargs or '-MM' in newargs:
-        input_files = map(lambda x: x[1], input_files)
+        input_files = [x[1] for x in input_files]
         cmd = get_bitcode_args(input_files)
         if specified_target:
           cmd += ['-o', specified_target]
@@ -2308,7 +2308,7 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
   if shared.Settings.BINARYEN_PASSES:
     shutil.move(wasm_binary_target, wasm_binary_target + '.pre')
     # BINARYEN_PASSES is comma-separated, and we support both '-'-prefixed and unprefixed pass names
-    passes = map(lambda p: ('--' + p) if p[0] != '-' else p, shared.Settings.BINARYEN_PASSES.split(','))
+    passes = [('--' + p) if p[0] != '-' else p for p in shared.Settings.BINARYEN_PASSES.split(',')]
     cmd = [os.path.join(binaryen_bin, 'wasm-opt'), wasm_binary_target + '.pre', '-o', wasm_binary_target] + passes
     if debug_info:
       cmd += ['-g'] # preserve the debug info

--- a/emcc.py
+++ b/emcc.py
@@ -188,7 +188,7 @@ class JSOptimizer(object):
     self.js_transform_tempfiles = js_transform_tempfiles
 
   def flush(self, title='js_opts'):
-    self.queue = filter(lambda p: p not in self.blacklist, self.queue)
+    self.queue = [p for p in self.queue if p not in self.blacklist]
 
     assert not shared.Settings.WASM_BACKEND, 'JSOptimizer should not run with pure wasm output'
 
@@ -297,7 +297,7 @@ def run():
   stderr = PIPE if not DEBUG else None # unless we are in DEBUG mode
 
   EMCC_CXX = '--emscripten-cxx' in sys.argv
-  sys.argv = filter(lambda x: x != '--emscripten-cxx', sys.argv)
+  sys.argv = [x for x in sys.argv if x != '--emscripten-cxx']
 
   if len(sys.argv) <= 1 or ('--help' not in sys.argv and len(sys.argv) >= 2 and sys.argv[1] != '--version'):
     shared.check_sanity(force=DEBUG)
@@ -374,14 +374,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # fake running the command, to see the full args we pass to clang
     debug_env = os.environ.copy()
     debug_env['EMCC_DEBUG'] = '1'
-    args = filter(lambda x: x != '--cflags', sys.argv)
+    args = [x for x in sys.argv if x != '--cflags']
     with misc_temp_files.get_file(suffix='.o') as temp_target:
       input_file = 'hello_world.c'
       out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', input_file), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env).communicate()
-      lines = filter(lambda x: shared.CLANG_CC in x and input_file in x, err.split(os.linesep))
+      lines = [x for x in err.split(os.linesep) if shared.CLANG_CC in x and input_file in x]
       line = re.search('running: (.*)', lines[0]).group(1)
       parts = shlex.split(line.replace('\\', '\\\\'))
-      parts = filter(lambda x: x != '-c' and x != '-o' and input_file not in x and temp_target not in x and '-emit-llvm' not in x, parts)
+      parts = [x for x in parts if x != '-c' and x != '-o' and input_file not in x and temp_target not in x and '-emit-llvm' not in x]
       print(' '.join(shared.Building.doublequote_spaces(parts[1:])))
     exit(0)
 
@@ -814,7 +814,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # command line already now.
 
       def get_last_setting_change(setting):
-        return ([None] + filter(lambda x: x.startswith(setting + '='), settings_changes))[-1]
+        return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
 
       strict_cmdline = get_last_setting_change('STRICT')
       if strict_cmdline:

--- a/emscripten.py
+++ b/emscripten.py
@@ -210,7 +210,7 @@ def compiler_glue(metadata, settings, libraries, compiler_engine, temp_files, DE
       break
 
   # FIXME: do these one by one as normal js lib funcs
-  metadata['declares'] = filter(lambda i64_func: i64_func not in ['getHigh32', 'setHigh32'], metadata['declares'])
+  metadata['declares'] = [i64_func for i64_func in metadata['declares'] if i64_func not in ['getHigh32', 'setHigh32']]
 
   optimize_syscalls(metadata['declares'], settings, DEBUG)
   update_settings_glue(settings, metadata)
@@ -993,7 +993,7 @@ def global_simd_funcs(access_quote, metadata, settings):
 
   def generate_symbols(types, funcs):
     symbols = ['  var SIMD_' + ty + '_' + g + '=SIMD_' + ty + access_quote(g) + ';\n' for ty in types for g in funcs]
-    symbols = filter(lambda x: not string_contains_any(x, nonexisting_simd_symbols), symbols)
+    symbols = [x for x in symbols if not string_contains_any(x, nonexisting_simd_symbols)]
     return ''.join(symbols)
 
   simd_func_text += generate_symbols(simd['int_types'], simd['int_funcs'])
@@ -2085,7 +2085,7 @@ def add_metadata_from_wast(metadata, wast):
         assert False, 'Unhandled export type "%s"' % export_type
 
   # we emit those ourselves
-  metadata['declares'] = filter(lambda x: not x.startswith('emscripten_asm_const'), metadata['declares'])
+  metadata['declares'] = [x for x in metadata['declares'] if not x.startswith('emscripten_asm_const')]
 
 
 def create_invoke_wrappers(invoke_funcs):

--- a/tools/bindings_generator.py
+++ b/tools/bindings_generator.py
@@ -355,7 +355,7 @@ for classname, clazz in parsed.classes.items() + parsed.structs.items():
       'parameters': [[]],
     })
 
-  clazz['methods'] = filter(lambda method: not method.get('ignore'), clazz['methods'])
+  clazz['methods'] = [method for method in clazz['methods'] if not method.get('ignore')]
 
 # Explore all functions we need to generate, including parent classes, handling of overloading, etc.
 

--- a/tools/bindings_generator.py
+++ b/tools/bindings_generator.py
@@ -435,7 +435,7 @@ for classname, clazz in parsed.classes.items() + parsed.structs.items():
           continue
         # TODO: Other compatibility checks, if any?
 
-        curr['parameters'] += map(copy_args, method['parameters'])
+        curr['parameters'] += list(map(copy_args, method['parameters']))
 
         print('zz ', classname, 'has updated parameters of ', curr['parameters'])
 
@@ -662,13 +662,13 @@ def generate_class(generating_classname, classname, clazz): # TODO: deprecate ge
     need_self = not constructor and not static
 
     def typedargs(args):
-      return ([] if not need_self else [classname + ' * self']) + map(lambda i: args[i]['type'] + ' arg' + str(i), range(len(args)))
+      return ([] if not need_self else [classname + ' * self']) + [args[i]['type'] + ' arg' + str(i) for i in range(len(args))]
     def justargs(args):
-      return map(lambda i: 'arg' + str(i), range(len(args)))
+      return ['arg' + str(i) for i in range(len(args))]
     def justtypes(args): # note: this ignores 'self'
-      return map(lambda i: args[i]['type'], range(len(args)))
+      return [args[i]['type'] for i in range(len(args))]
     def dummyargs(args):
-      return ([] if not need_self else ['(%s*)argv[argc]' % classname]) + map(lambda i: '(%s)argv[argc]' % args[i]['type'], range(len(args)))
+      return ([] if not need_self else ['(%s*)argv[argc]' % classname]) + ['(%s)argv[argc]' % args[i]['type'] for i in range(len(args))]
 
     fullname = ('emscripten_bind_' + generating_classname + '__' + mname).replace('::', '__')
     generating_classname_suffixed = generating_classname

--- a/tools/bisect_pair.py
+++ b/tools/bisect_pair.py
@@ -61,7 +61,7 @@ print('beginning bisection, %d chunks' % high)
 for mid in range(high):
   print('  current: %d' % mid, end=' ')
   # Take chunks from the middle and on. This is important because the eliminator removes variables, so starting from the beginning will add errors
-  curr_diff = '\n'.join(map(lambda parts: '\n'.join(parts), chunks[mid:])) + '\n'
+  curr_diff = '\n'.join(['\n'.join(parts) for parts in chunks[mid:]]) + '\n'
   difff = open('diff.diff', 'w')
   difff.write(curr_diff)
   difff.close()

--- a/tools/bisect_pair.py
+++ b/tools/bisect_pair.py
@@ -27,7 +27,7 @@ rightf.close()
 def run_code(name):
   ret = run_js(name, stderr=PIPE, full_output=True, assert_returncode=None, engine=SPIDERMONKEY_ENGINE)
   # fix stack traces
-  ret = filter(lambda line: not line.startswith('    at ') and not name in line, ret.split('\n'))
+  ret = [line for line in ret.split('\n') if not line.startswith('    at ') and not name in line]
   return '\n'.join(ret)
 
 print('running files')

--- a/tools/bisect_pair_lines.py
+++ b/tools/bisect_pair_lines.py
@@ -29,7 +29,7 @@ rightf.close()
 def run_code(name):
   ret = run_js(name, stderr=PIPE, full_output=True)
   # fix stack traces
-  ret = filter(lambda line: not line.startswith('    at ') and not name in line, ret.split('\n'))
+  ret = [line for line in ret.split('\n') if not line.startswith('    at ') and not name in line]
   return '\n'.join(ret)
 
 print('running files')

--- a/tools/bisect_pair_wast.py
+++ b/tools/bisect_pair_wast.py
@@ -28,7 +28,7 @@ def run_code(name):
   shutil.copyfile(name, 'src.cpp.o.wast')
   ret = run_js('src.cpp.o.js', stderr=PIPE, full_output=True, assert_returncode=None, engine=SPIDERMONKEY_ENGINE)
   # fix stack traces
-  ret = filter(lambda line: not line.startswith('    at ') and not name in line, ret.split('\n'))
+  ret = [line for line in ret.split('\n') if not line.startswith('    at ') and not name in line]
   return '\n'.join(ret)
 
 print('running files')

--- a/tools/bisect_pair_wast.py
+++ b/tools/bisect_pair_wast.py
@@ -62,7 +62,7 @@ print('beginning bisection, %d chunks' % high)
 for mid in range(high):
   print('  current: %d' % mid, end=' ')
   # Take chunks from the middle and on. This is important because the eliminator removes variables, so starting from the beginning will add errors
-  curr_diff = '\n'.join(map(lambda parts: '\n'.join(parts), chunks[mid:])) + '\n'
+  curr_diff = '\n'.join(['\n'.join(parts) for parts in chunks[mid:]]) + '\n'
   difff = open('diff.diff', 'w')
   difff.write(curr_diff)
   difff.close()

--- a/tools/clean_webconsole.py
+++ b/tools/clean_webconsole.py
@@ -17,7 +17,7 @@ repdata = open(path_from_root('system', 'include', 'GL', 'gl.h')).readlines() + 
 reps = {}
 for rep in repdata:
   rep = rep.replace('\t', ' ').replace('\n', '')
-  parts = filter(lambda part: part != '', rep.split(' '))
+  parts = [part for part in rep.split(' ') if part != '']
   if len(parts) == 3 and parts[0] == '#define':
     reps[nice(parts[2])] = '%s (%s)' % (parts[1], parts[2])
 

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -250,10 +250,10 @@ def pad_to_length(s, length):
   return s + max(0, length - len(s)) * ' '
 
 def longest_dom_pk_code_length():
-  return max(map(len, map(lambda x: x[2], input_strings)))
+  return max(list(map(len, [x[2] for x in input_strings])))
 
 def longest_key_code_length():
-  return max(map(len, map(lambda x: x[1], input_strings)))
+  return max(list(map(len, [x[1] for x in input_strings])))
 
 h_file = open('system/include/emscripten/dom_pk_codes.h', 'w')
 c_file = open('system/lib/html5/dom_pk_codes.c', 'w')

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -40,7 +40,7 @@ def find_ctors_data(js, num):
   ctors_start, ctors_end = find_ctors(js)
   assert ctors_start > 0
   ctors_text = js[ctors_start:ctors_end]
-  all_ctors = filter(lambda ctor: ctor.endswith('()') and not ctor == 'function()' and '.' not in ctor, ctors_text.split(' '))
+  all_ctors = [ctor for ctor in ctors_text.split(' ') if ctor.endswith('()') and not ctor == 'function()' and '.' not in ctor]
   all_ctors = [ctor.replace('()', '') for ctor in all_ctors]
   assert len(all_ctors) > 0
   ctors = all_ctors[:num]
@@ -75,7 +75,7 @@ def eval_ctors_js(js, mem_init, num):
   pre_funcs_end = asm.find('function ', pre_funcs_start)
   pre_funcs_end = asm.rfind(';', pre_funcs_start, pre_funcs_end) + 1
   pre_funcs = asm[pre_funcs_start:pre_funcs_end]
-  parts = filter(lambda x: x.startswith('var '), [x.strip() for x in pre_funcs.split(';')])
+  parts = [x for x in [x.strip() for x in pre_funcs.split(';')] if x.startswith('var ')]
   global_vars = []
   new_globals = '\n'
   for part in parts:
@@ -353,7 +353,7 @@ if __name__ == '__main__':
     exports = [x.split(':')[1].strip() for x in exports_text.replace(' ', '').split(',')]
     for r in removed:
       assert r in exports, 'global ctors were exported'
-    exports = filter(lambda e: e not in removed, exports)
+    exports = [e for e in exports if e not in removed]
     # fix up the exports
     js = open(js_file).read()
     absolute_exports_start = js.find(exports_text)

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -41,7 +41,7 @@ def find_ctors_data(js, num):
   assert ctors_start > 0
   ctors_text = js[ctors_start:ctors_end]
   all_ctors = filter(lambda ctor: ctor.endswith('()') and not ctor == 'function()' and '.' not in ctor, ctors_text.split(' '))
-  all_ctors = map(lambda ctor: ctor.replace('()', ''), all_ctors)
+  all_ctors = [ctor.replace('()', '') for ctor in all_ctors]
   assert len(all_ctors) > 0
   ctors = all_ctors[:num]
   return ctors_start, ctors_end, all_ctors, ctors
@@ -75,14 +75,14 @@ def eval_ctors_js(js, mem_init, num):
   pre_funcs_end = asm.find('function ', pre_funcs_start)
   pre_funcs_end = asm.rfind(';', pre_funcs_start, pre_funcs_end) + 1
   pre_funcs = asm[pre_funcs_start:pre_funcs_end]
-  parts = filter(lambda x: x.startswith('var '), map(lambda x: x.strip(), pre_funcs.split(';')))
+  parts = filter(lambda x: x.startswith('var '), [x.strip() for x in pre_funcs.split(';')])
   global_vars = []
   new_globals = '\n'
   for part in parts:
     part = part[4:] # skip 'var '
-    bits = map(lambda x: x.strip(), part.split(','))
+    bits = [x.strip() for x in part.split(',')]
     for bit in bits:
-      name, value = map(lambda x: x.strip(), bit.split('=', 1))
+      name, value = [x.strip() for x in bit.split('=', 1)]
       if value in ['0', '+0', '0.0'] or name in [
         'STACKTOP', 'STACK_MAX', 'DYNAMICTOP_PTR',
         'HEAP8', 'HEAP16', 'HEAP32',
@@ -273,7 +273,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
   else:
     elements = []
     if len(atexits) > 0:
-      elements.append('{ func: function() { %s } }' % '; '.join(map(lambda x: '_atexit(' + str(x[0]) + ',' + str(x[1]) + ')', atexits)))
+      elements.append('{ func: function() { %s } }' % '; '.join(['_atexit(' + str(x[0]) + ',' + str(x[1]) + ')' for x in atexits]))
     for ctor in all_ctors[num:]:
       elements.append('{ func: function() { %s() } }' % ctor)
     new_ctors = '__ATINIT__.push(' + ', '.join(elements) + ');'
@@ -319,7 +319,7 @@ if __name__ == '__main__':
     # js path
     mem_init_file = binary_file
     if os.path.exists(mem_init_file):
-      mem_init = json.dumps(map(ord, open(mem_init_file, 'rb').read()))
+      mem_init = json.dumps(list(map(ord, open(mem_init_file, 'rb').read())))
     else:
       mem_init = []
 
@@ -350,14 +350,14 @@ if __name__ == '__main__':
     exports_start = asm.find('return {')
     exports_end = asm.find('};', exports_start)
     exports_text = asm[asm.find('{', exports_start) + 1 : exports_end]
-    exports = map(lambda x: x.split(':')[1].strip(), exports_text.replace(' ', '').split(','))
+    exports = [x.split(':')[1].strip() for x in exports_text.replace(' ', '').split(',')]
     for r in removed:
       assert r in exports, 'global ctors were exported'
     exports = filter(lambda e: e not in removed, exports)
     # fix up the exports
     js = open(js_file).read()
     absolute_exports_start = js.find(exports_text)
-    js = js[:absolute_exports_start] + ', '.join(map(lambda e: e + ': ' + e, exports)) + js[absolute_exports_start + len(exports_text):]
+    js = js[:absolute_exports_start] + ', '.join([e + ': ' + e for e in exports]) + js[absolute_exports_start + len(exports_text):]
     open(js_file, 'w').write(js)
     # find unreachable methods and remove them
     reachable = shared.Building.calculate_reachable_functions(js_file, exports, can_reach=False)['reachable']

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -37,7 +37,7 @@ def run_on_chunk(command):
     if os.environ.get('EMCC_SAVE_OPT_TEMP') and os.environ.get('EMCC_SAVE_OPT_TEMP') != '0':
       saved = 'save_' + os.path.basename(filename)
       while os.path.exists(saved): saved = 'input' + str(int(saved.replace('input', '').replace('.txt', ''))+1) + '.txt'
-      print('running DFE command', ' '.join(map(lambda c: c if c != filename else saved, command)), file=sys.stderr)
+      print('running DFE command', ' '.join([c if c != filename else saved for c in command]), file=sys.stderr)
       shutil.copyfile(filename, os.path.join(shared.get_emscripten_temp_dir(), saved))
 
     if shared.EM_BUILD_VERBOSE_LEVEL >= 3: print('run_on_chunk: ' + str(command), file=sys.stderr)
@@ -223,7 +223,7 @@ def run_on_js(filename, gen_hash_info=False):
   chunks = shared.chunkify(funcs, chunk_size)
 
   chunks = filter(lambda chunk: len(chunk) > 0, chunks)
-  if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(map(len, chunks)), '-', min(map(len, chunks)), file=sys.stderr)
+  if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
   funcs = None
 
   if len(chunks) > 0:
@@ -243,7 +243,7 @@ def run_on_js(filename, gen_hash_info=False):
 
   old_filenames = filenames[:]
   if len(filenames) > 0:
-    commands = map(lambda filename: js_engine + [DUPLICATE_FUNCTION_ELIMINATOR, filename, '--gen-hash-info' if gen_hash_info else '--use-hash-info', '--no-minimize-whitespace'], filenames)
+    commands = [js_engine + [DUPLICATE_FUNCTION_ELIMINATOR, filename, '--gen-hash-info' if gen_hash_info else '--use-hash-info', '--no-minimize-whitespace'] for filename in filenames]
 
     if DEBUG and commands is not None:
       print([' '.join(command if command is not None else '(null)') for command in commands], file=sys.stderr)

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -222,7 +222,7 @@ def run_on_js(filename, gen_hash_info=False):
   chunk_size = min(MAX_CHUNK_SIZE, max(MIN_CHUNK_SIZE, total_size / intended_num_chunks))
   chunks = shared.chunkify(funcs, chunk_size)
 
-  chunks = filter(lambda chunk: len(chunk) > 0, chunks)
+  chunks = [chunk for chunk in chunks if len(chunk) > 0]
   if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
   funcs = None
 

--- a/tools/emprofile.py
+++ b/tools/emprofile.py
@@ -43,7 +43,7 @@ def create_profiling_graph():
       json_data = open(f, 'r').read()
       lines = json_data.split('\n')
       lines = filter(lambda x: x != '[' and x != ']' and x != ',' and len(x.strip()) > 0, lines)
-      lines = map(lambda x: (x + ',') if not x.endswith(',') else x, lines)
+      lines = [(x + ',') if not x.endswith(',') else x for x in lines]
       lines[-1] = lines[-1][:-1]
       json_data = '[' + '\n'.join(lines) + ']'
       all_results += json.loads(json_data)

--- a/tools/emprofile.py
+++ b/tools/emprofile.py
@@ -42,7 +42,7 @@ def create_profiling_graph():
     try:
       json_data = open(f, 'r').read()
       lines = json_data.split('\n')
-      lines = filter(lambda x: x != '[' and x != ']' and x != ',' and len(x.strip()) > 0, lines)
+      lines = [x for x in lines if x != '[' and x != ']' and x != ',' and len(x.strip()) > 0]
       lines = [(x + ',') if not x.endswith(',') else x for x in lines]
       lines[-1] = lines[-1][:-1]
       json_data = '[' + '\n'.join(lines) + ']'

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -54,7 +54,7 @@ if DEBUG:
 if FROUND:
   shared.Settings.PRECISE_F32 = 1
 
-sys.argv = filter(handle_arg, sys.argv)
+sys.argv = list(filter(handle_arg, sys.argv))
 
 # consts
 
@@ -780,7 +780,7 @@ if __name__ == '__main__':
       curr = json.loads(line[len('// REACHABLE '):])
       reachable_funcs = set(list(reachable_funcs) + curr)
 
-  external_emterpreted_funcs = filter(lambda func: func in tabled_funcs or func in exported_funcs or func in reachable_funcs, emterpreted_funcs)
+  external_emterpreted_funcs = [func for func in emterpreted_funcs if func in tabled_funcs or func in exported_funcs or func in reachable_funcs]
 
   # process functions, generating bytecode
   with temp_files.get_file('.js') as temp:
@@ -960,7 +960,7 @@ if __name__ == '__main__':
         lines[i] = lines[i].replace(call, '(eb + %s | 0)' % (funcs[func]))
 
   # finalize funcs JS (first line has the marker, add emterpreters right after that)
-  asm.funcs_js = '\n'.join([lines[0], make_emterpreter(), make_emterpreter(zero=True) if ZERO else '', '\n'.join(filter(lambda line: len(line) > 0, lines[1:]))]) + '\n'
+  asm.funcs_js = '\n'.join([lines[0], make_emterpreter(), make_emterpreter(zero=True) if ZERO else '', '\n'.join([line for line in lines[1:] if len(line) > 0])]) + '\n'
   lines = None
 
   # set up emterpreter stack top (note we must use malloc if in a shared lib, or other enviroment where static memory is sealed)

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -544,7 +544,7 @@ def main():
     if sys.argv[i] in options: sys.argv[i] = ''
     if sys.argv[i] in options_with_value: sys.argv[i+1] = ''
 
-  sys.argv = filter(lambda x: len(x) > 0, sys.argv)
+  sys.argv = [x for x in sys.argv if len(x) > 0]
 
   # Double-check that the device is found via adb:
   if (HOST == 'localhost' or HOST == '127.0.0.1') and not connect_to_simulator:
@@ -610,7 +610,7 @@ def main():
     print_only_running = '--running' in sys.argv and not '--all' in sys.argv
     if print_only_running: # Print running apps only?
       print('Running applications by id:')
-      printed_apps = filter(lambda x: x['manifestURL'] in running_app_manifests, apps)
+      printed_apps = [x for x in apps if x['manifestURL'] in running_app_manifests]
     else:
       print('Installed applications by id:')
     num_printed = print_applist(printed_apps, running_app_manifests, '--all' in sys.argv or print_only_running)

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -178,7 +178,7 @@ def adb_devices():
   try:
     devices = subprocess.check_output([ADB, 'devices'])
     devices = devices.strip().split('\n')[1:]
-    devices = map(lambda x: x.strip().split('\t'), devices)
+    devices = [x.strip().split('\t') for x in devices]
     return devices
   except Exception as e:
     return []

--- a/tools/file2json.py
+++ b/tools/file2json.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import os, sys
 
 data = open(sys.argv[1], 'rb').read()
-sdata = map(lambda x: str(ord(x)) + ',', data)
+sdata = [str(ord(x)) + ',' for x in data]
 sdata[-1] = sdata[-1].replace(',', '')
 lined = []
 while len(sdata) > 0:

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -482,7 +482,7 @@ for file_ in data_files:
   basename = os.path.basename(filename)
   if file_['mode'] == 'embed':
     # Embed
-    data = map(ord, open(file_['srcpath'], 'rb').read())
+    data = list(map(ord, open(file_['srcpath'], 'rb').read()))
     code += '''var fileData%d = [];\n''' % counter
     if data:
       parts = []

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -271,7 +271,7 @@ for file_ in data_files:
       os.path.walk(file_['srcpath'], add, [file_['mode'], file_['srcpath'], file_['dstpath']])
     else:
       new_data_files.append(file_)
-data_files = filter(lambda file_: not os.path.isdir(file_['srcpath']), new_data_files)
+data_files = [file_ for file_ in new_data_files if not os.path.isdir(file_['srcpath'])]
 if len(data_files) == 0:
   print('Nothing to do!', file=sys.stderr) 
   sys.exit(1)
@@ -308,7 +308,7 @@ def was_seen(name):
   if seen.get(name): return True
   seen[name] = 1
   return False
-data_files = filter(lambda file_: not was_seen(file_['dstpath']), data_files)
+data_files = [file_ for file_ in data_files if not was_seen(file_['dstpath'])]
 
 if AV_WORKAROUND:
   random.shuffle(data_files)

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -33,8 +33,8 @@ import_sig = re.compile('(var|const) ([_\w$]+ *=[^;]+);')
 NATIVE_OPTIMIZER = os.environ.get('EMCC_NATIVE_OPTIMIZER') or '2' # use optimized native optimizer by default, unless disabled by EMCC_NATIVE_OPTIMIZER=0 in the env
 
 def split_funcs(js, just_split=False):
-  if just_split: return map(lambda line: ('(json)', line), js.split('\n'))
-  parts = map(lambda part: part, js.split('\n}\n'))
+  if just_split: return [('(json)', line) for line in js.split('\n')]
+  parts = [part for part in js.split('\n}\n')]
   funcs = []
   for i in range(len(parts)):
     func = parts[i]
@@ -280,7 +280,7 @@ def run_on_chunk(command):
     if os.environ.get('EMCC_SAVE_OPT_TEMP') and os.environ.get('EMCC_SAVE_OPT_TEMP') != '0':
       saved = 'save_' + os.path.basename(filename)
       while os.path.exists(saved): saved = 'input' + str(int(saved.replace('input', '').replace('.txt', ''))+1) + '.txt'
-      print('running js optimizer command', ' '.join(map(lambda c: c if c != filename else saved, command)), file=sys.stderr)
+      print('running js optimizer command', ' '.join([c if c != filename else saved for c in command]), file=sys.stderr)
       shutil.copyfile(filename, os.path.join(shared.get_emscripten_temp_dir(), saved))
     if shared.EM_BUILD_VERBOSE_LEVEL >= 3: print('run_on_chunk: ' + str(command), file=sys.stderr)
     proc = subprocess.Popen(command, stdout=subprocess.PIPE)
@@ -327,7 +327,7 @@ def run_on_js(filename, passes, js_engine, source_map=False, extra_info=None, ju
 
     minify_globals = 'minifyNames' in passes and 'asm' in passes
     if minify_globals:
-      passes = map(lambda p: p if p != 'minifyNames' else 'minifyLocals', passes)
+      passes = [p if p != 'minifyNames' else 'minifyLocals' for p in passes]
       start_asm = js.find(start_asm_marker)
       end_asm = js.rfind(end_asm_marker)
       assert (start_asm >= 0) == (end_asm >= 0)
@@ -415,10 +415,10 @@ EMSCRIPTEN_FUNCS();
       chunks = shared.chunkify(funcs, chunk_size)
     else:
       # keep same chunks as before
-      chunks = map(lambda f: f[1], funcs)
+      chunks = [f[1] for f in funcs]
 
     chunks = filter(lambda chunk: len(chunk) > 0, chunks)
-    if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(map(len, chunks)), '-', min(map(len, chunks)), file=sys.stderr)
+    if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
     funcs = None
 
     if len(chunks) > 0:
@@ -442,14 +442,14 @@ EMSCRIPTEN_FUNCS();
   with ToolchainProfiler.profile_block('run_optimizer'):
     if len(filenames) > 0:
       if not use_native(passes, source_map) or not get_native_optimizer():
-        commands = map(lambda filename: js_engine +
+        commands = [js_engine +
             [JS_OPTIMIZER, filename, 'noPrintMetadata'] +
-            (['--debug'] if source_map else []) + passes, filenames)
+            (['--debug'] if source_map else []) + passes for filename in filenames]
       else:
         # use the native optimizer
         shared.logging.debug('js optimizer using native')
         assert not source_map # XXX need to use js optimizer
-        commands = map(lambda filename: [get_native_optimizer(), filename] + passes, filenames)
+        commands = [[get_native_optimizer(), filename] + passes for filename in filenames]
       #print [' '.join(command) for command in commands]
 
       cores = min(cores, len(filenames))

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -334,11 +334,11 @@ def run_on_js(filename, passes, js_engine, source_map=False, extra_info=None, ju
 
     closure = 'closure' in passes
     if closure:
-      passes = filter(lambda p: p != 'closure', passes) # we will do it manually
+      passes = [p for p in passes if p != 'closure'] # we will do it manually
 
     cleanup = 'cleanup' in passes
     if cleanup:
-      passes = filter(lambda p: p != 'cleanup', passes) # we will do it manually
+      passes = [p for p in passes if p != 'cleanup'] # we will do it manually
 
     split_memory = 'splitMemory' in passes
 
@@ -378,7 +378,7 @@ EMSCRIPTEN_FUNCS();
           minifier.profiling_funcs = True
           return False
         return True
-      passes = filter(check_symbol_mapping, passes)
+      passes = list(filter(check_symbol_mapping, passes))
       asm_shell_pre, asm_shell_post = minifier.minify_shell(asm_shell, 'minifyWhitespace' in passes, source_map).split('EMSCRIPTEN_FUNCS();');
       asm_shell_post = asm_shell_post.replace('});', '})');
       pre += asm_shell_pre + '\n' + start_funcs_marker
@@ -417,7 +417,7 @@ EMSCRIPTEN_FUNCS();
       # keep same chunks as before
       chunks = [f[1] for f in funcs]
 
-    chunks = filter(lambda chunk: len(chunk) > 0, chunks)
+    chunks = [chunk for chunk in chunks if len(chunk) > 0]
     if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
     funcs = None
 

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -15,7 +15,7 @@ def timeout_run(proc, timeout=None, note='unnamed process', full_output=False, n
       proc.kill() # XXX bug: killing emscripten.py does not kill it's child process!
       raise Exception("Timed out: " + note)
   out = proc.communicate()
-  out = map(lambda o: '' if o is None else o, out)
+  out = ['' if o is None else o for o in out]
   if throw_on_failure and proc.returncode != 0:
     raise Exception('Subprocess "' + ' '.join(note_args) + '" failed with exit code ' + str(proc.returncode) + '!')
   if TRACK_PROCESS_SPAWNS:

--- a/tools/profile_stripper.py
+++ b/tools/profile_stripper.py
@@ -30,7 +30,7 @@ for orig in open(sys.argv[2]).readlines():
     if ']' in line:
       end = line.index(']')
     contents = line[start:end]
-    fixed = map(lambda name: '"' + name + '"' if not used.get(name) else name, contents.split(','))
+    fixed = ['"' + name + '"' if not used.get(name) else name for name in contents.split(',')]
     print((line[:start] + ','.join(fixed) + line[end:]).replace('""', ''))
   else:
     if show:

--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -11,7 +11,7 @@ def create_response_file(args, directory):
   (response_fd, response_filename) = tempfile.mkstemp(prefix='emscripten_', suffix='.rsp', dir=directory, text=True)
   response_fd = os.fdopen(response_fd, "w")
 
-  args = map(lambda p: p.replace('\\', '\\\\').replace('"', '\\"'), args)
+  args = [p.replace('\\', '\\\\').replace('"', '\\"') for p in args]
   contents = '"' + '" "'.join(args) + '"'
   if DEBUG:
     logging.warning('Creating response file ' + response_filename + ': ' + contents)

--- a/tools/scan_js.py
+++ b/tools/scan_js.py
@@ -17,5 +17,5 @@ for line in open(sys.argv[1]):
     funcs.append((inside, i-start))
     inside = None
 
-print('\n'.join(map(lambda func: str(func[1]) + ':' + func[0], sorted(funcs, key=lambda func: -func[1]))))
+print('\n'.join([str(func[1]) + ':' + func[0] for func in sorted(funcs, key=lambda func: -func[1])]))
 

--- a/tools/scan_ll.py
+++ b/tools/scan_ll.py
@@ -15,5 +15,5 @@ for line in open(sys.argv[1]):
   elif line.startswith('}'):
     funcs.append((inside, i-start))
 
-print('\n'.join(map(lambda func: str(func[1]) + ':' + func[0], sorted(funcs, key=lambda func: -func[1]))))
+print('\n'.join([str(func[1]) + ':' + func[0] for func in sorted(funcs, key=lambda func: -func[1])]))
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -278,7 +278,7 @@ def listify(x):
 
 def fix_js_engine(old, new):
   global JS_ENGINES
-  JS_ENGINES = map(lambda x: new if x == old else x, JS_ENGINES)
+  JS_ENGINES = [new if x == old else x for x in JS_ENGINES]
   return new
 
 try:
@@ -484,7 +484,7 @@ def get_emscripten_version(path):
 try:
   EMSCRIPTEN_VERSION = get_emscripten_version(path_from_root('emscripten-version.txt'))
   try:
-    parts = map(int, EMSCRIPTEN_VERSION.split('.'))
+    parts = list(map(int, EMSCRIPTEN_VERSION.split('.')))
     EMSCRIPTEN_VERSION_MAJOR = parts[0]
     EMSCRIPTEN_VERSION_MINOR = parts[1]
     EMSCRIPTEN_VERSION_TINY = parts[2]
@@ -1269,7 +1269,7 @@ def extract_archive_contents(f):
         safe_ensure_dirs(dirname)
     proc = Popen([LLVM_AR, 'xo', f], stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate() # if absolute paths, files will appear there. otherwise, in this directory
-    contents = map(os.path.abspath, contents)
+    contents = list(map(os.path.abspath, contents))
     nonexisting_contents = filter(lambda x: not os.path.exists(x), contents)
     if len(nonexisting_contents) != 0:
       raise Exception('llvm-ar failed to extract file(s) ' + str(nonexisting_contents) + ' from archive file ' + f + '! Error:' + str(stdout) + str(stderr))
@@ -1597,7 +1597,7 @@ class Building(object):
     except:
       old_dir = None
     os.chdir(project_dir)
-    generated_libs = map(lambda lib: os.path.join(project_dir, lib), generated_libs)
+    generated_libs = [os.path.join(project_dir, lib) for lib in generated_libs]
     #for lib in generated_libs:
     #  try:
     #    os.unlink(lib) # make sure compilation completed successfully
@@ -2049,14 +2049,14 @@ class Building(object):
 
     exps = expand_response(Settings.EXPORTED_FUNCTIONS)
     internalize_public_api = '-internalize-public-api-'
-    internalize_list = ','.join(map(lambda exp: exp[1:], exps))
+    internalize_list = ','.join([exp[1:] for exp in exps])
 
     # EXPORTED_FUNCTIONS can potentially be very large.
     # 8k is a bit of an arbitrary limit, but a reasonable one
     # for max command line size before we use a response file
     if len(internalize_list) > 8192:
       logging.debug('using response file for EXPORTED_FUNCTIONS in internalize')
-      finalized_exports = '\n'.join(map(lambda exp: exp[1:], exps))
+      finalized_exports = '\n'.join([exp[1:] for exp in exps])
       internalize_list_file = configuration.get_temp_files().get(suffix='.response').name
       internalize_list_fh = open(internalize_list_file, 'w')
       internalize_list_fh.write(finalized_exports)
@@ -2144,7 +2144,7 @@ class Building(object):
           can_call[func] = set(targets)
       # function tables too - treat a function all as a function that can call anything in it, which is effectively what it is
       for name, funcs in asm.tables.iteritems():
-        can_call[name] = set(map(lambda x: x.strip(), funcs[1:-1].split(',')))
+        can_call[name] = set([x.strip() for x in funcs[1:-1].split(',')])
       #print can_call
       # Note: We ignore calls in from outside the asm module, so you could do emterpreted => outside => emterpreted, and we would
       #       miss the first one there. But this is acceptable to do, because we can't save such a stack anyhow, due to the outside!
@@ -2316,7 +2316,7 @@ class Building(object):
     if 'LZ4=1' in link_settings: system_js_libraries += ['library_lz4.js']
     if 'USE_SDL=1' in link_settings: system_js_libraries += ['library_sdl.js']
     if 'USE_SDL=2' in link_settings: system_js_libraries += ['library_egl.js', 'library_glut.js', 'library_gl.js']
-    return map(lambda x: path_from_root('src', x), system_js_libraries)
+    return [path_from_root('src', x) for x in system_js_libraries]
 
 # compatibility with existing emcc, etc. scripts
 Cache = cache.Cache(debug=DEBUG_CACHE)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1119,7 +1119,7 @@ def unique_ordered(values): # return a list of unique values in an input list, w
     if value in seen: return False
     seen.add(value)
     return True
-  return filter(check, values)
+  return list(filter(check, values))
 
 def expand_response(data):
   if type(data) == str and data[0] == '@':
@@ -1251,7 +1251,7 @@ def extract_archive_contents(f):
     temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
     safe_ensure_dirs(temp_dir)
     os.chdir(temp_dir)
-    contents = filter(lambda x: len(x) > 0, Popen([LLVM_AR, 't', f], stdout=PIPE).communicate()[0].split('\n'))
+    contents = [x for x in Popen([LLVM_AR, 't', f], stdout=PIPE).communicate()[0].split('\n') if len(x) > 0]
     warn_if_duplicate_entries(contents, f)
     if len(contents) == 0:
       logging.debug('Archive %s appears to be empty (recommendation: link an .so instead of .a)' % f)
@@ -1270,7 +1270,7 @@ def extract_archive_contents(f):
     proc = Popen([LLVM_AR, 'xo', f], stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate() # if absolute paths, files will appear there. otherwise, in this directory
     contents = list(map(os.path.abspath, contents))
-    nonexisting_contents = filter(lambda x: not os.path.exists(x), contents)
+    nonexisting_contents = [x for x in contents if not os.path.exists(x)]
     if len(nonexisting_contents) != 0:
       raise Exception('llvm-ar failed to extract file(s) ' + str(nonexisting_contents) + ' from archive file ' + f + '! Error:' + str(stdout) + str(stderr))
 
@@ -1486,7 +1486,7 @@ class Building(object):
     env = env.copy()
     if not WINDOWS: return env
     path = env['PATH'].split(';')
-    path = filter(lambda p: not os.path.exists(os.path.join(p, 'sh.exe')), path)
+    path = [p for p in path if not os.path.exists(os.path.join(p, 'sh.exe'))]
     env['PATH'] = ';'.join(path)
     return env
 
@@ -1770,7 +1770,7 @@ class Building(object):
       logging.debug('done running loop of archive %s' % (f))
       return added_any_objects
 
-    Building.read_link_inputs(filter(lambda x: not x.startswith('-'), files))
+    Building.read_link_inputs([x for x in files if not x.startswith('-')])
 
     current_archive_group = None
     for f in files:
@@ -1937,7 +1937,7 @@ class Building(object):
     for line in output.split('\n'):
       if len(line) == 0: continue
       if ':' in line: continue # e.g.  filename.o:  , saying which file it's from
-      parts = filter(lambda seg: len(seg) > 0, line.split(' '))
+      parts = [seg for seg in line.split(' ') if len(seg) > 0]
       # pnacl-nm will print zero offsets for bitcode, and newer llvm-nm will print present symbols as  -------- T name
       if len(parts) == 3 and parts[0] in ["00000000", "--------"]:
         parts.pop(0)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -265,7 +265,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     src_dir = shared.path_from_root('system', 'lib', 'html5')
     files = []
     for dirpath, dirnames, filenames in os.walk(src_dir):
-      files += map(lambda f: os.path.join(src_dir, f), filenames)
+      files += [os.path.join(src_dir, f) for f in filenames]
     return build_libc(libname, files, ['-Oz'])
 
   def create_compiler_rt(libname):
@@ -404,7 +404,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       add_back_deps(need) # recurse to get deps of deps
 
   # Scan symbols
-  symbolses = shared.Building.parallel_llvm_nm(map(os.path.abspath, temp_files))
+  symbolses = shared.Building.parallel_llvm_nm(list(map(os.path.abspath, temp_files)))
 
   if len(symbolses) == 0:
     class Dummy(object):
@@ -587,7 +587,7 @@ class Ports(object):
       # note that tag **must** be the tag in sdl.py, it is where we store to (not where we load from, we just load the local dir)
       local_ports = os.environ.get('EMCC_LOCAL_PORTS')
       if local_ports:
-        local_ports = map(lambda pair: pair.split('=', 1), local_ports.split(','))
+        local_ports = [pair.split('=', 1) for pair in local_ports.split(',')]
         for local in local_ports:
           if name == local[0]:
             path, subdir = local[1].split('|')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -509,7 +509,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       # we might have exception-supporting versions of them from elsewhere, and if libcxxabi
       # is first then it would "win", breaking exception throwing from those string
       # header methods. To avoid that, we link libcxxabi last.
-      ret = filter(lambda f: f != actual, ret) + [actual]
+      ret = [f for f in ret if f != actual] + [actual]
 
   return ret
 
@@ -707,7 +707,7 @@ def get_ports(settings):
     process_dependencies(settings)
     for port in ports.ports:
       # ports return their output files, which will be linked, or a txt file
-      ret += filter(lambda f: not f.endswith('.txt'), port.get(Ports, settings, shared))
+      ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
     ok = True
   finally:
     if not ok:

--- a/tools/traverse.py
+++ b/tools/traverse.py
@@ -24,7 +24,7 @@ for d in os.listdir(curr):
     for c in os.listdir('.'):
       if c.endswith('.c'):
         execute([EMCC, c, '-O2', '--embed-file', 'input.txt'])
-        js = jsrun.run_js('a.out.js', filter(lambda x: x != '-w', SPIDERMONKEY_ENGINE), stdout=PIPE)
+        js = jsrun.run_js('a.out.js', [x for x in SPIDERMONKEY_ENGINE if x != '-w'], stdout=PIPE)
 
         execute([CLANG_CC, '-m32', c])
         n1 = execute(['./a.out'], stdout=PIPE)[0]

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -472,11 +472,11 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
   for i in range(min_args, max_args+1):
     raw = sigs.get(i)
     if raw is None: continue
-    sig = map(full_typename, raw)
+    sig = list(map(full_typename, raw))
     if array_attribute:
-      sig = map(lambda x: x.replace('[]', ''), sig) # for arrays, ignore that this is an array - our get/set methods operate on the elements
+      sig = [x.replace('[]', '') for x in sig] # for arrays, ignore that this is an array - our get/set methods operate on the elements
 
-    c_arg_types = map(type_to_c, sig)
+    c_arg_types = list(map(type_to_c, sig))
 
     normal_args = ', '.join(['%s arg%d' % (c_arg_types[j], j) for j in range(i)])
     if constructor:
@@ -526,7 +526,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
 
     if not constructor:
       if i == max_args:
-        dec_args = ', '.join(map(lambda j: type_to_cdec(raw[j]) + ' arg' + str(j), range(i)))
+        dec_args = ', '.join([type_to_cdec(raw[j]) + ' arg' + str(j) for j in range(i)])
         js_call_args = ', '.join(['%sarg%d' % (('(int)' if sig[j] in interfaces else '') + ('&' if raw[j].getExtendedAttribute('Ref') or raw[j].getExtendedAttribute('Value') else ''), j) for j in range(i)])
 
         js_impl_methods += [r'''  %s %s(%s) {


### PR DESCRIPTION
`map()`/`filter()` in Python 3 does not return list anymore, it rather returns an iterable object which does not support indexing. This PR:

1. converts maps/filters to list comprehensions if they are using lambda functions
2. otherwise wraps them by `list()`