### PR TITLE
Python 3 compatibility: ordered set/dicts

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -16,6 +16,7 @@ if __name__ == '__main__':
 import difflib
 import os, sys, json, argparse, subprocess, re, time, logging
 import shutil
+from collections import OrderedDict
 
 from tools import shared
 from tools import jsrun, cache as cache_module, tempfiles
@@ -144,7 +145,7 @@ def parse_backend_output(backend_output, DEBUG):
 
   try:
     #if DEBUG: print >> sys.stderr, "METAraw", metadata_raw
-    metadata = json.loads(metadata_raw)
+    metadata = json.loads(metadata_raw, object_pairs_hook=OrderedDict)
   except Exception as e:
     logging.error('emscript: failure to parse metadata output from compiler backend. raw output is: \n' + metadata_raw)
     raise e

--- a/emscripten.py
+++ b/emscripten.py
@@ -1229,7 +1229,7 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
     asm_runtime_funcs.append('setAsync')
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data, settings)
   if settings['EMULATED_FUNCTION_POINTERS']:
-    all_exported = set(all_exported).union(in_table)
+    all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):
     exports.append(quote(export) + ": " + export)

--- a/emscripten.py
+++ b/emscripten.py
@@ -299,7 +299,7 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
     global_vars = metadata['externs']
   else:
     global_vars = [] # linkable code accesses globals through function calls
-  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].items() if value != 2])
+  global_funcs = sorted(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].items() if value != 2])
                       .difference(set(global_vars)).difference(implemented_functions))
   if settings['RELOCATABLE']:
     global_funcs += ['g$' + extern for extern in metadata['externs']]
@@ -505,7 +505,7 @@ def update_settings_glue(settings, metadata):
     logging.warning('disabling asm.js validation due to use of non-supported features: ' + metadata['cantValidate'])
     settings['ASM_JS'] = 2
 
-  settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] = list(
+  settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] = sorted(
     set(settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE'] + list(map(shared.JS.to_nice_ident, metadata['declares']))).difference(
       [x[1:] for x in metadata['implementedFunctions']]
     )
@@ -635,7 +635,7 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
       funcs += ['setTempRet0', 'getTempRet0']
     if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
       funcs += ['setThrew']
-  return list(set(funcs))
+  return sorted(set(funcs))
 
 
 def get_implemented_functions(metadata):
@@ -1228,9 +1228,9 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
     asm_runtime_funcs.append('setAsync')
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data, settings)
   if settings['EMULATED_FUNCTION_POINTERS']:
-    all_exported = list(set(all_exported).union(in_table))
+    all_exported = set(all_exported).union(in_table)
   exports = []
-  for export in set(all_exported):
+  for export in sorted(set(all_exported)):
     exports.append(quote(export) + ": " + export)
   if settings['BINARYEN'] and settings['SIDE_MODULE']:
     # named globals in side wasm modules are exported globals from asm/wasm


### PR DESCRIPTION
Python 3 by default does not promise the same hash value for an object [because of security](https://www.python.org/dev/peps/pep-0456/). 

`set()` and `dict()` are sorted using hash value so it may cause nondeterministic order for each Python instance.

![image](https://user-images.githubusercontent.com/3396686/32767043-0d450e24-c955-11e7-8beb-920d2d1ab8fc.png)

This PR explicitly sorts `set()` and uses OrderedDict for json so that builds can be deterministic. (to not break `test_iostream_and_determinism`)