### PR TITLE
Closure compiler fixes for gl

### DIFF
--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1110,3 +1110,9 @@ var SDL;
  * @param {Function} wrapper
  */
 var define = function (wrapper) {};
+
+/**
+ * @param {string} type
+ * @param {!Function} listener
+ */
+var addEventListener = function (type, listener) {};

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1235,12 +1235,33 @@ var _emscripten_glDisableVertexAttribArray;
  */
 var _emscripten_glVertexAttribPointer;
 
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glDrawArrays;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glDrawElements;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glTexEnvf;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glTexEnvi;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glTexEnvfv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glGetTexEnviv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _glGetTexEnvfv;
 
 var _glutPostRedisplay = function() {};

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1102,7 +1102,15 @@ var GL;
 /**
  * @suppress {duplicate, undefinedVars}
  */
+var WebGLClient;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var SDL;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var JSEvents;
 
 // Module loaders externs, for AMD etc.
 
@@ -1148,6 +1156,19 @@ var _glTexEnvi;
 var _glTexEnvfv;
 var _glGetTexEnviv;
 var _glGetTexEnvfv;
+
+/**
+ * @typy {Worker}
+ */
+var worker;
+/**
+ * @type {number}
+ */
+var majorVersion;
+/**
+ * @type {number}
+ */
+var minorVersion;
 
 /**
  * @param {string} type

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1122,32 +1122,113 @@ var define = function (wrapper) {};
 /**
  * GL functions (https://github.com/kripken/emscripten/commit/97a464a654fdadf5dfb8aa082b48516e6bf8d402#commitcomment-25520648)
  */
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDrawArrays;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDrawElements;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glActiveTexture;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glEnable;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDisable;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glTexEnvf;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glTexEnvi;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glTexEnvfv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glGetIntegerv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glIsEnabled;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glGetBooleanv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glGetString;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glCreateShader;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glShaderSource;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glCompileShader;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glAttachShader;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDetachShader;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glUseProgram;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDeleteProgram;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glBindAttribLocation;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glLinkProgram;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glBindBuffer;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glGetFloatv;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glHint;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glEnableVertexAttribArray;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glDisableVertexAttribArray;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var _emscripten_glVertexAttribPointer;
 
 var _glDrawArrays;
@@ -1175,3 +1256,21 @@ var minorVersion;
  * @param {!Function} listener
  */
 var addEventListener = function (type, listener) {};
+
+/**
+ * @param {HTMLCanvasElement} canvas
+ *
+ * @suppress {duplicate}
+ * @todo: https://github.com/kripken/emscripten/commit/946a27ee58ddd6cdcfcc896fea0f8187e2263795#commitcomment-25545119
+ */
+var __registerRestoreOldStyle = function(canvas) {};
+
+/**
+ * @param {HTMLCanvasElement} element
+ * @param {number} topBottom
+ * @param {number} leftRight
+ *
+ * @suppress {duplicate}
+ * @todo: https://github.com/kripken/emscripten/commit/946a27ee58ddd6cdcfcc896fea0f8187e2263795#commitcomment-25545119
+ */
+var __setLetterbox = function(element, topBottom, leftRight) {};

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1110,6 +1110,10 @@ var SDL;
 /**
  * @suppress {duplicate, undefinedVars}
  */
+var SDL2;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
 var JSEvents;
 
 // Module loaders externs, for AMD etc.
@@ -1232,11 +1236,14 @@ var _emscripten_glDisableVertexAttribArray;
 var _emscripten_glVertexAttribPointer;
 
 var _glDrawArrays;
+var _glDrawElements;
 var _glTexEnvf;
 var _glTexEnvi;
 var _glTexEnvfv;
 var _glGetTexEnviv;
 var _glGetTexEnvfv;
+
+var _glutPostRedisplay = function() {};
 
 /**
  * @typy {Worker}

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -801,6 +801,9 @@ SIMD.Bool16x8.fromFloat64x2 = function() {};
 SIMD.Bool32x4.fromFloat64x2 = function() {};
 SIMD.Bool64x2.fromFloat64x2 = function() {};
 
+/**
+ * @suppress {duplicate}
+ */
 var GLctx = {};
 
 /**
@@ -1093,11 +1096,11 @@ var FUNCTION_TABLE;
  */
 var MozBlobBuilder;
 /**
- * @suppress {undefinedVars}
+ * @suppress {duplicate, undefinedVars}
  */
 var GL;
 /**
- * @suppress {undefinedVars}
+ * @suppress {duplicate, undefinedVars}
  */
 var SDL;
 

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1112,6 +1112,44 @@ var SDL;
 var define = function (wrapper) {};
 
 /**
+ * GL functions (https://github.com/kripken/emscripten/commit/97a464a654fdadf5dfb8aa082b48516e6bf8d402#commitcomment-25520648)
+ */
+var _emscripten_glDrawArrays;
+var _emscripten_glDrawElements;
+var _emscripten_glActiveTexture;
+var _emscripten_glEnable;
+var _emscripten_glDisable;
+var _emscripten_glTexEnvf;
+var _emscripten_glTexEnvi;
+var _emscripten_glTexEnvfv;
+var _emscripten_glGetIntegerv;
+var _emscripten_glIsEnabled;
+var _emscripten_glGetBooleanv;
+var _emscripten_glGetString;
+var _emscripten_glCreateShader;
+var _emscripten_glShaderSource;
+var _emscripten_glCompileShader;
+var _emscripten_glAttachShader;
+var _emscripten_glDetachShader;
+var _emscripten_glUseProgram;
+var _emscripten_glDeleteProgram;
+var _emscripten_glBindAttribLocation;
+var _emscripten_glLinkProgram;
+var _emscripten_glBindBuffer;
+var _emscripten_glGetFloatv;
+var _emscripten_glHint;
+var _emscripten_glEnableVertexAttribArray;
+var _emscripten_glDisableVertexAttribArray;
+var _emscripten_glVertexAttribPointer;
+
+var _glDrawArrays;
+var _glTexEnvf;
+var _glTexEnvi;
+var _glTexEnvfv;
+var _glGetTexEnviv;
+var _glGetTexEnvfv;
+
+/**
  * @param {string} type
  * @param {!Function} listener
  */

--- a/src/gl-matrix.js
+++ b/src/gl-matrix.js
@@ -61,7 +61,7 @@ var MatrixArray = Float32Array;
 /*
  * vec3
  */
