### PR TITLE
Use read bit to get execute bit on Windows

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -24,9 +24,9 @@ mergeInto(LibraryManager.library, {
       try {
         stat = fs.lstatSync(path);
         if (NODEFS.isWindows) {
-          // On Windows, directories return permission bits 'rw-rw-rw-', even though they have 'rwxrwxrwx', so
-          // propagate write bits to execute bits.
-          stat.mode = stat.mode | ((stat.mode & 146) >> 1);
+          // Node.js on Windows never represents permission bit 'x', so
+          // propagate read bits to execute bits
+          stat.mode = stat.mode | ((stat.mode & 292) >> 2);
         }
       } catch (e) {
         if (!e.code) throw e;

--- a/tests/fs/test_nodefs_home.c
+++ b/tests/fs/test_nodefs_home.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <emscripten.h>
+
+int main(void)
+{
+    EM_ASM(
+        var path = require("path");
+        var home = process.env.HOME;
+        var parent = path.dirname(process.env.HOME);
+        var relative = path.relative(parent, home);
+        FS.mkdir('/nodefs_home');
+        FS.mount(NODEFS, { root: parent }, '/nodefs_home');
+        // Reading C:/Users/(username) on Windows, /home/(username) on Linux
+        // C:/Users on Windows disallows write access but should still allow access to its children
+        FS.readdir('/nodefs_home/' + relative);
+    );
+    printf("success\n");
+    return 0;
+}

--- a/tests/fs/test_nodefs_home.c
+++ b/tests/fs/test_nodefs_home.c
@@ -6,7 +6,7 @@ int main(void)
     EM_ASM(
         var path = require("path");
         var home = process.env.HOME;
-        var parent = path.dirname(process.env.HOME);
+        var parent = path.dirname(home);
         var relative = path.relative(parent, home);
         FS.mkdir('/nodefs_home');
         FS.mount(NODEFS, { root: parent }, '/nodefs_home');

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4521,6 +4521,11 @@ def process(filename):
     src = open(path_from_root('tests', 'fs', 'test_nodefs_cloexec.c'), 'r').read()
     self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
 
+  def test_fs_nodefs_home(self):
+    Settings.FORCE_FILESYSTEM = 1
+    src = open(path_from_root('tests', 'fs', 'test_nodefs_home.c'), 'r').read()
+    self.do_run(src, 'success', js_engines=[NODE_JS])
+
   def test_fs_trackingdelegate(self):
     src = path_from_root('tests', 'fs', 'test_trackingdelegate.c')
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')


### PR DESCRIPTION
Currently NODEFS propagates write bit to get execute bit but this causes #5268 where `C:/Users` has permission 444. This PR uses read bit instead to fix this.

Fixes #5268 
Closes #5819 