### PR TITLE
Rename BINARYEN_MEM_MAX to WASM_MEM_MAX

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -690,8 +690,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Handle aliases in settings flags
       settings_aliases = {
-          'BINARYEN_MEM_MAX': 'WASM_MEM_MAX',
           'BINARYEN': 'WASM' # TODO: change all references to BINARYEN in emcc to WASM
+          'BINARYEN_MEM_MAX': 'WASM_MEM_MAX',
           # TODO: change most (all?) other BINARYEN* names to WASM*
       }
       def setting_sub(s):

--- a/emcc.py
+++ b/emcc.py
@@ -688,6 +688,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             assert key != 'WASM_BACKEND', 'do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment'
       newargs = [arg for arg in newargs if arg is not '']
 
+      # Handle aliases in settings flags
+      settings_aliases = {
+          'BINARYEN_MEM_MAX': 'WASM_MEM_MAX',
+          'BINARYEN': 'WASM' # TODO: change all references to BINARYEN in emcc to WASM
+          # TODO: change most (all?) other BINARYEN* names to WASM*
+      }
+      def setting_sub(s):
+        key, rest = s.split('=', 1)
+        return '='.join([settings_aliases.get(key, key), rest])
+      settings_changes = map(setting_sub, settings_changes)
+
       # Find input files
 
       # These three arrays are used to store arguments of different types for
@@ -874,7 +885,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         key, value = change.split('=', 1)
 
         # In those settings fields that represent amount of memory, translate suffixes to multiples of 1024.
-        if key in ['TOTAL_STACK', 'TOTAL_MEMORY', 'GL_MAX_TEMP_BUFFER_SIZE', 'SPLIT_MEMORY', 'BINARYEN_MEM_MAX']:
+        if key in ['TOTAL_STACK', 'TOTAL_MEMORY', 'GL_MAX_TEMP_BUFFER_SIZE', 'SPLIT_MEMORY', 'WASM_MEM_MAX']:
           value = str(shared.expand_byte_size_suffixes(value))
 
         original_exported_response = False
@@ -1110,7 +1121,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       else:
         assert shared.Settings.TOTAL_MEMORY % (16*1024*1024) == 0, 'For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY)
       assert shared.Settings.TOTAL_MEMORY >= shared.Settings.TOTAL_STACK, 'TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')'
-      assert shared.Settings.BINARYEN_MEM_MAX == -1 or shared.Settings.BINARYEN_MEM_MAX % 65536 == 0, 'BINARYEN_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.BINARYEN_MEM_MAX)
+      assert shared.Settings.WASM_MEM_MAX == -1 or shared.Settings.WASM_MEM_MAX % 65536 == 0, 'WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX)
 
       if shared.Settings.WASM_BACKEND:
         options.js_opts = None
@@ -2273,8 +2284,8 @@ def do_binaryen(final, target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['--table-max=-1']
     if shared.Settings.SIDE_MODULE:
       cmd += ['--mem-max=-1']
-    elif shared.Settings.BINARYEN_MEM_MAX >= 0:
-      cmd += ['--mem-max=' + str(shared.Settings.BINARYEN_MEM_MAX)]
+    elif shared.Settings.WASM_MEM_MAX >= 0:
+      cmd += ['--mem-max=' + str(shared.Settings.WASM_MEM_MAX)]
     if shared.Settings.LEGALIZE_JS_FFI != 1:
       cmd += ['--no-legalize-javascript-ffi']
     if shared.Building.is_wasm_only():

--- a/emcc.py
+++ b/emcc.py
@@ -690,7 +690,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Handle aliases in settings flags
       settings_aliases = {
-          'BINARYEN': 'WASM' # TODO: change all references to BINARYEN in emcc to WASM
           'BINARYEN_MEM_MAX': 'WASM_MEM_MAX',
           # TODO: change most (all?) other BINARYEN* names to WASM*
       }

--- a/src/library.js
+++ b/src/library.js
@@ -289,8 +289,8 @@ LibraryManager.library = {
 #else
         var maxHeapSize = 2*1024*1024*1024 - 16777216;
 #endif
-#if BINARYEN_MEM_MAX != -1
-        maxHeapSize = {{{ BINARYEN_MEM_MAX }}};
+#if WASM_MEM_MAX != -1
+        maxHeapSize = {{{ WASM_MEM_MAX }}};
 #endif
 #if !ALLOW_MEMORY_GROWTH
         maxHeapSize = HEAPU8.length;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1259,11 +1259,11 @@ if (Module['buffer']) {
     assert(TOTAL_MEMORY % WASM_PAGE_SIZE === 0);
 #endif
 #if ALLOW_MEMORY_GROWTH
-#if BINARYEN_MEM_MAX
+#if WASM_MEM_MAX
 #if ASSERTIONS
-    assert({{{ BINARYEN_MEM_MAX }}} % WASM_PAGE_SIZE == 0);
+    assert({{{ WASM_MEM_MAX }}} % WASM_PAGE_SIZE == 0);
 #endif
-    Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': {{{ BINARYEN_MEM_MAX }}} / WASM_PAGE_SIZE });
+    Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE });
 #else
     Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE });
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -718,7 +718,7 @@ var BINARYEN_TRAP_MODE = "allow"; // How we handle wasm operations that may trap
 var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the binaryen optimizer,
                           // for example, "dce,precompute,vacuum".
                           // When set, this overrides the default passes we would normally run.
