### PR TITLE
Fix webidl binder regression + add test_w* testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 - TEST_TARGET=asm2i.test_p*
 - TEST_TARGET="asm3.test_p*"
 - TEST_TARGET="ALL.test_q* ALL.test_r* ALL.test_s*"
+- TEST_TARGET="ALL.test_w*"
 - TEST_TARGET="ALL.test_t* ALL.test_u* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*"
 - TEST_TARGET=other
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -8,7 +8,9 @@ http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascr
 from __future__ import print_function
 import os, sys
 
-from . import shared
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools import shared
 
 sys.path.append(shared.path_from_root('third_party'))
 sys.path.append(shared.path_from_root('third_party', 'ply'))


### PR DESCRIPTION
The test broke, and we were missing that test on the bots so we missed it.