### PR TITLE
Fix for undefined `ASSERTIONS` variable in html output of emcc

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2574,6 +2574,8 @@ def generate_html(target, options, js_target, target_basename,
       script.inline = f.read() + script.inline
       f.close()
 
+    script.inline = 'var ASSERTIONS = %s;\n%s' % (shared.Settings.ASSERTIONS, script.inline)
+
   # inline script for SINGLE_FILE output
   if shared.Settings.SINGLE_FILE:
     js_contents = script.inline or ''

--- a/src/arrayUtils.js
+++ b/src/arrayUtils.js
@@ -9,28 +9,17 @@ function intArrayFromString(stringy, dontAddNull, length) {
   return u8array;
 }
 
-var intArrayToString = ASSERTIONS ?
-  function (array) {
-    var ret = [];
-    for (var i = 0; i < array.length; i++) {
-      var chr = array[i];
-      if (chr > 0xFF) {
+function intArrayToString(array) {
+  var ret = [];
+  for (var i = 0; i < array.length; i++) {
+    var chr = array[i];
+    if (chr > 0xFF) {
+      if (ASSERTIONS) {
         assert(false, 'Character code ' + chr + ' (' + String.fromCharCode(chr) + ')  at offset ' + i + ' not in 0x00-0xFF.');
-        chr &= 0xFF;
       }
-      ret.push(String.fromCharCode(chr));
+      chr &= 0xFF;
     }
-    return ret.join('');
-  } :
-  function (array) {
-    var ret = [];
-    for (var i = 0; i < array.length; i++) {
-      var chr = array[i];
-      if (chr > 0xFF) {
-        chr &= 0xFF;
-      }
-      ret.push(String.fromCharCode(chr));
-    }
-    return ret.join('');
+    ret.push(String.fromCharCode(chr));
   }
-;
+  return ret.join('');
+}

--- a/src/arrayUtils.js
+++ b/src/arrayUtils.js
@@ -9,7 +9,6 @@ function intArrayFromString(stringy, dontAddNull, length) {
   return u8array;
 }
 
-// Temporarily duplicating function pending Python preprocessor support
 var intArrayToString = ASSERTIONS ?
   function (array) {
     var ret = [];


### PR DESCRIPTION
It seems to be specific to HTML builds, since `src/arrayUtils.js` doesn't define `ASSERTIONS` anymore (https://github.com/kripken/emscripten/pull/5720/files#diff-86414f2ed951321c81d9a4aa55bb139cL13).

Also removed comment (left from the PR linked above): it indicated that previously the code didn't work at all, but should start working with this PR.

@buu700, did I interpret it correctly?

This is a response to https://github.com/kripken/emscripten/commit/93479ecbd390aec4f8a3765fe04bcb365d0b31b2#commitcomment-25492064