### PR TITLE
Python 3 compatibility: Use proper string types

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -45,7 +45,7 @@ def run():
             full_name = os.path.abspath(orig_name)
             dir_name = os.path.dirname(full_name)
             base_name = os.path.basename(full_name)
-            h = hashlib.md5(full_name).hexdigest()[:8]
+            h = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
             parts = base_name.split('.')
             parts[0] += '_' + h
             newname = '.'.join(parts)

--- a/emcc.py
+++ b/emcc.py
@@ -164,7 +164,7 @@ class EmccOptions(object):
     self.cfi = False
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on Linux&OSX)
-    self.output_eol = os.linesep.encode()
+    self.output_eol = os.linesep
 
 
 class JSOptimizer(object):
@@ -1847,7 +1847,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.try_delete(memfile)
 
       for f in generated_text_files_with_native_eols:
-        tools.line_endings.convert_line_endings_in_file(f, os.linesep.encode(), options.output_eol)
+        tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
     log_time('final emitting')
     # exit block 'final emitting'
 
@@ -2112,9 +2112,9 @@ def parse_args(newargs):
       options.cfi = True
     elif newargs[i] == "--output_eol":
       if newargs[i+1].lower() == 'windows':
-        options.output_eol = b'\r\n'
+        options.output_eol = '\r\n'
       elif newargs[i+1].lower() == 'linux':
-        options.output_eol = b'\n'
+        options.output_eol = '\n'
       else:
         logging.error('Invalid value "' + newargs[i+1] + '" to --output_eol!')
         exit(1)
@@ -2595,9 +2595,9 @@ def generate_html(target, options, js_target, target_basename,
     script.inline = js_contents
 
   html = open(target, 'wb')
-  html_contents = shell.replace('{{{ SCRIPT }}}', script.replacement()).encode('utf-8')
-  html_contents = tools.line_endings.convert_line_endings(html_contents, b'\n', options.output_eol)
-  html.write(html_contents)
+  html_contents = shell.replace('{{{ SCRIPT }}}', script.replacement())
+  html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', options.output_eol)
+  html.write(html_contents.encode('utf-8'))
   html.close()
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -164,7 +164,7 @@ class EmccOptions(object):
     self.cfi = False
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on Linux&OSX)
-    self.output_eol = os.linesep
+    self.output_eol = os.linesep.encode()
 
 
 class JSOptimizer(object):
@@ -1847,7 +1847,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.try_delete(memfile)
 
       for f in generated_text_files_with_native_eols:
-        tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
+        tools.line_endings.convert_line_endings_in_file(f, os.linesep.encode(), options.output_eol)
     log_time('final emitting')
     # exit block 'final emitting'
 
@@ -2112,9 +2112,9 @@ def parse_args(newargs):
       options.cfi = True
     elif newargs[i] == "--output_eol":
       if newargs[i+1].lower() == 'windows':
-        options.output_eol = '\r\n'
+        options.output_eol = b'\r\n'
       elif newargs[i+1].lower() == 'linux':
-        options.output_eol = '\n'
+        options.output_eol = b'\n'
       else:
         logging.error('Invalid value "' + newargs[i+1] + '" to --output_eol!')
         exit(1)
