### PR TITLE
sockfs option to not specify subprotocols exactly

### DIFF
--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -194,6 +194,12 @@ mergeInto(LibraryManager.library, {
             // The node ws library API for specifying optional subprotocol is slightly different than the browser's.
             var opts = ENVIRONMENT_IS_NODE ? {'protocol': subProtocols.toString()} : subProtocols;
 
+            // some webservers (azure) does not support subprotocol header
+            if (runtimeConfig && null === Module['websocket']['subprotocol']) {
+              subProtocols = 'null';
+              opts = undefined;
+            }
+
 #if SOCKET_DEBUG
             Module.print('connect: ' + url + ', ' + subProtocols.toString());
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -246,6 +246,7 @@ var SOCKET_WEBRTC = 0; // Select socket backend, either webrtc or websockets. XX
 // settings may configured at run time via the Module object e.g.
 // Module['websocket'] = {subprotocol: 'base64, binary, text'};
 // Module['websocket'] = {url: 'wss://', subprotocol: 'base64'};
+// You can set 'subprotocol' to null, if you don't want to specify it
 // Run time configuration may be useful as it lets an application select multiple different services.
 var WEBSOCKET_URL = 'ws://'; // A string containing either a WebSocket URL prefix (ws:// or wss://) or a complete
                              // RFC 6455 URL - "ws[s]:" "//" host [ ":" port ] path [ "?" query ].


### PR DESCRIPTION
Hi. I faced problem that azure webapps does not support subprotocol headers, websocket works only if subprotocols not specified. In this PR I add option to fix this problem. If you set websocket.subprotocols to null, then subportocols will not apply on WebSocket.