### PR TITLE
Take `randomBytes` in quotes, otherwise Closure Compiler will mangle it

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1278,7 +1278,7 @@ mergeInto(LibraryManager.library, {
         random_device = function() { crypto.getRandomValues(randomBuffer); return randomBuffer[0]; };
       } else if (ENVIRONMENT_IS_NODE) {
         // for nodejs
-        random_device = function() { return require('crypto').randomBytes(1)[0]; };
+        random_device = function() { return require('crypto')['randomBytes'](1)[0]; };
       } else {
         // default for ES5 platforms
         random_device = function() { return (Math.random()*256)|0; };

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -8,7 +8,7 @@ mergeInto(LibraryManager.library, {
   },
 
   // Compare whether or not two 'compact' UUIDs are the same.
-  // Returns an integer less than, equal to, or greater than zero if uu1  is found, respectively, to be   
+  // Returns an integer less than, equal to, or greater than zero if uu1  is found, respectively, to be
   // lexigraphically  less  than,  equal, or greater than uu2.
   uuid_compare__deps: ['memcmp'],
   uuid_compare: function(uu1, uu2) {
@@ -32,11 +32,11 @@ mergeInto(LibraryManager.library, {
     if (ENVIRONMENT_IS_NODE) {
       // If Node.js try to use crypto.randomBytes
       try {
-        var rb = require('crypto').randomBytes;
+        var rb = require('crypto')['randomBytes'];
         uuid = rb(16);
       } catch(e) {}
     } else if (ENVIRONMENT_IS_WEB &&
-               typeof(window.crypto) !== 'undefined' && 
+               typeof(window.crypto) !== 'undefined' &&
                typeof(window.crypto.getRandomValues) !== 'undefined') {
       // If crypto.getRandomValues is available try to use it.
       uuid = new Uint8Array(16);
@@ -98,7 +98,7 @@ mergeInto(LibraryManager.library, {
       return -1;
     }
   },
- 
+
   // Convert a 'compact' form UUID to a string, if the upper parameter is supplied make the string upper case.
   uuid_unparse: function(uu, out, upper) {
     // void uuid_unparse(const uuid_t uu, char *out);


### PR DESCRIPTION
This is a trivial fix for failing `test_uuid` test