### PR TITLE
Eval elimination #4

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -125,10 +125,7 @@ var globalScope = this;
 // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
 function getCFunc(ident) {
   var func = Module['_' + ident]; // closure exported function
-  if (!func) {
-    {{{ makeEval("try { func = eval('_' + ident); } catch(e) {}") }}}
-  }
-  assert(func, 'Cannot call unknown function ' + ident + ' (perhaps LLVM optimizations or closure removed it?)');
+  assert(func, 'Cannot call unknown function ' + ident + ', make sure it is exported');
   return func;
 }
 


### PR DESCRIPTION
`getCFunc()` removed since we can't expect functions names to be preserved after Closure Compiler or something like UglifyJS applied on top of the build, thus in practice we always need to have functions exported on `Module`.

This addresses `2.` from #5753 and eliminates one more potential `eval()` from build result.