### PR TITLE
Smaller timer value for Python 3 on Windows

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -25,6 +25,8 @@ def run_commands(commands):
   else:
     pool = shared.Building.get_multiprocessing_pool()
     # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool, https://bugs.python.org/issue8296
+    # 999999 seconds (about 11 days) is reasonably huge to not trigger actual timeout
+    # and is smaller than the maximum timeout value 4294967.0 for Python 3 on Windows (threading.TIMEOUT_MAX)
     pool.map_async(call_process, commands, chunksize=1).get(999999)
 
 def files_in_path(path_components, filenames):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -3,7 +3,6 @@ import os, json, logging, zipfile, glob, shutil
 import shared
 from subprocess import Popen, CalledProcessError
 import subprocess, multiprocessing, re
-from sys import maxint
 from tools.shared import check_call
 
 stdout = None
@@ -26,7 +25,7 @@ def run_commands(commands):
   else:
     pool = shared.Building.get_multiprocessing_pool()
     # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool, https://bugs.python.org/issue8296
-    pool.map_async(call_process, commands, chunksize=1).get(maxint)
+    pool.map_async(call_process, commands, chunksize=1).get(999999)
 
 def files_in_path(path_components, filenames):
   srcdir = shared.path_from_root(*path_components)


### PR DESCRIPTION
Python 3 limits timeout value to [`threading.TIMEOUT_MAX`](https://docs.python.org/3/library/threading.html#threading.TIMEOUT_MAX) (4294967.0 on Windows), so current `sys.maxint` causes *OverflowError: timeout value is too large* when generating system libs on Windows.

Unfortunately Python 2 does not provide `threading.TIMEOUT_MAX` so this PR reduces the timeout value to 999999 seconds (about 11 days) which should be reasonable enough.