### PR TITLE
Eval elimination #2

### DIFF
--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -947,6 +947,10 @@ var quit = function() {};
  * @return {number}
  */
 var dateNow = function() {};
+/**
+ * This is to prevent Closure Compiler to use `gc` as variable name anywhere, otherwise it might collide with SpiderMonkey's shell `gc()` function
+ */
+var gc = function () {};
 
 // WebIDL
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -184,10 +184,6 @@ else if (ENVIRONMENT_IS_SHELL) {
       quit(status);
     }
   }
-
-#if USE_CLOSURE_COMPILER
-  eval("if (typeof gc === 'function' && gc.toString().indexOf('[native code]') > 0) var gc = undefined"); // wipe out the SpiderMonkey shell 'gc' function, which can confuse closure (uses it as a minified name, and it is then initted to a non-falsey value unexpectedly)
-#endif
 }
 else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   Module['read'] = function shell_read(url) {


### PR DESCRIPTION
This PR eliminates the second of several `eval()` calls in Emscripten that happens when Closure Compiler is used (which doesn't allow it to be used with `unsafe-eval` Content Security Policy).

Basically, we define an extern and modern Closure Compiler will not touch it and will not use it for any purposes that might cause conflicts.