### PR TITLE
SINGLE_FILE html and worker fixes + tests

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2588,9 +2588,16 @@ def generate_html(target, options, js_target, target_basename,
 
 
 def generate_worker_js(target, js_target, target_basename):
-  shutil.move(js_target, unsuffixed(js_target) + '.worker.js') # compiler output goes in .worker.js file
-  worker_target_basename = target_basename + '.worker'
-  proxy_worker_filename = shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename
+  # compiler output is embedded as base64
+  if shared.Settings.SINGLE_FILE:
+    proxy_worker_filename = shared.JS.get_subresource_location(js_target)
+
+  # compiler output goes in .worker.js file
+  else:
+    shutil.move(js_target, unsuffixed(js_target) + '.worker.js')
+    worker_target_basename = target_basename + '.worker'
+    proxy_worker_filename = (shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename) + '.js'
+
   target_contents = worker_js_script(proxy_worker_filename)
   open(target, 'w').write(target_contents)
 

--- a/emcc.py
+++ b/emcc.py
@@ -2445,10 +2445,11 @@ def generate_html(target, options, js_target, target_basename,
                                     minified = 'minifyNames' in optimizer.queue_history,
                                     separate_asm = options.separate_asm)
 
-  if shared.Settings.EMTERPRETIFY_FILE:
-    # We need to load the emterpreter file before anything else, it has to be synchronously ready
-    script.un_src()
-    script.inline = '''
+  if not shared.Settings.SINGLE_FILE:
+    if shared.Settings.EMTERPRETIFY_FILE:
+      # We need to load the emterpreter file before anything else, it has to be synchronously ready
+      script.un_src()
+      script.inline = '''
           var emterpretURL = '%s';
           var emterpretXHR = new XMLHttpRequest();
           emterpretXHR.open('GET', emterpretURL, true);
@@ -2467,10 +2468,10 @@ def generate_html(target, options, js_target, target_basename,
           emterpretXHR.send(null);
 ''' % (shared.JS.get_subresource_location(shared.Settings.EMTERPRETIFY_FILE), script.inline)
 
-  if options.memory_init_file:
-    # start to load the memory init file in the HTML, in parallel with the JS
-    script.un_src()
-    script.inline = ('''
+    if options.memory_init_file:
+      # start to load the memory init file in the HTML, in parallel with the JS
+      script.un_src()
+      script.inline = ('''
           var memoryInitializer = '%s';
           if (typeof Module['locateFile'] === 'function') {
             memoryInitializer = Module['locateFile'](memoryInitializer);
@@ -2484,15 +2485,15 @@ def generate_html(target, options, js_target, target_basename,
           meminitXHR.send(null);
 ''' % shared.JS.get_subresource_location(memfile)) + script.inline
 
-  # Download .asm.js if --separate-asm was passed in an asm.js build, or if 'asmjs' is one
-  # of the wasm run methods.
-  if not options.separate_asm or (shared.Settings.BINARYEN and 'asmjs' not in shared.Settings.BINARYEN_METHOD):
-    assert len(asm_mods) == 0, 'no --separate-asm means no client code mods are possible'
-  else:
-    script.un_src()
-    if len(asm_mods) == 0:
-      # just load the asm, then load the rest
-      script.inline = '''
+    # Download .asm.js if --separate-asm was passed in an asm.js build, or if 'asmjs' is one
+    # of the wasm run methods.
+    if not options.separate_asm or (shared.Settings.BINARYEN and 'asmjs' not in shared.Settings.BINARYEN_METHOD):
+      assert len(asm_mods) == 0, 'no --separate-asm means no client code mods are possible'
+    else:
+      script.un_src()
+      if len(asm_mods) == 0:
+        # just load the asm, then load the rest
+        script.inline = '''
     var filename = '%s';
     var fileBytes = tryParseAsDataURI(filename);
     var script = document.createElement('script');
@@ -2508,9 +2509,9 @@ def generate_html(target, options, js_target, target_basename,
     };
     document.body.appendChild(script);
 ''' % (shared.JS.get_subresource_location(asm_target), script.inline)
-    else:
-      # may need to modify the asm code, load it as text, modify, and load asynchronously
-      script.inline = '''
+      else:
+        # may need to modify the asm code, load it as text, modify, and load asynchronously
+        script.inline = '''
     var codeURL = '%s';
     var codeXHR = new XMLHttpRequest();
     codeXHR.open('GET', codeURL, true);
@@ -2541,10 +2542,10 @@ def generate_html(target, options, js_target, target_basename,
     codeXHR.send(null);
 ''' % (shared.JS.get_subresource_location(asm_target), '\n'.join(asm_mods), script.inline)
 
-  if shared.Settings.BINARYEN and not shared.Settings.BINARYEN_ASYNC_COMPILATION:
-    # We need to load the wasm file before anything else, it has to be synchronously ready TODO: optimize
-    script.un_src()
-    script.inline = '''
+    if shared.Settings.BINARYEN and not shared.Settings.BINARYEN_ASYNC_COMPILATION:
+      # We need to load the wasm file before anything else, it has to be synchronously ready TODO: optimize
+      script.un_src()
+      script.inline = '''
           var wasmURL = '%s';
           var wasmXHR = new XMLHttpRequest();
           wasmXHR.open('GET', wasmURL, true);
@@ -2569,6 +2570,15 @@ def generate_html(target, options, js_target, target_basename,
       f = open(shared.path_from_root(file), 'r')
       script.inline = f.read() + script.inline
       f.close()
+
+  # inline script for SINGLE_FILE output
+  if shared.Settings.SINGLE_FILE:
+    js = open(js_target, 'r')
+    js_contents = (script.inline or '') + js.read()
+    js.close()
+    shared.try_delete(js_target)
+    script.src = None
+    script.inline = js_contents
 
   html = open(target, 'wb')
   html_contents = shell.replace('{{{ SCRIPT }}}', script.replacement())

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -101,7 +101,7 @@ var SUPPORT_BASE64_EMBEDDING;
 
 // Worker
 
-var filename = '{{{ filename }}}.js';
+var filename = '{{{ filename }}}';
 
 var workerURL = filename;
 if (SUPPORT_BASE64_EMBEDDING) {

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -101,7 +101,10 @@ var SUPPORT_BASE64_EMBEDDING;
 
 // Worker
 
-var filename = '{{{ filename }}}';
+var filename;
+if (!filename) {
+  filename = '{{{ filename }}}';
+}
 
 var workerURL = filename;
 if (SUPPORT_BASE64_EMBEDDING) {
@@ -110,7 +113,7 @@ if (SUPPORT_BASE64_EMBEDDING) {
     workerURL = URL.createObjectURL(new Blob([fileBytes], {type: 'application/javascript'}));
   }
 }
-var worker = new Worker(filename);
+var worker = new Worker(workerURL);
 
 WebGLClient.prefetch();
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3708,20 +3708,20 @@ window.close = function() {
     ''')
     self.run_browser('a.html', '...', '/report_result?0')
 
-  # Tests that SINGLE_FILE works in generated HTML
+  # Tests that SINGLE_FILE works as intended in generated HTML
   def test_single_file_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"])
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
     assert os.path.exists('test.html') and not os.path.exists('test.js')
 
   # Tests that SINGLE_FILE works as intended in a Worker in HTML output
   def test_single_file_worker_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"])
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
     assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
 
   # Tests that SINGLE_FILE works as intended in a Worker in JS output
   def test_single_file_worker_js(self):
     open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
-    Popen([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"]).communicate()
+    Popen([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"]).communicate()
     open('test.html', 'w').write('<script src="test.js"></script>')
     self.run_browser('test.html', None, '/report_result?0')
     assert os.path.exists('test.js') and not os.path.exists('test.worker.js')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3707,3 +3707,21 @@ window.close = function() {
       </script>
     ''')
     self.run_browser('a.html', '...', '/report_result?0')
+
+  # Tests that SINGLE_FILE works in generated HTML
+  def test_single_file_html(self):
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"])
+    assert os.path.exists('test.html') and not os.path.exists('test.js')
+
+  # Tests that SINGLE_FILE works as intended in a Worker in HTML output
+  def test_single_file_worker_html(self):
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"])
+    assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
+
+  # Tests that SINGLE_FILE works as intended in a Worker in JS output
+  def test_single_file_worker_js(self):
+    open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+    Popen([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"]).communicate()
+    open('test.html', 'w').write('<script src="test.js"></script>')
+    self.run_browser('test.html', None, '/report_result?0')
+    assert os.path.exists('test.js') and not os.path.exists('test.worker.js')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3708,14 +3708,9 @@ window.close = function() {
     ''')
     self.run_browser('a.html', '...', '/report_result?0')
 
-  # Tests that SINGLE_FILE works as intended in generated HTML
+  # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
   def test_single_file_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
-    assert os.path.exists('test.html') and not os.path.exists('test.js')
-
-  # Tests that SINGLE_FILE works as intended in a Worker in HTML output
-  def test_single_file_worker_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"], also_proxied=True)
     assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
 
   # Tests that SINGLE_FILE works as intended in a Worker in JS output


### PR DESCRIPTION
While further investigating [this](https://github.com/kripken/emscripten/pull/5720#discussion_r147468365) as requested, I found some SINGLE_FILE bugs that impacted html output and workers.

Specifically:

1. SINGLE_FILE with html output would fail to compile, due to embedding the wasm in the js and deleting it, then afterwards trying to embed the deleted wasm in the html.

2. In the case of both html and workers, multiple files would be produced/required (respectively, test.html + test.js and test.js + test.worker.js).

Most of the lines changed in emcc.py are just indentation, so this will be easier to [view with ?w=1](https://github.com/kripken/emscripten/pull/5736/files?w=1).