### PR TITLE
Python 3 compatibility: explicit integer division

### DIFF
--- a/tests/gen_large_switchcase.py
+++ b/tests/gen_large_switchcase.py
@@ -23,7 +23,7 @@ const char *foo(int x)
 
 int main()
 {
-	for(int i = 0; i < ''' + str((num_cases+99)/100) + '''; ++i)
+	for(int i = 0; i < ''' + str((num_cases+99)//100) + '''; ++i)
 		printf("%d: %s\\n", i*301, foo(i*301));
 	printf("Success!\\n");
 }'''

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -50,7 +50,7 @@ class Benchmarker(object):
     std = math.sqrt(mean_of_squared - mean*mean)
     sorted_times = self.times[:]
     sorted_times.sort()
-    median = sum(sorted_times[len(sorted_times)/2 - 1:len(sorted_times)/2 + 1])/2
+    median = sum(sorted_times[len(sorted_times)//2 - 1:len(sorted_times)//2 + 1])//2
 
     print('   %10s: mean: %4.3f (+-%4.3f) secs  median: %4.3f  range: %4.3f-%4.3f  (noise: %4.3f%%)  (%d runs)' % (self.name, mean, std, median, min(self.times), max(self.times), 100*std/mean, self.reps), end=' ')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4565,8 +4565,8 @@ def process(filename):
 
   def test_unistd_sysconf_phys_pages(self):
     src = open(path_from_root('tests', 'unistd', 'sysconf_phys_pages.c'), 'r').read()
-    if Settings.ALLOW_MEMORY_GROWTH: expected = (2*1024*1024*1024-16777216) / 16384
-    else: expected = 16*1024*1024 / 16384
+    if Settings.ALLOW_MEMORY_GROWTH: expected = (2*1024*1024*1024-16777216) // 16384
+    else: expected = 16*1024*1024 // 16384
     self.do_run(src, str(expected) + ', errno: 0')
 
   def test_unistd_login(self):

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -840,7 +840,7 @@ if __name__ == '__main__':
     global global_func_id
     absolute_start = len(all_code) # true absolute starting point of this function (except for eb)
     #print 'processing code', func, absolute_start
-    for i in range(len(code)/4):
+    for i in range(len(code)//4):
       j = i*4
       if code[j] == 'EXTCALL':
         # fix CALL instructions' targets and signatures
@@ -897,7 +897,7 @@ if __name__ == '__main__':
         raise e
       assert len(curr) % 4 == 0, len(curr)
       funcs[func] = len(all_code) # no operation here should change the length
-      if LOG_CODE: print('raw bytecode for %s:' % func, curr, 'insts:', len(curr)/4, file=sys.stderr)
+      if LOG_CODE: print('raw bytecode for %s:' % func, curr, 'insts:', len(curr)//4, file=sys.stderr)
       process_code(func, curr, absolute_targets)
       #print >> sys.stderr, 'processed bytecode for %s:' % func, curr
       all_code += curr
@@ -917,7 +917,7 @@ if __name__ == '__main__':
   assert global_var_id < 256, [global_vars, global_var_id]
 
   def post_process_code(code):
-    for i in range(len(code)/4):
+    for i in range(len(code)//4):
       j = i*4
       if code[j] == 'absolute-funcaddr':
         # put the 32-bit absolute value of an abolute function here
@@ -931,7 +931,7 @@ if __name__ == '__main__':
         relocations.append(j)
 
     # finalize instruction string names to opcodes
-    for i in range(len(code)/4):
+    for i in range(len(code)//4):
       j = i*4
       if type(code[j]) in (str, unicode):
         opcode_used[code[j]] = True


### PR DESCRIPTION
Python 3 [redefined `/` operator to return float](https://docs.python.org/3/tutorial/introduction.html#numbers). This PR uses the integer division operator `//` instead of `/`.