### PR TITLE
Python 3 compatibility: Pass bytearray rather than string

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1665,7 +1665,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if shared.Settings.MEM_INIT_METHOD == 2:
             # memory initializer in a string literal
             return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
-          open(memfile, 'wb').write(bytes(bytearray(membytes)))
+          open(memfile, 'wb').write(bytearray(membytes))
           if DEBUG:
             # Copy into temp dir as well, so can be run there too
             shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1284,11 +1284,11 @@ keydown(100);keyup(100); // trigger the end
     import random
     self.clear()
     os.mkdir('subdir')
-    open('file1.txt', 'wb').write('0123456789' * (1024*128))
-    open(os.path.join('subdir', 'file2.txt'), 'wb').write('1234567890' * (1024*128))
-    random_data = [chr(random.randint(0,255)) for x in range(1024*128*10 + 1)]
-    random_data[17] = 'X'
-    open('file3.txt', 'wb').write(''.join(random_data))
+    open('file1.txt', 'w').write('0123456789' * (1024*128))
+    open(os.path.join('subdir', 'file2.txt'), 'w').write('1234567890' * (1024*128))
+    random_data = bytearray([random.randint(0,255) for x in range(1024*128*10 + 1)])
+    random_data[17] = ord('X')
+    open('file3.txt', 'wb').write(random_data)
 
     # compress in emcc,  -s LZ4=1  tells it to tell the file packager
     print('emcc-normal')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1286,7 +1286,7 @@ keydown(100);keyup(100); // trigger the end
     os.mkdir('subdir')
     open('file1.txt', 'w').write('0123456789' * (1024*128))
     open(os.path.join('subdir', 'file2.txt'), 'w').write('1234567890' * (1024*128))
-    random_data = bytearray([random.randint(0,255) for x in range(1024*128*10 + 1)])
+    random_data = bytearray(random.randint(0,255) for x in range(1024*128*10 + 1))
     random_data[17] = ord('X')
     open('file3.txt', 'wb').write(random_data)
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -984,13 +984,13 @@ __ATPRERUN__.push(function() {
     n = len(all_code)
     while n % 4 != 0:
       n += 1
-    bytecode_file.write(''.join(map(chr, all_code)))
+    bytecode_file.write(bytearray(all_code))
     for i in range(len(all_code), n):
-      bytecode_file.write(chr(0))
+      bytecode_file.write(bytearray([0]))
     for i in range(len(relocations)):
       bytes = bytify(relocations[i])
       for j in range(4):
-        bytecode_file.write(chr(bytes[j]))
+        bytecode_file.write(bytearray([bytes[j]]))
     bytecode_file.close()
 
     js += ['''

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2492,10 +2492,10 @@ class WebAssembly(object):
       more = x != 0
       if more:
         byte = byte | 128
-      ret.append(chr(byte))
+      ret.append(byte)
       if not more:
         break
-    return ret
+    return bytearray(ret)
 
   @staticmethod
   def make_shared_library(js_file, wasm_file):
@@ -2512,14 +2512,14 @@ class WebAssembly(object):
     f = open(wso, 'wb')
     f.write(wasm[0:8]) # copy magic number and version
     # write the special section
-    f.write('\0') # user section is code 0
+    f.write(b'\0') # user section is code 0
     # need to find the size of this section
-    name = "\06dylink" # section name, including prefixed size
+    name = b"\06dylink" # section name, including prefixed size
     contents = WebAssembly.lebify(mem_size) + WebAssembly.lebify(table_size)
     size = len(name) + len(contents)
-    f.write(''.join(WebAssembly.lebify(size)))
+    f.write(WebAssembly.lebify(size))
     f.write(name)
-    f.write(''.join(contents))
+    f.write(contents)
     f.write(wasm[8:]) # copy rest of binary
     f.close()
     return wso


### PR DESCRIPTION
I found some more Python 3 compat errors on recently enabled binaryen-related tests, so this fixes them by again using bytearray.

(I found there is no need to cast from bytearray to bytes when writing)