### PR TITLE
no_heap_copy_with_wasm_heap_resizing

### DIFF
--- a/tests/access_file_after_heap_resize.c
+++ b/tests/access_file_after_heap_resize.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  FILE *fp;
+  int c;
+
+  malloc(20000000);  // Enlarge memory
+
+  fp = fopen("test.txt", "r");
+  int nChars = 0;
+  while ((c = fgetc(fp)) != EOF)
+  {
+    putchar(c);
+    ++nChars;
+  }
+#ifdef REPORT_RESULT
+  REPORT_RESULT(nChars);
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3724,3 +3724,9 @@ window.close = function() {
     open('test.html', 'w').write('<script src="test.js"></script>')
     self.run_browser('test.html', None, '/report_result?0')
     assert os.path.exists('test.js') and not os.path.exists('test.worker.js')
+
+  def test_access_file_after_heap_resize(self):
+    open('test.txt', 'w').write('hello from file')
+    open('page.c', 'w').write(self.with_report_result(open(path_from_root('tests', 'access_file_after_heap_resize.c'), 'r').read()))
+    Popen([PYTHON, EMCC, 'page.c', '-s', 'WASM=1', '-s', 'ALLOW_MEMORY_GROWTH=1', '--preload-file', 'test.txt', '-o', 'page.html']).communicate()
+    self.run_browser('page.html', 'hello from file', '/report_result?15')


### PR DESCRIPTION
Require --no-heap-copy mode when Wasm with allow memory growth is used with MEMFS. Fixes #5179