### PR TITLE
Python 3 compatibility: prefer unicode on test runners

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -477,12 +477,16 @@ class RunnerCore(unittest.TestCase):
   def assertPathsIdentical(self, path1, path2):
     path1 = path1.replace('\\', '/')
     path2 = path2.replace('\\', '/')
+    if type(path1) == bytes: path1 = path1.decode()
+    if type(path2) == bytes: path2 = path2.decode()
     return self.assertIdentical(path1, path2)
 
   # Tests that the given two multiline text content are identical, modulo line ending differences (\r\n on Windows, \n on Unix).
   def assertTextDataIdentical(self, text1, text2):
     text1 = text1.replace('\r\n', '\n')
     text2 = text2.replace('\r\n', '\n')
+    if type(text1) == bytes: text1 = text1.decode()
+    if type(text2) == bytes: text2 = text2.decode()
     return self.assertIdentical(text1, text2)
 
   def assertIdentical(self, values, y):
@@ -502,8 +506,9 @@ class RunnerCore(unittest.TestCase):
   def assertContained(self, values, string, additional_info=''):
     if type(values) not in [list, tuple]: values = [values]
     for value in values:
-      if type(value) is unicode: string = string.decode('UTF-8') # If we have any non-ASCII chars in the expected string, treat the test string from ASCII as UTF8 as well.
-      if type(string) is not str and type(string) is not unicode: string = string()
+      if callable(string): string = string()
+      if type(value) is bytes: value = value.decode()
+      if type(string) is bytes: string = string.decode()
       if value in string: return # success
     raise Exception("Expected to find '%s' in '%s', diff:\n\n%s\n%s" % (
       limit_size(values[0]), limit_size(string),
@@ -512,8 +517,10 @@ class RunnerCore(unittest.TestCase):
     ))
 
   def assertNotContained(self, value, string):
-    if type(value) is not str: value = value() # lazy loading
-    if type(string) is not str: string = string()
+    if callable(value): value = value() # lazy loading
+    if callable(string): string = string()
+    if type(value) is bytes: value = value.decode()
+    if type(string) is bytes: string = string.decode()
     if value in string:
       raise Exception("Expected to NOT find '%s' in '%s', diff:\n\n%s" % (
         limit_size(value), limit_size(string),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6931,21 +6931,7 @@ Module.printErr = Module['printErr'] = function(){};
       # optimizer can deal with both types.
       map_filename = map_referent + '.map'
 
-      def encode_utf8(data):
-        if isinstance(data, dict):
-          for key in data:
-            data[key] = encode_utf8(data[key])
-          return data
-        elif isinstance(data, list):
-          for i in range(len(data)):
-            data[i] = encode_utf8(data[i])
-          return data
-        elif isinstance(data, unicode):
-          return data.encode('utf8')
-        else:
-          return data
-
-      data = encode_utf8(json.load(open(map_filename, 'r')))
+      data = json.load(open(map_filename, 'r'))
       if hasattr(data, 'file'):
         # the file attribute is optional, but if it is present it needs to refer
         # the output file.
@@ -6956,9 +6942,9 @@ Module.printErr = Module['printErr'] = function(){};
         # the sourcesContent attribute is optional, but if it is present it
         # needs to containt valid source text.
         self.assertTextDataIdentical(src, data['sourcesContent'][0])
-      mappings = encode_utf8(json.loads(jsrun.run_js(
+      mappings = json.loads(jsrun.run_js(
         path_from_root('tools', 'source-maps', 'sourcemap2json.js'),
-        tools.shared.NODE_JS, [map_filename])))
+        tools.shared.NODE_JS, [map_filename]))
       seen_lines = set()
       for m in mappings:
         self.assertPathsIdentical(src_filename, m['source'])

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -413,7 +413,7 @@ int main () {
     # generate a large string literal to use as our message
     message = ''
     for i in range(256*256*2):
-        message += str(unichr(ord('a') + (i % 26)))
+        message += str(chr(ord('a') + (i % 26)))
 
     # re-write the client test with this literal (it's too big to pass via command line)
     input_filename = path_from_root('tests', 'sockets', 'test_sockets_echo_client.c')


### PR DESCRIPTION
Python 3 disallows comparing byte strings with unprefixed string literals but this is what currently most of tests do. Adding `b` prefix for every tests is nearly undoable, so this PR decodes every byte string to Unicode.

Still there are so many remaining `'some expected string' in open(file).read()` lines but this PR at least make some tests including `test_hello_word` pass on Python 3.

(Bonus: No `unichr` on Python 3 so it changes to `chr`. It shouldn't be a problem as it only receives English alphabets.)