### PR TITLE
Test + fix for recent main() change

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -284,6 +284,10 @@ function run(args) {
 
 #if HAS_MAIN
     if (Module['_main'] && shouldRunNow) Module['callMain'](args);
+#else
+#if ASSERTIONS
+    assert(!Module['_main'], 'compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]');
+#endif // ASSERTIONS
 #endif // HAS_MAIN
 
     postRun();

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2131,13 +2131,6 @@ void *getBindBuffer() {
       }, 1000);
     '''
 
-    open('pre_main.js', 'w').write(r'''
-      Module._main = function(){
-        myJSCallback();
-        return 0;
-      };
-    ''')
-
     open('pre_runtime.js', 'w').write(r'''
       Module.onRuntimeInitialized = function(){
         myJSCallback();
@@ -2146,7 +2139,6 @@ void *getBindBuffer() {
 
     for filename, extra_args, second_code in [
       ('runtime_misuse.cpp', [], 600),
-      ('runtime_misuse_2.cpp', ['--pre-js', 'pre_main.js'], 600),
       ('runtime_misuse_2.cpp', ['--pre-js', 'pre_runtime.js'], 601) # 601, because no main means we *do* run another call after exit()
     ]:
       for mode in [[], ['-s', 'WASM=1']]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4684,6 +4684,20 @@ main(const int argc, const char * const * const argv)
     self.assertContained('locale set to waka: waka;waka;waka;waka;waka;waka',
                          run_js('a.out.js', args=['waka']))
 
+  def test_js_main(self):
+    # try to add a main() from JS, at runtime. this is not supported (the
+    # compiler needs to know at compile time about main).
+    open('pre_main.js', 'w').write(r'''
+      var Module = {
+        '_main': function() {
+        }
+      };
+    ''')
+    open('src.cpp', 'w').write('')
+    subprocess.check_call([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre_main.js'])
+    self.assertContained('compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]',
+                         run_js('a.out.js', assert_returncode=None, stderr=PIPE))
+
   def test_js_malloc(self):
     open('src.cpp', 'w').write(r'''
 #include <stdio.h>


### PR DESCRIPTION
#5850 checks at compile time if `main()` exists. Turns out that we very hackishly allowed `main()` to be added at runtime from JS, and used this in a test. I doubt anyone ever used this "feature", but there is a simple workaround (the `onRuntimeInitialized` callback, which is made for basically that). This PR fixes the test that broke, and adds a runtime assertion with a explanation of what to do to avoid this, and a test for that.