### PR TITLE
Travis browser tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 env:
 - TEST_TARGET=other
+- TEST_TARGET=browser
 - TEST_TARGET="ALL.test_a* ALL.test_b*"
 - TEST_TARGET=ALL.test_c*
 - TEST_TARGET="default.test_d* asm1.test_d* asm2.test_d* asm2f.test_d* asm2g.test_d* asm3.test_d*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN cd /root/ \
  && echo EMSCRIPTEN_ROOT="'/root/emscripten/'" >> .emscripten
 
 ARG TEST_TARGET
-RUN python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:ALL.test_binaryen skip:other.test_binaryen* skip:other.test_on_abort skip:other.test_sysconf_phys_pages skip:other.test_wasm_targets skip:other.test_symbol_map skip:other.test_legalize_js_ffi
+RUN export EMSCRIPTEN_BROWSER=0 \
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:ALL.test_binaryen skip:other.test_binaryen* skip:other.test_on_abort skip:other.test_sysconf_phys_pages skip:other.test_wasm_targets skip:other.test_symbol_map skip:other.test_legalize_js_ffi

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import multiprocessing, os, shutil, subprocess, unittest, zlib, webbrowser, time, shlex
-from runner import BrowserCore, path_from_root
+from runner import BrowserCore, path_from_root, has_browser
 from tools.shared import *
 
 try:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -8,17 +8,6 @@ try:
 except ImportError:
   from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
-# User can specify an environment variable EMSCRIPTEN_BROWSER to force the browser test suite to
-# run using another browser command line than the default system browser.
-emscripten_browser = os.environ.get('EMSCRIPTEN_BROWSER')
-if emscripten_browser:
-  cmd = shlex.split(emscripten_browser)
-  def run_in_other_browser(url):
-    Popen(cmd + [url])
-  if EM_BUILD_VERBOSE_LEVEL >= 3:
-    print("using Emscripten browser: " + str(cmd), file=sys.stderr)
-  webbrowser.open_new = run_in_other_browser
-
 def test_chunked_synchronous_xhr_server(support_byte_ranges, chunkSize, data, checksum):
   class ChunkedServerHandler(BaseHTTPRequestHandler):
     def sendheaders(s, extra=[], length=len(data)):
@@ -85,6 +74,7 @@ class browser(BrowserCore):
     self.btest('hello_world_sdl.cpp', reference='htmltest.png', args=['-s', 'USE_SDL=1', '-lGL']) # is the default anyhow
 
   def test_html_source_map(self):
+    if not has_browser(): return self.skip('need a browser')
     cpp_file = os.path.join(self.get_dir(), 'src.cpp')
     html_file = os.path.join(self.get_dir(), 'src.html')
     # browsers will try to 'guess' the corresponding original line if a
@@ -2211,6 +2201,7 @@ void *getBindBuffer() {
     assert 'Traceback' not in result
 
   def test_emrun(self):
+    if not has_browser(): return self.skip('need a browser')
     Popen([PYTHON, EMCC, path_from_root('tests', 'test_emrun.c'), '--emrun', '-o', 'hello_world.html']).communicate()
     outdir = os.getcwd()
     # We cannot run emrun from the temp directory the suite will clean up afterwards, since the browser that is launched will have that directory as startup directory,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2192,6 +2192,7 @@ void *getBindBuffer() {
       self.btest(path_from_root('tests', 'mmap_file.c'), expected='1', args=['--preload-file', 'data.dat'] + extra_args)
 
   def test_emrun_info(self):
+    if not has_browser(): return self.skip('need a browser')
     result = subprocess.check_output([PYTHON, path_from_root('emrun'), '--system_info', '--browser_info'])
     assert 'CPU' in result
     assert 'Browser' in result


### PR DESCRIPTION
This adds an option to run browser tests without opening a browser, so it just checks compilation in that case. This is used on travis, where it gives us coverage of compilation errors in the browser suite.

This may be useful for testing #5765 and others.

Any opposition to landing it first, with the new errors it creates?