### PR TITLE
Python 3 compatibility: Use key for sort()

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2151,7 +2151,7 @@ int f() {
                 for i in stuff:
                   if i not in func: return func
                 indexes = [[i, func.index(i)] for i in stuff]
-                indexes.sort(lambda x, y: x[1] - y[1])
+                indexes.sort(key=lambda x: x[1])
                 for j in range(len(indexes)):
                   func = func.replace(indexes[j][0], 'STD_' + str(j))
                 return func

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -286,14 +286,8 @@ def run_on_js(filename, gen_hash_info=False):
     funcses.append(split_funcs(open(out_file).read(), False))
   funcs = [item for sublist in funcses for item in sublist]
   funcses = None
-  def sorter(x, y):
-    diff = len(y[1]) - len(x[1])
-    if diff != 0: return diff
-    if x[0] < y[0]: return 1
-    elif x[0] > y[0]: return -1
-    return 0
   if not os.environ.get('EMCC_NO_OPT_SORT'):
-    funcs.sort(sorter)
+    funcs.sort(key=lambda x: (len(x[1]), x[0]), reverse=True)
 
   for func in funcs:
     f.write(func[1])

--- a/tools/find_bigfuncs.py
+++ b/tools/find_bigfuncs.py
@@ -78,7 +78,7 @@ def uniq_compare(data1, data2):
 
 def list_bigfuncs(data):
     data = list(data.items())
-    data.sort(lambda (f1, d1), (f2, d2): d1[0] - d2[0])
+    data.sort(key=lambda (f, d): d[0])
     print(''.join(['%6d lines (%6s) : %s' % (d[0], humanbytes(d[1]), f) for f, d in data]))
 
 def main():

--- a/tools/find_bigvars.py
+++ b/tools/find_bigvars.py
@@ -20,6 +20,6 @@ for line in open(filename):
   elif line.startswith('}') and curr:
     data.append([curr, size])
     curr = None
-data.sort(lambda x, y: x[1] - y[1])
+data.sort(key=lambda x: x[1])
 print(''.join(['%6d : %s' % (x[1], x[0]) for x in data]))
 

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -537,14 +537,8 @@ EMSCRIPTEN_FUNCS();
         funcses.append(split_funcs(open(out_file).read(), False))
       funcs = [item for sublist in funcses for item in sublist]
       funcses = None
-      def sorter(x, y):
-        diff = len(y[1]) - len(x[1])
-        if diff != 0: return diff
-        if x[0] < y[0]: return 1
-        elif x[0] > y[0]: return -1
-        return 0
       if not os.environ.get('EMCC_NO_OPT_SORT'):
-        funcs.sort(sorter)
+        funcs.sort(key=lambda x: (len(x[1]), x[0]), reverse=True)
 
       if 'last' in passes and len(funcs) > 0:
         count = funcs[0][1].count('\n')

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -574,7 +574,7 @@ for child, parent in implements.items():
       parent = None
 
 names = list(interfaces.keys())
-names.sort(lambda x, y: nodeHeight.get(y, 0) - nodeHeight.get(x, 0))
+names.sort(key=lambda x: nodeHeight.get(x, 0), reverse=True)
 
 for name in names:
   interface = interfaces[name]


### PR DESCRIPTION
[Python 3 removed support for cmp-style sort](https://docs.python.org/3.3/howto/sorting.html):

>In Py3.0, the cmp parameter was removed entirely (as part of a larger effort to simplify and unify the language, eliminating the conflict between rich comparisons and the \_\_cmp\_\_() magic method).

(The first argument of `sort()` automatically becomes `cmp` parameter in Python 2)

Thus, this PR converts them to `key` parameter.