### PR TITLE
Python 3 compatibility: Use bytearray

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2315,7 +2315,7 @@ The current type of b is: 9
 def process(filename):
   src = open(filename, 'r').read().replace(
     '// {{PRE_RUN_ADDITIONS}}',
-    "FS.createDataFile('/', 'liblib.so', " + str(map(ord, open('liblib.so', 'rb').read())) + ", true, false, false);"
+    "FS.createDataFile('/', 'liblib.so', " + str(list(bytearray(open('liblib.so', 'rb').read()))) + ", true, false, false);"
   )
   open(filename, 'w').write(src)
 '''

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -322,7 +322,7 @@ if __name__ == '__main__':
     # js path
     mem_init_file = binary_file
     if os.path.exists(mem_init_file):
-      mem_init = json.dumps(list(map(ord, open(mem_init_file, 'rb').read())))
+      mem_init = json.dumps(list(bytearray(open(mem_init_file, 'rb').read())))
     else:
       mem_init = []
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -485,7 +485,7 @@ for file_ in data_files:
   basename = os.path.basename(filename)
   if file_['mode'] == 'embed':
     # Embed
-    data = list(map(ord, open(file_['srcpath'], 'rb').read()))
+    data = list(bytearray(open(file_['srcpath'], 'rb').read()))
     code += '''var fileData%d = [];\n''' % counter
     if data:
       parts = []


### PR DESCRIPTION
I found some more `map(ord, open().read())` patterns after #5702 so here are fixes for them.