### PR TITLE
Simplify allocation of DYNAMICTOP_PTR, shorter and better

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -508,7 +508,7 @@ function JSify(data, functionsOnly) {
         for(i in proxiedFunctionInvokers) print(proxiedFunctionInvokers[i]+'\n');
         print('if (!ENVIRONMENT_IS_PTHREAD) {\n // Only main thread initializes these, pthreads copy them over at thread worker init time (in pthread-main.js)');
       }
-      print('DYNAMICTOP_PTR = allocate(1, "i32", ALLOC_STATIC);\n');
+      print('DYNAMICTOP_PTR = Runtime.staticAlloc(4);\n');
       print('STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);\n');
       if (STACK_START > 0) print('if (STACKTOP < ' + STACK_START + ') STACK_BASE = STACKTOP = Runtime.alignMemory(' + STACK_START + ');\n');
       print('STACK_MAX = STACK_BASE + TOTAL_STACK;\n');


### PR DESCRIPTION
Do not use the more generic `allocate` which might keep more code alive, just directly allocate 4 bytes of static memory.