### PR TITLE
Python 3 compatibility: use universal_newlines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For travis
 FROM buildpack-deps:xenial
 SHELL ["/bin/bash", "-c"]
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
 RUN mkdir -p /root/emscripten/
 COPY . /root/emscripten/
 

--- a/emcc.py
+++ b/emcc.py
@@ -377,7 +377,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     with misc_temp_files.get_file(suffix='.o') as temp_target:
       input_file = 'hello_world.c'
       out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', input_file), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env, universal_newlines=True).communicate()
-      lines = [x for x in err.split(os.linesep) if shared.CLANG_CC in x and input_file in x]
+      lines = [x for x in err.split('\n') if shared.CLANG_CC in x and input_file in x]
       line = re.search('running: (.*)', lines[0]).group(1)
       parts = shlex.split(line.replace('\\', '\\\\'))
       parts = [x for x in parts if x != '-c' and x != '-o' and input_file not in x and temp_target not in x and '-emit-llvm' not in x]

--- a/emcc.py
+++ b/emcc.py
@@ -376,7 +376,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     args = [x for x in sys.argv if x != '--cflags']
     with misc_temp_files.get_file(suffix='.o') as temp_target:
       input_file = 'hello_world.c'
-      out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', input_file), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env).communicate()
+      out, err = subprocess.Popen([shared.PYTHON] + args + [shared.path_from_root('tests', input_file), '-c', '-o', temp_target], stderr=subprocess.PIPE, env=debug_env, universal_newlines=True).communicate()
       lines = [x for x in err.split(os.linesep) if shared.CLANG_CC in x and input_file in x]
       line = re.search('running: (.*)', lines[0]).group(1)
       parts = shlex.split(line.replace('\\', '\\\\'))

--- a/emscripten.py
+++ b/emscripten.py
@@ -120,7 +120,7 @@ def compile_js(infile, settings, temp_files, DEBUG):
       logging.debug('emscript: llvm backend: ' + ' '.join(backend_args))
       t = time.time()
     with ToolchainProfiler.profile_block('emscript_llvm_backend'):
-      shared.jsrun.timeout_run(subprocess.Popen(backend_args, stdout=subprocess.PIPE), note_args=backend_args)
+      shared.jsrun.timeout_run(subprocess.Popen(backend_args, stdout=subprocess.PIPE, universal_newlines=True), note_args=backend_args)
     if DEBUG:
       logging.debug('  emscript: llvm backend took %s seconds' % (time.time() - t))
 

--- a/tests/benchmark_sse1.py
+++ b/tests/benchmark_sse1.py
@@ -11,13 +11,13 @@ from tools.shared import *
 temp_dir = tempfile.mkdtemp()
 
 # System info
