### PR TITLE
Added AMD externs so that Binaryen builds fine

### DIFF
--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1100,3 +1100,10 @@ var GL;
  * @suppress {undefinedVars}
  */
 var SDL;
+
+// Module loaders externs, primarily for Binaryen
+
+/**
+ * @param {Function} wrapper
+ */
+var define = function (wrapper) {};


### PR DESCRIPTION
This is a fix for building [Binaryen.js](https://github.com/AssemblyScript/binaryen.js) as noted here: https://github.com/kripken/emscripten/pull/5720#issuecomment-342822528

With this change I've compiled Binaryen.js master branch without issues.

@dcodeIO, does it work for you too?