### PR TITLE
Fix build error in libcxx with recent clang

### DIFF
--- a/system/lib/libcxx/string.cpp
+++ b/system/lib/libcxx/string.cpp
@@ -18,7 +18,7 @@
 #endif // _LIBCPP_MSVCRT
 #include <stdio.h>
 
-// Recent versions of clang will generate this warning in as_integer() below
+// XXX EMSCRIPTEN: Recent versions of clang generates warning in as_integer.
 #pragma clang diagnostic ignored "-Wtautological-compare"
 
 _LIBCPP_BEGIN_NAMESPACE_STD

--- a/system/lib/libcxx/string.cpp
+++ b/system/lib/libcxx/string.cpp
@@ -18,6 +18,9 @@
 #endif // _LIBCPP_MSVCRT
 #include <stdio.h>
 
+// Recent versions of clang will generate this warning in as_integer() below
+#pragma clang diagnostic ignored "-Wtautological-compare"
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __basic_string_common<true>;


### PR DESCRIPTION
libcxx build generates the following warning when building
with recent version of clang:

system/lib/libcxx/string.cpp:139:11: warning:
      comparison 'long' < -2147483648 is always false [-Wtautological-constant-compare]
    if (r < numeric_limits<int>::min() || numeric_limits<int>::max() < r)

Upstream libcxx seems to also geneate this warning whenever
sizeof(int) == sizeof(long) but doesn't itself build with
-Werror.