### PR TITLE
Eval elimination #5

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -165,7 +165,7 @@ var cwrap, ccall;
   var toC = {'string' : JSfuncs['stringToC'], 'array' : JSfuncs['arrayToC']};
 
   // C calling interface.
-  ccall = function ccallFunc(ident, returnType, argTypes, args, opts) {
+  ccall = function (ident, returnType, argTypes, args, opts) {
     var func = getCFunc(ident);
     var cArgs = [];
     var stack = 0;


### PR DESCRIPTION
Simplify `cwrap()` implementation: borrowed one optimization from `NO_DYNAMIC_EXECUTION == 0`, the rest doesn't make things faster.

This addresses `3.` from #5753 and eliminates one more potential `eval()` from build result.

In my testing the only performance win under Chromium Nighty is `if (numericRet && numericArgs)`, which can indeed be applied to so-called "slow" branch, making it as fast as "fast" branch for numbers and faster otherwise.

If someone can show code where this regresses in modern browsers - let me now. I was testing with and without `-s WASM=1` and for me it is even faster now.