### PR TITLE
Python 3 compatibility: Remove unicode/basestring

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2226,7 +2226,7 @@ WARNING: You should normally never use this! Use emcc instead.
   if len(positional) != 1:
     raise RuntimeError('Must provide exactly one positional argument. Got ' + str(len(positional)) + ': "' + '", "'.join(positional) + '"')
   keywords.infile = os.path.abspath(positional[0])
-  if isinstance(keywords.outfile, basestring):
+  if isinstance(keywords.outfile, (type(u''), bytes)):
     keywords.outfile = open(keywords.outfile, 'w')
 
   if keywords.temp_dir is None:

--- a/tests/gen_large_switchcase.py
+++ b/tests/gen_large_switchcase.py
@@ -8,7 +8,7 @@ for x in range(0, num_cases):
 	i += incr
 	incr = (incr % 5) + 1
 
-print '''#include <stdio.h>
+print('''#include <stdio.h>
 #include <stdlib.h>
 #include <emscripten.h>
 
@@ -26,4 +26,4 @@ int main()
 	for(int i = 0; i < ''' + str((num_cases+99)/100) + '''; ++i)
 		printf("%d: %s\\n", i*301, foo(i*301));
 	printf("Success!\\n");
-}'''
+}''')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5660,14 +5660,14 @@ Descriptor desc;
 
     open('test.py', 'w').write('''
 import os
-print os.environ.get('CROSS_COMPILE')
+print(os.environ.get('CROSS_COMPILE'))
 ''')
     check('emconfigure', [PYTHON, 'test.py'], expect=path_from_root('em'))
     check('emmake', [PYTHON, 'test.py'], expect=path_from_root('em'))
 
     open('test.py', 'w').write('''
 import os
-print os.environ.get('NM')
+print(os.environ.get('NM'))
 ''')
     check('emconfigure', [PYTHON, 'test.py'], expect=tools.shared.LLVM_NM)
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -874,7 +874,7 @@ if __name__ == '__main__':
         code[j+1] = global_vars[target]
       elif code[j] == 'absolute-value':
         # put the 32-bit absolute value of an abolute target here (correct except for adding eb to relocate at runtime)
-        absolute_value = absolute_start + absolute_targets[unicode(code[j+1])]
+        absolute_value = absolute_start + absolute_targets[str(code[j+1])]
         #print '  fixing absolute value', code[j+1], absolute_targets[unicode(code[j+1])], absolute_value
         assert absolute_value < (1 << 31)
         assert absolute_value % 4 == 0
@@ -933,7 +933,7 @@ if __name__ == '__main__':
     # finalize instruction string names to opcodes
     for i in range(len(code)/4):
       j = i*4
-      if type(code[j]) in (str, unicode):
+      if type(code[j]) in (type(u''), bytes):
         opcode_used[code[j]] = True
         code[j] = ROPCODES[code[j]]
 

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -414,7 +414,7 @@ def b2g_screenshot(filename):
   global deviceActorName
   data_reply = send_b2g_cmd(deviceActorName, 'screenshotToDataURL')
   data = data_reply['value']
-  if not isinstance(data, basestring): # The device is sending the screenshot in multiple fragments since it's too long to fit in one message?
+  if not isinstance(data, (type(u''), bytes)): # The device is sending the screenshot in multiple fragments since it's too long to fit in one message?
     data_get_actor = data['actor']
     data_len = int(data['length'])
     data = data['initial']


### PR DESCRIPTION
...as they are not available on Python 3.