### PR TITLE
Remove legacy support for polyfilling Math.clz32, imul, trunc

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1678,6 +1678,7 @@ function writeAsciiToMemory(str, buffer, dontAddNull) {
 {{{ unSign }}}
 {{{ reSign }}}
 
+#if LEGACY_VM_SUPPORT
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
 if (!Math['imul'] || Math['imul'](0xffffffff, 5) !== -5) Math['imul'] = function imul(a, b) {
   var ah  = a >>> 16;
@@ -1717,6 +1718,9 @@ if (!Math['trunc']) Math['trunc'] = function(x) {
   return x < 0 ? Math.ceil(x) : Math.floor(x);
 };
 Math.trunc = Math['trunc'];
+#else // LEGACY_VM_SUPPORT
+assert(Math['imul'] && Math['fround'] && Math['clz32'] && Math['trunc'], 'this is a legacy browser, build with LEGACY_VM_SUPPORT');
+#endif // LEGACY_VM_SUPPORT
 
 var Math_abs = Math.abs;
 var Math_cos = Math.cos;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1678,46 +1678,6 @@ function writeAsciiToMemory(str, buffer, dontAddNull) {
 {{{ unSign }}}
 {{{ reSign }}}
 
-// check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
-if (!Math['imul'] || Math['imul'](0xffffffff, 5) !== -5) Math['imul'] = function imul(a, b) {
-  var ah  = a >>> 16;
-  var al = a & 0xffff;
-  var bh  = b >>> 16;
-  var bl = b & 0xffff;
-  return (al*bl + ((ah*bl + al*bh) << 16))|0;
-};
-Math.imul = Math['imul'];
-
-#if PRECISE_F32
-#if PRECISE_F32 == 1
-if (!Math['fround']) {
-  var froundBuffer = new Float32Array(1);
-  Math['fround'] = function(x) { froundBuffer[0] = x; return froundBuffer[0] };
-}
-#else // 2
-if (!Math['fround']) Math['fround'] = function(x) { return x };
-#endif
-Math.fround = Math['fround'];
-#else
-#if SIMD
-if (!Math['fround']) Math['fround'] = function(x) { return x };
-#endif
-#endif
-
-if (!Math['clz32']) Math['clz32'] = function(x) {
-  x = x >>> 0;
-  for (var i = 0; i < 32; i++) {
-    if (x & (1 << (31 - i))) return i;
-  }
-  return 32;
-};
-Math.clz32 = Math['clz32']
-
-if (!Math['trunc']) Math['trunc'] = function(x) {
-  return x < 0 ? Math.ceil(x) : Math.floor(x);
-};
-Math.trunc = Math['trunc'];
-
 var Math_abs = Math.abs;
 var Math_cos = Math.cos;
 var Math_sin = Math.sin;

--- a/src/settings.js
+++ b/src/settings.js
@@ -286,6 +286,9 @@ var STB_IMAGE = 0; // Enables building of stb-image, a tiny public-domain librar
                    // When enabled, stb-image will be used automatically from IMG_Load and IMG_Load_RW. You
                    // can also call the stbi_* functions directly yourself.
 
+var LEGACY_VM_SUPPORT = 0; // Enable this to get support for non-modern browsers, node.js, etc. This adds:
+                           //  * Polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround
+
 var LZ4 = 0; // Enable this to support lz4-compressed file packages. They are stored compressed in memory, and
              // decompressed on the fly, avoiding storing the entire decompressed data in memory at once.
              // If you run the file packager separately, you still need to build the main program with this flag,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3117,6 +3117,15 @@ int main() {
     assert 'emcc: warning: unaligned store' in output[1], output[1]
     assert '@line 11 "src.cpp"' in output[1], output[1]
 
+  def test_LEGACY_VM_SUPPORT(self):
+    # when modern features are lacking, we can polyfill them or at least warn
+    with open('pre.js', 'w') as f: f.write('Math.imul = undefined;')
+    def test(expected, opts=[]):
+      subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--pre-js', 'pre.js'] + opts)
+      self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS, assert_returncode=None))
+    test('this is a legacy browser, build with LEGACY_VM_SUPPORT')
+    test('hello, world!', ['-s', 'LEGACY_VM_SUPPORT=1'])
+
   def test_on_abort(self):
     expected_output = 'Module.onAbort was called'
 


### PR DESCRIPTION
These have been present in modern browsers for quite some time, see compatibility sections in

 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc

There is some risk in removing these polyfills, though, as IE doesn't support them (Edge of course does), and possibly very old mobile browsers don't (I couldn't find an online resource on that). If there are concerns, this could be behind a flag.