### PR TITLE
Python 3 compatibility: Convert keys()/values()/items() to list

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -159,9 +159,9 @@ def fixup_metadata_tables(metadata, settings):
   # if emulating pointer casts, force all tables to the size of the largest
   if settings['EMULATE_FUNCTION_POINTER_CASTS']:
     max_size = 0
-    for k, v in metadata['tables'].iteritems():
+    for k, v in metadata['tables'].items():
       max_size = max(max_size, v.count(',')+1)
-    for k, v in metadata['tables'].iteritems():
+    for k, v in metadata['tables'].items():
       curr = v.count(',')+1
       if curr < max_size:
         metadata['tables'][k] = v.replace(']', (',0'*(max_size - curr)) + ']')
@@ -174,7 +174,7 @@ def fixup_metadata_tables(metadata, settings):
 def fixup_functions(funcs, metadata, settings):
   # function table masks
   table_sizes = {}
-  for k, v in metadata['tables'].iteritems():
+  for k, v in metadata['tables'].items():
     table_sizes[k] = str(v.count(',')) # undercounts by one, but that is what we want
     #if settings['ASSERTIONS'] >= 2 and table_sizes[k] == 0:
     #  print >> sys.stderr, 'warning: no function pointers with signature ' + k + ', but there is a call, which will abort if it occurs (this can result from undefined behavior, check for compiler warnings on your source files and consider -Werror)'
@@ -272,7 +272,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
   else:
     pre_tables = ''
 
-  function_table_sigs = function_table_data.keys()
+  function_table_sigs = list(function_table_data.keys())
 
   in_table, debug_tables, function_tables_defs = make_function_tables_defs(
     implemented_functions, all_implemented, function_table_data, settings, metadata)
@@ -299,7 +299,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     global_vars = metadata['externs']
   else:
     global_vars = [] # linkable code accesses globals through function calls
-  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2])
+  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].items() if value != 2])
                       .difference(set(global_vars)).difference(implemented_functions))
   if settings['RELOCATABLE']:
     global_funcs += ['g$' + extern for extern in metadata['externs']]
@@ -340,7 +340,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
 
 
 def finalize_output(outfile, post, function_table_data, bundled_args, metadata, settings, DEBUG):
-  function_table_sigs = function_table_data.keys()
+  function_table_sigs = list(function_table_data.keys())
   module = create_module(function_table_sigs, metadata, settings, *bundled_args)
 
   if DEBUG:
@@ -593,7 +593,7 @@ def get_all_exported_functions(function_table_data, settings):
 
 
 def get_all_implemented(forwarded_json, metadata):
-  return metadata['implementedFunctions'] + forwarded_json['Functions']['implementedFunctions'].keys() # XXX perf?
+  return metadata['implementedFunctions'] + list(forwarded_json['Functions']['implementedFunctions'].keys()) # XXX perf?
 
 
 def check_all_implemented(all_implemented, pre, settings):
@@ -689,7 +689,7 @@ def trim_asm_const_body(body):
 def all_asm_consts(metadata):
   asm_consts = [0]*len(metadata['asmConsts'])
   all_sigs = []
-  for k, v in metadata['asmConsts'].iteritems():
+  for k, v in metadata['asmConsts'].items():
     const = v[0].encode('utf-8')
     sigs = v[1]
     const = trim_asm_const_body(const)
@@ -725,7 +725,7 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
   # when emulating function pointer casts, we need to know what is the target of each pointer
   if settings['EMULATE_FUNCTION_POINTER_CASTS']:
     function_pointer_targets = {}
-    for sig, table in function_table_data.iteritems():
+    for sig, table in function_table_data.items():
       start = table.index('[')
       end = table.rindex(']')
       body = table[start+1:end].split(',')
@@ -835,7 +835,7 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
     body = ','.join(map(fix_item, body))
     return ('\n'.join(Counter.pre), ''.join([raw[:start+1], body, raw[end:]]))
 
-  infos = [make_table(sig, raw) for sig, raw in function_table_data.iteritems()]
+  infos = [make_table(sig, raw) for sig, raw in function_table_data.items()]
   Counter.pre = []
 
   function_tables_defs = '\n'.join([info[0] for info in infos]) + '\n'
@@ -854,7 +854,7 @@ def math_fix(g):
 
 def make_function_tables_impls(function_table_data, settings):
   function_tables_impls = []
