### PR TITLE
Make options.llvm_opts always be a list

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -66,10 +66,10 @@ DEFERRED_REPONSE_FILES = ('EMTERPRETIFY_BLACKLIST', 'EMTERPRETIFY_WHITELIST')
 # llvm opt level 3, and speed-wise emcc level 2 is already the slowest/most optimizing
 # level)
 LLVM_OPT_LEVEL = {
-  0: 0,
-  1: 1,
-  2: 3,
-  3: 3,
+  0: ['-O0'],
+  1: ['-O1'],
+  2: ['-O3'],
+  3: ['-O3'],
 }
 
 DEBUG = os.environ.get('EMCC_DEBUG')
@@ -665,6 +665,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         options.js_opts = options.opt_level >= 2
       if options.llvm_opts is None:
         options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
+      if type(options.llvm_opts) == int:
+        options.llvm_opts = ['-O%d' % options.llvm_opts]
       if options.memory_init_file is None:
         options.memory_init_file = options.opt_level >= 2
 
@@ -1359,7 +1361,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert len(temp_files) == len(input_files)
 
         # Optimize source files
-        if options.llvm_opts > 0:
+        if '-O0' not in options.llvm_opts:
           for pos, (_, input_file) in enumerate(input_files):
             file_ending = filename_type_ending(input_file)
             if file_ending.endswith(SOURCE_ENDINGS):
@@ -1488,7 +1490,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # something similar, which we can do with a param to opt
           link_opts += ['-disable-debug-info-type-map']
 
-        if options.llvm_lto >= 2 and options.llvm_opts > 0:
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and '-O0' not in options.llvm_opts:
           logging.debug('running LLVM opts as pre-LTO')
           final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
           if DEBUG: save_intermediate('opt', 'bc')

--- a/emcc.py
+++ b/emcc.py
@@ -470,7 +470,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       exit(subprocess.call(cmd))
     else:
       only_object = '-c' in cmd
-      for i in reversed(list(range(len(cmd)-1))): # Last -o directive should take precedence, if multiple are specified
+      for i in reversed(range(len(cmd)-1)): # Last -o directive should take precedence, if multiple are specified
         if cmd[i] == '-o':
           if not only_object:
             cmd[i+1] += '.js'
@@ -537,7 +537,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if sys.argv[i].startswith('-o='):
       raise Exception('Invalid syntax: do not use -o=X, use -o X')
 
-  for i in reversed(list(range(len(sys.argv)-1))): # Last -o directive should take precedence, if multiple are specified
+  for i in reversed(range(len(sys.argv)-1)): # Last -o directive should take precedence, if multiple are specified
     if sys.argv[i] == '-o':
       target = sys.argv[i+1]
       sys.argv = sys.argv[:i] + sys.argv[i+2:]

--- a/emcc.py
+++ b/emcc.py
@@ -588,6 +588,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     suffix = filename_type_suffix(filename)
     return '' if not suffix else ('.' + suffix)
 
+  def optimizing(opts):
+    return '-O0' not in opts
+
   use_cxx = True
 
   try:
@@ -1361,7 +1364,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert len(temp_files) == len(input_files)
 
         # Optimize source files
-        if '-O0' not in options.llvm_opts:
+        if optimizing(options.llvm_opts):
           for pos, (_, input_file) in enumerate(input_files):
             file_ending = filename_type_ending(input_file)
             if file_ending.endswith(SOURCE_ENDINGS):
@@ -1490,7 +1493,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # something similar, which we can do with a param to opt
           link_opts += ['-disable-debug-info-type-map']
 
-        if options.llvm_lto is not None and options.llvm_lto >= 2 and '-O0' not in options.llvm_opts:
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
           logging.debug('running LLVM opts as pre-LTO')
           final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
           if DEBUG: save_intermediate('opt', 'bc')

--- a/emscripten.py
+++ b/emscripten.py
@@ -695,7 +695,7 @@ def all_asm_consts(metadata):
     const = trim_asm_const_body(const)
     const = '{ ' + const + ' }'
     args = []
