### PR TITLE
Python 3 compatibility: Remove metaclass

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1133,7 +1133,7 @@ def expand_byte_size_suffixes(value):
 
 # Settings. A global singleton. Not pretty, but nicer than passing |, settings| everywhere
 
-class Settings2(type):
+class Settings2(object):
   class __impl(object):
     attrs = {}
 
@@ -1227,8 +1227,7 @@ class Settings2(type):
   def __setattr__(self, attr, value):
     return setattr(self.instance(), attr, value)
 
-class Settings(object):
-  __metaclass__ = Settings2
+Settings = Settings2()
 
 # llvm-ar appears to just use basenames inside archives. as a result, files with the same basename
 # will trample each other when we extract them. to help warn of such situations, we warn if there

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1133,7 +1133,7 @@ def expand_byte_size_suffixes(value):
 
 # Settings. A global singleton. Not pretty, but nicer than passing |, settings| everywhere
 
-class Settings2(object):
+class SettingsManager(object):
   class __impl(object):
     attrs = {}
 
@@ -1217,9 +1217,9 @@ class Settings2(object):
 
   @staticmethod
   def instance():
-    if Settings2.__instance is None:
-      Settings2.__instance = Settings2.__impl()
-    return Settings2.__instance
+    if SettingsManager.__instance is None:
+      SettingsManager.__instance = SettingsManager.__impl()
+    return SettingsManager.__instance
 
   def __getattr__(self, attr):
     return getattr(self.instance(), attr)
@@ -1227,7 +1227,7 @@ class Settings2(object):
   def __setattr__(self, attr, value):
     return setattr(self.instance(), attr, value)
 
-Settings = Settings2()
+Settings = SettingsManager()
 
 # llvm-ar appears to just use basenames inside archives. as a result, files with the same basename
 # will trample each other when we extract them. to help warn of such situations, we warn if there

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1154,9 +1154,9 @@ class Settings2(type):
       exec(settings)
 
       # Apply additional settings. First -O, then -s
-      for i in range(len(args)):
-        if args[i].startswith('-O'):
-          v = args[i][2]
+      for arg in args:
+        if arg.startswith('-O'):
+          v = arg[2]
           shrink = 0
           if v in ['s', 'z']:
             shrink = 1 if v == 's' else 2


### PR DESCRIPTION
Python 3 also supports metaclasses but there is no common compatible syntax for both Python 2 and 3. This PR converts Settings object from a class type to an instance so that the metaclass can be safely removed without any harm.