-  for sig, table in function_table_data.iteritems():
+  for sig, table in function_table_data.items():
     args = ','.join(['a' + str(i) for i in range(1, len(sig))])
     arg_coercions = ' '.join(['a' + str(i) + '=' + shared.JS.make_coercion('a' + str(i), sig[i], settings) + ';' for i in range(1, len(sig))])
     coerced_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], settings) for i in range(1, len(sig))])
@@ -890,7 +890,7 @@ def create_mftCall_funcs(function_table_data, settings):
   mftCall_funcs = []
   if settings.get('EMULATED_FUNCTION_POINTERS'):
     if settings.get('RELOCATABLE') and not settings['BINARYEN']: # in wasm, emulated function pointers are just simple table calls
-      for sig, table in function_table_data.iteritems():
+      for sig, table in function_table_data.items():
         params = ','.join(['ptr'] + ['p%d' % p for p in range(len(sig)-1)])
         coerced_params = ','.join([shared.JS.make_coercion('ptr', 'i', settings)] + [shared.JS.make_coercion('p%d', unfloat(sig[p+1]), settings) % p for p in range(len(sig)-1)])
         coercions = ';'.join(['ptr = ptr | 0'] + ['p%d = %s' % (p, shared.JS.make_coercion('p%d' % p, unfloat(sig[p+1]), settings)) for p in range(len(sig)-1)]) + ';'
@@ -1101,7 +1101,7 @@ def provide_fround(settings):
 
 
 def create_asm_setup(debug_tables, function_table_data, metadata, settings):
-  function_table_sigs = function_table_data.keys()
+  function_table_sigs = list(function_table_data.keys())
 
   asm_setup = ''
   if settings['ASSERTIONS'] >= 2:
@@ -1117,7 +1117,7 @@ def create_asm_setup(debug_tables, function_table_data, metadata, settings):
         return 0
       return table_contents.count(',') + 1
 
-    table_total_size = sum(map(table_size, function_table_data.values()))
+    table_total_size = sum(map(table_size, list(function_table_data.values())))
     asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
     if not settings['EMULATED_FUNCTION_POINTERS']:
       asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size
@@ -1234,10 +1234,10 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
     exports.append(quote(export) + ": " + export)
   if settings['BINARYEN'] and settings['SIDE_MODULE']:
     # named globals in side wasm modules are exported globals from asm/wasm
-    for k, v in metadata['namedGlobals'].iteritems():
+    for k, v in metadata['namedGlobals'].items():
       exports.append(quote('_' + str(k)) + ': ' + str(v))
     # aliases become additional exports
-    for k, v in metadata['aliases'].iteritems():
+    for k, v in metadata['aliases'].items():
       exports.append(quote(str(k)) + ': ' + str(v))
   return '{ ' + ', '.join(exports) + ' }'
 
@@ -1324,7 +1324,7 @@ for (var named in NAMED_GLOBALS) {
   Module['_' + named] = gb + NAMED_GLOBALS[named];
 }
 Module['NAMED_GLOBALS'] = NAMED_GLOBALS;
-''' % ', '.join('"' + k + '": ' + str(v) for k, v in metadata['namedGlobals'].iteritems())
+''' % ', '.join('"' + k + '": ' + str(v) for k, v in metadata['namedGlobals'].items())
     if settings['BINARYEN']:
       # wasm side modules are pure wasm, and cannot create their g$..() methods, so we help them out
       # TODO: this works if we are the main module, but if the supplying module is later, it won't, so
