### PR TITLE
Python 3 compatibility: Avoid string type check

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -99,7 +99,7 @@ class Intermediate(object):
   counter = 0
 def save_intermediate(name=None, suffix='js'):
   name = os.path.join(shared.get_emscripten_temp_dir(), 'emcc-%d%s.%s' % (Intermediate.counter, '' if name is None else '-' + name, suffix))
-  if type(final) != str:
+  if isinstance(final, list):
     logging.debug('(not saving intermediate %s because deferring linking)' % name)
     return
   shutil.copyfile(final, name)
@@ -1437,7 +1437,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       DEFAULT_FINAL = in_temp(target_basename + '.bc')
       def get_final():
         global final
-        if type(final) != str:
+        if isinstance(final, list):
           final = DEFAULT_FINAL
         return final
 
@@ -1535,7 +1535,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         final = next
         if DEBUG: save_intermediate('autodebug', 'll')
 
-      assert type(final) == str, 'we must have linked the final files, if linking was deferred, by this point'
+      assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
 
     # exit block 'post-link'
     log_time('post-link')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -502,8 +502,8 @@ class RunnerCore(unittest.TestCase):
   def assertContained(self, values, string, additional_info=''):
     if type(values) not in [list, tuple]: values = [values]
     for value in values:
-      if type(value) is unicode: string = string.decode('UTF-8') # If we have any non-ASCII chars in the expected string, treat the test string from ASCII as UTF8 as well.
-      if type(string) is not str and type(string) is not unicode: string = string()
+      if not isinstance(value, bytes): string = string.decode('UTF-8') # If we have any non-ASCII chars in the expected string, treat the test string from ASCII as UTF8 as well.
+      if callable(string): string = string()
       if value in string: return # success
     raise Exception("Expected to find '%s' in '%s', diff:\n\n%s\n%s" % (
       limit_size(values[0]), limit_size(string),
@@ -512,8 +512,8 @@ class RunnerCore(unittest.TestCase):
     ))
 
   def assertNotContained(self, value, string):
-    if type(value) is not str: value = value() # lazy loading
-    if type(string) is not str: string = string()
+    if callable(value): value = value() # lazy loading
+    if callable(string): string = string()
     if value in string:
       raise Exception("Expected to NOT find '%s' in '%s', diff:\n\n%s" % (
         limit_size(value), limit_size(string),
@@ -973,7 +973,7 @@ class BrowserCore(RunnerCore):
     Popen(all_args).communicate()
     assert os.path.exists(outfile)
     if post_build: post_build()
-    if type(expected) is str: expected = [expected]
+    if not isinstance(expected, list): expected = [expected]
     self.run_browser(outfile + url_suffix, message, ['/report_result?' + e for e in expected], timeout=timeout)
     if also_proxied:
       print('proxied...')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2130,7 +2130,7 @@ int f() {
     ]:
       print(input, passes)
 
-      if type(expected) == str: expected = [expected]
+      if not isinstance(expected, list): expected = [expected]
       expected = [out.replace('\n\n', '\n').replace('\n\n', '\n') for out in expected]
 
       # test calling js optimizer

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -735,7 +735,7 @@ fi
       proc = Popen(command, stdout=PIPE, stderr=STDOUT)
       out, err = proc.communicate()
       assert (proc.returncode == 0) == success, out
-      if type(expected) == str: expected = [expected]
+      if not isinstance(expected, list): expected = [expected]
       for ex in expected:
         print('    seek', ex)
         assert ex in out, out

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -206,8 +206,8 @@ def get_native_optimizer():
 def use_native(x, source_map=False):
   if source_map: return False
   if not NATIVE_OPTIMIZER or NATIVE_OPTIMIZER == '0': return False
-  if type(x) == str: return x in NATIVE_PASSES
-  return len(NATIVE_PASSES.intersection(x)) == len(x) and 'asm' in x
+  if isinstance(x, list): return len(NATIVE_PASSES.intersection(x)) == len(x) and 'asm' in x
+  return x in NATIVE_PASSES
 
 class Minifier(object):
   '''
@@ -308,7 +308,7 @@ def run_on_chunk(command):
 
 def run_on_js(filename, passes, js_engine, source_map=False, extra_info=None, just_split=False, just_concat=False):
   with ToolchainProfiler.profile_block('js_optimizer.split_markers'):
-    if type(passes) == str:
+    if not isinstance(passes, list):
       passes = [passes]
 
     js = open(filename).read()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1864,7 +1864,7 @@ class Building(object):
   @staticmethod
   def llvm_opt(filename, opts, out=None):
     inputs = filename
-    if type(inputs) is str:
+    if not isinstance(inputs, list):
       inputs = [inputs]
     else:
       assert out, 'must provide out if llvm_opt on a list of inputs'


### PR DESCRIPTION
This PR is a prior work before adding `from __future__ import unicode_literals` (which changes the type of `''` from `str` to `unicode` on Python 2)  to fix Unicode compatibility problem with Python 3.