@@ -2595,8 +2595,8 @@ def generate_html(target, options, js_target, target_basename,
     script.inline = js_contents
 
   html = open(target, 'wb')
-  html_contents = shell.replace('{{{ SCRIPT }}}', script.replacement())
-  html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', options.output_eol)
+  html_contents = shell.replace('{{{ SCRIPT }}}', script.replacement()).encode('utf-8')
+  html_contents = tools.line_endings.convert_line_endings(html_contents, b'\n', options.output_eol)
   html.write(html_contents)
   html.close()
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -549,7 +549,7 @@ class RunnerCore(unittest.TestCase):
     build_dir = self.get_build_dir()
     output_dir = self.get_dir()
 
-    cache_name = name + ','.join([opt for opt in Building.COMPILER_TEST_OPTS if len(opt) < 10]) + '_' + hashlib.md5(str(Building.COMPILER_TEST_OPTS)).hexdigest() + cache_name_extra
+    cache_name = name + ','.join([opt for opt in Building.COMPILER_TEST_OPTS if len(opt) < 10]) + '_' + hashlib.md5(str(Building.COMPILER_TEST_OPTS).encode('utf-8')).hexdigest() + cache_name_extra
 
     valid_chars = "_%s%s" % (string.ascii_letters, string.digits)
     cache_name = ''.join([(c if c in valid_chars else '_') for c in cache_name])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4196,7 +4196,7 @@ def process(filename):
         printf("*%d\n", c);
       }
     '''
-    open('file_with_byte_234.txt', 'wb').write('\xea')
+    open('file_with_byte_234.txt', 'wb').write(b'\xea')
     self.emcc_args += ['--embed-file', 'file_with_byte_234.txt']
     self.do_run(src, '*234\n')
 
@@ -4219,7 +4219,7 @@ def process(filename):
         return 0;
       }
     '''
-    open('eol.txt', 'wb').write('\n')
+    open('eol.txt', 'wb').write(b'\n')
     self.emcc_args += ['--embed-file', 'eol.txt']
     self.do_run(src, 'SUCCESS\n')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2152,7 +2152,7 @@ The current type of b is: 9
 
       def check(result, err):
         result = result.replace('\n \n', '\n') # remove extra node output
-        return hashlib.sha1(result).hexdigest()
+        return hashlib.sha1(result.encode('utf-8')).hexdigest()
 
       self.do_run_from_file(src, output, output_nicerizer = check)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7391,7 +7391,7 @@ int main() {
       try_delete('a.out.js')
       subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'BINARYEN=1'])
       code = open('a.out.wasm', 'rb').read()
-      assert ('__fflush_unlocked' in code) == expect_names, 'an internal function not exported nor imported must only appear in the binary if we have a names section'
+      assert (b'__fflush_unlocked' in code) == expect_names, 'an internal function not exported nor imported must only appear in the binary if we have a names section'
       sizes[str(args)] = os.stat('a.out.wasm').st_size
     print(sizes)
     assert sizes["['-O2']"] < sizes["['-O2', '--profiling-funcs']"], 'when -profiling-funcs, the size increases due to function names'
@@ -7639,9 +7639,9 @@ int main() {
     for args, expected in [
         ([], 1024),
         (['-s', 'TOTAL_MEMORY=32MB'], 2048),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1'], (2*1024*1024*1024 - 16777216) / 16384),
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1'], (2*1024*1024*1024 - 16777216) // 16384),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], 2048),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], (2*1024*1024*1024 - 65536) / 16384),
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], (2*1024*1024*1024 - 65536) // 16384),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"', '-s', 'BINARYEN_MEM_MAX=128MB'], 2048*4)
       ]:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')] + args
@@ -7664,7 +7664,7 @@ int main() {
       print(target)
       self.clear()
       subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-s', 'SIDE_MODULE=1'] + opts)
-      assert 'dylink' in open(target).read()
+      assert b'dylink' in open(target, 'rb').read()
       for x in os.listdir('.'):
         assert not x.endswith('.js'), 'we should not emit js when making a wasm side module'
 

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -10,7 +10,7 @@ def convert_line_endings_in_file(filename, from_eol, to_eol):
   if from_eol == to_eol: return # No conversion needed
 
   text = open(filename, 'rb').read()
-  text = convert_line_endings(text, from_eol, to_eol)
+  text = convert_line_endings(text, from_eol.encode(), to_eol.encode())
   open(filename, 'wb').write(text)
 
 # This function checks and prints out the detected line endings in the given file.


### PR DESCRIPTION
This PR adds explicit `b` prefix or `.encode()` where the required type is `bytes` rather than native string type.