### PR TITLE
Fix ErrnoError stack

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1367,7 +1367,8 @@ mergeInto(LibraryManager.library, {
         };
         this.setErrno(errno);
         this.message = ERRNO_MESSAGES[errno];
-        if (this.stack) this.stack = (new Error).stack;
+        // Node.js compatibility: assigning on this.stack fails on Node 4
+        if (this.stack) Object.defineProperty(this, "stack", { value: (new Error).stack });
 #if ASSERTIONS
         if (this.stack) this.stack = demangleAll(this.stack);
 #endif

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1367,6 +1367,7 @@ mergeInto(LibraryManager.library, {
         };
         this.setErrno(errno);
         this.message = ERRNO_MESSAGES[errno];
+        if (this.stack) this.stack = (new Error).stack;
 #if ASSERTIONS
         if (this.stack) this.stack = demangleAll(this.stack);
 #endif

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4522,6 +4522,18 @@ def process(filename):
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run_from_file(src, out)
 
+  def test_fs_errorstack(self):
+    Settings.FORCE_FILESYSTEM = 1
+    self.do_run(r'''
+      #include <emscripten.h>
+      int main(void) {
+        EM_ASM(
+          FS.write('/dummy.txt', 'homu');
+        );
+        return 0;
+      }
+    ''', 'at new ErrnoError', js_engines=[NODE_JS]) # engines has different error stack format
+
   def test_unistd_access(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]


### PR DESCRIPTION
Current ErrnoError stack always looks like:

```
Error
    at Object.FS.ensureErrnoError (/tmp/emscripten_test_default_23dTdR/src.c.o.js:4026:35)
    at Object.FS.staticInit (/tmp/emscripten_test_default_23dTdR/src.c.o.js:4034:12)
    at Object.<anonymous> (/tmp/emscripten_test_default_23dTdR/src.c.o.js:4766:4)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
```

which causes debugging difficult. This PR introduces better stack information:

```
Error
    at new ErrnoError (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:4025:74)
    at Object.FS.write (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:3797:17)
    at Array.ASM_CONSTS (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:1526:35)
    at _emscripten_asm_const_i (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:1529:26)
    at _main (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:5026:7)
    at Object.asm._main (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:8141:21)
    at Object.callMain (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:8347:30)
    at doRun (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:8411:60)
    at run (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:8425:5)
    at Object.<anonymous> (/tmp/emscripten_test_default_LCD6gK/src.cpp.o.js:8503:1)
```