-    arity = max(list(map(len, sigs))) - 1
+    arity = max(map(len, sigs)) - 1
     for i in range(arity):
       args.append('$' + str(i))
     const = 'function(' + ', '.join(args) + ') ' + const
@@ -1861,7 +1861,7 @@ def create_asm_consts_wasm(forwarded_json, metadata):
     const = trim_asm_const_body(const)
     const = '{ ' + const + ' }'
     args = []
-    arity = max(list(map(len, sigs))) - 1
+    arity = max(map(len, sigs)) - 1
     for i in range(arity):
       args.append('$' + str(i))
     const = 'function(' + ', '.join(args) + ') ' + const

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -299,7 +299,7 @@ class RunnerCore(unittest.TestCase):
   # Build JavaScript code from source code
   def build(self, src, dirname, filename, output_processor=None, main_file=None, additional_files=[], libraries=[], includes=[], build_ll_hook=None, extra_emscripten_args=[], post_build=None, js_outfile=True):
 
-    Building.pick_llvm_opts(3) # pick llvm opts here, so we include changes to Settings in the test case code
+    Building.LLVM_OPT_OPTS = ['-O3'] # pick llvm opts here, so we include changes to Settings in the test case code
 
     # Copy over necessary files for compiling the source
     if main_file is None:
@@ -348,7 +348,7 @@ class RunnerCore(unittest.TestCase):
                  filename + '.o')
         if not os.path.exists(filename + '.o'):
           print("Failed to link LLVM binaries:\n\n", output)
-          raise Exception("Linkage error");
+          raise Exception("Linkage error")
 
       # Finalize
       self.prep_ll_run(filename, filename + '.o', build_ll_hook=build_ll_hook)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -248,7 +248,6 @@ class RunnerCore(unittest.TestCase):
       else:
         shutil.copy(ll_file, filename + '.o.ll')
 
-      Building.ll_opts(filename)
       if build_ll_hook:
         need_post = build_ll_hook(filename)
       Building.llvm_as(filename)

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -250,10 +250,10 @@ def pad_to_length(s, length):
   return s + max(0, length - len(s)) * ' '
 
 def longest_dom_pk_code_length():
-  return max(list(map(len, [x[2] for x in input_strings])))
+  return max(map(len, [x[2] for x in input_strings]))
 
 def longest_key_code_length():
-  return max(list(map(len, [x[1] for x in input_strings])))
+  return max(map(len, [x[1] for x in input_strings]))
 
 h_file = open('system/include/emscripten/dom_pk_codes.h', 'w')
 c_file = open('system/lib/html5/dom_pk_codes.c', 'w')

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -226,7 +226,7 @@ def run_on_js(filename, gen_hash_info=False):
   chunks = shared.chunkify(funcs, chunk_size)
 
   chunks = [chunk for chunk in chunks if len(chunk) > 0]
-  if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
+  if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(map(len, chunks)), '-', min(map(len, chunks)), file=sys.stderr)
   funcs = None
 
   if len(chunks) > 0:

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -425,7 +425,7 @@ EMSCRIPTEN_FUNCS();
       chunks = [f[1] for f in funcs]
 
     chunks = [chunk for chunk in chunks if len(chunk) > 0]
-    if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(list(map(len, chunks))), '-', min(list(map(len, chunks))), file=sys.stderr)
+    if DEBUG and len(chunks) > 0: print('chunkification: num funcs:', len(funcs), 'actual num chunks:', len(chunks), 'chunk size range:', max(map(len, chunks)), '-', min(map(len, chunks)), file=sys.stderr)
     funcs = None
 
     if len(chunks) > 0:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1849,19 +1849,8 @@ class Building(object):
       # just calculating; return the link arguments which is the final list of files to link
       return link_args
 
-  # Emscripten optimizations that we run on the .ll file
-  @staticmethod
-  def ll_opts(filename):
-    ## Remove target info. This helps LLVM opts, if we run them later
-    #cleaned = filter(lambda line: not line.startswith('target datalayout = ') and not line.startswith('target triple = '),
-    #                 open(filename + '.o.ll', 'r').readlines())
-    #os.unlink(filename + '.o.ll')
-    #open(filename + '.o.ll.orig', 'w').write(''.join(cleaned))
-    pass
-
   # LLVM optimizations
