### PR TITLE
Fix some open() modes

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2371,10 +2371,10 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
       if DEBUG: save_intermediate('postclean', 'js')
   # replace placeholder strings with correct subresource locations
   if shared.Settings.SINGLE_FILE:
-    f = open(final, 'rb')
+    f = open(final, 'r')
     js = f.read()
     f.close()
-    f = open(final, 'wb')
+    f = open(final, 'w')
     for target, replacement_string, should_embed in [
       (wasm_text_target, shared.FilenameReplacementStrings.WASM_TEXT_FILE, True),
       (wasm_binary_target, shared.FilenameReplacementStrings.WASM_BINARY_FILE, True),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6121,7 +6121,7 @@ def process(filename):
 
     js_funcs.append('_main')
     exported_func_json_file = os.path.join(self.get_dir(), 'large_exported_response.json')
-    open(exported_func_json_file, 'wb').write(json.dumps(js_funcs))
+    open(exported_func_json_file, 'w').write(json.dumps(js_funcs))
 
     self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=@' + exported_func_json_file]
     self.do_run(src, '''waka 4999!''')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3062,7 +3062,7 @@ var Module = { print: function(x) { throw '<{(' + x + ')}>' } };
       assert os.path.exists('header.h.gch') # default output is gch
       if suffix != 'gch':
         Popen([PYTHON, EMCC, '-xc++-header', 'header.h', '-o', 'header.h.' + suffix]).communicate()
-        assert open('header.h.gch').read() == open('header.h.' + suffix).read()
+        assert open('header.h.gch', 'rb').read() == open('header.h.' + suffix, 'rb').read()
 
       open('src.cpp', 'w').write(r'''
 #include <stdio.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2568,7 +2568,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
                          run_js ('index.js', engine=NODE_JS, stderr=STDOUT, assert_returncode=None))
 
   def test_fs_stream_proto(self):
-    open('src.cpp', 'wb').write(r'''
+    open('src.cpp', 'w').write(r'''
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
Use text mode when manipulating text files and use binary mode when opening binary files. This matters on Python 3 as the return type depends on the mode.