### PR TITLE
 Fix browser.test_binaryen_async for use of instantiateStreaming

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3514,6 +3514,7 @@ window.close = function() {
     {{{ SCRIPT }}}
 '''
     shell_with_script('shell.html', 'shell.html', script)
+    common_args = ['-s', 'WASM=1', '--shell-file', 'shell.html']
     for opts, expect in [
       ([], 1),
       (['-O1'], 1),
@@ -3524,8 +3525,11 @@ window.close = function() {
       (['-s', 'BINARYEN_ASYNC_COMPILATION=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'], 0), # try to force it on, but have it disabled
     ]:
       print opts, expect
-      self.btest('binaryen_async.c', expected=str(expect), args=['-s', 'BINARYEN=1', '--shell-file', 'shell.html'] + opts)
-    shell_with_script('shell.html', 'shell_no_streaming.html', '' + script)
+      self.btest('binaryen_async.c', expected=str(expect), args=common_args + opts)
+    # Ensure that compilation still works and is async without instantiateStreaming available
+    no_streaming = ' <script> WebAssembly.instantiateStreaming = undefined;</script>'
+    shell_with_script('shell.html', 'shell_no_streaming.html', no_streaming + script)
+    self.btest('binaryen_async.c', expected='1', args=common_args)
 
   # Test that implementing Module.instantiateWasm() callback works.
   def test_manual_wasm_instantiate(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3488,10 +3488,18 @@ window.close = function() {
     <script>
       // note if we do async compilation
       var real_wasm_instantiate = WebAssembly.instantiate;
-      WebAssembly.instantiate = function(a, b) {
-        Module.sawAsyncCompilation = true;
-        return real_wasm_instantiate(a, b);
-      };
+      var real_wasm_instantiateStreaming = WebAssembly.instantiateStreaming;
+      if (typeof real_wasm_instantiateStreaming === 'function') {
+        WebAssembly.instantiateStreaming = function(a, b) {
+          Module.sawAsyncCompilation = true;
+          return real_wasm_instantiateStreaming(a, b);
+        };
+      } else {
+        WebAssembly.instantiate = function(a, b) {
+          Module.sawAsyncCompilation = true;
+          return real_wasm_instantiate(a, b);
+        };
+      }
       // show stderr for the viewer's fun
       Module.printErr = function(x) {
         Module.print('<<< ' + x + ' >>>');

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3528,7 +3528,7 @@ window.close = function() {
       self.btest('binaryen_async.c', expected=str(expect), args=common_args + opts)
     # Ensure that compilation still works and is async without instantiateStreaming available
     no_streaming = ' <script> WebAssembly.instantiateStreaming = undefined;</script>'
-    shell_with_script('shell.html', 'shell_no_streaming.html', no_streaming + script)
+    shell_with_script('shell.html', 'shell.html', no_streaming + script)
     self.btest('binaryen_async.c', expected='1', args=common_args)
 
   # Test that implementing Module.instantiateWasm() callback works.


### PR DESCRIPTION
Previously the test checked that `WebAssembly.instantiate` was called, but we now call `WebAssembly.instantiateStreaming` if available. Update it to ensure that the latter is used
if possible.