@@ -1337,7 +1337,7 @@ for (var named in NAMED_GLOBALS) {
   })(named);
 }
 '''
-    named_globals += ''.join(["Module['%s'] = Module['%s']\n" % (k, v) for k, v in metadata['aliases'].iteritems()])
+    named_globals += ''.join(["Module['%s'] = Module['%s']\n" % (k, v) for k, v in metadata['aliases'].items()])
   return named_globals
 
 
@@ -1831,7 +1831,7 @@ def create_exported_implemented_functions_wasm(pre, forwarded_json, metadata, se
   all_exported_functions = set(shared.expand_response(settings['EXPORTED_FUNCTIONS'])) # both asm.js and otherwise
   for additional_export in settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE']: # additional functions to export from asm, if they are implemented
     all_exported_functions.add('_' + additional_export)
-  all_implemented = metadata['implementedFunctions'] + forwarded_json['Functions']['implementedFunctions'].keys() # XXX perf?
+  all_implemented = metadata['implementedFunctions'] + list(forwarded_json['Functions']['implementedFunctions'].keys()) # XXX perf?
 
   export_bindings = settings['EXPORT_BINDINGS']
   export_all = settings['EXPORT_ALL']
@@ -1855,7 +1855,7 @@ def create_exported_implemented_functions_wasm(pre, forwarded_json, metadata, se
 def create_asm_consts_wasm(forwarded_json, metadata):
   asm_consts = [0]*len(metadata['asmConsts'])
   all_sigs = []
-  for k, v in metadata['asmConsts'].iteritems():
+  for k, v in metadata['asmConsts'].items():
     const = v[0].encode('utf-8')
     sigs = v[1]
     const = trim_asm_const_body(const)
@@ -1907,7 +1907,7 @@ def create_sending_wasm(invoke_funcs, forwarded_json, metadata, settings):
     global_vars = [] # linkable code accesses globals through function calls
 
   implemented_functions = set(metadata['implementedFunctions'])
-  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2]).difference(set(global_vars)).difference(implemented_functions))
+  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].items() if value != 2]).difference(set(global_vars)).difference(implemented_functions))
 
   send_items = basic_funcs + invoke_funcs + global_funcs + basic_vars + global_vars
   def math_fix(g):
@@ -2038,7 +2038,7 @@ def load_metadata(metadata_raw):
     'exports': [],
   }
 
-  for k, v in metadata_json.iteritems():
+  for k, v in metadata_json.items():
     metadata[k] = v
 
   # Initializers call the global var version of the export, so they get the mangled name.

--- a/tools/asm_module.py
+++ b/tools/asm_module.py
@@ -114,7 +114,7 @@ class AsmModule():
 
     # imports
     all_imports = main.imports
-    for key, value in self.imports.iteritems():
+    for key, value in self.imports.items():
       if key in self.funcs or key in main.funcs: continue # external function in one module, implemented in the other
       value_concrete = '.' not in value # env.key means it is an import, an external value, and not a concrete one
       main_value = main.imports.get(key)
@@ -133,7 +133,7 @@ class AsmModule():
     for key in all_imports.keys():
       if key in self.funcs:
         del all_imports[key] # import in main, provided in side
-    main.imports_js = '\n'.join(['var %s = %s;' % (key, value) for key, value in all_imports.iteritems()]) + '\n'
+    main.imports_js = '\n'.join(['var %s = %s;' % (key, value) for key, value in all_imports.items()]) + '\n'
 
     # check for undefined references to global variables
     def check_import(key, value):
@@ -141,10 +141,10 @@ class AsmModule():
         if key not in all_sendings:
           print('warning: external variable %s is still not defined after linking' % key, file=sys.stderr)
           all_sendings[key] = '0'
-    for key, value in all_imports.iteritems(): check_import(key, value)
+    for key, value in all_imports.items(): check_import(key, value)
 
     if added_sending:
-      sendings_js = ', '.join(['%s: %s' % (key, value) for key, value in all_sendings.iteritems()])
+      sendings_js = ', '.join(['%s: %s' % (key, value) for key, value in all_sendings.items()])
       sendings_start = main.post_js.find('}, { ')+5
       sendings_end = main.post_js.find(' }, buffer);')
       main.post_js = main.post_js[:sendings_start] + sendings_js + main.post_js[sendings_end:]
@@ -152,7 +152,7 @@ class AsmModule():
     # tables
     f_bases = {}
     f_sizes = {}
-    for table, data in self.tables.iteritems():
+    for table, data in self.tables.items():
       main.tables[table] = self.merge_tables(table, main.tables.get(table), data, replacements, f_bases, f_sizes)
     main.combine_tables()
     #print >> sys.stderr, 'f bases', f_bases
@@ -296,7 +296,7 @@ class AsmModule():
 
   def combine_tables(self):
     self.tables_js = '// EMSCRIPTEN_END_FUNCS\n'
-    for table, data in self.tables.iteritems():
+    for table, data in self.tables.items():
       self.tables_js += 'var %s = %s;\n' % (table, data)
 
   def get_table_funcs(self):

--- a/tools/bindings_generator.py
+++ b/tools/bindings_generator.py
@@ -173,8 +173,8 @@ all_h.write(text)
 all_h.close()
 
 parsed = CppHeaderParser.CppHeader(all_h_name)
-print('zz dir: ', parsed.__dict__.keys())
-for classname, clazz in parsed.classes.items() + parsed.structs.items():
+print('zz dir: ', list(parsed.__dict__.keys()))
+for classname, clazz in list(parsed.classes.items()) + list(parsed.structs.items()):
   print('zz see', classname, clazz, type(clazz))
   classes[classname] = clazz
   if type(clazz['methods']) == dict:
@@ -186,7 +186,7 @@ for classname, clazz in parsed.classes.items() + parsed.structs.items():
     parents[classname.split('::')[1]] = classname.split('::')[0]
 
   if hasattr(clazz, '_public_structs'): # This is a class
-    for sname, struct in clazz._public_structs.iteritems():
+    for sname, struct in clazz._public_structs.items():
       parents[sname] = classname
       classes[classname + '::' + sname] = struct
       struct['name'] = sname # Missing in CppHeaderParser
@@ -204,7 +204,7 @@ def check_has_constructor(clazz):
     if method['constructor'] and not method['destructor']: return True
   return False
 
-for classname, clazz in parsed.classes.items() + parsed.structs.items():
+for classname, clazz in list(parsed.classes.items()) + list(parsed.structs.items()):
   # Various precalculations
   print('zz precalc', classname)
   for method in clazz['methods'][:]:
@@ -379,7 +379,7 @@ def copy_args(args):
     ret.append(copiedarg)
   return ret
 
-for classname, clazz in parsed.classes.items() + parsed.structs.items():
+for classname, clazz in list(parsed.classes.items()) + list(parsed.structs.items()):
   clazz['final_methods'] = {}
 
   def explore(subclass, template_name=None, template_value=None):
@@ -459,7 +459,7 @@ for classname, clazz in parsed.classes.items() + parsed.structs.items():
 
   explore(clazz)
 
-  for method in clazz['final_methods'].itervalues():
+  for method in clazz['final_methods'].values():
     method['parameters'].sort(key=len)
 
 # Second pass - generate bindings
@@ -611,8 +611,8 @@ def generate_class(generating_classname, classname, clazz): # TODO: deprecate ge
       gen_js.write('''Module['%s'] = %s;
 ''' % (generating_classname_head, generating_classname_head))
 
-  print('zz methods: ', clazz['final_methods'].keys())
-  for method in clazz['final_methods'].itervalues():
+  print('zz methods: ', list(clazz['final_methods'].keys()))
+  for method in clazz['final_methods'].values():
     mname = method['name']
     if classname_head + '::' + mname in ignored:
       print('zz ignoring', mname)
@@ -808,7 +808,7 @@ Module['%s'] = %s;
 
 # Main loop
 
-for classname, clazz in parsed.classes.items() + parsed.structs.items():
+for classname, clazz in list(parsed.classes.items()) + list(parsed.structs.items()):
   if any([name in ignored for name in classname.split('::')]):
     print('zz ignoring', classname)
     continue

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -84,7 +84,7 @@ def dump_equivalent_functions(passed_in_filename, global_data):
 
   # Merge the global data's fn_hash_to_fn_name structure into
   # the equivalent function info hash.
-  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].iteritems():
+  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].items():
     if fn_hash not in equivalent_fn_info:
       # Exclude single item arrays as they are of no use to us.
       if len(fn_names) > 1:
@@ -111,7 +111,7 @@ def write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename):
 
       # Merge the data's fn_hash_to_fn_name structure into
       # the global data hash.
-      for fn_hash, fn_names in data['fn_hash_to_fn_name'].iteritems():
+      for fn_hash, fn_names in data['fn_hash_to_fn_name'].items():
         if fn_hash not in global_data['fn_hash_to_fn_name']:
             global_data['fn_hash_to_fn_name'][fn_hash] = fn_names[:]
             global_data['fn_hash_to_fn_body'][fn_hash] = data['fn_hash_to_fn_body'][fn_hash]
@@ -124,7 +124,7 @@ def write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename):
 
       # Merge the data's variable_names structure into
       # the global data hash.
-      for variable, value in data['variable_names'].iteritems():
+      for variable, value in data['variable_names'].items():
         if variable not in global_data['variable_names']:
             global_data['variable_names'][variable] = value
 
@@ -132,7 +132,7 @@ def write_equivalent_fn_hash_to_file(f, json_files, passed_in_filename):
 
   # Lets generate the equivalent function hash from the global data set
   equivalent_fn_hash = {}
-  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].iteritems():
+  for fn_hash, fn_names in global_data['fn_hash_to_fn_name'].items():
     shortest_fn = None
     for fn_name in fn_names:
       if (fn_name not in variable_names) and (shortest_fn is None or (len(fn_name) < len(shortest_fn))):

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -107,7 +107,7 @@ def read_b2g_response(print_errors_to_console = True):
 def send_b2g_cmd(to, cmd, data = {}, print_errors_to_console = True):
   global b2g_socket
   msg = { 'to': to, 'type': cmd}
-  msg = dict(msg.items() + data.items())
+  msg = dict(list(msg.items()) + list(data.items()))
   msg = json.dumps(msg, encoding='latin-1')
   msg = msg.replace('\\\\', '\\')
   msg = str(len(msg))+':'+msg

--- a/tools/find_bigfuncs.py
+++ b/tools/find_bigfuncs.py
@@ -77,7 +77,7 @@ def uniq_compare(data1, data2):
     print('file 2 has {} {} than file 1 overall in unique functions'.format(humanbytes(abs(uniqbytediff)), bytesword))
 
 def list_bigfuncs(data):
-    data = data.items()
+    data = list(data.items())
     data.sort(lambda (f1, d1), (f2, d2): d1[0] - d2[0])
     print(''.join(['%6d lines (%6s) : %s' % (d[0], humanbytes(d[1]), f) for f, d in data]))
 

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -320,7 +320,7 @@ def gen_inspect_code(path, struct, code):
   for field in struct:
     if isinstance(field, dict):
       # We have to recurse to inspect the nested dict.
-      fname = field.keys()[0]
+      fname = list(field.keys())[0]
       gen_inspect_code(path + [fname], field[fname], code)
     else:
       c_set(field, 'i%zu', 'offsetof(' + prefix + path[0] + ', ' + '.'.join(path[1:] + [field]) + ')', code)

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -252,7 +252,7 @@ class Minifier(object):
 
     if self.symbols_file:
       mapfile = open(self.symbols_file, 'w')
-      for key, value in self.globs.iteritems():
+      for key, value in self.globs.items():
         mapfile.write(value + ':' + key + '\n')
       mapfile.close()
       print('wrote symbol map file to', self.symbols_file, file=sys.stderr)
@@ -387,7 +387,7 @@ EMSCRIPTEN_FUNCS();
       minify_info = minifier.serialize()
 
       if extra_info:
-        for key, value in extra_info.iteritems():
+        for key, value in extra_info.items():
           assert key not in minify_info or value == minify_info[key], [key, value, minify_info[key]]
           minify_info[key] = value
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1176,7 +1176,7 @@ class Settings2(type):
     @classmethod
     def serialize(self):
       ret = []
-      for key, value in self.attrs.iteritems():
+      for key, value in self.attrs.items():
         if key == key.upper(): # this is a hack. all of our settings are ALL_CAPS, python internals are not
           jsoned = json.dumps(value, sort_keys=True)
           ret += ['-s', key + '=' + jsoned]
@@ -1206,7 +1206,7 @@ class Settings2(type):
       if attr not in self.attrs:
         import difflib
         logging.warning('''Assigning a non-existent settings attribute "%s"''' % attr)
-        suggestions = ', '.join(difflib.get_close_matches(attr, self.attrs.keys()))
+        suggestions = ', '.join(difflib.get_close_matches(attr, list(self.attrs.keys())))
         if suggestions:
           logging.warning(''' - did you mean one of %s?''' % suggestions)
         logging.warning(''' - perhaps a typo in emcc's  -s X=Y  notation?''')
