### PR TITLE
Fix webidl_binder import error

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -8,7 +8,9 @@ http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascr
 from __future__ import print_function
 import os, sys
 
-from . import shared
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
 
 sys.path.append(shared.path_from_root('third_party'))
 sys.path.append(shared.path_from_root('third_party', 'ply'))


### PR DESCRIPTION
Sorry, couldn't catch this error as Travis doesn't cover binaryen tests yet. 