- 
+
 /**
  * Creates a new instance of a vec3 using the default array type
  * Any javascript array-like objects containing at least 3 numeric elements can serve as a vec3
@@ -352,7 +352,7 @@ vec3.dist = function (vec, vec2) {
     var x = vec2[0] - vec[0],
         y = vec2[1] - vec[1],
         z = vec2[2] - vec[2];
-        
+
     return Math.sqrt(x*x + y*y + z*z);
 };
 
@@ -373,22 +373,22 @@ vec3.unproject = function (vec, view, proj, viewport, dest) {
 
     var m = mat4.create();
     var v = new MatrixArray(4);
-    
+
     v[0] = (vec[0] - viewport[0]) * 2.0 / viewport[2] - 1.0;
     v[1] = (vec[1] - viewport[1]) * 2.0 / viewport[3] - 1.0;
     v[2] = 2.0 * vec[2] - 1.0;
     v[3] = 1.0;
-    
+
     mat4.multiply(proj, view, m);
     if(!mat4.inverse(m)) { return null; }
-    
+
     mat4.multiplyVec4(m, v);
     if(v[3] === 0.0) { return null; }
 
     dest[0] = v[0] / v[3];
     dest[1] = v[1] / v[3];
     dest[2] = v[2] / v[3];
-    
+
     return dest;
 };
 
@@ -481,8 +481,6 @@ mat3.identity = function (dest) {
  * Params:
  * @param {mat3} mat mat3 to transpose
  * @param {mat3} [dest] mat3 receiving transposed values. If not specified result is written to mat
- *
- * @returns {mat3} dest is specified, mat otherwise
  */
 mat3.transpose = function (mat, dest) {
     // If we are transposing ourselves we can skip a few steps but have to cache some values
@@ -726,9 +724,7 @@ mat4.determinant = function (mat) {
  * Calculates the inverse matrix of a mat4
  *
  * @param {mat4} mat mat4 to calculate inverse of
- * @param {mat4} [dest] mat4 receiving inverse matrix. If not specified result is written to mat
- *
- * @param {mat4} dest is specified, mat otherwise, null if matrix cannot be inverted
+ * @param {mat4} [dest] mat4 receiving inverse matrix. If not specified result is written to mat, null if matrix cannot be inverted
  */
 mat4.inverse = function (mat, dest) {
     if (!dest) { dest = mat; }
@@ -881,8 +877,6 @@ mat4.toInverseMat3 = function (mat, dest) {
  * @param {mat4} mat First operand
  * @param {mat4} mat2 Second operand
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.multiply = function (mat, mat2, dest) {
     if (!dest) { dest = mat; }
@@ -968,8 +962,6 @@ mat4.multiplyVec4 = function (mat, vec, dest) {
  * @param {mat4} mat mat4 to translate
  * @param {vec3} vec vec3 specifying the translation
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.translate = function (mat, vec, dest) {
     var x = vec[0], y = vec[1], z = vec[2],
@@ -1006,8 +998,6 @@ mat4.translate = function (mat, vec, dest) {
  * @param {mat4} mat mat4 to scale
  * @param {vec3} vec vec3 specifying the scale for each axis
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @param {mat4} dest if specified, mat otherwise
  */
 mat4.scale = function (mat, vec, dest) {
     var x = vec[0], y = vec[1], z = vec[2];
@@ -1053,10 +1043,8 @@ mat4.scale = function (mat, vec, dest) {
  *
  * @param {mat4} mat mat4 to rotate
  * @param {number} angle Angle (in radians) to rotate
- * @param {vec3} axis vec3 representing the axis to rotate around 
+ * @param {vec3} axis vec3 representing the axis to rotate around
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.rotate = function (mat, angle, axis, dest) {
     var x = axis[0], y = axis[1], z = axis[2],
@@ -1123,8 +1111,6 @@ mat4.rotate = function (mat, angle, axis, dest) {
  * @param {mat4} mat mat4 to rotate
  * @param {number} angle Angle (in radians) to rotate
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.rotateX = function (mat, angle, dest) {
     var s = Math.sin(angle),
@@ -1171,8 +1157,6 @@ mat4.rotateX = function (mat, angle, dest) {
  * @param {mat4} mat mat4 to rotate
  * @param {number} angle Angle (in radians) to rotate
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.rotateY = function (mat, angle, dest) {
     var s = Math.sin(angle),
@@ -1219,8 +1203,6 @@ mat4.rotateY = function (mat, angle, dest) {
  * @param {mat4} mat mat4 to rotate
  * @param {number} angle Angle (in radians) to rotate
  * @param {mat4} [dest] mat4 receiving operation result. If not specified result is written to mat
- *
- * @returns {mat4} dest if specified, mat otherwise
  */
 mat4.rotateZ = function (mat, angle, dest) {
     var s = Math.sin(angle),
@@ -1496,7 +1478,7 @@ mat4.fromRotationTranslation = function (quat, vec, dest) {
     dest[13] = vec[1];
     dest[14] = vec[2];
     dest[15] = 1;
-    
+
     return dest;
 };
 
@@ -1558,8 +1540,8 @@ quat4.set = function (quat, dest) {
 
 /**
  * Calculates the W component of a quat4 from the X, Y, and Z components.
- * Assumes that quaternion is 1 unit in length. 
- * Any existing W component will be ignored. 
+ * Assumes that quaternion is 1 unit in length.
+ * Any existing W component will be ignored.
  *
  * @param {quat4} quat quat4 to calculate W component of
  * @param {quat4} [dest] quat4 receiving calculated values. If not specified result is written to quat
@@ -1604,9 +1586,9 @@ quat4.inverse = function(quat, dest) {
     var q0 = quat[0], q1 = quat[1], q2 = quat[2], q3 = quat[3],
         dot = q0*q0 + q1*q1 + q2*q2 + q3*q3,
         invDot = dot ? 1.0/dot : 0;
-    
+
     // TODO: Would be faster to return [0,0,0,0] immediately if dot == 0
-    
+
     if(!dest || quat === dest) {
         quat[0] *= -invDot;
         quat[1] *= -invDot;

--- a/src/gl-matrix.js
+++ b/src/gl-matrix.js
@@ -654,8 +654,6 @@ mat4.identity = function (dest) {
  *
  * @param {mat4} mat mat4 to transpose
  * @param {mat4} [dest] mat4 receiving transposed values. If not specified result is written to mat
- *
- * @param {mat4} dest is specified, mat otherwise
  */
 mat4.transpose = function (mat, dest) {
     // If we are transposing ourselves we can skip a few steps but have to cache some values

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -84,7 +84,7 @@ var LibraryGL = {
       }
     },
 
-    // Records a GL error condition that occurred, stored until user calls glGetError() to fetch it. As per GLES2 spec, only the first error 
+    // Records a GL error condition that occurred, stored until user calls glGetError() to fetch it. As per GLES2 spec, only the first error
     // is remembered, and subsequent errors are discarded until the user has cleared the stored error by a call to glGetError().
     recordError: function recordError(errorCode) {
       if (!GL.lastError) {
@@ -379,9 +379,9 @@ var LibraryGL = {
         case 0x1401 /* GL_UNSIGNED_BYTE */:
           sizeBytes = 1;
           break;
-        case 0x1402 /* GL_SHORT */: 
-        case 0x1403 /* GL_UNSIGNED_SHORT */: 
-          sizeBytes = 2; 
+        case 0x1402 /* GL_SHORT */:
+        case 0x1403 /* GL_UNSIGNED_SHORT */:
+          sizeBytes = 2;
           break;
         case 0x1404 /* GL_INT */:
         case 0x1405 /* GL_UNSIGNED_INT */:
@@ -468,15 +468,15 @@ var LibraryGL = {
         this.hookWebGLFunction(f, glCtx);
       }
       // The above injection won't work for texImage2D and texSubImage2D, which have multiple overloads.
-      glCtx['texImage2D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9) { 
+      glCtx['texImage2D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9) {
         var ret = (a7 !== undefined) ? glCtx['real_texImage2D'](a1, a2, a3, a4, a5, a6, a7, a8, a9) : glCtx['real_texImage2D'](a1, a2, a3, a4, a5, a6);
         return ret;
       };
-      glCtx['texSubImage2D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9) { 
+      glCtx['texSubImage2D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9) {
         var ret = (a8 !== undefined) ? glCtx['real_texSubImage2D'](a1, a2, a3, a4, a5, a6, a7, a8, a9) : glCtx['real_texSubImage2D'](a1, a2, a3, a4, a5, a6, a7);
         return ret;
       };
-      glCtx['texSubImage3D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) { 
+      glCtx['texSubImage3D'] = function(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) {
         var ret = (a9 !== undefined) ? glCtx['real_texSubImage3D'](a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) : glCtx['real_texSubImage2D'](a1, a2, a3, a4, a5, a6, a7, a8);
         return ret;
       };
@@ -611,7 +611,7 @@ var LibraryGL = {
       GL.generateTempBuffers(false, context);
 #endif
 
-      // Detect the presence of a few extensions manually, this GL interop layer itself will need to know if they exist. 
+      // Detect the presence of a few extensions manually, this GL interop layer itself will need to know if they exist.
 #if LEGACY_GL_EMULATION
       context.compressionExt = GLctx.getExtension('WEBGL_compressed_texture_s3tc');
       context.anisotropicExt = GLctx.getExtension('EXT_texture_filter_anisotropic');
@@ -712,7 +712,7 @@ var LibraryGL = {
           name = name.slice(0, ls);
         }
 
-        // Optimize memory usage slightly: If we have an array of uniforms, e.g. 'vec3 colors[3];', then 
+        // Optimize memory usage slightly: If we have an array of uniforms, e.g. 'vec3 colors[3];', then
         // only store the string 'colors' in utable, and 'colors[0]', 'colors[1]' and 'colors[2]' will be parsed as 'colors'+i.
         // Note that for the GL.uniforms table, we still need to fetch the all WebGLUniformLocations for all the indices.
         var loc = GLctx.getUniformLocation(p, name);
@@ -747,7 +747,7 @@ var LibraryGL = {
   glGetString__sig: 'ii',
   glGetString: function(name_) {
     if (GL.stringCache[name_]) return GL.stringCache[name_];
-    var ret; 
+    var ret;
     switch(name_) {
       case 0x1F00 /* GL_VENDOR */:
       case 0x1F01 /* GL_RENDERER */:
@@ -1424,7 +1424,7 @@ var LibraryGL = {
   glGetTexParameterfv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetTexParameterfv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1438,7 +1438,7 @@ var LibraryGL = {
   glGetTexParameteriv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetTexParameteriv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1509,7 +1509,7 @@ var LibraryGL = {
   glGetBufferParameteriv: function(target, value, data) {
     if (!data) {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
-      // if data == null, issue a GL error to notify user about it. 
+      // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetBufferParameteriv(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
 #endif
@@ -1524,7 +1524,7 @@ var LibraryGL = {
   glGetBufferParameteri64v: function(target, value, data) {
     if (!data) {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
-      // if data == null, issue a GL error to notify user about it. 
+      // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetBufferParameteri64v(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
 #endif
@@ -1640,7 +1640,7 @@ var LibraryGL = {
   glGetQueryivEXT: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetQueryivEXT(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1654,7 +1654,7 @@ var LibraryGL = {
   glGetQueryObjectivEXT: function(id, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetQueryObject(u)ivEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1680,7 +1680,7 @@ var LibraryGL = {
   glGetQueryObjecti64vEXT: function(id, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetQueryObject(u)i64vEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1767,7 +1767,7 @@ var LibraryGL = {
   glGetBufferPointerv__deps: ['$emscriptenWebGLGetBufferBinding'],
   glGetBufferPointerv: function(target, pname, params) {
     if (pname == 0x88BD/*GL_BUFFER_MAP_POINTER*/) {
-      var ptr = 0; 
+      var ptr = 0;
       var mappedBuffer = GL.mappedBuffers[emscriptenWebGLGetBufferBinding(target)];
       if (mappedBuffer) {
         ptr = mappedBuffer.mem;
@@ -1942,7 +1942,7 @@ var LibraryGL = {
   glGetQueryiv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetQueryiv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -1956,7 +1956,7 @@ var LibraryGL = {
   glGetQueryObjectuiv: function(id, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetQueryObjectuiv(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -2176,7 +2176,7 @@ var LibraryGL = {
   $emscriptenWebGLGetIndexed: function(target, index, data, type) {
     if (!data) {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
-      // if data == null, issue a GL error to notify user about it. 
+      // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetInteger(64)i_v(target=' + target + ', index=' + index + ', data=0): Function called with null out pointer!');
 #endif
@@ -2274,7 +2274,7 @@ var LibraryGL = {
 #endif
     if (!uniformIndices) {
       // GLES2 specification does not specify how to behave if uniformIndices is a null pointer. Since calling this function does not make sense
-      // if uniformIndices == null, issue a GL error to notify user about it. 
+      // if uniformIndices == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetUniformIndices(program=' + program + ', uniformCount=' + uniformCount + ', uniformNames=' + uniformNames + ', uniformIndices=0): Function called with null out pointer!');
 #endif
@@ -2306,7 +2306,7 @@ var LibraryGL = {
 #endif
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if params == null, issue a GL error to notify user about it. 
+      // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetActiveUniformsiv(program=' + program + ', uniformCount=' + uniformCount + ', uniformIndices=' + uniformIndices + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -2346,7 +2346,7 @@ var LibraryGL = {
   glGetActiveUniformBlockiv: function(program, uniformBlockIndex, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if params == null, issue a GL error to notify user about it. 
+      // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetActiveUniformBlockiv(program=' + program + ', uniformBlockIndex=' + uniformBlockIndex + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -2490,7 +2490,7 @@ var LibraryGL = {
     }
     if (!values) {
       // GLES3 specification does not specify how to behave if values is a null pointer. Since calling this function does not make sense
-      // if values == null, issue a GL error to notify user about it. 
+      // if values == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetSynciv(sync=' + sync + ', pname=' + pname + ', bufSize=' + bufSize + ', length=' + length + ', values=0): Function called with null out pointer!');
 #endif
@@ -2520,7 +2520,7 @@ var LibraryGL = {
     }
     if (!params) {
       // GLES3 specification does not specify how to behave if values is a null pointer. Since calling this function does not make sense
-      // if values == null, issue a GL error to notify user about it. 
+      // if values == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetInternalFormativ(target=' + target + ', internalformat=' + internalformat + ', pname=' + pname + ', bufSize=' + bufSize + ', params=0): Function called with null out pointer!');
 #endif
@@ -2587,7 +2587,7 @@ var LibraryGL = {
   glGetRenderbufferParameteriv: function(target, pname, params) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if params == null, issue a GL error to notify user about it. 
+      // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetRenderbufferParameteriv(target=' + target + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -2607,7 +2607,7 @@ var LibraryGL = {
   $emscriptenWebGLGetUniform: function(program, location, params, type) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if params == null, issue a GL error to notify user about it. 
+      // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetUniform*v(program=' + program + ', location=' + location + ', params=0): Function called with null out pointer!');
 #endif
@@ -2701,7 +2701,7 @@ var LibraryGL = {
   $emscriptenWebGLGetVertexAttrib: function(index, pname, params, type) {
     if (!params) {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
-      // if params == null, issue a GL error to notify user about it. 
+      // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetVertexAttrib*v(index=' + index + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
@@ -2771,7 +2771,7 @@ var LibraryGL = {
   glGetVertexAttribPointerv: function(index, pname, pointer) {
     if (!pointer) {
       // GLES2 specification does not specify how to behave if pointer is a null pointer. Since calling this function does not make sense
-      // if pointer == null, issue a GL error to notify user about it. 
+      // if pointer == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetVertexAttribPointerv(index=' + index + ', pname=' + pname + ', pointer=0): Function called with null out pointer!');
 #endif
@@ -3583,7 +3583,7 @@ var LibraryGL = {
   glGetShaderiv : function(shader, pname, p) {
     if (!p) {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetShaderiv(shader=' + shader + ', pname=' + pname + ', p=0): Function called with null out pointer!');
 #endif
@@ -3610,7 +3610,7 @@ var LibraryGL = {
   glGetProgramiv : function(program, pname, p) {
     if (!p) {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
-      // if p == null, issue a GL error to notify user about it. 
+      // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
       Module.printErr('GL_INVALID_VALUE in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0): Function called with null out pointer!');
 #endif
@@ -3925,7 +3925,7 @@ var LibraryGL = {
     }
 #endif
   },
-  
+
 #if LEGACY_GL_EMULATION
   glDeleteVertexArrays__deps: ['emulGlDeleteVertexArrays'],
 #endif
@@ -3944,7 +3944,7 @@ var LibraryGL = {
     }
 #endif
   },
-  
+
 #if LEGACY_GL_EMULATION
   glBindVertexArray__deps: ['emulGlBindVertexArray'],
 #endif
@@ -3974,7 +3974,7 @@ var LibraryGL = {
 #else
 #if GL_ASSERTIONS
     assert(GLctx['isVertexArray'], 'Must have WebGL2 or OES_vertex_array_object to use vao');
-#endif  
+#endif
 
     var vao = GL.vaos[array];
     if (!vao) return 0;
@@ -4997,7 +4997,7 @@ var LibraryGL = {
           0x0300 /* GL_SRC_COLOR */: 0,
           0x0301 /* GL_ONE_MINUS_SRC_COLOR */: 1,
           0x0302 /* GL_SRC_ALPHA */: 2,
-          0x0300 /* GL_ONE_MINUS_SRC_ALPHA */: 3
+          0x0303 /* GL_ONE_MINUS_SRC_ALPHA */: 3
         };
 
         // The tuple (key0,key1,key2) uniquely identifies the state of the variables in CTexEnv.
@@ -5025,12 +5025,12 @@ var LibraryGL = {
         this.computeKey1 = function() {
           var k = this.traverseKey;
           key = k[this.colorOp[0]] * 4096;
-          key += k[this.colorOp[1]] * 1024;             
+          key += k[this.colorOp[1]] * 1024;
           key += k[this.colorOp[2]] * 256;
           key += k[this.alphaOp[0]] * 16;
           key += k[this.alphaOp[1]] * 4;
           key += k[this.alphaOp[2]];
-          return key;            
+          return key;
         }
         // TODO: remove this. The color should not be part of the key!
         this.computeKey2 = function() {
@@ -6560,7 +6560,7 @@ var LibraryGL = {
       // for this is that it allows the emulation code to get away with using just one VBO buffer for rendering,
       // and not have to maintain multiple ones. Therefore cases (1) and (3) will be very slow, and case (2) is fast.
 
-      // Detect which case we are in by using a quick heuristic by examining the strides of the buffers. If all the buffers have identical 
+      // Detect which case we are in by using a quick heuristic by examining the strides of the buffers. If all the buffers have identical
       // stride, we assume we have case (2), otherwise we have something more complex.
       var clientStartPointer = 0x7FFFFFFF;
       var bytes = 0; // Total number of bytes taken up by a single vertex.
@@ -7721,7 +7721,7 @@ glFuncs.forEach(function(data) {
 
 autoAddDeps(LibraryGL, '$GL');
 
-// Legacy GL emulation 
+// Legacy GL emulation
 if (LEGACY_GL_EMULATION) {
   DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$GLEmulation');
 }

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -4276,7 +4276,7 @@ var LibraryGL = {
           GL.shaderInfos[shader].ftransform = need_pm || need_mm || need_pv; // we will need to provide the fixed function stuff as attributes and uniforms
           for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
             // XXX To handle both regular texture mapping and cube mapping, we use vec4 for tex coordinates.
-            var old = source;
+            old = source;
             var need_vtc = source.search('v_texCoord' + i) == -1;
             source = source.replace(new RegExp('gl_TexCoord\\[' + i + '\\]', 'g'), 'v_texCoord' + i)
                            .replace(new RegExp('gl_MultiTexCoord' + i, 'g'), 'a_texCoord' + i);
@@ -4312,8 +4312,8 @@ var LibraryGL = {
           }
           source = ensurePrecision(source);
         } else { // Fragment shader
-          for (var i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
-            var old = source;
+          for (i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
+            old = source;
             source = source.replace(new RegExp('gl_TexCoord\\[' + i + '\\]', 'g'), 'v_texCoord' + i);
             if (source != old) {
               source = 'varying vec4 v_texCoord' + i + ';   \n' + source;

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -3776,7 +3776,7 @@ var LibraryGL = {
 
   glIsProgram__sig: 'ii',
   glIsProgram: function(program) {
-    var program = GL.programs[program];
+    program = GL.programs[program];
     if (!program) return 0;
     return GLctx.isProgram(program);
   },

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -286,7 +286,7 @@ var LibraryGL = {
       }
 #if LEGACY_GL_EMULATION
       // Let's see if we need to enable the standard derivatives extension
-      type = GLctx.getShaderParameter(GL.shaders[shader], 0x8B4F /* GL_SHADER_TYPE */);
+      var type = GLctx.getShaderParameter(GL.shaders[shader], 0x8B4F /* GL_SHADER_TYPE */);
       if (type == 0x8B30 /* GL_FRAGMENT_SHADER */) {
         if (GL.findToken(source, "dFdx") ||
             GL.findToken(source, "dFdy") ||
@@ -3646,7 +3646,7 @@ var LibraryGL = {
       {{{ makeSetValue('p', '0', 'ptable.maxUniformLength', 'i32') }}};
     } else if (pname == 0x8B8A /* GL_ACTIVE_ATTRIBUTE_MAX_LENGTH */) {
       if (ptable.maxAttributeLength == -1) {
-        var program = GL.programs[program];
+        program = GL.programs[program];
         var numAttribs = GLctx.getProgramParameter(program, GLctx.ACTIVE_ATTRIBUTES);
         ptable.maxAttributeLength = 0; // Spec says if there are no active attribs, 0 must be returned.
         for (var i = 0; i < numAttribs; ++i) {
@@ -3657,7 +3657,7 @@ var LibraryGL = {
       {{{ makeSetValue('p', '0', 'ptable.maxAttributeLength', 'i32') }}};
     } else if (pname == 0x8A35 /* GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH */) {
       if (ptable.maxUniformBlockNameLength == -1) {
-        var program = GL.programs[program];
+        program = GL.programs[program];
         var numBlocks = GLctx.getProgramParameter(program, GLctx.ACTIVE_UNIFORM_BLOCKS);
         ptable.maxUniformBlockNameLength = 0;
         for (var i = 0; i < numBlocks; ++i) {

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -659,7 +659,7 @@ var LibraryGL = {
       function shouldEnableAutomatically(extension) {
         var ret = false;
         automaticallyEnabledExtensions.forEach(function(include) {
-          if (ext.indexOf(include) != -1) {
+          if (extension.indexOf(include) != -1) {
             ret = true;
           }
         });

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -23,7 +23,7 @@ var LibrarySDL = {
       // If true, SDL_LockSurface will copy the contents of each surface back to the Emscripten HEAP so that C code can access it. If false,
       // the surface contents are captured only back to JS code.
       copyOnLock: true,
-      // If true, SDL_LockSurface will discard the contents of each surface when SDL_LockSurface() is called. This greatly improves performance 
+      // If true, SDL_LockSurface will discard the contents of each surface when SDL_LockSurface() is called. This greatly improves performance
       // of SDL_LockSurface(). If discardOnLock is true, copyOnLock is ignored.
       discardOnLock: false,
       // If true, emulate compatibility with desktop SDL by ignoring alpha on the screen frontbuffer canvas. Setting this to false will improve
@@ -97,7 +97,7 @@ var LibrarySDL = {
     DOMEventToSDLEvent: {},
 
     TOUCH_DEFAULT_ID: 0, // Our default deviceID for touch events (we get nothing from the browser)
-    
+
     eventHandler: null,
     eventHandlerContext: null,
     eventHandlerTemp: 0,
@@ -120,10 +120,10 @@ var LibrarySDL = {
       44: 316, // print screen
       45: 73 | 1<<10, // insert
       46: 127, // SDLK_DEL == '\177'
-      
+
       91: 227 | 1<<10, // windows key or super key on linux (doesn't work on Mac)
       93: 101 | 1<<10, // application
-      
+
       96: 98 | 1<<10, // keypad 0
       97: 89 | 1<<10, // keypad 1
       98: 90 | 1<<10, // keypad 2
@@ -136,7 +136,7 @@ var LibrarySDL = {
       105: 97 | 1<<10, // keypad 9
       106: 85 | 1<<10, // keypad multiply
       107: 87 | 1<<10, // keypad plus
-      109: 86 | 1<<10, // keypad minus	  
+      109: 86 | 1<<10, // keypad minus
       110: 99 | 1<<10, // keypad decimal point
       111: 84 | 1<<10, // keypad divide
       112: 58 | 1<<10, // F1
@@ -150,7 +150,7 @@ var LibrarySDL = {
       120: 66 | 1<<10, // F9
       121: 67 | 1<<10, // F10
       122: 68 | 1<<10, // F11
-      123: 69 | 1<<10, // F12      
+      123: 69 | 1<<10, // F12
       124: 104 | 1<<10, // F13
       125: 105 | 1<<10, // F14
       126: 106 | 1<<10, // F15
@@ -165,7 +165,7 @@ var LibrarySDL = {
       135: 115 | 1<<10, // F24
 
       144: 83 | 1<<10, // keypad num lock
-      
+
       160: 94, // caret
       161: 33, // exclaim
       162: 34, // double quote
@@ -178,16 +178,16 @@ var LibrarySDL = {
       169: 41, // close parenthesis
       170: 42, // asterix
       171: 43, // plus
-      172: 124, // pipe     
+      172: 124, // pipe
       173: 45, // minus
       174: 123, // open curly bracket
       175: 125, // close curly bracket
       176: 126, // tilde
-      
+
       181: 127, // audio mute
       182: 129, // audio volume down
       183: 128, // audio volume up
-      
+
       188: 44, // comma
       190: 46, // period
       191: 47, // slash (/)
@@ -196,7 +196,7 @@ var LibrarySDL = {
       220: 92, // back slash
       221: 93, // close square bracket
       222: 39, // quote
-      224: 227 | 1<<10, // meta (command/windows)      
+      224: 227 | 1<<10, // meta (command/windows)
     },
 
     scanCodes: { // SDL keycode ==> SDL scancode. See SDL_scancode.h
@@ -206,13 +206,13 @@ var LibrarySDL = {
       27: 41, // escape
       32: 44, // space
       35: 204, // hash
-      
+
       39: 53, // grave
-      
+
       44: 54, // comma
       46: 55, // period
       47: 56, // slash
-      48: 39, // 0      
+      48: 39, // 0
       49: 30, // 1
       50: 31, // 2
       51: 32, // 3
@@ -226,11 +226,11 @@ var LibrarySDL = {
       59: 51, // semicolon
 
       61: 46, // equals
-      
+
       91: 47, // left bracket
       92: 49, // backslash
       93: 48, // right bracket
-      
+
       96: 52, // apostrophe
       97: 4, // A
       98: 5, // B
@@ -260,11 +260,11 @@ var LibrarySDL = {
       122: 29, // Z
 
       127: 76, // delete
-      
+
       305: 224, // ctrl
-      
+
       308: 226, // alt
-      
+
       316: 70, // print screen
     },
     loadRect: function(rect) {
@@ -393,9 +393,9 @@ var LibrarySDL = {
         stencil: (SDL.glAttributes[7 /*SDL_GL_STENCIL_SIZE*/] > 0),
         alpha: (SDL.glAttributes[3 /*SDL_GL_ALPHA_SIZE*/] > 0)
       };
-      
+
       var ctx = Browser.createContext(canvas, is_SDL_OPENGL, usePageCanvas, webGLContextAttributes);
-            
+
       SDL.surfaces[surf] = {
         width: width,
         height: height,
@@ -418,7 +418,7 @@ var LibrarySDL = {
       return surf;
     },
 
-    // Copy data from the C++-accessible storage to the canvas backing 
+    // Copy data from the C++-accessible storage to the canvas backing
     // for surface with HWPALETTE flag(8bpp depth)
     copyIndexedColorData: function(surfData, rX, rY, rW, rH) {
       // HWPALETTE works with palette
@@ -426,7 +426,7 @@ var LibrarySDL = {
       if (!surfData.colors) {
         return;
       }
-      
+
       var fullWidth  = Module['canvas'].width;
       var fullHeight = Module['canvas'].height;
 
@@ -434,7 +434,7 @@ var LibrarySDL = {
       var startY  = rY || 0;
       var endX    = (rW || (fullWidth - startX)) + startX;
       var endY    = (rH || (fullHeight - startY)) + startY;
-      
+
       var buffer  = surfData.buffer;
 
       if (!surfData.image.data32) {
@@ -489,12 +489,12 @@ var LibrarySDL = {
       if (dstData.clipRect) {
         var widthScale = (!scale || sr.w === 0) ? 1 : sr.w / dr.w;
         var heightScale = (!scale || sr.h === 0) ? 1 : sr.h / dr.h;
-        
+
         dr = SDL.intersectionOfRects(dstData.clipRect, dr);
-        
+
         sr.w = dr.w * widthScale;
         sr.h = dr.h * heightScale;
-        
+
         if (dstrect) {
           SDL.updateRect(dstrect, dr);
         }
@@ -546,7 +546,7 @@ var LibrarySDL = {
           event.preventDefault();
 
           var touches = [];
-          
+
           // Clear out any touchstart events that we've already processed
           if (event.type === 'touchstart') {
             for (var i = 0; i < event.touches.length; i++) {
@@ -559,7 +559,7 @@ var LibrarySDL = {
           } else {
             touches = event.touches;
           }
-          
+
           var firstTouch = touches[0];
           if (firstTouch) {
             if (event.type == 'touchstart') {
@@ -590,7 +590,7 @@ var LibrarySDL = {
         }
         case 'touchend': {
           event.preventDefault();
-          
+
           // Remove the entry in the SDL.downFingers hash
           // because the finger is no longer down.
           for(var i = 0; i < event.changedTouches.length; i++) {
@@ -608,7 +608,7 @@ var LibrarySDL = {
           };
           SDL.DOMButtons[0] = 0;
           SDL.events.push(mouseEvent);
-          
+
           for (var i = 0; i < event.changedTouches.length; i++) {
             var touch = event.changedTouches[i];
             SDL.events.push({
@@ -943,8 +943,8 @@ var LibrarySDL = {
         case 'wheel': {
           {{{ makeSetValue('ptr', C_STRUCTS.SDL_MouseWheelEvent.type, 'SDL.DOMEventToSDLEvent[event.type]', 'i32') }}};
           {{{ makeSetValue('ptr', C_STRUCTS.SDL_MouseWheelEvent.x, 'event.deltaX', 'i32') }}};
-          {{{ makeSetValue('ptr', C_STRUCTS.SDL_MouseWheelEvent.y, 'event.deltaY', 'i32') }}}; 
-          break;       
+          {{{ makeSetValue('ptr', C_STRUCTS.SDL_MouseWheelEvent.y, 'event.deltaY', 'i32') }}};
+          break;
         }
         case 'touchstart': case 'touchend': case 'touchmove': {
           var touch = event.touch;
@@ -1354,7 +1354,7 @@ var LibrarySDL = {
     SDL.DOMEventToSDLEvent['mousedown']  = 0x401  /* SDL_MOUSEBUTTONDOWN */;
     SDL.DOMEventToSDLEvent['mouseup']    = 0x402  /* SDL_MOUSEBUTTONUP */;
     SDL.DOMEventToSDLEvent['mousemove']  = 0x400  /* SDL_MOUSEMOTION */;
-    SDL.DOMEventToSDLEvent['wheel']      = 0x403  /* SDL_MOUSEWHEEL */; 
+    SDL.DOMEventToSDLEvent['wheel']      = 0x403  /* SDL_MOUSEWHEEL */;
     SDL.DOMEventToSDLEvent['touchstart'] = 0x700  /* SDL_FINGERDOWN */;
     SDL.DOMEventToSDLEvent['touchend']   = 0x701  /* SDL_FINGERUP */;
     SDL.DOMEventToSDLEvent['touchmove']  = 0x702  /* SDL_FINGERMOTION */;
@@ -1401,7 +1401,7 @@ var LibrarySDL = {
   },
 
   SDL_VideoModeOK: function(width, height, depth, flags) {
-    // SDL_VideoModeOK returns 0 if the requested mode is not supported under any bit depth, or returns the 
+    // SDL_VideoModeOK returns 0 if the requested mode is not supported under any bit depth, or returns the
     // bits-per-pixel of the closest available mode with the given width, height and requested surface flags
     return depth; // all modes are ok.
   },
@@ -1418,7 +1418,7 @@ var LibrarySDL = {
       return 0; //return NULL
     }
     //driverName - emscripten_sdl_driver
-    var driverName = [101, 109, 115, 99, 114, 105, 112, 116, 101, 
+    var driverName = [101, 109, 115, 99, 114, 105, 112, 116, 101,
       110, 95, 115, 100, 108, 95, 100, 114, 105, 118, 101, 114];
 
     var index = 0;
@@ -1573,9 +1573,9 @@ var LibrarySDL = {
         // var data = '';
         // for (var i = 0; i<size; i++) {
         //   var color = SDL.translateRGBAToColor(
-        //     surfData.image.data[i*4   ], 
-        //     surfData.image.data[i*4 +1], 
-        //     surfData.image.data[i*4 +2], 
+        //     surfData.image.data[i*4   ],
+        //     surfData.image.data[i*4 +1],
+        //     surfData.image.data[i*4 +2],
         //     255);
         //   var index = surfData.colorMap[color];
         //   {{{ makeSetValue('surfData.buffer', 'i', 'index', 'i8') }}};
@@ -1750,7 +1750,7 @@ var LibrarySDL = {
   SDL_GetKeyState: function() {
     return _SDL_GetKeyboardState();
   },
-  
+
   SDL_GetKeyName__proxy: 'sync',
   SDL_GetKeyName__sig: 'ii',
   SDL_GetKeyName: function(key) {
@@ -1842,7 +1842,7 @@ var LibrarySDL = {
       console.log('TODO: Partially unimplemented SDL_CreateRGBSurfaceFrom called!');
       return surf;
     }
-    
+
     var data = SDL.surfaces[surf];
     var image = data.ctx.createImageData(width, height);
     var pitchOfDst = width * 4;
@@ -1857,7 +1857,7 @@ var LibrarySDL = {
     }
 
     data.ctx.putImageData(image, 0, 0);
- 
+
     return surf;
   },
 
@@ -1871,7 +1871,7 @@ var LibrarySDL = {
     var oldData = SDL.surfaces[surf];
     var ret = SDL.makeSurface(oldData.width, oldData.height, oldData.flags, false, 'copy:' + oldData.source);
     var newData = SDL.surfaces[ret];
-    
+
     newData.ctx.globalCompositeOperation = "copy";
     newData.ctx.drawImage(oldData.canvas, 0, 0);
     newData.ctx.globalCompositeOperation = oldData.ctx.globalCompositeOperation;
@@ -2082,7 +2082,7 @@ var LibrarySDL = {
       SDL.handleEvent(event);
     });
   },
-  
+
   // An Emscripten-specific extension to SDL: Some browser APIs require that they are called from within an event handler function.
   // Allow recording a callback that will be called for each received event.
   emscripten_SDL_SetEventHandler__proxy: 'sync',
@@ -2102,13 +2102,13 @@ var LibrarySDL = {
 
     // we should create colors array
     // only once cause client code
-    // often wants to change portion 
+    // often wants to change portion
     // of palette not all palette.
     if (!surfData.colors) {
       var buffer = new ArrayBuffer(256 * 4); // RGBA, A is unused, but faster this way
       surfData.colors = new Uint8Array(buffer);
       surfData.colors32 = new Uint32Array(buffer);
-    } 
+    }
 
     for (var i = 0; i < nColors; ++i) {
       var index = (firstColor + i) * 4;
@@ -2194,7 +2194,7 @@ var LibrarySDL = {
   },
 
   SDL_WM_GrabInput: function() {},
-  
+
   SDL_WM_ToggleFullScreen__proxy: 'sync',
   SDL_WM_ToggleFullScreen__sig: 'ii',
   SDL_WM_ToggleFullScreen: function(surf) {
@@ -2437,14 +2437,14 @@ var LibrarySDL = {
       } else if ((SDL.audio.samples & (SDL.audio.samples-1)) != 0) {
         throw 'Audio callback buffer size ' + SDL.audio.samples + ' must be a power-of-two!';
       }
-      
+
       var totalSamples = SDL.audio.samples*SDL.audio.channels;
       SDL.audio.bytesPerSample = (SDL.audio.format == 0x0008 /*AUDIO_U8*/ || SDL.audio.format == 0x8008 /*AUDIO_S8*/) ? 1 : 2;
       SDL.audio.bufferSize = totalSamples*SDL.audio.bytesPerSample;
       SDL.audio.bufferDurationSecs = SDL.audio.bufferSize / SDL.audio.bytesPerSample / SDL.audio.channels / SDL.audio.freq; // Duration of a single queued buffer in seconds.
       SDL.audio.bufferingDelay = 50 / 1000; // Audio samples are played with a constant delay of this many seconds to account for browser and jitter.
       SDL.audio.buffer = _malloc(SDL.audio.bufferSize);
-      
+
       // To account for jittering in frametimes, always have multiple audio buffers queued up for the audio output device.
       // This helps that we won't starve that easily if a frame takes long to complete.
       SDL.audio.numSimultaneouslyQueuedBuffers = Module['SDL_numSimultaneouslyQueuedBuffers'] || 5;
@@ -2467,7 +2467,7 @@ var LibrarySDL = {
           // And queue it to be played after the currently playing audio stream.
           SDL.audio.pushAudio(SDL.audio.buffer, SDL.audio.bufferSize);
         }
-      } 
+      }
 
 #if EMTERPRETIFY_ASYNC
       var yieldCallback = function() {
@@ -2502,7 +2502,7 @@ var LibrarySDL = {
           }
         }
       };
-      
+
       SDL.audio.audioOutput = new Audio();
 
       // Initialize Web Audio API if we haven't done so yet. Note: Only initialize Web Audio context ever once on the web page,
@@ -2510,7 +2510,7 @@ var LibrarySDL = {
       SDL.openAudioContext();
       if (!SDL.audioContext) throw 'Web Audio API is not available!';
       SDL.audio.nextPlayTime = 0; // Time in seconds when the next audio block is due to start.
-      
+
       // The pushAudio function with a new audio buffer whenever there is new audio data to schedule to be played back on the device.
       SDL.audio.pushAudio=function(ptr,sizeBytes) {
         try {
@@ -2529,7 +2529,7 @@ var LibrarySDL = {
           SDL.fillWebAudioBufferFromHeap(ptr, sizeSamplesPerChannel, soundBuffer);
           // Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=883675 by setting the buffer only after filling. The order is important here!
           source['buffer'] = soundBuffer;
-          
+
           // Schedule the generated sample buffer to be played out at the correct time right after the previously scheduled
           // sample buffer has finished.
           var curtime = SDL.audioContext['currentTime'];
@@ -2538,7 +2538,7 @@ var LibrarySDL = {
             console.log('warning: Audio callback had starved sending audio by ' + (curtime - SDL.audio.nextPlayTime) + ' seconds.');
           }
 #endif
-          // Don't ever start buffer playbacks earlier from current time than a given constant 'SDL.audio.bufferingDelay', since a browser 
+          // Don't ever start buffer playbacks earlier from current time than a given constant 'SDL.audio.bufferingDelay', since a browser
           // may not be able to mix that audio clip in immediately, and there may be subsequent jitter that might cause the stream to starve.
           var playtime = Math.max(curtime + SDL.audio.bufferingDelay, SDL.audio.nextPlayTime);
           if (typeof source['start'] !== 'undefined') {
@@ -2554,7 +2554,7 @@ var LibrarySDL = {
           }
           SDL.audio.curBufferEnd = Math.round(playtime * SDL.audio.freq + sizeSamplesPerChannel);
           */
-          
+
           SDL.audio.nextPlayTime = playtime + SDL.audio.bufferDurationSecs;
         } catch(e) {
           console.log('Web Audio API error playing back audio: ' + e.toString());
@@ -3077,7 +3077,7 @@ var LibrarySDL = {
     }
     return 0;
   },
-  
+
   Mix_Pause__proxy: 'sync',
   Mix_Pause__sig: 'vi',
   Mix_Pause: function(channel) {
@@ -3094,7 +3094,7 @@ var LibrarySDL = {
       //Module.printErr('Mix_Pause: no sound found for channel: ' + channel);
     }
   },
-  
+
   // http://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_39.html#SEC39
   Mix_Paused__proxy: 'sync',
   Mix_Paused__sig: 'ii',
@@ -3169,14 +3169,14 @@ var LibrarySDL = {
     var fontData = SDL.fonts[font];
     var w = SDL.estimateTextWidth(fontData, text);
     var h = fontData.size;
-    var color = SDL.loadColorToCSSRGB(color); // XXX alpha breaks fonts?
+    color = SDL.loadColorToCSSRGB(color); // XXX alpha breaks fonts?
     var fontString = SDL.makeFontString(h, fontData.name);
     var surf = SDL.makeSurface(w, h, 0, false, 'text:' + text); // bogus numbers..
     var surfData = SDL.surfaces[surf];
     surfData.ctx.save();
     surfData.ctx.fillStyle = color;
     surfData.ctx.font = fontString;
-    // use bottom alligment, because it works 
+    // use bottom alligment, because it works
     // same in all browsers, more info here:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=737852
     surfData.ctx.textBaseline = 'bottom';
@@ -3207,21 +3207,21 @@ var LibrarySDL = {
   TTF_GlyphMetrics: function(font, ch, minx, maxx, miny, maxy, advance) {
     var fontData = SDL.fonts[font];
     var width = SDL.estimateTextWidth(fontData,  String.fromCharCode(ch));
-    
+
     if (advance) {
       {{{ makeSetValue('advance', '0', 'width', 'i32') }}};
     }
     if (minx) {
-      {{{ makeSetValue('minx', '0', '0', 'i32') }}}; 
+      {{{ makeSetValue('minx', '0', '0', 'i32') }}};
     }
     if (maxx) {
-      {{{ makeSetValue('maxx', '0', 'width', 'i32') }}}; 
+      {{{ makeSetValue('maxx', '0', 'width', 'i32') }}};
     }
     if (miny) {
-      {{{ makeSetValue('miny', '0', '0', 'i32') }}}; 
+      {{{ makeSetValue('miny', '0', '0', 'i32') }}};
     }
     if (maxy) {
-      {{{ makeSetValue('maxy', '0', 'fontData.size', 'i32') }}}; 
+      {{{ makeSetValue('maxy', '0', 'fontData.size', 'i32') }}};
     }
   },
 
@@ -3634,7 +3634,7 @@ var LibrarySDL = {
     SDL.rwops.push({ filename: name, mimetype: Browser.getMimetype(name) });
     return id;
   },
-  
+
   SDL_FreeRW__proxy: 'sync',
   SDL_FreeRW__sig: 'vi',
   SDL_FreeRW: function(rwopsID) {

--- a/tests/canvas_style_proxy_shell.html
+++ b/tests/canvas_style_proxy_shell.html
@@ -51,7 +51,7 @@
     <figure style="overflow:visible;" id="spinner"><div class="spinner"></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
     <div class="emscripten" id="status">Downloading...</div>
     <div class="emscripten">
-      <progress value="0" max="100" id="progress" hidden=1></progress>  
+      <progress value="0" max="100" id="progress" hidden=1></progress>
     </div>
     <div class="emscripten_border">
       <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
@@ -61,10 +61,10 @@
       <input type="checkbox" id="resize">Resize canvas
       <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
       &nbsp;&nbsp;&nbsp;
-      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 
+      <input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked,
                                                                                 document.getElementById('resize').checked)">
     </div>
-    
+
     <hr/>
     <textarea class="emscripten" id="output" rows="8"></textarea>
     <hr>
@@ -153,7 +153,7 @@
 
       window.verifyCanvasStyle = function () {
         var success = Module.canvas.style.cursor === 'pointer';
-        xhr = new XMLHttpRequest();
+        var xhr = new XMLHttpRequest();
         xhr.open('GET', 'http://localhost:8888/report_result?' + (success ? 1 : 0));
         xhr.send();
         setTimeout(function() { window.close() }, 1000);

--- a/tests/custom_messages_proxy_shell.html
+++ b/tests/custom_messages_proxy_shell.html
@@ -16,7 +16,7 @@
       function sendResult(success) {
         if (window.sentTestResult) return;
         window.sentTestResult = true;
-        xhr = new XMLHttpRequest();
+        var xhr = new XMLHttpRequest();
         xhr.open('GET', 'http://localhost:8888/report_result?' + (success ? 1 : 0));
         xhr.send();
         setTimeout(function() { window.close() }, 1000);

--- a/tests/emterpreter_async_bad.cpp
+++ b/tests/emterpreter_async_bad.cpp
@@ -34,7 +34,7 @@ int main() {
     window.onerror = function(err) {
       assert(err.toString().indexOf('This error happened during an emterpreter-async save or load of the stack') > 0, 'expect good error message');
       // manually REPORT_RESULT; we can't call back into native code at this point, assertions would trigger
-      xhr = new XMLHttpRequest();
+      var xhr = new XMLHttpRequest();
       xhr.open("GET", "http://localhost:8888/report_result?1");
       xhr.onload = xhr.onerror = function() {
         window.close();

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -912,7 +912,7 @@ class BrowserCore(RunnerCore):
             }
             var wrong = Math.floor(total / (img.width*img.height*3)); // floor, to allow some margin of error for antialiasing
 
-            xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest();
             xhr.open('GET', 'http://localhost:8888/report_result?' + wrong);
             xhr.send();
             if (wrong < 10 /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000);

--- a/third_party/closure-compiler/browser-externs/webgl2.js
+++ b/third_party/closure-compiler/browser-externs/webgl2.js
@@ -1,0 +1,30 @@
+/**
+ * WebGL2
+ */
+/**
+ * @constructor
+ * @extends {WebGLRenderingContext}
+ */
+function WebGL2RenderingContext() {}
+// TODO: WebGL2RenderingContext is not exactly the same as WebGLRenderingContext, so more externs will be needed here
+
+/**
+ * @constructor
+ */
+function WebGLQuery() {}
+/**
+ * @constructor
+ */
+function WebGLSampler() {}
+/**
+ * @constructor
+ */
+function WebGLSync() {}
+/**
+ * @constructor
+ */
+function WebGLTransformFeedback() {}
+/**
+ * @constructor
+ */
+function WebGLVertexArrayObject() {}


### PR DESCRIPTION
As noted in https://github.com/kripken/emscripten/commit/93479ecbd390aec4f8a3765fe04bcb365d0b31b2#commitcomment-25520093 GL tests were failing.

Closure Compiler found 2 actual bugs in `src/library_gl.js` (which should ideally be covered by tests now):
* incorrect duplicated key `0x0300` instead of correct `0x0303` (correctness results from context)
* incorrect undefined `ext` variable used instead of `extension` (correctness results from context)

Also multiple undeclared/redeclared variables were either fixed or silenced (where they seem to be correct as is).

With this patch `browser.test_cubegeom_glew` passes for me locally. I recommend to review PR with `?w=1` as there are some trailing whitespaces removed in edited files.

Also see discussion here: https://github.com/kripken/emscripten/commit/97a464a654fdadf5dfb8aa082b48516e6bf8d402#commitcomment-25520648