@@ -1604,7 +1604,7 @@ class Building(object):
     #  except:
     #    pass
     env = Building.get_building_env(native, True)
-    for k, v in env_init.iteritems():
+    for k, v in env_init.items():
       env[k] = v
     if configure: # Useful in debugging sometimes to comment this out (and the lines below up to and including the |link| call)
       try:
@@ -2143,14 +2143,14 @@ class Building(object):
           targets = curr[2]
           can_call[func] = set(targets)
       # function tables too - treat a function all as a function that can call anything in it, which is effectively what it is
-      for name, funcs in asm.tables.iteritems():
+      for name, funcs in asm.tables.items():
         can_call[name] = set([x.strip() for x in funcs[1:-1].split(',')])
       #print can_call
       # Note: We ignore calls in from outside the asm module, so you could do emterpreted => outside => emterpreted, and we would
       #       miss the first one there. But this is acceptable to do, because we can't save such a stack anyhow, due to the outside!
       #print 'can call', can_call, '\n!!!\n', asm.tables, '!'
       reachable_from = {}
-      for func, targets in can_call.iteritems():
+      for func, targets in can_call.items():
         for target in targets:
           if target not in reachable_from:
             reachable_from[target] = set()
@@ -2170,7 +2170,7 @@ class Building(object):
       else:
         # find all functions that are reachable from the initial list, including it
         # all tables are assumed reachable, as they can be called from dyncall from outside