-var BINARYEN_MEM_MAX = -1; // Set the maximum size of memory in the wasm module (in bytes).
+var WASM_MEM_MAX = -1; // Set the maximum size of memory in the wasm module (in bytes).
                            // Without this, TOTAL_MEMORY is used (as it is used for the initial value),
                            // or if memory growth is enabled, no limit is set. This overrides both of those.
 var BINARYEN_ASYNC_COMPILATION = 1; // Whether to compile the wasm asynchronously, which is more

--- a/src/settings.js
+++ b/src/settings.js
@@ -719,8 +719,9 @@ var BINARYEN_PASSES = ""; // A comma-separated list of passes to run in the bina
                           // for example, "dce,precompute,vacuum".
                           // When set, this overrides the default passes we would normally run.
 var WASM_MEM_MAX = -1; // Set the maximum size of memory in the wasm module (in bytes).
-                           // Without this, TOTAL_MEMORY is used (as it is used for the initial value),
-                           // or if memory growth is enabled, no limit is set. This overrides both of those.
+                       // Without this, TOTAL_MEMORY is used (as it is used for the initial value),
+                       // or if memory growth is enabled, no limit is set. This overrides both of those.
+                       // (This option was formerly called BINARYEN_MEM_MAX)
 var BINARYEN_ASYNC_COMPILATION = 1; // Whether to compile the wasm asynchronously, which is more
                                     // efficient and does not block the main thread. This is currently
                                     // required for all but the smallest modules to run in V8

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7464,8 +7464,8 @@ int main() {
     for args, expect_initial, expect_max in [
         (['-s', 'TOTAL_MEMORY=20971520'], 320, 320),
         (['-s', 'TOTAL_MEMORY=20971520', '-s', 'ALLOW_MEMORY_GROWTH=1'], 320, None),
-        (['-s', 'TOTAL_MEMORY=20971520',                                '-s', 'BINARYEN_MEM_MAX=41943040'], 320, 640),
-        (['-s', 'TOTAL_MEMORY=20971520', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN_MEM_MAX=41943040'], 320, 640),
+        (['-s', 'TOTAL_MEMORY=20971520',                                '-s', 'WASM_MEM_MAX=41943040'], 320, 640),
+        (['-s', 'TOTAL_MEMORY=20971520', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM_MEM_MAX=41943040'], 320, 640),
       ]:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2', '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
       print(' '.join(cmd))
@@ -7493,11 +7493,11 @@ int main() {
       ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=33MB'], stderr=subprocess.PIPE).communicate()[1]
       assert 'TOTAL_MEMORY must be a multiple of 16MB' in ret, ret
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB'], stderr=subprocess.PIPE).communicate()[1]
-      assert 'BINARYEN_MEM_MAX must be a multiple of 64KB' not in ret, ret
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=33MB'], stderr=subprocess.PIPE).communicate()[1]
+      assert 'WASM_MEM_MAX must be a multiple of 64KB' not in ret, ret
 
-      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_MEM_MAX=33MB+1'], stderr=subprocess.PIPE).communicate()[1]
-      assert 'BINARYEN_MEM_MAX must be a multiple of 64KB' in ret, ret
+      ret = subprocess.Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=33MB+1'], stderr=subprocess.PIPE).communicate()[1]
+      assert 'WASM_MEM_MAX must be a multiple of 64KB' in ret, ret
 
   def test_binaryen_ctors(self):
     if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey')
@@ -7642,7 +7642,7 @@ int main() {
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1'], (2*1024*1024*1024 - 16777216) / 16384),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], 2048),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], (2*1024*1024*1024 - 65536) / 16384),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"', '-s', 'BINARYEN_MEM_MAX=128MB'], 2048*4)
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"', '-s', 'WASM_MEM_MAX=128MB'], 2048*4)
       ]:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')] + args
       print(str(cmd))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7845,3 +7845,17 @@ end
     result = subprocess.check_output([PYTHON, EMAR, 't', 'combined.a'])
     assert 'file1' in result
     assert 'file2' in result
+
+
+  def test_flag_aliases(self):
+    def assert_aliases_match(flag1, flag2, flagarg, extra_args):
+      results = {}
+      for f in (flag1, flag2):
+        outfile = 'aliases.js'
+        subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', f + '=' + flagarg, '-o', outfile] + extra_args)
+        with open(outfile) as out:
+          results[f] = out.read()
+      self.assertEqual(results[flag1], results[flag2], 'results should be identical')
+
+
+    assert_aliases_match('WASM_MEM_MAX', 'BINARYEN_MEM_MAX', '16777216', ['-s', 'WASM=1'])


### PR DESCRIPTION
The name 'binaryen' is mostly an implementation detail of emscripten,
and the user-facing feature is actually wasm output.

Also introduces a settings-alias mechanism that we can use to canonicalize
flag names for backward compatibility.