### PR TITLE
Python 3 compatibility: Convert ranges to lists

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -470,7 +470,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       exit(subprocess.call(cmd))
     else:
       only_object = '-c' in cmd
-      for i in reversed(range(len(cmd)-1)): # Last -o directive should take precedence, if multiple are specified
+      for i in reversed(list(range(len(cmd)-1))): # Last -o directive should take precedence, if multiple are specified
         if cmd[i] == '-o':
           if not only_object:
             cmd[i+1] += '.js'
@@ -537,7 +537,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if sys.argv[i].startswith('-o='):
       raise Exception('Invalid syntax: do not use -o=X, use -o X')
 
-  for i in reversed(range(len(sys.argv)-1)): # Last -o directive should take precedence, if multiple are specified
+  for i in reversed(list(range(len(sys.argv)-1))): # Last -o directive should take precedence, if multiple are specified
     if sys.argv[i] == '-o':
       target = sys.argv[i+1]
       sys.argv = sys.argv[:i] + sys.argv[i+2:]

--- a/tools/bindings_generator.py
+++ b/tools/bindings_generator.py
@@ -231,7 +231,7 @@ for classname, clazz in list(parsed.classes.items()) + list(parsed.structs.items
         break
 
     method['parameters'] = [args[:i] for i in range(default_param-1, len(args)+1)]
-    print('zz ', classname, 'has parameters in range', range(default_param-1, len(args)+1))
+    print('zz ', classname, 'has parameters in range', list(range(default_param-1, len(args)+1)))
 
     method['returns_text'] = method['returns']
     if method['static']:

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -165,7 +165,7 @@ if EM_PROFILE_TOOLCHAIN:
 
     @staticmethod
     def remove_last_occurrence_if_exists(lst, item):
-      for i in xrange(len(lst)):
+      for i in range(len(lst)):
         if lst[i] == item:
           lst.pop(i)
           return True


### PR DESCRIPTION
`range()` in Python 3 does not return lists but returns iterators. Thus, this PR wraps them in `list()` and removes deprecated `xrange` variations.