-        for name, funcs in asm.tables.iteritems():
+        for name, funcs in asm.tables.items():
           to_check.append(name)
         while len(to_check) > 0:
           curr = to_check.pop()

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -393,7 +393,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   added = set()
   def add_back_deps(need):
     more = False
-    for ident, deps in deps_info.iteritems():
+    for ident, deps in deps_info.items():
       if ident in need.undefs and not ident in added:
         added.add(ident)
         more = True
@@ -424,7 +424,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   # and must assume all of deps_info must be exported. Note that this might cause
   # warnings on exports that do not exist.
   if only_forced:
-    for key, value in deps_info.iteritems():
+    for key, value in deps_info.items():
       for dep in value:
         shared.Settings.EXPORTED_FUNCTIONS.append('_' + dep)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -28,7 +28,7 @@ if DEBUG: print("Debug print ON, CHECKS=%s" % CHECKS)
 
 class Dummy(object):
   def __init__(self, init):
-    for k, v in init.iteritems():
+    for k, v in init.items():
       self.__dict__[k] = v
 
   def getExtendedAttribute(self, name):
@@ -341,7 +341,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
   all_args = sigs.get(max_args)
 
   if DEBUG:
-    print('renderfunc', class_name, func_name, sigs.keys(), return_type, constructor)
+    print('renderfunc', class_name, func_name, list(sigs.keys()), return_type, constructor)
     for i in range(max_args):
       a = all_args[i]
       if isinstance(a, WebIDL.IDLArgument):