-system_info = Popen([PYTHON, path_from_root('emrun'), '--system_info'], stdout=PIPE, stderr=PIPE).communicate()
+system_info = Popen([PYTHON, path_from_root('emrun'), '--system_info'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Native info
-native_info = Popen(['clang', '-v'], stdout=PIPE, stderr=PIPE).communicate()
+native_info = Popen(['clang', '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Emscripten info
-emscripten_info = Popen([PYTHON, EMCC, '-v'], stdout=PIPE, stderr=PIPE).communicate()
+emscripten_info = Popen([PYTHON, EMCC, '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Run native build
 out_file = os.path.join(temp_dir, 'benchmark_sse1_native')
@@ -25,12 +25,12 @@ if WINDOWS: out_file += '.exe'
 cmd = [CLANG_CPP] + get_clang_native_args() + [path_from_root('tests', 'benchmark_sse1.cpp'), '-O3', '-o', out_file]
 print 'Building native version of the benchmark:'
 print ' '.join(cmd)
-build = Popen(cmd, env=get_clang_native_env())
+build = Popen(cmd, env=get_clang_native_env(), universal_newlines=True)
 out = build.communicate()
 if build.returncode != 0:
     sys.exit(1)
 
-native_results = Popen([out_file], stdout=PIPE, stderr=PIPE).communicate()
+native_results = Popen([out_file], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 print native_results[0]
 
 # Run emscripten build
@@ -38,7 +38,7 @@ out_file = os.path.join(temp_dir, 'benchmark_sse1_html.html')
 cmd = [PYTHON, EMCC, path_from_root('tests', 'benchmark_sse1.cpp'), '-O3', '-msse', '--emrun', '-s', 'TOTAL_MEMORY=536870912', '-o', out_file]
 print 'Building Emscripten version of the benchmark:'
 print ' '.join(cmd)
-build = Popen(cmd)
+build = Popen(cmd, universal_newlines=True)
 out = build.communicate()
 if build.returncode != 0:
     sys.exit(1)
@@ -52,7 +52,7 @@ if 'almost asm' in js:
     open(out_js_file, 'w').write(js.replace('almost asm', 'use asm'))
 
 # Enforce asm.js validation for the output file so that we can capture any validation errors.
-asmjs_validation_status = Popen([PYTHON, path_from_root('tools', 'validate_asmjs.py'), out_file], stdout=PIPE, stderr=PIPE).communicate()
+asmjs_validation_status = Popen([PYTHON, path_from_root('tools', 'validate_asmjs.py'), out_file], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 asmjs_validation_status = (asmjs_validation_status[0].strip() + '\n' + asmjs_validation_status[1].strip()).strip()
 if 'is not valid asm.js' in asmjs_validation_status:
     print >> sys.stderr, asmjs_validation_status
@@ -72,7 +72,7 @@ print ''
 print 'Once the test has finished, close the browser application to continue.'
 cmd = [PYTHON, path_from_root('emrun'), '--safe_firefox_profile', '--browser=' + browser, out_file]
 print ' '.join(cmd)
-html_results = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+html_results = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 if not html_results or not html_results[0].strip():
     print html_results[1]

--- a/tests/benchmark_sse2.py
+++ b/tests/benchmark_sse2.py
@@ -11,13 +11,13 @@ from tools.shared import *
 temp_dir = tempfile.mkdtemp()
 
 # System info
-system_info = Popen([PYTHON, path_from_root('emrun'), '--system_info'], stdout=PIPE, stderr=PIPE).communicate()
+system_info = Popen([PYTHON, path_from_root('emrun'), '--system_info'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Native info
-native_info = Popen(['clang', '-v'], stdout=PIPE, stderr=PIPE).communicate()
+native_info = Popen(['clang', '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Emscripten info
-emscripten_info = Popen([PYTHON, EMCC, '-v'], stdout=PIPE, stderr=PIPE).communicate()
+emscripten_info = Popen([PYTHON, EMCC, '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 # Run native build
 out_file = os.path.join(temp_dir, 'benchmark_sse2_native')
@@ -25,12 +25,12 @@ if WINDOWS: out_file += '.exe'
 cmd = [CLANG_CPP] + get_clang_native_args() + [path_from_root('tests', 'benchmark_sse2.cpp'), '-O3', '-o', out_file]
 print 'Building native version of the benchmark:'
 print ' '.join(cmd)
-build = Popen(cmd, env=get_clang_native_env())
+build = Popen(cmd, env=get_clang_native_env(), universal_newlines=True)
 out = build.communicate()
 if build.returncode != 0:
     sys.exit(1)
 
-native_results = Popen([out_file], stdout=PIPE, stderr=PIPE).communicate()
+native_results = Popen([out_file], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 print native_results[0]
 
 # Run emscripten build
@@ -38,7 +38,7 @@ out_file = os.path.join(temp_dir, 'benchmark_sse2_html.html')
 cmd = [PYTHON, EMCC, path_from_root('tests', 'benchmark_sse2.cpp'), '-O3', '-msse2', '--emrun', '-s', 'TOTAL_MEMORY=536870912', '-o', out_file]
 print 'Building Emscripten version of the benchmark:'
 print ' '.join(cmd)
-build = Popen(cmd)
+build = Popen(cmd, universal_newlines=True)
 out = build.communicate()
 if build.returncode != 0:
     sys.exit(1)
@@ -52,7 +52,7 @@ if 'almost asm' in js:
     open(out_js_file, 'w').write(js.replace('almost asm', 'use asm'))
 
 # Enforce asm.js validation for the output file so that we can capture any validation errors.
-asmjs_validation_status = Popen([PYTHON, path_from_root('tools', 'validate_asmjs.py'), out_file], stdout=PIPE, stderr=PIPE).communicate()
+asmjs_validation_status = Popen([PYTHON, path_from_root('tools', 'validate_asmjs.py'), out_file], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 asmjs_validation_status = (asmjs_validation_status[0].strip() + '\n' + asmjs_validation_status[1].strip()).strip()
 if 'is not valid asm.js' in asmjs_validation_status:
     print >> sys.stderr, asmjs_validation_status
@@ -72,7 +72,7 @@ print ''
 print 'Once the test has finished, close the browser application to continue.'
 cmd = [PYTHON, path_from_root('emrun'), '--safe_firefox_profile', '--browser=' + browser, out_file]
 print ' '.join(cmd)
-html_results = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+html_results = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 if not html_results or not html_results[0].strip():
     print html_results[1]

--- a/tests/parallel_test_core.py
+++ b/tests/parallel_test_core.py
@@ -79,7 +79,7 @@ def run_mode(args):
     # If args has only one argument, e.g. args=['default'] or args=['asm1'], all tests are run in one suite.
     print '<< running %s >>' % mode
 
-  proc = subprocess.Popen([PYTHON, path_from_root('tests', 'runner.py')] + args, stdout=open(mode + '.out', 'w'), stderr=open(mode + '.err', 'w'))
+  proc = subprocess.Popen([PYTHON, path_from_root('tests', 'runner.py')] + args, stdout=open(mode + '.out', 'w'), stderr=open(mode + '.err', 'w'), universal_newlines=True)
   proc.communicate()
   print '<< %s finished with exit code %d >>' % (mode, proc.returncode)
   return proc.returncode

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -473,14 +473,14 @@ class RunnerCore(unittest.TestCase):
 
   def build_native(self, filename, args=[]):
     compiler = CLANG if filename.endswith('cpp') else CLANG_CC
-    process = Popen([compiler, '-O2', '-fno-math-errno', filename, '-o', filename+'.native'] + args, stdout=PIPE, stderr=self.stderr_redirect)
+    process = Popen([compiler, '-O2', '-fno-math-errno', filename, '-o', filename+'.native'] + args, stdout=PIPE, stderr=self.stderr_redirect, universal_newlines=True)
     output = process.communicate()
     if process.returncode is not 0:
       print("Building native executable with command '%s' failed with a return code %d!" % (' '.join([CLANG, '-O2', filename, '-o', filename+'.native']), process.returncode), file=sys.stderr)
       print("Output: " + output[0])
 
   def run_native(self, filename, args):
-    process = Popen([filename+'.native'] + args, stdout=PIPE);
+    process = Popen([filename+'.native'] + args, stdout=PIPE, universal_newlines=True);
     output = process.communicate()
     if process.returncode is not 0:
       print("Running native executable with command '%s' failed with a return code %d!" % (' '.join([filename+'.native'] + args), process.returncode), file=sys.stderr)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -74,7 +74,7 @@ class NativeBenchmarker(Benchmarker):
     if not native_exec:
       compiler = self.cxx if filename.endswith('cpp') else self.cc
       cmd = [compiler, '-fno-math-errno', filename, '-o', filename+'.native'] + self.args + shared_args + native_args + get_clang_native_args()
-      process = Popen(cmd, stdout=PIPE, stderr=parent.stderr_redirect, env=get_clang_native_env())
+      process = Popen(cmd, stdout=PIPE, stderr=parent.stderr_redirect, env=get_clang_native_env(), universal_newlines=True)
       output = process.communicate()
       if process.returncode is not 0:
         print("Building native executable with command failed", ' '.join(cmd), file=sys.stderr)
@@ -88,7 +88,7 @@ class NativeBenchmarker(Benchmarker):
     self.filename = final
 
   def run(self, args):
-    process = Popen([self.filename] + args, stdout=PIPE, stderr=PIPE)
+    process = Popen([self.filename] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     return process.communicate()[0]
 
 class JSBenchmarker(Benchmarker):
@@ -127,7 +127,7 @@ process(sys.argv[1])
                     '-s', 'BENCHMARK=%d' % (1 if IGNORE_COMPILATION and not has_output_parser else 0),
                     #'--profiling',
                     #'--closure', '1',
-                    '-o', final] + shared_args + emcc_args + self.extra_args, stdout=PIPE, stderr=PIPE, env=self.env).communicate()
+                    '-o', final] + shared_args + emcc_args + self.extra_args, stdout=PIPE, stderr=PIPE, env=self.env, universal_newlines=True).communicate()
     assert os.path.exists(final), 'Failed to compile file: ' + output[0] + ' (looked for ' + final + ')'
     self.filename = final
 
@@ -170,7 +170,7 @@ class benchmark(RunnerCore):
     try:
       d = os.getcwd()
       os.chdir(os.path.expanduser('~/Dev/mozilla-central'))
-      fingerprint.append('sm: ' + [line for line in Popen(['hg', 'tip'], stdout=PIPE).communicate()[0].split('\n') if 'changeset' in line][0])
+      fingerprint.append('sm: ' + [line for line in Popen(['hg', 'tip'], stdout=PIPE, universal_newlines=True).communicate()[0].split('\n') if 'changeset' in line][0])
     except:
       pass
     finally:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2193,12 +2193,12 @@ void *getBindBuffer() {
 
   def test_emrun_info(self):
     if not has_browser(): return self.skip('need a browser')
-    result = subprocess.check_output([PYTHON, path_from_root('emrun'), '--system_info', '--browser_info'])
+    result = subprocess.check_output([PYTHON, path_from_root('emrun'), '--system_info', '--browser_info'], universal_newlines=True)
     assert 'CPU' in result
     assert 'Browser' in result
     assert 'Traceback' not in result
 
-    result = subprocess.check_output([PYTHON, path_from_root('emrun'), '--list_browsers'])
+    result = subprocess.check_output([PYTHON, path_from_root('emrun'), '--list_browsers'], universal_newlines=True)
     assert 'Traceback' not in result
 
   def test_emrun(self):
@@ -3002,7 +3002,7 @@ window.close = function() {
     # see original in test_core.py
     output = Popen([PYTHON, path_from_root('tools', 'webidl_binder.py'),
                             path_from_root('tests', 'webidl', 'test.idl'),
-                            'glue']).communicate()[0]
+                            'glue'], universal_newlines=True).communicate()[0]
     assert os.path.exists('glue.cpp')
     assert os.path.exists('glue.js')
     for opts in [[], ['-O1'], ['-O2']]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1775,7 +1775,7 @@ int main() {
   @no_emterpreter
   def test_biggerswitch(self):
     num_cases = 20000
-    switch_case, err = Popen([PYTHON, path_from_root('tests', 'gen_large_switchcase.py'), str(num_cases)], stdout=PIPE, stderr=PIPE).communicate()
+    switch_case, err = Popen([PYTHON, path_from_root('tests', 'gen_large_switchcase.py'), str(num_cases)], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     self.do_run(switch_case, '''58996: 589965899658996
 59297: 592975929759297
 59598: default
@@ -2007,7 +2007,7 @@ The current type of b is: 9
       Building.link([supp_name + '.o', main_name + '.o'], all_name)
 
       # This will fail! See explanation near the warning we check for, in the compiler source code
-      output = Popen([PYTHON, EMCC, all_name], stderr=PIPE).communicate()
+      output = Popen([PYTHON, EMCC, all_name], stderr=PIPE, universal_newlines=True).communicate()
 
       # Check for warning in the generated code
       generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
@@ -4928,7 +4928,7 @@ int main(void) {
 
       try_delete(os.path.join(self.get_dir(), 'src.cpp.o.js'))
       output = Popen([PYTHON, EMCC, path_from_root('tests', 'dlmalloc_test.c'), '-s', 'TOTAL_MEMORY=128MB',
-                      '-o', os.path.join(self.get_dir(), 'src.cpp.o.js')], stdout=PIPE, stderr=self.stderr_redirect).communicate()
+                      '-o', os.path.join(self.get_dir(), 'src.cpp.o.js')], stdout=PIPE, stderr=self.stderr_redirect, universal_newlines=True).communicate()
 
       self.do_run('x', '*1,0*', ['200', '1'], no_build=True)
       self.do_run('x', '*400,0*', ['400', '400'], no_build=True)
@@ -5087,7 +5087,7 @@ return malloc(size);
   @SIMD
   def test_sse1_full(self):
     Popen([CLANG, path_from_root('tests', 'test_sse1_full.cpp'), '-o', 'test_sse1_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
-    native_result, err = Popen('./test_sse1_full', stdout=PIPE).communicate()
+    native_result, err = Popen('./test_sse1_full', stdout=PIPE, universal_newlines=True).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
     Settings.PRECISE_F32 = 1 # SIMD currently requires Math.fround
@@ -5110,7 +5110,7 @@ return malloc(size);
     args = []
     if '-O0' in self.emcc_args: args += ['-D_DEBUG=1']
     Popen([CLANG, path_from_root('tests', 'test_sse2_full.cpp'), '-o', 'test_sse2_full', '-D_CRT_SECURE_NO_WARNINGS=1'] + args + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
-    native_result, err = Popen('./test_sse2_full', stdout=PIPE).communicate()
+    native_result, err = Popen('./test_sse2_full', stdout=PIPE, universal_newlines=True).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
     Settings.PRECISE_F32 = 1 # SIMD currently requires Math.fround
@@ -5128,7 +5128,7 @@ return malloc(size);
     args = []
     if '-O0' in self.emcc_args: args += ['-D_DEBUG=1']
     Popen([CLANG, path_from_root('tests', 'test_sse3_full.cpp'), '-o', 'test_sse3_full', '-D_CRT_SECURE_NO_WARNINGS=1', '-msse3'] + args + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
-    native_result, err = Popen('./test_sse3_full', stdout=PIPE).communicate()
+    native_result, err = Popen('./test_sse3_full', stdout=PIPE, universal_newlines=True).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
     Settings.PRECISE_F32 = 1 # SIMD currently requires Math.fround
@@ -5142,7 +5142,7 @@ return malloc(size);
     args = []
     if '-O0' in self.emcc_args: args += ['-D_DEBUG=1']
     Popen([CLANG, path_from_root('tests', 'test_ssse3_full.cpp'), '-o', 'test_ssse3_full', '-D_CRT_SECURE_NO_WARNINGS=1', '-mssse3'] + args + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
-    native_result, err = Popen('./test_ssse3_full', stdout=PIPE).communicate()
+    native_result, err = Popen('./test_ssse3_full', stdout=PIPE, universal_newlines=True).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
     Settings.PRECISE_F32 = 1 # SIMD currently requires Math.fround
@@ -5156,7 +5156,7 @@ return malloc(size);
     args = []
     if '-O0' in self.emcc_args: args += ['-D_DEBUG=1']
     Popen([CLANG, path_from_root('tests', 'test_sse4_1_full.cpp'), '-o', 'test_sse4_1_full', '-D_CRT_SECURE_NO_WARNINGS=1', '-msse4.1'] + args + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE).communicate()
-    native_result, err = Popen('./test_sse4_1_full', stdout=PIPE).communicate()
+    native_result, err = Popen('./test_sse4_1_full', stdout=PIPE, universal_newlines=True).communicate()
     native_result = native_result.replace('\r\n', '\n') # Windows line endings fix
 
     Settings.PRECISE_F32 = 1 # SIMD currently requires Math.fround
@@ -5814,7 +5814,7 @@ def process(filename):
   # Autodebug the code
   def do_autodebug(self, filename):
     Building.llvm_dis(filename)
-    output = Popen([PYTHON, AUTODEBUGGER, filename+'.o.ll', filename+'.o.ll.ll'], stdout=PIPE, stderr=self.stderr_redirect).communicate()[0]
+    output = Popen([PYTHON, AUTODEBUGGER, filename+'.o.ll', filename+'.o.ll.ll'], stdout=PIPE, stderr=self.stderr_redirect, universal_newlines=True).communicate()[0]
     assert 'Success.' in output, output
     self.prep_ll_run(filename, filename+'.o.ll.ll', force_recompile=True) # rebuild .bc # TODO: use code in do_autodebug_post for this
 
@@ -5826,7 +5826,7 @@ def process(filename):
       return True
     print('Autodebugging during post time')
     delattr(self, 'post')
-    output = Popen([PYTHON, AUTODEBUGGER, filename+'.o.ll', filename+'.o.ll.ll'], stdout=PIPE, stderr=self.stderr_redirect).communicate()[0]
+    output = Popen([PYTHON, AUTODEBUGGER, filename+'.o.ll', filename+'.o.ll.ll'], stdout=PIPE, stderr=self.stderr_redirect, universal_newlines=True).communicate()[0]
     assert 'Success.' in output, output
     shutil.copyfile(filename + '.o.ll.ll', filename + '.o.ll')
     Building.llvm_as(filename)
@@ -6485,7 +6485,7 @@ someweirdtext
 
       output = Popen([PYTHON, path_from_root('tools', 'webidl_binder.py'),
                               path_from_root('tests', 'webidl', 'test.idl'),
-                              'glue']).communicate()[0]
+                              'glue'], universal_newlines=True).communicate()[0]
       assert os.path.exists('glue.cpp')
       assert os.path.exists('glue.js')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10,7 +10,7 @@ import tools.line_endings
 
 # Runs an emcc task (used from another process in test test_emcc_multiprocess_cache_access, needs to be at top level for it to be pickleable).
 def multiprocess_task(c_file, cache_dir_name):
-  output = subprocess.check_output([PYTHON, EMCC, c_file, '--cache', cache_dir_name], stderr=subprocess.STDOUT)
+  output = subprocess.check_output([PYTHON, EMCC, c_file, '--cache', cache_dir_name], stderr=subprocess.STDOUT, universal_newlines=True)
   if len(output.strip()) > 0:
     print('------')
     print(output)
@@ -57,7 +57,7 @@ class other(RunnerCore):
       suffix = '.c' if compiler == EMCC else '.cpp'
 
       # --version
-      output = Popen([PYTHON, compiler, '--version'], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, '--version'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       output = output[0].replace('\r', '')
       self.assertContained('''emcc (Emscripten gcc/clang-like replacement)''', output)
       self.assertContained('''Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
@@ -66,24 +66,24 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 ''', output)
 
       # -v, without input files
-      output = Popen([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained('''clang version %s.0 ''' % expected_llvm_version(), output[1].replace('\r', ''), output[1].replace('\r', ''))
       self.assertContained('''GNU''', output[0])
       self.assertNotContained('this is dangerous', output[0])
       self.assertNotContained('this is dangerous', output[1])
 
       # --help
-      output = Popen([PYTHON, compiler, '--help'], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, '--help'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained('Display this information', output[0])
       self.assertContained('Most clang options will work', output[0])
 
       # -dumpmachine
-      output = Popen([PYTHON, compiler, '-dumpmachine'], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, '-dumpmachine'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained(get_llvm_target(), output[0])
 
       # emcc src.cpp ==> writes a.out.js
       self.clear()
-      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert len(output[0]) == 0, output[0]
       assert os.path.exists('a.out.js'), '\n'.join(output)
       self.assertContained('hello, world!', run_js('a.out.js'))
@@ -91,7 +91,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # properly report source code errors, and stop there
       self.clear()
       assert not os.path.exists('a.out.js')
-      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world_error' + suffix)], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world_error' + suffix)], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       output = process.communicate()
       assert not os.path.exists('a.out.js'), 'compilation failed, so no output file is expected'
       assert len(output[0]) == 0, output[0]
@@ -112,7 +112,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           continue
         target = args[1] if len(args) == 2 else 'hello_world.o'
         self.clear()
-        proc = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)] + args, stdout=PIPE, stderr=PIPE)
+        proc = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         proc.communicate()
         assert proc.returncode == 0, [proc.returncode, args]
         if args[-1] == '/dev/null':
@@ -123,7 +123,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if target == 'js': # make sure emcc can recognize the target as a bitcode file
           shutil.move(target, target + '.bc')
           target += '.bc'
-        output = Popen([PYTHON, compiler, target, '-o', target + '.js'], stdout = PIPE, stderr = PIPE).communicate()
+        output = Popen([PYTHON, compiler, target, '-o', target + '.js'], stdout = PIPE, stderr = PIPE, universal_newlines=True).communicate()
         assert len(output[0]) == 0, output[0]
         assert os.path.exists(target + '.js'), 'Expected %s to exist since args are %s : %s' % (target + '.js', str(args), '\n'.join(output))
         self.assertContained('hello, world!', run_js(target + '.js'))
@@ -133,13 +133,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix), '-o', 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
       Popen([LLVM_AR, 'r', 'a.a', 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
       assert os.path.exists('a.a')
-      output = Popen([PYTHON, compiler, 'a.a']).communicate()
+      output = Popen([PYTHON, compiler, 'a.a'], universal_newlines=True).communicate()
       assert os.path.exists('a.out.js'), output
       self.assertContained('hello, world!', run_js('a.out.js'))
 
       # emcc src.ll ==> generates .js
       self.clear()
-      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.ll')], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.ll')], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert len(output[0]) == 0, output[0]
       assert os.path.exists('a.out.js'), '\n'.join(output)
       self.assertContained('hello, world!', run_js('a.out.js'))
@@ -153,7 +153,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if not os.path.exists('a_dir'): os.mkdir('a_dir')
           os.chdir('a_dir')
           if not os.path.exists('b_dir'): os.mkdir('b_dir')
-          output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.ll'), '-o', path], stdout=PIPE, stderr=PIPE).communicate()
+          output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.ll'), '-o', path], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
           print(output)
           assert os.path.exists(path), path + ' does not exist; ' + '\n'.join(output)
           last = os.getcwd()
@@ -195,7 +195,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           assert os.path.exists('something.bc'), output[1]
           bc_args = [PYTHON, compiler, 'something.bc', '-o', 'something.js'] + bc_params
           print('....', bc_args)
-          output = Popen(bc_args, stdout=PIPE, stderr=PIPE).communicate()
+          output = Popen(bc_args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert os.path.exists('something.js'), output[1]
         self.assertContained('hello, world!', run_js('something.js'))
 
@@ -251,7 +251,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       ]:
         print(params, text)
         self.clear()
-        output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world_loop.cpp'), '-o', 'a.out.js'] + params, stdout=PIPE, stderr=PIPE).communicate()
+        output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world_loop.cpp'), '-o', 'a.out.js'] + params, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert len(output[0]) == 0, output[0]
         assert os.path.exists('a.out.js'), '\n'.join(output)
         self.assertContained('hello, world!', run_js('a.out.js'))
@@ -261,7 +261,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       for args, target in [([], 'a.out.js'), (['-o', 'combined.js'], 'combined.js')]:
         self.clear()
         output = Popen([PYTHON, compiler, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp')] + args,
-                       stdout=PIPE, stderr=PIPE).communicate()
+                       stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert len(output[0]) == 0, output[0]
         assert os.path.exists(target), '\n'.join(output)
         self.assertContained('side got: hello from main, over', run_js(target))
@@ -269,7 +269,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # Compiling two files with -c will generate separate .bc files
         self.clear()
         output = Popen([PYTHON, compiler, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp'), '-c'] + args,
-                       stdout=PIPE, stderr=PIPE).communicate()
+                       stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         if '-o' in args:
           # specifying -o and -c is an error
           assert 'fatal error' in output[1], output[1]
@@ -280,24 +280,24 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert not os.path.exists(target), 'We should only have created bitcode here: ' + '\n'.join(output)
 
         # Compiling one of them alone is expected to fail
-        output = Popen([PYTHON, compiler, 'twopart_main.o', '-O1', '-g'] + args, stdout=PIPE, stderr=PIPE).communicate()
+        output = Popen([PYTHON, compiler, 'twopart_main.o', '-O1', '-g'] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert os.path.exists(target), '\n'.join(output)
         #print '\n'.join(output)
         self.assertContained('missing function', run_js(target, stderr=STDOUT, assert_returncode=None))
         try_delete(target)
 
         # Combining those bc files into js should work
-        output = Popen([PYTHON, compiler, 'twopart_main.o', 'twopart_side.o'] + args, stdout=PIPE, stderr=PIPE).communicate()
+        output = Popen([PYTHON, compiler, 'twopart_main.o', 'twopart_side.o'] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert os.path.exists(target), '\n'.join(output)
         self.assertContained('side got: hello from main, over', run_js(target))
 
         # Combining bc files into another bc should also work
         try_delete(target)
         assert not os.path.exists(target)
-        output = Popen([PYTHON, compiler, 'twopart_main.o', 'twopart_side.o', '-o', 'combined.bc'] + args, stdout=PIPE, stderr=PIPE).communicate()
+        output = Popen([PYTHON, compiler, 'twopart_main.o', 'twopart_side.o', '-o', 'combined.bc'] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         syms = Building.llvm_nm('combined.bc')
         assert len(syms.defs) == 2 and 'main' in syms.defs, 'Failed to generate valid bitcode'
-        output = Popen([PYTHON, compiler, 'combined.bc', '-o', 'combined.bc.js'], stdout = PIPE, stderr = PIPE).communicate()
+        output = Popen([PYTHON, compiler, 'combined.bc', '-o', 'combined.bc.js'], stdout = PIPE, stderr = PIPE, universal_newlines=True).communicate()
         assert len(output[0]) == 0, output[0]
         assert os.path.exists('combined.bc.js'), 'Expected %s to exist' % ('combined.bc.js')
         self.assertContained('side got: hello from main, over', run_js('combined.bc.js'))
@@ -313,13 +313,13 @@ f.write('transformed!')
 f.close()
 ''')
       trans_file.close()
-      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix), '--js-transform', '%s t.py' % (PYTHON)], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix), '--js-transform', '%s t.py' % (PYTHON)], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert open('a.out.js').read() == 'transformed!', 'Transformed output must be as expected'
 
       for opts in [0, 1, 2, 3]:
         print('mem init in', opts)
         self.clear()
-        output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.c'), '-O' + str(opts)], stdout=PIPE, stderr=PIPE).communicate()
+        output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.c'), '-O' + str(opts)], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert os.path.exists('a.out.js.mem') == (opts >= 2), 'mem file should exist in -O2+'
 
   # Test that if multiple processes attempt to access or build stuff to the cache on demand, that exactly one of the processes
@@ -378,7 +378,7 @@ f.close()
   def test_emcc_cflags(self):
     # see we print them out
     with clean_write_access_to_canonical_temp_dir(): # --cflags needs to set EMCC_DEBUG=1, which needs to create canonical temp directory.
-      output = Popen([PYTHON, EMCC, '--cflags'], stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, EMCC, '--cflags'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     flags = output[0].strip()
     self.assertContained(' '.join(Building.doublequote_spaces(COMPILER_OPTS)), flags)
     # check they work
@@ -391,7 +391,7 @@ f.close()
     # We expand this in case the EM_CONFIG is ~/.emscripten (default)
     config = os.path.expanduser(EM_CONFIG)
     # We pass -version twice to work around the newargs > 2 check in emar
-    (out, err) = Popen([PYTHON, EMAR, '--em-config', config, '-version', '-version'], stdout=PIPE, stderr=PIPE).communicate()
+    (out, err) = Popen([PYTHON, EMAR, '--em-config', config, '-version', '-version'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert out
     assert not err
     self.assertContained('LLVM', out)
@@ -493,7 +493,7 @@ f.close()
           if test_dir == 'target_html':
             env['EMCC_SKIP_SANITY_CHECK'] = '1'
           print(str(cmd))
-          ret = Popen(cmd, env=env, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else PIPE).communicate()
+          ret = Popen(cmd, env=env, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE_LEVEL >= 1 else PIPE, universal_newlines=True).communicate()
           if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
             logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
           if len(ret) > 1 and ret[1] != None and 'error' in ret[1].lower():
@@ -508,7 +508,7 @@ f.close()
           cmd = make
           if EM_BUILD_VERBOSE_LEVEL >= 3 and 'Ninja' not in generator:
             cmd += ['VERBOSE=1']
-          ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE).communicate()
+          ret = Popen(cmd, stdout=None if EM_BUILD_VERBOSE_LEVEL >= 2 else PIPE, universal_newlines=True).communicate()
           if len(ret) > 1 and ret[1] != None and len(ret[1].strip()) > 0:
             logging.error(ret[1]) # If there were any errors, print them directly to console for diagnostics.
           if len(ret) > 0 and ret[0] != None and 'error' in ret[0].lower() and not '0 error(s)' in ret[0].lower():
@@ -522,7 +522,7 @@ f.close()
 
           # Run through node, if CMake produced a .js file.
           if output_file.endswith('.js'):
-            ret = Popen(NODE_JS + [tempdirname + '/' + output_file], stdout=PIPE).communicate()[0]
+            ret = Popen(NODE_JS + [tempdirname + '/' + output_file], stdout=PIPE, universal_newlines=True).communicate()[0]
             self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt', 'r').read().strip(), ret.strip())
         finally:
           os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
@@ -544,7 +544,7 @@ f.close()
       os.chdir(tempdirname_native)
       cmd = ['cmake', '-DCMAKE_C_COMPILER=' + CLANG_CC, '-DCMAKE_CXX_COMPILER=' + CLANG_CPP, path_from_root('tests', 'cmake', 'stdproperty')]
       print(str(cmd))
-      native_features = Popen(cmd, stdout=PIPE).communicate()[0]
+      native_features = Popen(cmd, stdout=PIPE, universal_newlines=True).communicate()[0]
     finally:
       os.chdir(tempdirname_emscripten)
       try:
@@ -559,7 +559,7 @@ f.close()
       os.chdir(tempdirname_emscripten)
       cmd = [emconfigure, 'cmake', path_from_root('tests', 'cmake', 'stdproperty')]
       print(str(cmd))
-      emscripten_features = Popen(cmd, stdout=PIPE).communicate()[0]
+      emscripten_features = Popen(cmd, stdout=PIPE, universal_newlines=True).communicate()[0]
     finally:
       os.chdir(path_from_root('tests'))
       try:
@@ -587,7 +587,7 @@ f.close()
         print(str(build))
         subprocess.check_call(build)
 
-        ret = Popen(NODE_JS + [os.path.join(tempdirname, 'cpp_with_emscripten_val.js')], stdout=PIPE).communicate()[0].strip()
+        ret = Popen(NODE_JS + [os.path.join(tempdirname, 'cpp_with_emscripten_val.js')], stdout=PIPE, universal_newlines=True).communicate()[0].strip()
         if '-DNO_GNU_EXTENSIONS=1' in args:
           self.assertTextDataIdentical('Hello! __STRICT_ANSI__: 1, __cplusplus: 201103', ret)
         else:
@@ -641,7 +641,7 @@ f.close()
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't try to produce an output file.
-      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.c'), 'this_file_is_missing.c', '-o', 'this_output_file_should_never_exist.js'], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world.c'), 'this_file_is_missing.c', '-o', 'this_output_file_should_never_exist.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       process.communicate()
       assert process.returncode is not 0, 'Trying to compile a nonexisting file should return with a nonzero error code!'
       assert os.path.exists('this_output_file_should_never_exist.js') == False, 'Emcc should not produce an output file when build fails!'
@@ -649,30 +649,30 @@ f.close()
   def test_use_cxx(self):
     open('empty_file', 'w').write(' ')
     try:
-      dash_xc = Popen([PYTHON, EMCC, '-v', '-xc', 'empty_file'], stdout=PIPE, stderr=PIPE).communicate()[1]
+      dash_xc = Popen([PYTHON, EMCC, '-v', '-xc', 'empty_file'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
       self.assertNotContained('-std=c++03', dash_xc)
-      dash_xcpp = Popen([PYTHON, EMCC, '-v', '-xc++', 'empty_file'], stdout=PIPE, stderr=PIPE).communicate()[1]
+      dash_xcpp = Popen([PYTHON, EMCC, '-v', '-xc++', 'empty_file'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
       self.assertContained('-std=c++03', dash_xcpp)
     finally:
       try_delete('empty_file')
 
   def test_cxx03(self):
     for compiler in [EMCC, EMXX]:
-      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_cxx03.cpp')], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, compiler, path_from_root('tests', 'hello_cxx03.cpp')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       process.communicate()
       assert process.returncode is 0, 'By default, emscripten should build using -std=c++03!'
 
   def test_cxx11(self):
     for std in ['-std=c++11', '--std=c++11']:
       for compiler in [EMCC, EMXX]:
-        process = Popen([PYTHON, compiler, std, path_from_root('tests', 'hello_cxx11.cpp')], stdout=PIPE, stderr=PIPE)
+        process = Popen([PYTHON, compiler, std, path_from_root('tests', 'hello_cxx11.cpp')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
         process.communicate()
         assert process.returncode is 0, 'User should be able to specify custom -std= on the command line!'
 
   # Regression test for issue #4522: Incorrect CC vs CXX detection
   def test_incorrect_c_detection(self):
     for compiler in [EMCC, EMXX]:
-      process = Popen([PYTHON, compiler, "--bind", "--embed-file", path_from_root('tests', 'hello_world.c'), path_from_root('tests', 'hello_world.cpp')], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, compiler, "--bind", "--embed-file", path_from_root('tests', 'hello_world.c'), path_from_root('tests', 'hello_world.cpp')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       process.communicate()
       assert process.returncode is 0, 'Emscripten should not use the embed file for CC/CXX detection'
 
@@ -755,7 +755,7 @@ f.close()
     open('src.c', 'w').write(src)
     def test(args, expected, moar_expected=None):
       print(args, expected, moar_expected)
-      out, err = Popen([PYTHON, EMCC, 'src.c'] + args, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, EMCC, 'src.c'] + args, stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained(expected, run_js(self.in_dir('a.out.js'), stderr=PIPE, full_output=True, assert_returncode=None))
       print('with emulated function pointers')
       Popen([PYTHON, EMCC, 'src.c'] + args + ['-s', 'EMULATED_FUNCTION_POINTERS=1'], stderr=PIPE).communicate()
@@ -1047,7 +1047,7 @@ int main() {
 
     def test(lib_args, err_expected):
       print(err_expected)
-      output = Popen([PYTHON, EMCC, main_name, '-o', 'a.out.js'] + lib_args, stdout=PIPE, stderr=PIPE).communicate()
+      output = Popen([PYTHON, EMCC, main_name, '-o', 'a.out.js'] + lib_args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       #print output[1]
       if err_expected:
         self.assertContained(err_expected, output[1])
@@ -1133,14 +1133,14 @@ int f() {
 
     # lib_a does not satisfy any symbols from main, so it will not be included,
     # and there will be an unresolved symbol.
-    output = Popen([PYTHON, EMCC] + args + libs_list, stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC] + args + libs_list, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('error: unresolved symbol: x', output[1])
 
     # -Wl,--start-group and -Wl,--end-group around the libs will cause a rescan
     # of lib_a after lib_b adds undefined symbol "x", so a.c.o will now be
     # included (and the link will succeed).
     libs = ['-Wl,--start-group'] + libs_list + ['-Wl,--end-group']
-    output = Popen([PYTHON, EMCC] + args + libs, stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC] + args + libs, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     out_js = os.path.join(self.get_dir(), 'a.out.js')
     assert os.path.exists(out_js), '\n'.join(output)
     self.assertContained('result: 42', run_js(out_js))
@@ -1148,7 +1148,7 @@ int f() {
     # -( and -) should also work.
     args = ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1', main, '-o', 'a2.out.js']
     libs = ['-Wl,-('] + libs_list + ['-Wl,-)']
-    output = Popen([PYTHON, EMCC] + args + libs, stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC] + args + libs, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     out_js = os.path.join(self.get_dir(), 'a2.out.js')
     assert os.path.exists(out_js), '\n'.join(output)
     self.assertContained('result: 42', run_js(out_js))
@@ -1237,7 +1237,7 @@ int f() {
     ''')
     open('my_test.input', 'w').write('abc')
     Building.emcc('main.cpp', ['--embed-file', 'my_test.input'], output_filename='a.out.js')
-    self.assertContained('zyx', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained('zyx', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0])
 
   def test_abspaths(self):
     # Includes with absolute paths are generally dangerous, things like -I/usr/.. will get to system local headers, not our portable ones.
@@ -1254,7 +1254,7 @@ int f() {
                            (['-Lsubdir/something', '-Wwarn-absolute-paths'], False),
                            ([], False)]:
       print(args, expected)
-      proc = Popen([PYTHON, EMCC, 'main.c'] + args, stderr=PIPE)
+      proc = Popen([PYTHON, EMCC, 'main.c'] + args, stderr=PIPE, universal_newlines=True)
       err = proc.communicate()[1]
       assert proc.returncode is 0
       assert ('encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript)' in err) == expected, err
@@ -1413,13 +1413,13 @@ int f() {
         b();
       }
     ''')
-    out, err = Popen([PYTHON, EMCC, 'main.c', '-L.', '-la'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, 'main.c', '-L.', '-la'], stderr=PIPE, universal_newlines=True).communicate()
     assert 'loading from archive' not in err, err
     assert 'which has duplicate entries' not in err, err
     assert 'duplicate: common.o' not in err, err
     self.assertContained('a\nb...\n', run_js('a.out.js'))
 
-    text = Popen([PYTHON, EMAR, 't', 'liba.a'], stdout=PIPE).communicate()[0]
+    text = Popen([PYTHON, EMAR, 't', 'liba.a'], stdout=PIPE, universal_newlines=True).communicate()[0]
     assert 'common.o' not in text, text
     assert text.count('common_') == 2, text
     for line in text.split('\n'):
@@ -1427,7 +1427,7 @@ int f() {
 
     # make the hashing fail: 'q' is just a quick append, no replacement, so hashing is not done, and dupes are easy
     Popen([PYTHON, EMAR, 'q', 'liba.a', 'common.o', os.path.join('libdir', 'common.o')]).communicate()
-    out, err = Popen([PYTHON, EMCC, 'main.c', '-L.', '-la'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, 'main.c', '-L.', '-la'], stderr=PIPE, universal_newlines=True).communicate()
     assert 'loading from archive' in err, err
     assert 'which has duplicate entries' in err, err
     assert 'duplicate: common.o' in err, err
@@ -1643,16 +1643,16 @@ int f() {
   def test_libpng(self):
     shutil.copyfile(path_from_root('tests', 'pngtest.png'), 'pngtest.png')
     Building.emcc(path_from_root('tests','pngtest.c'), ['--embed-file', 'pngtest.png', '-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1'], output_filename='a.out.js')
-    self.assertContained('TESTS PASSED', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained('TESTS PASSED', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0])
 
   def test_bullet(self):
     Building.emcc(path_from_root('tests','bullet_hello_world.cpp'), ['-s', 'USE_BULLET=1'], output_filename='a.out.js')
-    self.assertContained('BULLET RUNNING', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained('BULLET RUNNING', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0])
 
   def test_vorbis(self):
     #This will also test if ogg compiles, because vorbis depends on ogg
     Building.emcc(path_from_root('tests','vorbis_test.c'), ['-s', 'USE_VORBIS=1'], output_filename='a.out.js')
-    self.assertContained('ALL OK', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained('ALL OK', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0])
 
   def test_freetype(self):
     # copy the Liberation Sans Bold truetype file located in the <emscripten_root>/tests/freetype to the compilation folder
@@ -1672,7 +1672,7 @@ int f() {
                      '  *****   ***** \n' + \
                      '  ****+   +***+ \n' + \
                      '  +***+   +***+ \n'
-    self.assertContained(expectedOutput, Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained(expectedOutput, Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0])
 
   def test_link_memcpy(self):
     # memcpy can show up *after* optimizations, so after our opportunity to link in libc, so it must be special-cased
@@ -1743,7 +1743,7 @@ int f() {
           clear()
           print('warn', args, action, value)
           extra = ['-s', action + '_ON_UNDEFINED_SYMBOLS=%d' % value] if action else []
-          output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp')] + extra + args, stderr=PIPE).communicate()
+          output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp')] + extra + args, stderr=PIPE, universal_newlines=True).communicate()
           if action == None or (action == 'WARN' and value):
             self.assertContained('unresolved symbol: something', output[1])
             self.assertContained('unresolved symbol: elsey', output[1])
@@ -1783,7 +1783,7 @@ int f() {
         return 0;
       }
     ''')
-    output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp')], stderr=PIPE).communicate()[1]
+    output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp')], stderr=PIPE, universal_newlines=True).communicate()[1]
     print(output)
     assert os.path.exists('a.out.js')
 
@@ -1979,7 +1979,7 @@ int f() {
 
       # test calling js optimizer
       print('  js')
-      output = Popen(NODE_JS + [path_from_root('tools', 'js-optimizer.js'), input] + passes, stdin=PIPE, stdout=PIPE).communicate()[0]
+      output = Popen(NODE_JS + [path_from_root('tools', 'js-optimizer.js'), input] + passes, stdin=PIPE, stdout=PIPE, universal_newlines=True).communicate()[0]
 
       def check_js(js, expected):
         #print >> sys.stderr, 'chak\n==========================\n', js, '\n===========================\n'
@@ -2039,21 +2039,21 @@ int f() {
         if 'last' not in passes and \
            'null_if' not in input and 'null_else' not in input:  # null-* tests are js optimizer or native, not a mixture (they mix badly)
           print('  native (receiveJSON)')
-          output = Popen([js_optimizer.get_native_optimizer(), input_temp + '.js'] + passes + ['receiveJSON', 'emitJSON'], stdin=PIPE, stdout=open(output_temp, 'w')).communicate()[0]
+          output = Popen([js_optimizer.get_native_optimizer(), input_temp + '.js'] + passes + ['receiveJSON', 'emitJSON'], stdin=PIPE, stdout=open(output_temp, 'w'), universal_newlines=True).communicate()[0]
           check_json()
 
           print('  native (parsing JS)')
-          output = Popen([js_optimizer.get_native_optimizer(), input] + passes + ['emitJSON'], stdin=PIPE, stdout=open(output_temp, 'w')).communicate()[0]
+          output = Popen([js_optimizer.get_native_optimizer(), input] + passes + ['emitJSON'], stdin=PIPE, stdout=open(output_temp, 'w'), universal_newlines=True).communicate()[0]
           check_json()
 
         print('  native (emitting JS)')
-        output = Popen([js_optimizer.get_native_optimizer(), input] + passes, stdin=PIPE, stdout=PIPE).communicate()[0]
+        output = Popen([js_optimizer.get_native_optimizer(), input] + passes, stdin=PIPE, stdout=PIPE, universal_newlines=True).communicate()[0]
         check_js(output, expected)
 
   def test_m_mm(self):
     open(os.path.join(self.get_dir(), 'foo.c'), 'w').write('''#include <emscripten.h>''')
     for opt in ['M', 'MM']:
-      output, err = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'foo.c'), '-' + opt], stdout=PIPE, stderr=PIPE).communicate()
+      output, err = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'foo.c'), '-' + opt], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert 'foo.o: ' in output, '-%s failed to produce the right output: %s' % (opt, output)
       assert 'error' not in err, 'Unexpected stderr: ' + err
 
@@ -2098,7 +2098,7 @@ int f() {
         ]:
         print(args, expect_llvm, expect_js)
         with clean_write_access_to_canonical_temp_dir():
-          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).communicate()
+          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert expect_llvm == ('strip-debug' not in err)
         assert expect_js == ('registerize' not in err)
     finally:
@@ -2174,10 +2174,10 @@ int f() {
     open(os.path.join(self.get_dir(), 'test.file'), 'w').write('''ay file..............,,,,,,,,,,,,,,''')
     open(os.path.join(self.get_dir(), 'stdin'), 'w').write('''inter-active''')
     subprocess.check_call([PYTHON, EMCC, os.path.join(self.get_dir(), 'files.cpp'), '-c'])
-    nativize_llvm = Popen([PYTHON, path_from_root('tools', 'nativize_llvm.py'), os.path.join(self.get_dir(), 'files.o')], stdout=PIPE)
+    nativize_llvm = Popen([PYTHON, path_from_root('tools', 'nativize_llvm.py'), os.path.join(self.get_dir(), 'files.o')], stdout=PIPE, universal_newlines=True)
     out = nativize_llvm.communicate(input)
     assert nativize_llvm.returncode == 0, out
-    output = Popen([os.path.join(self.get_dir(), 'files.o.run')], stdin=open(os.path.join(self.get_dir(), 'stdin')), stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen([os.path.join(self.get_dir(), 'files.o.run')], stdin=open(os.path.join(self.get_dir(), 'stdin')), stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('''size: 37
 data: 119,97,107,97,32,119,97,107,97,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35,35
 loop: 119 97 107 97 32 119 97 107 97 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 35 ''' + '''
@@ -2191,7 +2191,7 @@ seeked= file.
     self.assertContained('texte\n', output[1])
 
   def test_emconfig(self):
-    output = Popen([PYTHON, EMCONFIG, 'LLVM_ROOT'], stdout=PIPE, stderr=PIPE).communicate()[0].strip()
+    output = Popen([PYTHON, EMCONFIG, 'LLVM_ROOT'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0].strip()
     try:
       assert output == LLVM_ROOT
     except:
@@ -2199,16 +2199,16 @@ seeked= file.
       raise
     invalid = 'Usage: em-config VAR_NAME'
     # Don't accept variables that do not exist
-    output = Popen([PYTHON, EMCONFIG, 'VAR_WHICH_DOES_NOT_EXIST'], stdout=PIPE, stderr=PIPE).communicate()[0].strip()
+    output = Popen([PYTHON, EMCONFIG, 'VAR_WHICH_DOES_NOT_EXIST'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0].strip()
     assert output == invalid
     # Don't accept no arguments
-    output = Popen([PYTHON, EMCONFIG], stdout=PIPE, stderr=PIPE).communicate()[0].strip()
+    output = Popen([PYTHON, EMCONFIG], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0].strip()
     assert output == invalid
     # Don't accept more than one variable
-    output = Popen([PYTHON, EMCONFIG, 'LLVM_ROOT', 'EMCC'], stdout=PIPE, stderr=PIPE).communicate()[0].strip()
+    output = Popen([PYTHON, EMCONFIG, 'LLVM_ROOT', 'EMCC'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0].strip()
     assert output == invalid
     # Don't accept arbitrary python code
-    output = Popen([PYTHON, EMCONFIG, 'sys.argv[1]'], stdout=PIPE, stderr=PIPE).communicate()[0].strip()
+    output = Popen([PYTHON, EMCONFIG, 'sys.argv[1]'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0].strip()
     assert output == invalid
 
   def test_link_s(self):
@@ -2235,7 +2235,7 @@ seeked= file.
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '-o', 'main.o']).communicate()
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'supp.cpp'), '-o', 'supp.o']).communicate()
 
-    output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.o'), '-s', os.path.join(self.get_dir(), 'supp.o'), '-s', 'SAFE_HEAP=1'], stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.o'), '-s', os.path.join(self.get_dir(), 'supp.o'), '-s', 'SAFE_HEAP=1'], stderr=PIPE, universal_newlines=True).communicate()
     output = run_js('a.out.js')
     assert 'yello' in output, 'code works'
     code = open('a.out.js').read()
@@ -2249,7 +2249,7 @@ seeked= file.
     ''')
     os.environ["EMMAKEN_JUST_CONFIGURE"] = "1"
     cmd = [PYTHON, EMCC, '-s', 'ASSERTIONS=1', os.path.join(self.get_dir(), 'conftest.c'), '-o', 'conftest']
-    output = Popen(cmd, stderr=PIPE).communicate()
+    output = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
     del os.environ["EMMAKEN_JUST_CONFIGURE"]
     self.assertNotContained('emcc: warning: treating -s as linker option', output[1])
     assert os.path.exists('conftest')
@@ -2263,15 +2263,15 @@ seeked= file.
     os.chdir('subdir')
     open('data2.txt', 'w').write('data2')
     # relative path to below the current dir is invalid
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', '../data1.txt'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', '../data1.txt'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert len(out) == 0
     assert 'below the current directory' in err
     # relative path that ends up under us is cool
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', '../subdir/data2.txt'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', '../subdir/data2.txt'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert len(out) > 0
     assert 'below the current directory' not in err
     # direct path leads to the same code being generated - relative path does not make us do anything different
-    out2, err2 = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data2.txt'], stdout=PIPE, stderr=PIPE).communicate()
+    out2, err2 = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data2.txt'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert len(out2) > 0
     assert 'below the current directory' not in err2
     def clean(txt):
@@ -2314,7 +2314,7 @@ seeked= file.
         return
     full = os.path.join(unicode_name, 'data.txt')
     open(full, 'w').write('data')
-    proc = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', full], stdout=PIPE, stderr=PIPE)
+    proc = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', full], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode == 0, err
     assert len(out) > 0, err
@@ -2363,7 +2363,7 @@ done.
   def test_preprocess(self):
     self.clear()
 
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-E'], stdout=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-E'], stdout=PIPE, universal_newlines=True).communicate()
     assert not os.path.exists('a.out.js')
     # Test explicitly that the output contains a line typically written by the preprocessor.
     # Clang outputs on Windows lines like "#line 1", on Unix '# 1 '.
@@ -2979,11 +2979,11 @@ int main() {
     open('lib.js', 'w').write(r'''
 printErr('dir was ' + process.env.EMCC_BUILD_DIR);
 ''')
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('dir was ' + os.path.realpath(os.path.normpath(self.get_dir())), err)
 
   def test_float_h(self):
-    process = Popen([PYTHON, EMCC, path_from_root('tests', 'float+.c')], stdout=PIPE, stderr=PIPE)
+    process = Popen([PYTHON, EMCC, path_from_root('tests', 'float+.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     assert process.returncode is 0, 'float.h should agree with our system: ' + out + '\n\n\n' + err
 
@@ -2992,14 +2992,14 @@ printErr('dir was ' + process.env.EMCC_BUILD_DIR);
 
     self.clear()
     os.mkdir(outdir)
-    process = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir], stderr=PIPE)
+    process = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir], stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     assert not err, err
     assert os.path.isfile(outdir + 'hello_world.o')
 
     self.clear()
     os.mkdir(outdir)
-    process = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir, '--default-obj-ext', 'obj'], stderr=PIPE)
+    process = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir, '--default-obj-ext', 'obj'], stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     assert not err, err
     assert os.path.isfile(outdir + 'hello_world.obj')
@@ -3077,11 +3077,11 @@ int main() {
       assert '|5|' in output, output
 
       # also verify that the gch is actually used
-      err = Popen([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).communicate()
+      err = Popen([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE, universal_newlines=True).communicate()
       self.assertTextDataContained('*** PCH/Modules Loaded:\nModule: header.h.' + suffix, err[1])
       # and sanity check it is not mentioned when not
       try_delete('header.h.' + suffix)
-      err = Popen([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).communicate()
+      err = Popen([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE, universal_newlines=True).communicate()
       assert '*** PCH/Modules Loaded:\nModule: header.h.' + suffix not in err[1].replace('\r\n', '\n'), err[1]
 
       # with specified target via -o
@@ -3111,9 +3111,9 @@ int main() {
   return 0;
 }
 ''')
-    output = Popen([PYTHON, EMCC, 'src.cpp', '-s', 'WARN_UNALIGNED=1'], stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC, 'src.cpp', '-s', 'WARN_UNALIGNED=1'], stderr=PIPE, universal_newlines=True).communicate()
     assert 'emcc: warning: unaligned store' in output[1], output[1]
-    output = Popen([PYTHON, EMCC, 'src.cpp', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE).communicate()
+    output = Popen([PYTHON, EMCC, 'src.cpp', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE, universal_newlines=True).communicate()
     assert 'emcc: warning: unaligned store' in output[1], output[1]
     assert '@line 11 "src.cpp"' in output[1], output[1]
 
@@ -3246,7 +3246,7 @@ int main(int argc, char **argv) {
         ]:
         print(args, expect)
         with clean_write_access_to_canonical_temp_dir():
-          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).communicate()
+          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         self.assertContained(expect, err)
         if '-O3' in args or '-Oz' in args or '-Os' in args:
           self.assertContained('registerizeHarder', err)
@@ -3370,7 +3370,7 @@ int main()
     ]:
       print(opts, expected)
       try_delete('a.out.js')
-      stdout, stderr = Popen([PYTHON, EMCC, 'src.c'] + opts, stderr=PIPE).communicate()
+      stdout, stderr = Popen([PYTHON, EMCC, 'src.c'] + opts, stderr=PIPE, universal_newlines=True).communicate()
       for ce in compile_expected + ['''warning: incompatible pointer types''']:
         self.assertContained(ce, stderr)
       if expected is None:
@@ -3387,7 +3387,7 @@ int main()
         if opts != 1-asserts: extra = ['-s', 'ASSERTIONS=' + str(asserts)]
         cmd = [PYTHON, EMCC, path_from_root('tests', 'sillyfuncast2_noasm.ll'), '-O' + str(opts)] + extra
         print(cmd)
-        stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+        stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
         assert ('''unexpected number of arguments 3 in call to 'doit', should be 2''' in stderr) == asserts, stderr
         assert ('''unexpected return type i32 in call to 'doit', should be void''' in stderr) == asserts, stderr
         assert ('''unexpected argument type float at index 1 in call to 'doit', should be i32''' in stderr) == asserts, stderr
@@ -3404,33 +3404,33 @@ int main()
         raise Exception('cannot find llvm-lit tool')
     cmd = [PYTHON, LLVM_LIT, '-v', os.path.join(llvm_src, 'test', 'CodeGen', 'JS')]
     print(cmd)
-    p = Popen(cmd)
+    p = Popen(cmd, universal_newlines=True)
     p.communicate()
     assert p.returncode == 0, 'LLVM tests must pass with exit code 0'
 
   def test_bad_triple(self):
     Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
-    out, err = Popen([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert 'warning' in err or 'WARNING' in err, err
     assert 'incorrect target triple' in err or 'different target triples' in err, err
 
   def test_valid_abspath(self):
     # Test whether abspath warning appears
     abs_include_path = os.path.abspath(self.get_dir())
-    process = Popen([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE)
+    process = Popen([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
     assert(warning in err)
 
     # Passing an absolute path to a directory inside the emscripten tree is always ok and should not issue a warning.
     abs_include_path = path_from_root('tests')
-    process = Popen([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE)
+    process = Popen([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
     assert(warning not in err)
 
     # Hide warning for this include path
-    process = Popen([PYTHON, EMCC, '--valid-abspath', abs_include_path,'-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE)
+    process = Popen([PYTHON, EMCC, '--valid-abspath', abs_include_path,'-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = process.communicate()
     assert(warning not in err)
 
@@ -3438,7 +3438,7 @@ int main()
     shared_suffixes = ['.so', '.dylib', '.dll']
 
     for suffix in ['.o', '.a', '.bc', '.so', '.lib', '.dylib', '.js', '.html']:
-      process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out' + suffix], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out' + suffix], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       out, err = process.communicate()
       warning = 'Dynamic libraries (.so, .dylib, .dll) are currently not supported by Emscripten'
       if suffix in shared_suffixes:
@@ -3544,7 +3544,7 @@ int main()
         if m: cmd += ['--emit-symbol-map']
         if wasm: cmd += ['-s', 'WASM=1']
         print(cmd)
-        stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+        stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
         assert (os.path.exists('a.out.js.symbols') == m), stderr
         if m:
           symbols = open('a.out.js.symbols').read()
@@ -3555,9 +3555,9 @@ int main()
     # e.g. they assume our 'executable' extension is bc, and compile an .o to a .bc
     # (the user would then need to build bc to js of course, but we need to actually
     # emit the bc)
-    cmd = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')]).communicate()
+    cmd = Popen([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')], universal_newlines=True).communicate()
     assert os.path.exists('hello_world.o')
-    cmd = Popen([PYTHON, EMCC, 'hello_world.o', '-o', 'hello_world.bc']).communicate()
+    cmd = Popen([PYTHON, EMCC, 'hello_world.o', '-o', 'hello_world.bc'], universal_newlines=True).communicate()
     assert os.path.exists('hello_world.o')
     assert os.path.exists('hello_world.bc')
 
@@ -3658,7 +3658,7 @@ int main(int argc, char **argv) {
       self.clear()
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=["' + m + '_main"]']
       print(cmd)
-      stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+      stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
       if m:
         assert 'function requested to be exported, but not implemented: " _main"' in stderr, stderr
       else:
@@ -3666,7 +3666,7 @@ int main(int argc, char **argv) {
 
   def test_no_dynamic_execution(self):
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1']
-    stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+    stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('hello, world!', run_js('a.out.js'))
     src = open('a.out.js').read()
     assert 'eval(' not in src
@@ -3676,7 +3676,7 @@ int main(int argc, char **argv) {
 
     # Test that --preload-file doesn't add an use of eval().
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '--preload-file', 'temp.txt']
-    stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+    stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('hello, world!', run_js('a.out.js'))
     src = open('a.out.js').read()
     assert 'eval(' not in src
@@ -3686,14 +3686,14 @@ int main(int argc, char **argv) {
 
     # Test that -s NO_DYNAMIC_EXECUTION=1 and --closure 1 are not allowed together.
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '--closure', '1']
-    proc = Popen(cmd, stderr=PIPE)
+    proc = Popen(cmd, stderr=PIPE, universal_newlines=True)
     proc.communicate()
     assert proc.returncode != 0
     try_delete('a.out.js')
 
     # Test that -s NO_DYNAMIC_EXECUTION=1 and -s RELOCATABLE=1 are not allowed together.
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'NO_DYNAMIC_EXECUTION=1', '-s', 'RELOCATABLE=1']
-    proc = Popen(cmd, stderr=PIPE)
+    proc = Popen(cmd, stderr=PIPE, universal_newlines=True)
     proc.communicate()
     assert proc.returncode != 0
     try_delete('a.out.js')
@@ -3762,7 +3762,7 @@ int main(int argc, char **argv) {
     Popen([PYTHON, EMCC, 'src.cpp']).communicate()
     for engine in JS_ENGINES:
       print(engine)
-      process = Popen(engine + ['a.out.js'], stdout=PIPE, stderr=PIPE)
+      process = Popen(engine + ['a.out.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       output = process.communicate()
       assert process.returncode == 123, process.returncode
 
@@ -4059,14 +4059,14 @@ EMSCRIPTEN_KEEPALIVE __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny
 ''')
     def test(args=[]):
       print(args)
-      out = Popen([PYTHON, EMCC, 'src.cpp', '-E'] + args, stdout=PIPE).communicate()[0]
+      out = Popen([PYTHON, EMCC, 'src.cpp', '-E'] + args, stdout=PIPE, universal_newlines=True).communicate()[0]
       self.assertContained(r'''__attribute__((used)) %d %d %d __attribute__((used))''' % (EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY), out)
     test()
     test(['--bind'])
 
   def test_dashE_consistent(self): # issue #3365
-    normal = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-c'], stdout=PIPE, stderr=PIPE).communicate()[1]
-    dash_e = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE).communicate()[1]
+    normal = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-c'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
+    dash_e = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
 
     import difflib
     diff = [a.rstrip()+'\n' for a in difflib.unified_diff(normal.split('\n'), dash_e.split('\n'), fromfile='normal', tofile='dash_e')]
@@ -4077,18 +4077,18 @@ EMSCRIPTEN_KEEPALIVE __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny
     assert len(bad) == 0, '\n\n'.join(diff)
 
   def test_dashE_respect_dashO(self): # issue #3365
-    with_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E', '-o', '/dev/null'], stdout=PIPE, stderr=PIPE).communicate()[0]
-    without_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE).communicate()[0]
+    with_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E', '-o', '/dev/null'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0]
+    without_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0]
     assert len(with_dash_o) == 0
     assert len(without_dash_o) != 0
 
   def test_dashM(self):
-    out = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE).communicate()[0]
+    out = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE, universal_newlines=True).communicate()[0]
     self.assertContained('hello_world.o:', out) # Verify output is just a dependency rule instead of bitcode or js
 
   def test_dashM_consistent(self):
-    normal = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-c'], stdout=PIPE, stderr=PIPE).communicate()[1]
-    dash_m = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE, stderr=PIPE).communicate()[1]
+    normal = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-c'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
+    dash_m = Popen([PYTHON, EMXX, '-v', '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[1]
 
     import difflib
     diff = [a.rstrip()+'\n' for a in difflib.unified_diff(normal.split('\n'), dash_m.split('\n'), fromfile='normal', tofile='dash_m')]
@@ -4099,8 +4099,8 @@ EMSCRIPTEN_KEEPALIVE __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny
     assert len(bad) == 0, '\n\n'.join(diff)
 
   def test_dashM_respect_dashO(self):
-    with_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M', '-o', '/dev/null'], stdout=PIPE, stderr=PIPE).communicate()[0]
-    without_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE, stderr=PIPE).communicate()[0]
+    with_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M', '-o', '/dev/null'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0]
+    without_dash_o = Popen([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()[0]
     assert len(with_dash_o) == 0
     assert len(without_dash_o) != 0
 
@@ -4515,11 +4515,11 @@ Size of file is: 32
 
   def test_emcc_s_typo(self):
     # with suggestions
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DISABLE_EXCEPTION_CATCH=1'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DISABLE_EXCEPTION_CATCH=1'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained(r'''Assigning a non-existent settings attribute "DISABLE_EXCEPTION_CATCH"''', err)
     self.assertContained(r'''did you mean one of DISABLE_EXCEPTION_CATCHING?''', err)
     # no suggestions
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'CHEEZ=1'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'CHEEZ=1'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained(r'''perhaps a typo in emcc's  -s X=Y  notation?''', err)
     self.assertContained(r'''(see src/settings.js for valid values)''', err)
 
@@ -5227,7 +5227,7 @@ function _main() {
       print('log test', source, expected)
       try:
         os.environ['EMCC_LOG_EMTERPRETER_CODE'] = '1'
-        out, err = Popen([PYTHON, EMCC, source, '-O3', '-s', 'EMTERPRETIFY=1'], stderr=PIPE).communicate()
+        out, err = Popen([PYTHON, EMCC, source, '-O3', '-s', 'EMTERPRETIFY=1'], stderr=PIPE, universal_newlines=True).communicate()
       finally:
         del os.environ['EMCC_LOG_EMTERPRETER_CODE']
       lines = err.split('\n')
@@ -5246,10 +5246,10 @@ function _main() {
     do_log_test(path_from_root('tests', 'fannkuch.cpp'), list(range(226, 235)), '__Z15fannkuch_workerPv')
 
   def test_emterpreter_advise(self):
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise.cpp'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1'], stdout=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise.cpp'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1'], stdout=PIPE, universal_newlines=True).communicate()
     self.assertContained('-s EMTERPRETIFY_WHITELIST=\'["__Z6middlev", "__Z7sleeperv", "__Z8recurserv", "_main"]\'', out)
 
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise_funcptr.cpp'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1'], stdout=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise_funcptr.cpp'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1'], stdout=PIPE, universal_newlines=True).communicate()
     self.assertContained('-s EMTERPRETIFY_WHITELIST=\'["__Z4posti", "__Z5post2i", "__Z6middlev", "__Z7sleeperv", "__Z8recurserv", "_main"]\'', out)
 
   def test_link_with_a_static(self):
@@ -5302,23 +5302,23 @@ int main(void) {
   def test_require(self):
     inname = path_from_root('tests', 'hello_world.c')
     Building.emcc(inname, output_filename='a.out.js')
-    output = Popen(NODE_JS + ['-e', 'require("./a.out.js")'], stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen(NODE_JS + ['-e', 'require("./a.out.js")'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert output == ('hello, world!\n', ''), 'expected no output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % output
 
   def test_require_modularize(self):
     Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1']).communicate()
     src = open('a.out.js').read()
     assert "module['exports'] = Module;" in src
-    output = Popen(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert output == ('hello, world!\n', ''), 'expected output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % output
     Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="NotModule"']).communicate()
     src = open('a.out.js').read()
     assert "module['exports'] = NotModule;" in src
-    output = Popen(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert output == ('hello, world!\n', ''), 'expected output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % output
     Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1',  '-s', 'NO_EXIT_RUNTIME=1']).communicate()
     # We call require() twice to ensure it returns wrapper function each time
-    output = Popen(NODE_JS + ['-e', 'require("./a.out.js")();var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen(NODE_JS + ['-e', 'require("./a.out.js")();var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert output[0] == 'hello, world!\nhello, world!\n', 'expected output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % output
 
   def test_native_optimizer(self):
@@ -5330,7 +5330,7 @@ int main(void) {
         os.environ['EMCC_DEBUG'] = '1'
         os.environ['EMCC_NATIVE_OPTIMIZER'] = '1'
         with clean_write_access_to_canonical_temp_dir():
-          out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2',] + args, stderr=PIPE).communicate()
+          out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2',] + args, stderr=PIPE, universal_newlines=True).communicate()
       finally:
         if old_debug: os.environ['EMCC_DEBUG'] = old_debug
         else: del os.environ['EMCC_DEBUG']
@@ -5391,7 +5391,7 @@ int main(void) {
         if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
         try:
           os.environ['EMCC_DEBUG'] = '1'
-          out, err = Popen([PYTHON, EMCC, '-c', main_name, lib_name] + args, stderr=PIPE).communicate()
+          out, err = Popen([PYTHON, EMCC, '-c', main_name, lib_name] + args, stderr=PIPE, universal_newlines=True).communicate()
         finally:
           del os.environ['EMCC_DEBUG']
 
@@ -5481,7 +5481,7 @@ Descriptor desc;
     def check(what, args, fail=True, expect=''):
       args = [PYTHON, path_from_root(what)] + args
       print(what, args, fail, expect)
-      out, err = Popen(args, stdout=PIPE, stderr=PIPE).communicate()
+      out, err = Popen(args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert ('is a helper for' in err) == fail
       assert ('Typical usage' in err) == fail
       self.assertContained(expect, out)
@@ -5515,10 +5515,10 @@ print(os.environ.get('NM'))
       [['--cflags', '--libs'], '-s USE_SDL=2'],
     ]:
       print(args, expected)
-      out, err = Popen([PYTHON, path_from_root('system', 'bin', 'sdl2-config')] + args, stdout=PIPE, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, path_from_root('system', 'bin', 'sdl2-config')] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert expected in out, out
       print('via emmake')
-      out, err = Popen([PYTHON, path_from_root('emmake'), 'sdl2-config'] + args, stdout=PIPE, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, path_from_root('emmake'), 'sdl2-config'] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert expected in out, out
 
   def test_warn_toomany_vars(self):
@@ -5529,7 +5529,7 @@ print(os.environ.get('NM'))
       for opts in [0, 1, 2, 's']:
         print(source, opts)
         self.clear()
-        out, err = Popen([PYTHON, EMCC, source, '-O' + str(opts)], stderr=PIPE).communicate()
+        out, err = Popen([PYTHON, EMCC, source, '-O' + str(opts)], stderr=PIPE, universal_newlines=True).communicate()
         assert os.path.exists('a.out.js')
         assert ('emitted code will contain very large numbers of local variables' in err) == (warn and (opts in [0, 1]))
 
@@ -5559,9 +5559,9 @@ int main() {
   def test_file_packager_huge(self):
     open('huge.dat', 'w').write('a'*(1024*1024*257))
     open('tiny.dat', 'w').write('a')
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'tiny.dat'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'tiny.dat'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert err == '', err
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'huge.dat'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'huge.dat'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert 'warning: file packager is creating an asset bundle of 257 MB. this is very large, and browsers might have trouble loading it' in err, err
     self.clear()
 
@@ -5740,7 +5740,7 @@ int main(int argc, char** argv) {
     open('src.c', 'w').write(src)
     def test(args, expected):
       print(args, expected)
-      out, err = Popen([PYTHON, EMCC, 'src.c'] + args, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, EMCC, 'src.c'] + args, stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained(expected, run_js(self.in_dir('a.out.js')))
 
     for opts in [0, 1, 2, 3]:
@@ -6038,10 +6038,10 @@ main(int argc,char** argv)
 
     # file packager defauls to the safe closure case
 
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'temp.txt'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'temp.txt'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert BAD in out
 
-    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'temp.txt', '--no-closure'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'temp.txt', '--no-closure'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert BAD not in out, out[max(out.index(BAD)-80, 0) : min(out.index(BAD)+80, len(out)-1)]
 
   def test_debug_asmLastOpts(self):
@@ -6062,7 +6062,7 @@ int main() {
   printf("hello, world!\n");
 }
 ''')
-    out, err = Popen([PYTHON, EMCC, 'src.c', '-s', 'EXPORTED_FUNCTIONS=["_main", "_treecount"]', '--minify', '0', '-g4', '-Oz']).communicate()
+    out, err = Popen([PYTHON, EMCC, 'src.c', '-s', 'EXPORTED_FUNCTIONS=["_main", "_treecount"]', '--minify', '0', '-g4', '-Oz'], universal_newlines=True).communicate()
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_meminit_crc(self):
@@ -6071,7 +6071,7 @@ int main() {
 #include <stdio.h>
 int main() { printf("Mary had a little lamb.\n"); }
 ''')
-    out, err = Popen([PYTHON, EMCC, 'src.c', '-O2', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1']).communicate()
+    out, err = Popen([PYTHON, EMCC, 'src.c', '-O2', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1'], universal_newlines=True).communicate()
     with open('a.out.js', 'r') as f:
       d = f.read()
     d = d.replace('Mary had', 'Paul had')
@@ -6129,7 +6129,7 @@ int main() {
 ''', out)
 
   def test_no_warn_exported_jslibfunc(self):
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["alGetError"]', '-s', 'EXPORTED_FUNCTIONS=["_main", "_alGetError"]'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["alGetError"]', '-s', 'EXPORTED_FUNCTIONS=["_main", "_alGetError"]'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained('''function requested to be exported, but not implemented: "_alGetError"''', err)
 
   def test_almost_asm_warning(self):
@@ -6142,7 +6142,7 @@ int main() {
                            # last warning flag should "win"
                            (['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm', '-Walmost-asm'], True)]:
       print(args, expected)
-      proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')] + args, stderr=PIPE)
+      proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')] + args, stderr=PIPE, universal_newlines=True)
       err = proc.communicate()[1]
       assert proc.returncode is 0
       assert (warning in err) == expected, err
@@ -6158,7 +6158,7 @@ int main() {
 
   def test_emcc_dev_null(self):
     if WINDOWS: return self.skip('posix-only')
-    proc = Popen([PYTHON, EMCC, '-dM', '-E', '-x', 'c', '/dev/null'], stdout=PIPE)
+    proc = Popen([PYTHON, EMCC, '-dM', '-E', '-x', 'c', '/dev/null'], stdout=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode == 0
     self.assertContained('#define __EMSCRIPTEN__ 1', out) # all our defines should show up
@@ -6214,13 +6214,13 @@ mergeInto(LibraryManager.library, {
   }()),
 });
 ''')
-    proc = Popen([PYTHON, EMCC, 'test.cpp', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1', '--js-library', 'library_foo.js'], stderr=PIPE)
+    proc = Popen([PYTHON, EMCC, 'test.cpp', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1', '--js-library', 'library_foo.js'], stderr=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode != 0
     assert 'unresolved symbol' in err
 
     # and also for missing C code, of course (without the --js-library, it's just a missing C method)
-    proc = Popen([PYTHON, EMCC, 'test.cpp', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1'], stderr=PIPE)
+    proc = Popen([PYTHON, EMCC, 'test.cpp', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1'], stderr=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode != 0
     assert 'unresolved symbol' in err
@@ -6335,7 +6335,7 @@ Resolved: "/" => "/"
 ''', run_js('a.out.js'))
 
   def test_no_warnings(self):
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE, universal_newlines=True).communicate()
     assert err == '', err
 
   def test_emterpreter_file_suggestion(self):
@@ -6346,7 +6346,7 @@ Resolved: "/" => "/"
         if to_file:
           cmd += ['-s', 'EMTERPRETIFY_FILE="code.dat"']
         print(cmd)
-        stdout, stderr = Popen(cmd, stderr=PIPE).communicate()
+        stdout, stderr = Popen(cmd, stderr=PIPE, universal_newlines=True).communicate()
         need_warning = linkable and not to_file
         assert ('''warning: emterpreter bytecode is fairly large''' in stderr) == need_warning, stderr
         assert ('''It is recommended to use  -s EMTERPRETIFY_FILE=..''' in stderr) == need_warning, stderr
@@ -6744,7 +6744,7 @@ int main() {
     assert "high = 1234" in out
 
   def test_lib_include_flags(self):
-    process = Popen([PYTHON, EMCC] + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')], stdout=PIPE, stderr=PIPE)
+    process = Popen([PYTHON, EMCC] + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     process.communicate()
     assert process.returncode is 0, 'Empty -l/-L/-I flags should read the next arg as a param'
 
@@ -6785,26 +6785,26 @@ int main() {
 
   def test_separate_asm_warning(self):
     # Test that -s PRECISE_F32=2 raises a warning that --separate-asm is implied.
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2', '-o', 'a.html'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2', '-o', 'a.html'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('forcing separate asm output', stderr)
 
     # Test that -s PRECISE_F32=2 --separate-asm should not post a warning.
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2', '-o', 'a.html', '--separate-asm'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=2', '-o', 'a.html', '--separate-asm'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained('forcing separate asm output', stderr)
 
     # Test that -s PRECISE_F32=1 should not post a warning.
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=1', '-o', 'a.html'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'PRECISE_F32=1', '-o', 'a.html'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained('forcing separate asm output', stderr)
 
     # Manually doing separate asm should show a warning, if not targeting html
     warning = '--separate-asm works best when compiling to HTML'
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained(warning, stderr)
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm', '-o', 'a.html'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm', '-o', 'a.html'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained(warning, stderr)
 
     # test that the warning can be suppressed
-    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm', '-Wno-separate-asm'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--separate-asm', '-Wno-separate-asm'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained(warning, stderr)
 
   def test_canonicalize_nan_warning(self):
@@ -6823,10 +6823,10 @@ int main() {
 }
 ''')
 
-    stdout, stderr = Popen([PYTHON, EMCC, 'src.cpp', '-O1'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, 'src.cpp', '-O1'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained("emcc: warning: cannot represent a NaN literal", stderr)
 
-    stdout, stderr = Popen([PYTHON, EMCC, 'src.cpp', '-O1', '-g'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, 'src.cpp', '-O1', '-g'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained("emcc: warning: cannot represent a NaN literal", stderr)
     self.assertContained('//@line 12 "src.cpp"', stderr)
 
@@ -6900,7 +6900,7 @@ int main() {
   }, int64_t(0x12345678ABCDEF1FLL));
 }
 ''')
-    out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained('LLVM ERROR: EM_ASM should not receive i64s as inputs, they are not valid in JS', err)
 
   def test_eval_ctors(self):
@@ -6998,7 +6998,7 @@ C c;
 int main() {}
       ''')
       with clean_write_access_to_canonical_temp_dir():
-        out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE).communicate()
+        out, err = Popen([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE, universal_newlines=True).communicate()
       self.assertContained('___syscall54', err) # the failing call should be mentioned
       self.assertContained('ctorEval.js', err) # with a stack trace
       self.assertContained('ctor_evaller: not successful', err) # with logging
@@ -7120,7 +7120,7 @@ int main() {
     if use_hash_info:
       command.append('--use-hash-info')
 
-    output, err = Popen(NODE_JS + command, stdin=PIPE, stderr=PIPE, stdout=PIPE).communicate()
+    output, err = Popen(NODE_JS + command, stdin=PIPE, stderr=PIPE, stdout=PIPE, universal_newlines=True).communicate()
     assert err == '', err
     expected_output = self.get_file_contents(expected_output_file)
     output = self.normalize_line_endings(output)
@@ -7245,12 +7245,12 @@ int main() {
   return 0;
 }
     ''')
-    stdout, stderr = Popen([PYTHON, EMCC, '-Wall', '-std=c++14', '-x', 'c++', 'src_tmp_fixed_lang'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, '-Wall', '-std=c++14', '-x', 'c++', 'src_tmp_fixed_lang'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertNotContained("Input file has an unknown suffix, don't know what to do with it!", stderr)
     self.assertNotContained("Unknown file suffix when compiling to LLVM bitcode", stderr)
     self.assertContained("Test_source_fixed_lang_hello", run_js('a.out.js'))
 
-    stdout, stderr = Popen([PYTHON, EMCC, '-Wall', '-std=c++14', 'src_tmp_fixed_lang'], stderr=PIPE).communicate()
+    stdout, stderr = Popen([PYTHON, EMCC, '-Wall', '-std=c++14', 'src_tmp_fixed_lang'], stderr=PIPE, universal_newlines=True).communicate()
     self.assertContained("Input file has an unknown suffix, don't know what to do with it!", stderr)
 
   def test_disable_inlining(self):
@@ -7325,7 +7325,7 @@ int main() {
             try_delete('a.out.wast')
             cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c'), '-s', option + '=1', '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
             print(args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd))
-            proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+            proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
             output, err = proc.communicate()
             assert proc.returncode == 0
             assert expect_js_opts == ('applying js optimization passes:' in err), err
@@ -7368,7 +7368,7 @@ int main() {
         print(args, expect)
         try_delete('a.out.js')
         with clean_write_access_to_canonical_temp_dir():
-          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'] + args, stdout=PIPE, stderr=PIPE).communicate()
+          output, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'] + args, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
         assert expect == (' -emscripten-precise-f32' in err), err
         self.assertContained('hello, world!', run_js('a.out.js'))
     finally:
@@ -7417,7 +7417,7 @@ int main() {
       if method is not None:
         cmd += ['-s', 'BINARYEN_METHOD="' + method + '"']
       print(' '.join(cmd))
-      proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+      proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
       out, err = proc.communicate()
       print(err)
       warning = 'BINARYEN_ASYNC_COMPILATION disabled due to user options. This will reduce performance and compatibility'
@@ -7485,18 +7485,18 @@ int main() {
   def test_binaryen_invalid_mem(self):
       ret = subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-s', 'TOTAL_MEMORY=33MB'])
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-s', 'TOTAL_MEMORY=32MB+1'], stderr=subprocess.PIPE).communicate()[1]
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-s', 'TOTAL_MEMORY=32MB+1'], stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]
       assert 'TOTAL_MEMORY must be a multiple of 64KB' in ret, ret
 
       ret = subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=32MB'])
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=33MB'], stderr=subprocess.PIPE).communicate()[1]
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=33MB'], stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]
       assert 'TOTAL_MEMORY must be a multiple of 16MB' in ret, ret
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB'], stderr=subprocess.PIPE).communicate()[1]
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB'], stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]
       assert 'BINARYEN_MEM_MAX must be a multiple of 64KB' not in ret, ret
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB+1'], stderr=subprocess.PIPE).communicate()[1]
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB+1'], stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]
       assert 'BINARYEN_MEM_MAX must be a multiple of 64KB' in ret, ret
 
   def test_binaryen_ctors(self):
@@ -7546,7 +7546,7 @@ int main() {
           try_delete('a.out.wast')
           cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'] + args
           print(' '.join(cmd))
-          proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+          proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
           output, err = proc.communicate()
           assert proc.returncode == 0
           asm2wasm_line = [x for x in err.split('\n') if 'asm2wasm' in x][0]
@@ -7578,7 +7578,7 @@ int main() {
           print(args, expect)
           cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=1', '-O3'] + args
           print(' '.join(cmd))
-          output, err = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+          output, err = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
           asm2wasm_line = [x for x in err.split('\n') if 'asm2wasm' in x][0]
           asm2wasm_line = asm2wasm_line.strip() + ' ' # ensure it ends with a space, for simpler searches below
           print('|' + asm2wasm_line + '|')
@@ -7603,7 +7603,7 @@ int main() {
         try_delete('a.out.wast')
         cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'ffi.c'), '-s', 'WASM=1', '-g', '-o', 'a.out.js'] + args
         print(' '.join(cmd))
-        proc = Popen(cmd, stdout=PIPE)
+        proc = Popen(cmd, stdout=PIPE, universal_newlines=True)
         output, err = proc.communicate()
         assert proc.returncode == 0
         text = open('a.out.wast').read()
@@ -7653,7 +7653,7 @@ int main() {
 
   def test_wasm_targets(self):
     for f in ['a.wasm', 'a.wast']:
-      process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', f], stdout=PIPE, stderr=PIPE)
+      process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', f], stdout=PIPE, stderr=PIPE, universal_newlines=True)
       out, err = process.communicate()
       print(err)
       assert process.returncode is not 0, 'wasm suffix is an error'
@@ -7701,19 +7701,19 @@ int main() {
     env = os.environ.copy()
     if 'EMCC_STRICT' in env: del env['EMCC_STRICT']
 
-    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=1'], stdout=PIPE, stderr=PIPE, env=env)
+    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=1'], stdout=PIPE, stderr=PIPE, env=env, universal_newlines=True)
     process.communicate()
     assert process.returncode is not 0, '-llsomenonexistingfile is an error in strict mode'
 
-    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'ERROR_ON_MISSING_LIBRARIES=0'], stdout=PIPE, stderr=PIPE, env=env)
+    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'ERROR_ON_MISSING_LIBRARIES=0'], stdout=PIPE, stderr=PIPE, env=env, universal_newlines=True)
     process.communicate()
     assert process.returncode is 0, '-llsomenonexistingfile is not an error if -s ERROR_ON_MISSING_LIBRARIES=0 is passed'
 
-    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=1', '-s', 'ERROR_ON_MISSING_LIBRARIES=0'], stdout=PIPE, stderr=PIPE, env=env)
+    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=1', '-s', 'ERROR_ON_MISSING_LIBRARIES=0'], stdout=PIPE, stderr=PIPE, env=env, universal_newlines=True)
     process.communicate()
     assert process.returncode is 0, '-s ERROR_ON_MISSING_LIBRARIES=0 should override -s STRICT=1'
 
-    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=0'], stdout=PIPE, stderr=PIPE, env=env)
+    process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile', '-s', 'STRICT=0'], stdout=PIPE, stderr=PIPE, env=env, universal_newlines=True)
     process.communicate()
     # TODO: TEMPORARY: When -s ERROR_ON_MISSING_LIBRARIES=1 becomes the default, change the following line to expect failure instead of 0.
     assert process.returncode is 0, '-llsomenonexistingfile is not yet an error in non-strict mode'
@@ -7722,19 +7722,19 @@ int main() {
   def test_native_link_error_message(self):
     Popen([CLANG, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.o'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
     Popen([LLVM_AR, 'r', 'hello_world.a', 'hello_world.o'], env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
-    out, err = Popen([PYTHON, EMCC, 'hello_world.a', '-o', 'hello_world.js'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, 'hello_world.a', '-o', 'hello_world.js'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert 'exists but was not an LLVM bitcode file suitable for Emscripten. Perhaps accidentally mixing native built object files with Emscripten?' in err
 
   # Tests that the warning message about pairing WASM with EVAL_CTORS appropriately triggers the warning about NO_EXIT_RUNTIME.
   def test_binaryen_no_exit_runtime_warn_message(self):
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.js', '-s', 'WASM=1', '-Oz'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.js', '-s', 'WASM=1', '-Oz'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert 'you should enable  -s NO_EXIT_RUNTIME=1' in err
-    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.bc', '-s', 'WASM=1', '-Oz'], stdout=PIPE, stderr=PIPE).communicate()
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.bc', '-s', 'WASM=1', '-Oz'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
     assert 'you should enable  -s NO_EXIT_RUNTIME=1' not in err
 
   def test_o_level_clamp(self):
     for level in [3, 4, 20]:
-      out, err = Popen([PYTHON, EMCC, '-O' + str(level), path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, EMCC, '-O' + str(level), path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert os.path.exists('a.out.js'), '-O' + str(level) + ' should produce output'
       if level > 3:
         self.assertContained("optimization level '-O" + str(level) + "' is not supported; using '-O3' instead", err)
@@ -7818,7 +7818,7 @@ int main() {
 
                     print(' '.join(cmd))
                     self.clear()
-                    proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+                    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
                     output, err = proc.communicate()
                     print(os.listdir('.'))
                     assert expect_success == (proc.returncode == 0)
@@ -7835,13 +7835,13 @@ int main() {
     open('file2', 'w').write(' ')
     subprocess.call([PYTHON, EMAR, 'cr', 'file1.a', 'file1'])
     subprocess.call([PYTHON, EMAR, 'cr', 'file2.a', 'file2'])
-    emar = subprocess.Popen([PYTHON, EMAR, '-M'], stdin=PIPE)
+    emar = subprocess.Popen([PYTHON, EMAR, '-M'], stdin=PIPE, universal_newlines=True)
     emar.communicate('''create combined.a
 addlib file1.a
 addlib file2.a
 save
 end
 ''')
-    result = subprocess.check_output([PYTHON, EMAR, 't', 'combined.a'])
+    result = subprocess.check_output([PYTHON, EMAR, 't', 'combined.a'], universal_newlines=True)
     assert 'file1' in result
     assert 'file2' in result

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -50,7 +50,7 @@ class sanity(RunnerCore):
     if command[0] == EMCC:
       command = [PYTHON] + command
 
-    return Popen(command, stdout=PIPE, stderr=STDOUT).communicate()[0]
+    return Popen(command, stdout=PIPE, stderr=STDOUT, universal_newlines=True).communicate()[0]
 
   def check_working(self, command, expected=None):
     if type(command) is not list:
@@ -505,8 +505,8 @@ fi
 
     for compiler in [EMCC, EMXX]:
       print(compiler)
-      out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-v'], stdout=PIPE, stderr=PIPE).communicate()
-      out2, err2 = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-v', '-nostdinc++'], stdout=PIPE, stderr=PIPE).communicate()
+      out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-v'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
+      out2, err2 = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-v', '-nostdinc++'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
       assert out == out2
       def focus(e):
         assert 'search starts here:' in e, e
@@ -736,7 +736,7 @@ fi
       print(command)
       Cache.erase()
 
-      proc = Popen(command, stdout=PIPE, stderr=STDOUT)
+      proc = Popen(command, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
       out, err = proc.communicate()
       assert (proc.returncode == 0) == success, out
       if not isinstance(expected, list): expected = [expected]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -27,7 +27,7 @@ def clean_processes(processes):
 
 def make_relay_server(port1, port2):
   print('creating relay server on ports %d,%d' % (port1, port2), file=sys.stderr)
-  proc = Popen([PYTHON, path_from_root('tests', 'sockets', 'socket_relay.py'), str(port1), str(port2)])
+  proc = Popen([PYTHON, path_from_root('tests', 'sockets', 'socket_relay.py'), str(port1), str(port2)], universal_newlines=True)
   return proc
 
 class WebsockifyServerHarness(object):
@@ -46,11 +46,11 @@ class WebsockifyServerHarness(object):
     # NOTE empty filename support is a hack to support
     # the current test_enet
     if self.filename:
-      sp = Popen([CLANG_CC, path_from_root('tests', self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + get_clang_native_args() + self.args, env=get_clang_native_env(), stdout=PIPE, stderr=PIPE)
+      sp = Popen([CLANG_CC, path_from_root('tests', self.filename), '-o', 'server', '-DSOCKK=%d' % self.target_port] + get_clang_native_args() + self.args, env=get_clang_native_env(), stdout=PIPE, stderr=PIPE, universal_newlines=True)
       out = sp.communicate()
       print('Socket server build: out:', out[0] or '', '/ err:', out[1] or '')
       assert sp.returncode == 0
-      process = Popen([os.path.abspath('server')])
+      process = Popen([os.path.abspath('server')], universal_newlines=True)
       self.processes.append(process)
 
     # start the websocket proxy
@@ -96,7 +96,7 @@ class CompiledServerHarness(object):
   def __enter__(self):
     # assuming this is only used for WebSocket tests at the moment, validate that
     # the ws module is installed
-    child = Popen(NODE_JS + ['-e', 'require("ws");'])
+    child = Popen(NODE_JS + ['-e', 'require("ws");'], universal_newlines=True)
     child.communicate()
     global node_ws_module_installed
     # Attempt to automatically install ws module for Node.js.
@@ -104,17 +104,17 @@ class CompiledServerHarness(object):
       node_ws_module_installed = True
       Popen([NPM, 'install', path_from_root('tests', 'sockets', 'ws')], cwd=os.path.dirname(EMCC)).communicate()
       # Did installation succeed?
-      child = Popen(NODE_JS + ['-e', 'require("ws");'])
+      child = Popen(NODE_JS + ['-e', 'require("ws");'], universal_newlines=True)
       child.communicate()
     assert child.returncode == 0, 'ws module for Node.js not installed, and automatic installation failed! Please run \'npm install\' from %s' % EMSCRIPTEN_ROOT
 
     # compile the server
-    sp = Popen([PYTHON, EMCC, path_from_root('tests', self.filename), '-o', 'server.js', '-DSOCKK=%d' % self.listen_port] + self.args)
+    sp = Popen([PYTHON, EMCC, path_from_root('tests', self.filename), '-o', 'server.js', '-DSOCKK=%d' % self.listen_port] + self.args, universal_newlines=True)
     out = sp.communicate()
     print('Socket server build: out:', out[0] or '', '/ err:', out[1] or '')
     assert sp.returncode == 0
 
-    process = Popen(NODE_JS + ['server.js'])
+    process = Popen(NODE_JS + ['server.js'], universal_newlines=True)
     self.processes.append(process)
 
   def __exit__(self, *args, **kwargs):
@@ -578,7 +578,7 @@ int main () {
 
     # note: you may need to run this manually yourself, if npm is not in the path, or if you need a version that is not in the path
     Popen([NPM, 'install', path_from_root('tests', 'sockets', 'p2p')]).communicate()
-    broker = Popen(NODE_JS + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')])
+    broker = Popen(NODE_JS + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')], universal_newlines=True)
 
     expected = '1'
     self.run_browser(host_outfile, '.', ['/report_result?' + e for e in expected])

--- a/tools/bisect_pair.py
+++ b/tools/bisect_pair.py
@@ -37,7 +37,7 @@ assert left_result != right_result
 
 # Calculate diff chunks
 print('diffing')
-diff = Popen(['diff', '-U', '5', 'left', 'right'], stdout=PIPE).communicate()[0].split('\n')
+diff = Popen(['diff', '-U', '5', 'left', 'right'], stdout=PIPE, universal_newlines=True).communicate()[0].split('\n')
 pre_diff = diff[:2]
 diff = diff[2:]
 
@@ -81,7 +81,7 @@ for mid in range(high):
     found = mid
     break
 
-critical = Popen(['diff', '-U', '5', 'middle' + str(mid-1), 'middle' + str(mid)], stdout=PIPE).communicate()[0]
+critical = Popen(['diff', '-U', '5', 'middle' + str(mid-1), 'middle' + str(mid)], stdout=PIPE, universal_newlines=True).communicate()[0]
 c = open('critical.diff', 'w')
 c.write(critical)
 c.close()

--- a/tools/bisect_pair_wast.py
+++ b/tools/bisect_pair_wast.py
@@ -38,7 +38,7 @@ assert left_result != right_result
 
 # Calculate diff chunks
 print('diffing')
-diff = Popen(['diff', '-U', '5', 'left', 'right'], stdout=PIPE).communicate()[0].split('\n')
+diff = Popen(['diff', '-U', '5', 'left', 'right'], stdout=PIPE, universal_newlines=True).communicate()[0].split('\n')
 pre_diff = diff[:2]
 diff = diff[2:]
 
@@ -82,7 +82,7 @@ for mid in range(high):
     found = mid
     break
 
-critical = Popen(['diff', '-U', '5', 'middle' + str(mid-1), 'middle' + str(mid)], stdout=PIPE).communicate()[0]
+critical = Popen(['diff', '-U', '5', 'middle' + str(mid-1), 'middle' + str(mid)], stdout=PIPE, universal_newlines=True).communicate()[0]
 c = open('critical.diff', 'w')
 c.write(critical)
 c.close()

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -247,7 +247,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
     err_file = config.get_temp_files().get('.err').name
     out_file_handle = open(out_file, 'w')
     err_file_handle = open(err_file, 'w')
-    proc = subprocess.Popen(shared.NODE_JS + [temp_file], stdout=out_file_handle, stderr=err_file_handle)
+    proc = subprocess.Popen(shared.NODE_JS + [temp_file], stdout=out_file_handle, stderr=err_file_handle, universal_newlines=True)
     try:
       shared.jsrun.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
     except Exception as e:
@@ -289,7 +289,7 @@ def eval_ctors_wasm(js, wasm_file, num):
   if debug_info:
     cmd += ['-g']
   shared.logging.debug('wasm ctor cmd: ' + str(cmd))
-  out, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+  out, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
   num_successful = err.count('success on')
   shared.logging.debug(err)
   if len(ctors) == num_successful:

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -22,7 +22,7 @@ def process_shell(js, js_engine, shell, equivalentfn_hash_info=None):
 
     (output,error) = subprocess.Popen(js_engine +
         [DUPLICATE_FUNCTION_ELIMINATOR, temp_file, '--use-hash-info', '--no-minimize-whitespace'],
-        stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
   assert len(output) > 0
   assert len(error) == 0
 
@@ -45,7 +45,7 @@ def run_on_chunk(command):
 
     if shared.EM_BUILD_VERBOSE_LEVEL >= 3: print('run_on_chunk: ' + str(command), file=sys.stderr)
 
-    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True)
     output = proc.communicate()[0]
     assert proc.returncode == 0, 'Error in optimizer (return code ' + str(proc.returncode) + '): ' + output
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -51,9 +51,7 @@ def run_on_chunk(command):
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output
     filename = temp_files.get(os.path.basename(filename) + '.jo' + file_suffix).name
 
-    # Important to write out in binary mode, because the data we are writing contains Windows line endings '\r\n' because it was PIPED from console.
-    # Otherwise writing \r\n to ascii mode file will result in Windows amplifying \n to \r\n, generating bad \r\r\n line endings.
-    f = open(filename, 'wb')
+    f = open(filename, 'w')
     f.write(output)
     f.close()
     if DEBUG and not shared.WINDOWS: print('.', file=sys.stderr) # Skip debug progress indicator on Windows, since it doesn't buffer well with multiple threads printing to console.

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -176,7 +176,7 @@ def print_applist(applist, running_app_manifests, print_removable):
 
 def adb_devices():
   try:
-    devices = subprocess.check_output([ADB, 'devices'])
+    devices = subprocess.check_output([ADB, 'devices'], universal_newlines=True)
     devices = devices.strip().split('\n')[1:]
     devices = [x.strip().split('\t') for x in devices]
     return devices
@@ -184,10 +184,10 @@ def adb_devices():
     return []
 
 def b2g_get_prefs_filename():
-  return subprocess.check_output([ADB, 'shell', 'echo', '-n', '/data/b2g/mozilla/*.default/prefs.js'])
+  return subprocess.check_output([ADB, 'shell', 'echo', '-n', '/data/b2g/mozilla/*.default/prefs.js'], universal_newlines=True)
 
 def b2g_get_prefs_data():
-  return subprocess.check_output([ADB, 'shell', 'cat', '/data/b2g/mozilla/*.default/prefs.js'])
+  return subprocess.check_output([ADB, 'shell', 'cat', '/data/b2g/mozilla/*.default/prefs.js'], universal_newlines=True)
 
 def b2g_get_pref(sub):
   prefs_data = b2g_get_prefs_data().split('\n')

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -365,7 +365,7 @@ if crunch:
 
       # guess at format. this lets us tell crunch to not try to be clever and use odd formats like DXT5_AGBR
       try:
-        format = Popen(['file', file_['srcpath']], stdout=PIPE).communicate()[0]
+        format = Popen(['file', file_['srcpath']], stdout=PIPE, universal_newlines=True).communicate()[0]
         if 'DXT5' in format:
           format = ['-dxt5']
         elif 'DXT1' in format:

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -296,9 +296,7 @@ def run_on_chunk(command):
     assert proc.returncode == 0, 'Error in optimizer (return code ' + str(proc.returncode) + '): ' + output
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output
     filename = temp_files.get(os.path.basename(filename) + '.jo.js').name
-    # Important to write out in binary mode, because the data we are writing contains Windows line endings '\r\n' because it was PIPED from console.
-    # Otherwise writing \r\n to ascii mode file will result in Windows amplifying \n to \r\n, generating bad \r\r\n line endings.
-    f = open(filename, 'wb')
+    f = open(filename, 'w')
     f.write(output)
     f.close()
     if DEBUG and not shared.WINDOWS: print('.', file=sys.stderr) # Skip debug progress indicator on Windows, since it doesn't buffer well with multiple threads printing to console.

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -130,7 +130,7 @@ def get_native_optimizer():
           cmake_generators = ['Unix Makefiles']
 
         for cmake_generator in cmake_generators:
-          proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output)
+          proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output, universal_newlines=True)
           proc.communicate()
           make_env = os.environ.copy()
           if proc.returncode == 0:
@@ -143,7 +143,7 @@ def get_native_optimizer():
             else:
               make = ['make']
 
-            proc = subprocess.Popen(make, cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output, env=make_env)
+            proc = subprocess.Popen(make, cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output, env=make_env, universal_newlines=True)
             proc.communicate()
             if proc.returncode == 0:
               if WINDOWS and 'Visual Studio' in cmake_generator:
@@ -250,7 +250,8 @@ class Minifier(object):
           [JS_OPTIMIZER, temp_file, 'minifyGlobals', 'noPrintMetadata'] +
           (['minifyWhitespace'] if minify_whitespace else []) +
           (['--debug'] if source_map else []),
-          stdout=subprocess.PIPE).communicate()[0]
+          stdout=subprocess.PIPE,
+          universal_newlines=True).communicate()[0]
 
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in js optimizer: ' + output
     #print >> sys.stderr, "minified SHELL 3333333333333333", output, "\n44444444444444444444"
@@ -290,7 +291,7 @@ def run_on_chunk(command):
       print('running js optimizer command', ' '.join([c if c != filename else saved for c in command]), file=sys.stderr)
       shutil.copyfile(filename, os.path.join(shared.get_emscripten_temp_dir(), saved))
     if shared.EM_BUILD_VERBOSE_LEVEL >= 3: print('run_on_chunk: ' + str(command), file=sys.stderr)
-    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True)
     output = proc.communicate()[0]
     assert proc.returncode == 0, 'Error in optimizer (return code ' + str(proc.returncode) + '): ' + output
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output
@@ -508,7 +509,7 @@ EMSCRIPTEN_FUNCS();
           if DEBUG: print('running cleanup on shell code', file=sys.stderr)
           next = cld + '.cl.js'
           temp_files.note(next)
-          proc = subprocess.Popen(js_engine + [JS_OPTIMIZER, cld, 'noPrintMetadata', 'JSDCE'] + (['minifyWhitespace'] if 'minifyWhitespace' in passes else []), stdout=open(next, 'w'))
+          proc = subprocess.Popen(js_engine + [JS_OPTIMIZER, cld, 'noPrintMetadata', 'JSDCE'] + (['minifyWhitespace'] if 'minifyWhitespace' in passes else []), stdout=open(next, 'w'), universal_newlines=True)
           proc.communicate()
           assert proc.returncode == 0
           cld = next

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -100,7 +100,8 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
-        cwd=cwd)
+        cwd=cwd,
+        universal_newlines=True)
   except Exception as e:
     # the failure may be because the engine is not present. show the proper
     # error in that case

--- a/tools/parse_unaligned.py
+++ b/tools/parse_unaligned.py
@@ -8,7 +8,7 @@ for line in open(sys.argv[1]).readlines():
   try:
     x = line.split(' in ')[1].split(':')[0]
     #output = str([x, Popen(['c++filt', x], stdout=PIPE).communicate()])
-    output = Popen(['c++filt', x], stdout=PIPE).communicate()[0]
+    output = Popen(['c++filt', x], stdout=PIPE, universal_newlines=True).communicate()[0]
     if output not in shown:
       shown.add(output)
       print(output, end=' ')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -330,7 +330,7 @@ def expected_llvm_version():
 def get_clang_version():
   global actual_clang_version
   if actual_clang_version is None:
-    response = Popen([CLANG, '-v'], stderr=PIPE).communicate()[1]
+    response = Popen([CLANG, '-v'], stderr=PIPE, universal_newlines=True).communicate()[1]
     m = re.search(r'[Vv]ersion\s+(\d+\.\d+)', response)
     actual_clang_version = m and m.group(1)
   return actual_clang_version
@@ -368,7 +368,7 @@ def get_fastcomp_src_dir():
 
 def get_llc_targets():
   try:
-    llc_version_info = Popen([LLVM_COMPILER, '--version'], stdout=PIPE).communicate()[0]
+    llc_version_info = Popen([LLVM_COMPILER, '--version'], stdout=PIPE, universal_newlines=True).communicate()[0]
     pre, targets = llc_version_info.split('Registered Targets:')
     return targets
   except Exception as e:
@@ -420,7 +420,7 @@ def check_fastcomp():
 
       # check build versions. don't show it if the repos are wrong, user should fix that first
       if not shown_repo_version_error:
-        clang_v = Popen([CLANG, '--version'], stdout=PIPE).communicate()[0]
+        clang_v = Popen([CLANG, '--version'], stdout=PIPE, universal_newlines=True).communicate()[0]
         llvm_build_version, clang_build_version = clang_v.split('(emscripten ')[1].split(')')[0].split(' : ')
         if EMSCRIPTEN_VERSION != llvm_build_version or EMSCRIPTEN_VERSION != clang_build_version:
           logging.error('Emscripten, llvm and clang build versions do not match, this is dangerous (%s, %s, %s)', EMSCRIPTEN_VERSION, llvm_build_version, clang_build_version)
@@ -436,7 +436,7 @@ EXPECTED_NODE_VERSION = (0,8,0)
 def check_node_version():
   jsrun.check_engine(NODE_JS)
   try:
-    actual = Popen(NODE_JS + ['--version'], stdout=PIPE).communicate()[0].strip()
+    actual = Popen(NODE_JS + ['--version'], stdout=PIPE, universal_newlines=True).communicate()[0].strip()
     version = tuple(map(int, actual.replace('v', '').replace('-pre', '').split('.')))
     if version >= EXPECTED_NODE_VERSION:
       return True
@@ -1044,7 +1044,7 @@ except NameError:
 ENV_PREFIX = []
 if not WINDOWS:
   try:
-    assert 'Python' in Popen(['env', 'python', '-V'], stdout=PIPE, stderr=STDOUT).communicate()[0]
+    assert 'Python' in Popen(['env', 'python', '-V'], stdout=PIPE, stderr=STDOUT, universal_newlines=True).communicate()[0]
     ENV_PREFIX = ['env']
   except:
     pass
@@ -1247,7 +1247,7 @@ def extract_archive_contents(f):
     temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
     safe_ensure_dirs(temp_dir)
     os.chdir(temp_dir)
-    contents = [x for x in Popen([LLVM_AR, 't', f], stdout=PIPE).communicate()[0].split('\n') if len(x) > 0]
+    contents = [x for x in Popen([LLVM_AR, 't', f], stdout=PIPE, universal_newlines=True).communicate()[0].split('\n') if len(x) > 0]
     warn_if_duplicate_entries(contents, f)
     if len(contents) == 0:
       logging.debug('Archive %s appears to be empty (recommendation: link an .so instead of .a)' % f)
@@ -1263,7 +1263,7 @@ def extract_archive_contents(f):
       dirname = os.path.dirname(content)
       if dirname:
         safe_ensure_dirs(dirname)
-    proc = Popen([LLVM_AR, 'xo', f], stdout=PIPE, stderr=PIPE)
+    proc = Popen([LLVM_AR, 'xo', f], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     stdout, stderr = proc.communicate() # if absolute paths, files will appear there. otherwise, in this directory
     contents = list(map(os.path.abspath, contents))
     nonexisting_contents = [x for x in contents if not os.path.exists(x)]
@@ -1844,7 +1844,7 @@ class Building(object):
 
     if not just_calculate:
       logging.debug('emcc: llvm-linking: %s to %s', actual_files, target)
-      output = Popen([LLVM_LINK] + link_args + ['-o', target], stdout=PIPE).communicate()[0]
+      output = Popen([LLVM_LINK] + link_args + ['-o', target], stdout=PIPE, universal_newlines=True).communicate()[0]
       assert os.path.exists(target) and (output is None or 'Could not open input file' not in output), 'Linking error: ' + output
       return target
     else:
@@ -1876,7 +1876,7 @@ class Building(object):
 
     logging.debug('emcc: LLVM opts: ' + ' '.join(opts) + '  [num inputs: ' + str(len(inputs)) + ']')
     target = out or (filename + '.opt.bc')
-    proc = Popen([LLVM_OPT] + inputs + opts + ['-o', target], stdout=PIPE)
+    proc = Popen([LLVM_OPT] + inputs + opts + ['-o', target], stdout=PIPE, universal_newlines=True)
     output = proc.communicate()[0]
     if proc.returncode != 0 or not os.path.exists(target):
       logging.error('Failed to run llvm optimizations: ' + output)
@@ -1894,7 +1894,7 @@ class Building(object):
   def llvm_opts(filename): # deprecated version, only for test runner. TODO: remove
     if Building.LLVM_OPTS:
       shutil.move(filename + '.o', filename + '.o.pre')
-      output = Popen([LLVM_OPT, filename + '.o.pre'] + Building.LLVM_OPT_OPTS + ['-o', filename + '.o'], stdout=PIPE).communicate()[0]
+      output = Popen([LLVM_OPT, filename + '.o.pre'] + Building.LLVM_OPT_OPTS + ['-o', filename + '.o'], stdout=PIPE, universal_newlines=True).communicate()[0]
       assert os.path.exists(filename + '.o'), 'Failed to run llvm optimizations: ' + output
 
   @staticmethod
@@ -1905,7 +1905,7 @@ class Building(object):
       output_filename = input_filename + '.o.ll'
       input_filename = input_filename + '.o'
     try_delete(output_filename)
-    output = Popen([LLVM_DIS, input_filename, '-o', output_filename], stdout=PIPE).communicate()[0]
+    output = Popen([LLVM_DIS, input_filename, '-o', output_filename], stdout=PIPE, universal_newlines=True).communicate()[0]
     assert os.path.exists(output_filename), 'Could not create .ll file: ' + output
     return output_filename
 
@@ -1917,7 +1917,7 @@ class Building(object):
       output_filename = input_filename + '.o'
       input_filename = input_filename + '.o.ll'
     try_delete(output_filename)
-    output = Popen([LLVM_AS, input_filename, '-o', output_filename], stdout=PIPE).communicate()[0]
+    output = Popen([LLVM_AS, input_filename, '-o', output_filename], stdout=PIPE, universal_newlines=True).communicate()[0]
     assert os.path.exists(output_filename), 'Could not create bc file: ' + output
     return output_filename
 
@@ -1952,7 +1952,7 @@ class Building(object):
   @staticmethod
   def llvm_nm_uncached(filename, stdout=PIPE, stderr=PIPE, include_internal=False):
     # LLVM binary ==> list of symbols
-    proc = Popen([LLVM_NM, filename], stdout=stdout, stderr=stderr)
+    proc = Popen([LLVM_NM, filename], stdout=stdout, stderr=stderr, universal_newlines=True)
     stdout, stderr = proc.communicate()
     if proc.returncode == 0:
       return Building.parse_symbols(stdout, include_internal)
@@ -2191,7 +2191,7 @@ class Building(object):
       if os.environ.get('EMCC_CLOSURE_ARGS'):
         args += shlex.split(os.environ.get('EMCC_CLOSURE_ARGS'))
       logging.debug('closure compiler: ' + ' '.join(args))
-      process = Popen(args, stdout=PIPE, stderr=STDOUT)
+      process = Popen(args, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
       cc_output = process.communicate()[0]
       if process.returncode != 0 or not os.path.exists(filename + '.cc.js'):
         raise Exception('closure compiler error: ' + cc_output + ' (rc: %d)' % process.returncode)
@@ -2527,7 +2527,7 @@ class WebAssembly(object):
 def execute(cmd, *args, **kw):
   try:
     cmd[0] = Building.remove_quotes(cmd[0])
-    return Popen(cmd, *args, **kw).communicate() # let compiler frontend print directly, so colors are saved (PIPE kills that)
+    return Popen(cmd, universal_newlines=True, *args, **kw).communicate() # let compiler frontend print directly, so colors are saved (PIPE kills that)
   except:
     if not isinstance(cmd, str):
       cmd = ' '.join(cmd)
@@ -2586,7 +2586,7 @@ def safe_copy(src, dst):
 
 def clang_preprocess(filename):
   # TODO: REMOVE HACK AND PASS PREPROCESSOR FLAGS TO CLANG.
-  return subprocess.check_output([CLANG_CC, '-DFETCH_DEBUG=1', '-E', '-P', '-C', '-x', 'c', filename])
+  return subprocess.check_output([CLANG_CC, '-DFETCH_DEBUG=1', '-E', '-P', '-C', '-x', 'c', filename], universal_newlines=True)
 
 def read_and_preprocess(filename):
   f = open(filename, 'r').read()

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -25,7 +25,7 @@ def validate_asmjs_jsfile(filename, muteOutput):
     print('Could not find SpiderMonkey engine! Please set its location to SPIDERMONKEY_ENGINE in your ' + shared.hint_config_file_location() + ' configuration file!', file=sys.stderr)
     return False
   try:
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, universal_newlines=True)
   except Exception as e:
     print('Executing command ' + str(cmd) + ' failed due to an exception: ' + str(e) + '!', file=sys.stderr)
     return False


### PR DESCRIPTION
[`universal_newlines=True` enables text mode for `subprocess` functions](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module):

>If encoding or errors are specified, or universal_newlines is true, file objects for stdin, stdout and stderr are opened in text mode using the specified encoding and errors or the io.TextIOWrapper default. Otherwise, file objects are opened in binary mode.

This maximizes compatibility by returning native string type for both Python 2 and 3 whereas it currently always returns binary string.