-  # @param opt Either an integer, in which case it is the optimization level (-O1, -O2, etc.), or a list of raw
-  #            optimization passes passed to llvm opt
+  # @param opt A list of LLVM optimization parameters
   @staticmethod
   def llvm_opt(filename, opts, out=None):
     inputs = filename

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1871,6 +1871,8 @@ class Building(object):
       assert out, 'must provide out if llvm_opt on a list of inputs'
     assert len(opts) > 0, 'should not call opt with nothing to do'
     opts = opts[:]
+    if not '-Oz' in opts and not Building.can_inline():
+      opts.append('-disable-inlining')
     #opts += ['-debug-pass=Arguments']
     if not Settings.SIMD:
       opts += ['-disable-loop-vectorization', '-disable-slp-vectorization', '-vectorize-loops=false', '-vectorize-slp=false']

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1860,8 +1860,9 @@ class Building(object):
       assert out, 'must provide out if llvm_opt on a list of inputs'
     assert len(opts) > 0, 'should not call opt with nothing to do'
     opts = opts[:]
-    if not '-Oz' in opts and not Building.can_inline():
-      opts.append('-disable-inlining')
+    # TODO: disable inlining when needed
+    # if not '-Oz' in opts and not Building.can_inline():
+    #   opts.append('-disable-inlining')
     #opts += ['-debug-pass=Arguments']
     if not Settings.SIMD:
       opts += ['-disable-loop-vectorization', '-disable-slp-vectorization', '-vectorize-loops=false', '-vectorize-slp=false']

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1869,8 +1869,6 @@ class Building(object):
       inputs = [inputs]
     else:
       assert out, 'must provide out if llvm_opt on a list of inputs'
-    if type(opts) is int:
-      opts = Building.pick_llvm_opts(opts)
     assert len(opts) > 0, 'should not call opt with nothing to do'
     opts = opts[:]
     #opts += ['-debug-pass=Arguments']
@@ -2079,27 +2077,6 @@ class Building(object):
       return '-Oz'
     else:
       return '-O' + str(min(opt_level, 3))
-
-  @staticmethod
-  def pick_llvm_opts(optimization_level):
-    '''
-      It may be safe to use nonportable optimizations (like -OX) if we remove the platform info from the .ll
-      (which we do in do_ll_opts) - but even there we have issues (even in TA2) with instruction combining
-      into i64s. In any case, the handpicked ones here should be safe and portable. They are also tuned for
-      things that look useful.
-
-      An easy way to see LLVM's standard list of passes is
-
-        llvm-as < /dev/null | opt -std-compile-opts -disable-output -debug-pass=Arguments
-    '''
-    assert 0 <= optimization_level <= 3
-    opts = []
-    if optimization_level > 0:
-      if not Building.can_inline():
-        opts.append('-disable-inlining')
-      opts.append('-O%d' % optimization_level)
-    Building.LLVM_OPT_OPTS = opts
-    return opts
 
   @staticmethod
   def js_optimizer(filename, passes, debug=False, extra_info=None, output_filename=None, just_split=False, just_concat=False):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1861,7 +1861,7 @@ class Building(object):
     assert len(opts) > 0, 'should not call opt with nothing to do'
     opts = opts[:]
     # TODO: disable inlining when needed
-    # if not '-Oz' in opts and not Building.can_inline():
+    # if not Building.can_inline():
     #   opts.append('-disable-inlining')
     #opts += ['-debug-pass=Arguments']
     if not Settings.SIMD:


### PR DESCRIPTION
Superceding #5704.

Not sure whether `opts.append('-disable-inlining')` was actually in effect, as:

1. `-disable-inlining` was only being appended when `llvm_opts` is int.
2. ~~it wouldn't appended when with `emcc -O2` (which is the default) as it already made `llvm_opts` as a list.~~ it wouldn't appended when with `emcc -Os`/`emcc -Oz` as it already made `llvm_opts` as a list.
3. but `emcc -Os`/`emcc -Oz` is the only way to make `can_inline()` return false
4. removing it doesn't break any test.