@@ -546,7 +546,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
           (', ' if js_call_args else '') + js_call_args)]
 
 
-for name, interface in interfaces.iteritems():
+for name, interface in interfaces.items():
   js_impl = interface.getExtendedAttribute('JSImplementation')
   if not js_impl: continue
   implements[name] = [js_impl[0]]
@@ -560,7 +560,7 @@ for name, interface in interfaces.iteritems():
 # that invariant. Further, the height of a node never decreases. Therefore, when the loop
 # finishes, all ancestors of a given node should have a larger height number than that node.
 nodeHeight = {}
-for child, parent in implements.iteritems():
+for child, parent in implements.items():
   parent = parent[0]
   while parent:
     nodeHeight[parent] = max(nodeHeight.get(parent, 0), nodeHeight.get(child, 0) + 1)
@@ -571,7 +571,7 @@ for child, parent in implements.iteritems():
     else:
       parent = None
 
-names = interfaces.keys()
+names = list(interfaces.keys())
 names.sort(lambda x, y: nodeHeight.get(y, 0) - nodeHeight.get(x, 0))
 
 for name in names:
@@ -712,7 +712,7 @@ public:
 
 deferred_js = []
 
-for name, enum in enums.iteritems():
+for name, enum in enums.items():
   mid_c += ['\n// ' + name + '\n']
   deferred_js += ['\n', '// ' + name + '\n']
   for value in enum.values():


### PR DESCRIPTION
`dict.keys()`/`dict.values()`/`dict.items()` in Python 3 returns an iterator instead of a list. This PR:

1. wraps `keys()`/`values()`/`items()` by `list()`
2. replaces `iteritems()` with `items()` (as Python 3 removed it + lists won't harm in for-loop in Python 2)