### PR TITLE
Python 3 compatibility: check type before numeric comparison

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1359,7 +1359,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert len(temp_files) == len(input_files)
 
         # Optimize source files
-        if options.llvm_opts > 0:
+        if isinstance(options.llvm_opts, list) or options.llvm_opts > 0:
           for pos, (_, input_file) in enumerate(input_files):
             file_ending = filename_type_ending(input_file)
             if file_ending.endswith(SOURCE_ENDINGS):
@@ -1488,7 +1488,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # something similar, which we can do with a param to opt
           link_opts += ['-disable-debug-info-type-map']
 
-        if options.llvm_lto >= 2 and options.llvm_opts > 0:
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and (isinstance(options.llvm_opts, list) or options.llvm_opts > 0):
           logging.debug('running LLVM opts as pre-LTO')
           final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
           if DEBUG: save_intermediate('opt', 'bc')

--- a/emcc.py
+++ b/emcc.py
@@ -66,10 +66,10 @@ DEFERRED_REPONSE_FILES = ('EMTERPRETIFY_BLACKLIST', 'EMTERPRETIFY_WHITELIST')
 # llvm opt level 3, and speed-wise emcc level 2 is already the slowest/most optimizing
 # level)
 LLVM_OPT_LEVEL = {
-  0: 0,
-  1: 1,
-  2: 3,
-  3: 3,
+  0: ['-O0'],
+  1: ['-O1'],
+  2: ['-O3'],
+  3: ['-O3'],
 }
 
 DEBUG = os.environ.get('EMCC_DEBUG')
@@ -1359,7 +1359,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert len(temp_files) == len(input_files)
 
         # Optimize source files
-        if isinstance(options.llvm_opts, list) or options.llvm_opts > 0:
+        if len(options.llvm_opts) > 0:
           for pos, (_, input_file) in enumerate(input_files):
             file_ending = filename_type_ending(input_file)
             if file_ending.endswith(SOURCE_ENDINGS):
@@ -1488,7 +1488,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # something similar, which we can do with a param to opt
           link_opts += ['-disable-debug-info-type-map']
 
-        if options.llvm_lto is not None and options.llvm_lto >= 2 and (isinstance(options.llvm_opts, list) or options.llvm_opts > 0):
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and len(options.llvm_opts) > 0:
           logging.debug('running LLVM opts as pre-LTO')
           final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
           if DEBUG: save_intermediate('opt', 'bc')
@@ -1887,6 +1887,8 @@ def parse_args(newargs):
     elif newargs[i].startswith('--llvm-opts'):
       check_bad_eq(newargs[i])
       options.llvm_opts = eval(newargs[i+1])
+      if isinstance(options.llvm_opts, int):
+        options.llvm_opts = ['-O%d' % options.llvm_opts]
       newargs[i] = ''
       newargs[i+1] = ''
     elif newargs[i].startswith('--llvm-lto'):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -288,8 +288,10 @@ class RunnerCore(unittest.TestCase):
 
   # Build JavaScript code from source code
   def build(self, src, dirname, filename, output_processor=None, main_file=None, additional_files=[], libraries=[], includes=[], build_ll_hook=None, extra_emscripten_args=[], post_build=None, js_outfile=True):
-
-    Building.pick_llvm_opts(3) # pick llvm opts here, so we include changes to Settings in the test case code
+    # pick llvm opts here, so we include changes to Settings in the test case code
+    Building.LLVM_OPT_OPTS = ['-O3']
+    if not Building.can_inline():
+      Building.LLVM_OPT_OPTS.append('-disable-inlining')
 
     # Copy over necessary files for compiling the source
     if main_file is None:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1869,9 +1869,9 @@ class Building(object):
       inputs = [inputs]
     else:
       assert out, 'must provide out if llvm_opt on a list of inputs'
-    if type(opts) is int:
-      opts = Building.pick_llvm_opts(opts)
     assert len(opts) > 0, 'should not call opt with nothing to do'
+    if not Building.can_inline():
+      opts.append('-disable-inlining')
     opts = opts[:]
     #opts += ['-debug-pass=Arguments']
     if not Settings.SIMD:
@@ -2079,27 +2079,6 @@ class Building(object):
       return '-Oz'
     else:
       return '-O' + str(min(opt_level, 3))
-
-  @staticmethod
-  def pick_llvm_opts(optimization_level):
-    '''
-      It may be safe to use nonportable optimizations (like -OX) if we remove the platform info from the .ll
-      (which we do in do_ll_opts) - but even there we have issues (even in TA2) with instruction combining
-      into i64s. In any case, the handpicked ones here should be safe and portable. They are also tuned for
-      things that look useful.
-
-      An easy way to see LLVM's standard list of passes is
-
-        llvm-as < /dev/null | opt -std-compile-opts -disable-output -debug-pass=Arguments
-    '''
-    assert 0 <= optimization_level <= 3
-    opts = []
-    if optimization_level > 0:
-      if not Building.can_inline():
-        opts.append('-disable-inlining')
-      opts.append('-O%d' % optimization_level)
-    Building.LLVM_OPT_OPTS = opts
-    return opts
 
   @staticmethod
   def js_optimizer(filename, passes, debug=False, extra_info=None, output_filename=None, just_split=False, just_concat=False):


### PR DESCRIPTION
Python 3 does not allow comparison between `NoneType` or lists and numbers, while Python 2 did (`None` is smaller than any number and `list()` is larger than any number).

This PR tries to mimic the current behavior on both Python 2 and 3 by checking type before comparison, when options.llvm_opts can be a list and options.llvm_lto can be `None`.