### PR TITLE
Add docs on how to use emscripten in Travis [ci skip]

### DIFF
--- a/site/source/docs/compiling/Travis.rst
+++ b/site/source/docs/compiling/Travis.rst
@@ -1,0 +1,72 @@
+.. _Travis:
+
+==============================
+Building projects on Travis CI
+==============================
+
+`Travis CI <https://travis-ci.org/>`_ is a popular continuous integration service which offers free plans for open source projects. Thanks to a `Docker image by trzeci <https://hub.docker.com/r/trzeci/emscripten/>`_ installing emscripten in Travis CI is essentially a one line task.
+
+An example .travis.yml
+======================
+
+.. code-block:: yaml
+
+    notifications:
+      email: false
+
+    language: node_js
+    node_js:
+      - node
+
+    sudo: required
+
+    services:
+      - docker
+
+    before_install:
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-tag-1.37.22-64bit bash
+
+    script:
+      - docker exec -it emscripten make helloworld.js
+      - make test
+
+Let's break it down:
+
+.. code-block:: yaml
+
+    notifications:
+      email: false
+
+    language: node_js
+    node_js:
+      - node
+
+    sudo: required
+
+    services:
+      - docker
+
+These lines set up the basic settings for the Travis container. Most people do not want email notifications, but feel free to leave out those lines if you do.
+
+``language: node_js`` and ``node_js: - node`` tell Travis we are a Node.js project, and that we want the latest stable Node release.
+
+``sudo: required`` and ``services: - docker`` are required to enable Docker in the Travis container.
+
+.. code-block:: yaml
+
+    before_install:
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-tag-1.37.22-64bit bash
+
+In the before_install stage we download the Docker image, create a container with that image, and then give it the name ``emscripten``. The ``-dit`` options tell Docker that we want the container to run *bash* in the background.
+
+This Docker image contains everything emscripten needs to run, as well as several additional build tools such as *make* and *cmake*. If you do not need them you can use the `emscripten-slim image <https://hub.docker.com/r/trzeci/emscripten-slim/>`_ instead, which excludes them and will be downloaded and installed slightly quicker. The emscripten versions available are listed at `the Docker Hub <https://hub.docker.com/r/trzeci/emscripten/tags/>`_. Neither image includes tools such as *curl*, so if you need to download any files, do so as a normal Travis command rather than a Docker command.
+
+.. code-block:: yaml
+
+    script:
+      - docker exec -it emscripten make helloworld.js
+      - make test
+
+In the script stage we can now run the commands we want, inside the Docker container we created earlier. In this sample we are using *make*, but you can call *emcc* directly if you prefer.
+
+The Docker container is set up to use the same directories as Travis, so the second line uses the same *Makefile*, and can also depend on the output of the Docker command. If your test suite depends on later Node features than what is installed by *emsdk* (Node v4), you will need to run the tests outside of Docker as a normal Travis command.

--- a/site/source/docs/compiling/Travis.rst
+++ b/site/source/docs/compiling/Travis.rst
@@ -6,8 +6,8 @@ Building projects on Travis CI
 
 `Travis CI <https://travis-ci.org/>`_ is a popular continuous integration service which offers free plans for open source projects. Thanks to a `Docker image by trzeci <https://hub.docker.com/r/trzeci/emscripten/>`_ installing emscripten in Travis CI is essentially a one line task.
 
-An example .travis.yml
-======================
+A sample .travis.yml
+====================
 
 .. code-block:: yaml
 
@@ -24,7 +24,7 @@ An example .travis.yml
       - docker
 
     before_install:
-      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-tag-1.37.22-64bit bash
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
 
     script:
       - docker exec -it emscripten make helloworld.js
@@ -55,11 +55,11 @@ These lines set up the basic settings for the Travis container. Most people do n
 .. code-block:: yaml
 
     before_install:
-      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-tag-1.37.22-64bit bash
+      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
 
 In the before_install stage we download the Docker image, create a container with that image, and then give it the name ``emscripten``. The ``-dit`` options tell Docker that we want the container to run *bash* in the background.
 
-This Docker image contains everything emscripten needs to run, as well as several additional build tools such as *make* and *cmake*. If you do not need them you can use the `emscripten-slim image <https://hub.docker.com/r/trzeci/emscripten-slim/>`_ instead, which excludes them and will be downloaded and installed slightly quicker. The emscripten versions available are listed at `the Docker Hub <https://hub.docker.com/r/trzeci/emscripten/tags/>`_. Neither image includes tools such as *curl*, so if you need to download any files, do so as a normal Travis command rather than a Docker command.
+This Docker image contains everything emscripten needs to run, as well as several additional build tools such as *make* and *cmake*. If you do not need them you can use the `emscripten-slim image <https://hub.docker.com/r/trzeci/emscripten-slim/>`_ instead, which excludes them and will be downloaded and installed slightly quicker. The emscripten versions available are listed at `the Docker Hub <https://hub.docker.com/r/trzeci/emscripten/tags/>`_.
 
 .. code-block:: yaml
 
@@ -69,4 +69,6 @@ This Docker image contains everything emscripten needs to run, as well as severa
 
 In the script stage we can now run the commands we want, inside the Docker container we created earlier. In this sample we are using *make*, but you can call *emcc* directly if you prefer.
 
-The Docker container is set up to use the same directories as Travis, so the second line uses the same *Makefile*, and can also depend on the output of the Docker command. If your test suite depends on later Node features than what is installed by *emsdk* (Node v4), you will need to run the tests outside of Docker as a normal Travis command.
+The Docker container is set up to use the same directories as Travis, so the second line uses the same *Makefile*, and can also depend on the output of the Docker command. If your test suite needs a later version of Node than what is installed by *emsdk* (Node v4), you will need to run the tests outside of Docker as a normal Travis command.
+
+For an example of this setup in practice, see `the Travis page for emglken <https://travis-ci.org/curiousdannii/emglken>`_, which is also set up to use `Greenkeeper <https://greenkeeper.io/>`_ for automatic testing of dependency updates.

--- a/site/source/docs/compiling/index.rst
+++ b/site/source/docs/compiling/index.rst
@@ -8,6 +8,7 @@ This section contains topics about building projects and running the output.
 
 - :ref:`Building-Projects` shows how to use :ref:`emccdoc` as a drop-in replacement for *gcc* in your existing project.
 - :ref:`Running-html-files-with-emrun` explains how to use *emrun* to run generated HTML pages in a locally launched web server.
+- :ref:`Travis` explains how to build and test projects on Travis CI.
 - :ref:`Deploying-Pages` covers topics related to hosting Emscripten compiled web pages on a CDN.
 
 
@@ -16,4 +17,5 @@ This section contains topics about building projects and running the output.
    
    Building-Projects
    Running-html-files-with-emrun
+   Travis
    Deploying-Pages


### PR DESCRIPTION
Thanks to [the Docker image by trzeci](https://hub.docker.com/r/trzeci/emscripten/) it's actually really easy to install emscripten in Travis! I wrote some simple docs explaining how to do it. Feedback welcome of course!

[Here it is in practice on one of my repos](https://travis-ci.org/curiousdannii/emglken).