### PR TITLE
Eval elimination #3

### DIFF
--- a/src/hello_world.js
+++ b/src/hello_world.js
@@ -27,10 +27,6 @@ if (ENVIRONMENT_IS_NODE) {
     return ret;
   };
 
-  load = function(f) {
-    globalEval(read(f));
-  };
-
   arguments_ = process['argv'].slice(2);
 
 } else if (ENVIRONMENT_IS_SHELL) {
@@ -63,20 +59,8 @@ if (ENVIRONMENT_IS_NODE) {
 } else if (ENVIRONMENT_IS_WORKER) {
   // We can do very little here...
 
-  this['load'] = importScripts;
-
 } else {
   throw 'Unknown runtime environment. Where are we?';
-}
-
-function globalEval(x) {
-  eval.call(null, x);
-}
-
-if (typeof load == 'undefined' && typeof read != 'undefined') {
-  this['load'] = function(f) {
-    globalEval(read(f));
-  };
 }
 
 if (typeof printErr === 'undefined') {

--- a/src/shell.js
+++ b/src/shell.js
@@ -106,10 +106,6 @@ if (ENVIRONMENT_IS_NODE) {
     return ret;
   };
 
-  Module['load'] = function load(f) {
-    globalEval(read(f));
-  };
-
   if (!Module['thisProgram']) {
     if (process['argv'].length > 1) {
       Module['thisProgram'] = process['argv'][1].replace(/\\/g, '/');
@@ -270,10 +266,6 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
     }));
   }
 
-  if (ENVIRONMENT_IS_WORKER) {
-    Module['load'] = importScripts;
-  }
-
   if (typeof Module['setWindowTitle'] === 'undefined') {
     Module['setWindowTitle'] = function(title) { document.title = title };
   }
@@ -283,14 +275,6 @@ else {
   throw new Error('Unknown runtime environment. Where are we?');
 }
 
-function globalEval(x) {
-  {{{ makeEval('eval.call(null, x);') }}}
-}
-if (!Module['load'] && Module['read']) {
-  Module['load'] = function load(f) {
-    globalEval(Module['read'](f));
-  };
-}
 if (!Module['print']) {
   Module['print'] = function(){};
 }


### PR DESCRIPTION
Removed some `eval()` usages by removing `Module['load']`, which seems to not being used anymore.

This addresses `1.` from #5753 and eliminates one more potential `eval()` from build result.