### PR TITLE
Fix musl build with upstream wasm backend

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -74,7 +74,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     # TODO: When updating musl the next time, feel free to recheck which of their warnings might have been fixed, and which ones of these could be cleaned up.
     c_opts = ['-Wno-return-type', '-Wno-parentheses', '-Wno-ignored-attributes', '-Wno-shift-count-overflow', '-Wno-shift-negative-value', '-Wno-dangling-else', '-Wno-unknown-pragmas', '-Wno-shift-op-parentheses', '-Wno-string-plus-int', '-Wno-logical-op-parentheses', '-Wno-bitwise-op-parentheses', '-Wno-visibility', '-Wno-pointer-sign']
     if shared.Settings.WASM_BACKEND:
-      c_opts.append('-Wno-error=absolute-value')
+      c_opts += ['-Wno-absolute-value', '-Wno-empty-body']
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
       commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes() + default_opts + c_opts + lib_opts)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -72,9 +72,13 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     commands = []
     # Hide several musl warnings that produce a lot of spam to unit test build server logs.
     # TODO: When updating musl the next time, feel free to recheck which of their warnings might have been fixed, and which ones of these could be cleaned up.
-    c_opts = ['-Wno-return-type', '-Wno-parentheses', '-Wno-ignored-attributes', '-Wno-shift-count-overflow', '-Wno-shift-negative-value', '-Wno-dangling-else', '-Wno-unknown-pragmas', '-Wno-shift-op-parentheses', '-Wno-string-plus-int', '-Wno-logical-op-parentheses', '-Wno-bitwise-op-parentheses', '-Wno-visibility', '-Wno-pointer-sign']
-    if shared.Settings.WASM_BACKEND:
-      c_opts += ['-Wno-absolute-value', '-Wno-empty-body']
+    c_opts = ['-Wno-return-type', '-Wno-parentheses', '-Wno-ignored-attributes',
+              '-Wno-shift-count-overflow', '-Wno-shift-negative-value',
+              '-Wno-dangling-else', '-Wno-unknown-pragmas',
+              '-Wno-shift-op-parentheses', '-Wno-string-plus-int',
+              '-Wno-logical-op-parentheses', '-Wno-bitwise-op-parentheses',
+              '-Wno-visibility',
+              '-Wno-pointer-sign', '-Wno-absolute-value', '-Wno-empty-body' ]
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
       commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes() + default_opts + c_opts + lib_opts)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -77,8 +77,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
               '-Wno-dangling-else', '-Wno-unknown-pragmas',
               '-Wno-shift-op-parentheses', '-Wno-string-plus-int',
               '-Wno-logical-op-parentheses', '-Wno-bitwise-op-parentheses',
-              '-Wno-visibility',
-              '-Wno-pointer-sign', '-Wno-absolute-value', '-Wno-empty-body' ]
+              '-Wno-visibility', '-Wno-pointer-sign', '-Wno-absolute-value',
+              '-Wno-empty-body']
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
       commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes() + default_opts + c_opts + lib_opts)


### PR DESCRIPTION
Recently changes to llvm mean that -Wno-empty-body is required
to avoid build errors in musl