### PR TITLE
Switch wasm llvm target to 'wasm32-unknown-unkown-elf'

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -173,7 +173,7 @@ class RunnerCore(unittest.TestCase):
     return False
 
   def is_wasm_backend(self):
-    return LLVM_TARGET == WASM_TARGET
+    return Settings.WASM_BACKEND
 
   def uses_memory_init_file(self):
     if self.emcc_args is None:

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -868,9 +868,9 @@ fi
     try:
       os.environ['EMCC_DEBUG'] = '1'
       os.environ['EMCC_WASM_BACKEND'] = '1'
-      make_fake('wasm32-unknown-unknown')
+      make_fake('wasm32-unknown-unknown-elf')
       # see that we request the right backend from llvm
-      self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'wasm32-unknown-unknown')
+      self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'wasm32-unknown-unknown-elf')
       os.environ['EMCC_WASM_BACKEND'] = '0'
       make_fake('asmjs-unknown-emscripten')
       self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'asmjs-unknown-emscripten')
@@ -880,7 +880,7 @@ fi
       self.check_working(EMCC)
       output = self.check_working(EMCC, 'check tells us to use')
       if 'wasm backend' in output:
-        self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'wasm32-unknown-unknown')
+        self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'wasm32-unknown-unknown-elf')
       else:
         assert 'asm.js backend' in output
         self.check_working([EMCC, 'tests/hello_world.c', '-c'], 'asmjs-unknown-emscripten')      

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -905,7 +905,7 @@ except:
 
 # Target choice.
 ASM_JS_TARGET = 'asmjs-unknown-emscripten'
-WASM_TARGET = 'wasm32-unknown-unknown'
+WASM_TARGET = 'wasm32-unknown-unknown-elf'
 
 def check_vanilla():
   global LLVM_TARGET
@@ -957,7 +957,6 @@ def check_vanilla():
 check_vanilla()
 
 def get_llvm_target():
-  global LLVM_TARGET
   assert LLVM_TARGET is not None
   return LLVM_TARGET
 
@@ -976,7 +975,7 @@ COMPILER_OPTS = COMPILER_OPTS + [#'-fno-threadsafe-statics', # disabled due to i
                                  '-D__EMSCRIPTEN_tiny__=' + str(EMSCRIPTEN_VERSION_TINY),
                                  '-D_LIBCPP_ABI_VERSION=2']
 
-if LLVM_TARGET == WASM_TARGET:
+if get_llvm_target() == WASM_TARGET:
   # wasm target does not automatically define emscripten stuff, so do it here.
   COMPILER_OPTS = COMPILER_OPTS + ['-D__EMSCRIPTEN__',
                                    '-Dunix',


### PR DESCRIPTION
This will allow us to change the upstream default to
wasm32-unknown-unkown-wasm without breaking emscripten.

Also, remove check of LLVM_TARGET in general in favor
of Settings.WASM_BACKEND which is how we should be checking
for this.