### PR TITLE
Python 3 compatibility: Use bytearray on write() + use octal prefix '0o'

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1655,8 +1655,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if not membytes: return ''
           if shared.Settings.MEM_INIT_METHOD == 2:
             # memory initializer in a string literal
-            return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(list(membytes))
-          open(memfile, 'wb').write(''.join(map(chr, membytes)))
+            return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
+          open(memfile, 'wb').write(bytes(bytearray(membytes)))
           if DEBUG:
             # Copy into temp dir as well, so can be run there too
             shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -5,7 +5,7 @@ TAG = 'version_1'
 def build_with_configure(ports, shared, path): # not currently used
   if not sys.platform.startswith('win'): #TODO: test on windows
      autogen_path = os.path.join(path, 'bullet', 'autogen.sh')
-     os.chmod(autogen_path, os.stat(autogen_path).st_mode | 0111) #Make executable
+     os.chmod(autogen_path, os.stat(autogen_path).st_mode | 0o111) # Make executable
      subprocess.Popen(["sh", "autogen.sh"], cwd=os.path.join(path, 'bullet')).wait()
   subprocess.Popen(["python", "make.py"], cwd=path).wait()
   final = os.path.join(path, 'libbullet.bc')


### PR DESCRIPTION
1. `''` is Unicode in Python 3 and thus cannot be used with `wb` mode. `b''` would work but using bytearray is probably more efficient and readable.
2. `0111` is invalid on Python 3 and should use the new prefix `0o`.

My own test branch can now pass `test_hello_world` without errors on Python 3 :tada: