### PR TITLE
Don't export things as both quoted and unquoted on the Module object

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -164,7 +164,7 @@ dependenciesFulfilled = function runCaller() {
 }
 
 #if HAS_MAIN
-Module['callMain'] = Module.callMain = function callMain(args) {
+Module['callMain'] = function callMain(args) {
 #if ASSERTIONS
   assert(runDependencies == 0, 'cannot call main when async dependencies remain! (listen on __ATMAIN__)');
   assert(__ATPRERUN__.length == 0, 'cannot call main when preRun functions remain to be called');
@@ -304,7 +304,7 @@ function run(args) {
   checkStackCookie();
 #endif
 }
-Module['run'] = Module.run = run;
+Module['run'] = run;
 
 function exit(status, implicit) {
   if (implicit && Module['noExitRuntime']) {
@@ -337,7 +337,7 @@ function exit(status, implicit) {
   }
   Module['quit'](status, new ExitStatus(status));
 }
-Module['exit'] = Module.exit = exit;
+Module['exit'] = exit;
 
 var abortDecorators = [];
 
@@ -374,7 +374,7 @@ function abort(what) {
   }
   throw output;
 }
-Module['abort'] = Module.abort = abort;
+Module['abort'] = abort;
 
 // {{PRE_RUN_ADDITIONS}}
 


### PR DESCRIPTION
It is redundant: for things available externally, using quotes is necessary for closure compiler; for things only used internally, quotes are not needed. for the 4 things in this commit, they are used internally only.