### PR TITLE
Python 3 compatibility: Use relative imports

### DIFF
--- a/tools/asm_module.py
+++ b/tools/asm_module.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys, re, itertools
 
-import shared, js_optimizer
+from . import shared, js_optimizer
 
 
 class AsmModule():

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
-from toolchain_profiler import ToolchainProfiler
+from .toolchain_profiler import ToolchainProfiler
 import os.path, sys, shutil, time, logging
-import tempfiles, filelock
+from . import tempfiles, filelock
 
 # Permanent cache for dlmalloc and stdlibc++
 class Cache(object):
@@ -130,4 +130,8 @@ def chunkify(funcs, chunk_size, DEBUG=False):
       curr = None
     return [''.join([func[1] for func in chunk]) for chunk in chunks] # remove function names
 
-import shared
+try:
+  from . import shared
+except ImportError:
+  # Python 2 circular import compatibility
+  import shared

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -5,8 +5,11 @@ This is an LTO-like operation, and to avoid parsing the entire tree (we might fa
 '''
 
 import os, sys, json, subprocess, time
-import shared, js_optimizer
-from tempfiles import try_delete
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared, js_optimizer
+from tools.tempfiles import try_delete
 
 js_file = sys.argv[1]
 binary_file = sys.argv[2] # mem init for js, wasm binary for wasm

--- a/tools/distill_asm.py
+++ b/tools/distill_asm.py
@@ -11,7 +11,7 @@ XXX this probably doesn't work with closure compiler advanced yet XXX
 '''
 
 import os, sys
-import asm_module
+from . import asm_module
 
 infile = sys.argv[1]
 outfile = sys.argv[2]

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -1,8 +1,8 @@
 
 from __future__ import print_function
 import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging, traceback
-import shared
-from js_optimizer import *
+from . import shared
+from .js_optimizer import *
 
 DUPLICATE_FUNCTION_ELIMINATOR = path_from_root('tools', 'eliminate-duplicate-functions.js')
 

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -1,8 +1,11 @@
 
 from __future__ import print_function
 import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging, traceback
-from . import shared
-from .js_optimizer import *
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
+from tools.js_optimizer import *
 
 DUPLICATE_FUNCTION_ELIMINATOR = path_from_root('tools', 'eliminate-duplicate-functions.js')
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -7,8 +7,11 @@ Currently this requires the asm.js code to have been built with -s FINALIZE_ASM_
 '''
 
 from __future__ import print_function
-import os, sys, re, json
-import asm_module, shared, shutil
+import os, sys, re, json, shutil
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import asm_module, shared
 
 # params
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -61,15 +61,18 @@ TODO:        You can also provide .crn files yourself, pre-crunched. With this o
 '''
 
 from __future__ import print_function
-from toolchain_profiler import ToolchainProfiler
+import os, sys, shutil, random, uuid, ctypes
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.toolchain_profiler import ToolchainProfiler
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
 
-import os, sys, shutil, random, uuid, ctypes
 import posixpath
-import shared
-from shared import execute, suffix, unsuffixed
-from jsrun import run_js
+from tools import shared
+from tools.shared import execute, suffix, unsuffixed
+from tools.jsrun import run_js
 from subprocess import Popen, PIPE, STDOUT
 import fnmatch
 import json
@@ -153,7 +156,7 @@ for arg in sys.argv[2:]:
     leading = ''
   elif arg.startswith('--crunch'):
     try:
-      from shared import CRUNCH
+      from tools.shared import CRUNCH
     except Exception as e:
       print('could not import CRUNCH (make sure it is defined properly in ' + shared.hint_config_file_location() + ')', file=sys.stderr)
       raise e

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -76,7 +76,10 @@ The JSON output format is based on the return value of Runtime.generateStructInf
 '''
 
 import sys, os, re, json, argparse, tempfile, subprocess
-from . import shared
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
 
 DEBUG = os.environ.get('EMCC_DEBUG')
 if DEBUG == "0":

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -76,7 +76,7 @@ The JSON output format is based on the return value of Runtime.generateStructInf
 '''
 
 import sys, os, re, json, argparse, tempfile, subprocess
-import shared
+from . import shared
 
 DEBUG = os.environ.get('EMCC_DEBUG')
 if DEBUG == "0":

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -1,12 +1,15 @@
 
 from __future__ import print_function
-from .toolchain_profiler import ToolchainProfiler
+import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.toolchain_profiler import ToolchainProfiler
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
 
-import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging
 try:
-  from . import shared
+  from tools import shared
 except ImportError:
   # Python 2 circular import compatibility
   import shared

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -1,11 +1,15 @@
 
 from __future__ import print_function
-from toolchain_profiler import ToolchainProfiler
+from .toolchain_profiler import ToolchainProfiler
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
 
 import os, sys, subprocess, multiprocessing, re, string, json, shutil, logging
-import shared
+try:
+  from . import shared
+except ImportError:
+  # Python 2 circular import compatibility
+  import shared
 
 configuration = shared.configuration
 temp_files = configuration.get_temp_files()

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -1,4 +1,4 @@
-from toolchain_profiler import ToolchainProfiler
+from .toolchain_profiler import ToolchainProfiler
 import time, os, sys, logging
 from subprocess import Popen, PIPE, STDOUT
 

--- a/tools/make_minigzip.py
+++ b/tools/make_minigzip.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import os, sys
 from subprocess import Popen, PIPE, STDOUT
 
-import shared
+from . import shared
 
 print('Building zlib')
 

--- a/tools/merge_asm.py
+++ b/tools/merge_asm.py
@@ -8,7 +8,10 @@ that would be harmful to asm.js code.
 
 from __future__ import print_function
 import sys
-import shared
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
 
 try:
   me, in_shell, in_asm, outfile = sys.argv[:4]

--- a/tools/merge_pair.py
+++ b/tools/merge_pair.py
@@ -10,7 +10,9 @@ where a change occurs shows which function is the culprit.
 from __future__ import print_function
 import os, sys, shutil
 
-import asm_module, shared, shutil
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import asm_module, shared
 
 left = sys.argv[1]
 left_asm = asm_module.AsmModule(left)

--- a/tools/nativize_llvm.py
+++ b/tools/nativize_llvm.py
@@ -13,7 +13,9 @@ from __future__ import print_function
 import os, sys
 from subprocess import Popen, PIPE, STDOUT
 
-from shared import *
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.shared import *
 
 __rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 def path_from_root(*pathelems):

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -1,4 +1,4 @@
-import binaryen, bullet, cocos2d, freetype, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
+from . import binaryen, bullet, cocos2d, freetype, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
 ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, sdl_ttf, sdl_net, binaryen, cocos2d]

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -1,4 +1,5 @@
-import os, shutil, logging, zlib
+import os, shutil, logging
+from . import zlib
 
 TAG = 'version_1'
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -1,4 +1,5 @@
-import os, shutil, logging, subprocess, sys, stat, ogg
+import os, shutil, logging, subprocess, sys, stat
+from . import ogg
 
 TAG = 'version_1'
 

