### PR TITLE
msvc_bigobj_debug

### DIFF
--- a/tools/optimizer/CMakeLists.txt
+++ b/tools/optimizer/CMakeLists.txt
@@ -29,8 +29,12 @@ endif()
 
 if (MSVC)
 	set(cFlags "${cFlags} -D_CRT_SECURE_NO_WARNINGS=1")
+	set(cFlagsDebug "${cFlagsDebug} /bigobj") # Debug build in Visual Studio is large and generates error C1128 if not explicitly recognized, so pass /bigobj for that
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
 endif()
+
+set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} ${cFlagsDebug}")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${cFlagsDebug}")
 
 set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} ${cFlags}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cFlags}")


### PR DESCRIPTION
Add MSVC flag /bigobj to the CMAKE_BUILD_TYPE=Debug build of asm.js optimizer in Visual Studio

Visual Studio would otherwise fail with

```
  Generating Code...
D:\emsdk2\emscripten\incoming\tools\optimizer\optimizer.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj [D:\emsdk2\emscripten\incoming_vs2015
_64bit_optimizer\optimizer.vcxproj]
Build failed due to exception!
Working directory: D:/emsdk2/emscripten/incoming_vs2015_64bit_optimizer
Command '['C:\\Program Files (x86)\\MSBuild/14.0/Bin/amd64\\MSBuild.exe', '/t:Build', '/p:Configuration=Debug', '/p:Platform=x64', '/nologo', '/verbosity:minimal', 'asmjs_optimizer.sln']' returned non-zero exit status 1
Installation failed!
```