--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -7,7 +7,8 @@ if DEBUG == "0":
 # Routes the given cmdline param list in args into a new response file and returns the filename to it.
 # The returned filename has a suffix '.rsp'.
 def create_response_file(args, directory):
-  import tempfile, shared
+  import tempfile
+  from . import shared
   (response_fd, response_filename) = tempfile.mkstemp(prefix='emscripten_', suffix='.rsp', dir=directory, text=True)
   response_fd = os.fdopen(response_fd, "w")
 

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -5,7 +5,10 @@ This is useful because it lets you load the asm module first, then the main scri
 '''
 
 import os, sys
-import asm_module
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import asm_module
 
 infile = sys.argv[1]
 asmfile = sys.argv[2]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1,15 +1,15 @@
 from __future__ import print_function
-from toolchain_profiler import ToolchainProfiler
-import shutil, time, os, sys, base64, json, tempfile, copy, shlex, atexit, subprocess, hashlib, cPickle, re, errno
+from .toolchain_profiler import ToolchainProfiler
+import shutil, time, os, sys, base64, json, tempfile, copy, shlex, atexit, subprocess, hashlib, pickle, re, errno
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import mkstemp
 from distutils.spawn import find_executable
-import jsrun, cache, tempfiles
-import response_file
+from . import jsrun, cache, tempfiles
+from . import response_file
 import logging, platform, multiprocessing
 
 # Temp file utilities
-from tempfiles import try_delete
+from .tempfiles import try_delete
 
 # On Windows python suffers from a particularly nasty bug if python is spawning new processes while python itself is spawned from some other non-console process.
 # Use a custom replacement for Popen on Windows to avoid the "WindowsError: [Error 6] The handle is invalid" errors when emcc is driven through cmake or mingw32-make.
@@ -2123,13 +2123,13 @@ class Building(object):
 
   @staticmethod
   def eliminate_duplicate_funcs(filename):
-    import duplicate_function_eliminator
+    from . import duplicate_function_eliminator
     duplicate_function_eliminator.eliminate_duplicate_funcs(filename)
 
   @staticmethod
   def calculate_reachable_functions(infile, initial_list, can_reach=True):
     with ToolchainProfiler.profile_block('calculate_reachable_functions'):
-      import asm_module
+      from . import asm_module
       temp = configuration.get_temp_files().get('.js').name
       Building.js_optimizer(infile, ['dumpCallGraph'], output_filename=temp, just_concat=True)
       asm = asm_module.AsmModule(temp)
@@ -2260,7 +2260,7 @@ class Building(object):
     with ToolchainProfiler.profile_block('gen_struct_info'):
       Cache.ensure()
 
-      import gen_struct_info
+      from . import gen_struct_info
       gen_struct_info.main(['-qo', info_path, path_from_root('src/struct_info.json')])
 
   @staticmethod
@@ -2653,4 +2653,4 @@ def make_fetch_worker(source_file, output_file):
   open(output_file, 'w').write(fetch_worker_src)
 
 
-import js_optimizer
+from . import js_optimizer

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import os, json, logging, zipfile, glob, shutil
-import shared
+from . import shared
 from subprocess import Popen, CalledProcessError
 import subprocess, multiprocessing, re
 from sys import maxint
@@ -517,7 +517,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 # emscripten-ports library management (https://github.com/emscripten-ports)
 #---------------------------------------------------------------------------
 
-import ports
+from . import ports
 
 class Ports(object):
   @staticmethod

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -1,6 +1,6 @@
 import subprocess, os, time, sys, tempfile
 if sys.version_info.major == 2:
-  import response_file
+  from . import response_file
 else:
   from tools import response_file
 

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -13,7 +13,7 @@
 
 from __future__ import print_function
 import subprocess, sys, re, tempfile, os, time
-import shared
+from . import shared
 
 # Given a .js file, returns True/False depending on if that file is valid asm.js
 def validate_asmjs_jsfile(filename, muteOutput):

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -13,7 +13,10 @@
 
 from __future__ import print_function
 import subprocess, sys, re, tempfile, os, time
-from . import shared
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
 
 # Given a .js file, returns True/False depending on if that file is valid asm.js
 def validate_asmjs_jsfile(filename, muteOutput):

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -8,7 +8,7 @@ http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascr
 from __future__ import print_function
 import os, sys
 
-import shared
+from . import shared
 
 sys.path.append(shared.path_from_root('third_party'))
 sys.path.append(shared.path_from_root('third_party', 'ply'))


### PR DESCRIPTION
Python 3 forces `import module` to only import global modules from system path.

```py
# Python 2 only
import my_local_module
from my_local_module import my_variable
```

```py
# Python 2 and 3
from . import my_local_module
from .my_local_module import my_variable
```