### PR TITLE
Disable binaryen trap test on Wasm backend

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7142,7 +7142,6 @@ int main(int argc, char **argv) {
     self.emcc_args += ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"']
     self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')
 
-  @no_wasm_backend('test uses calls to expected js imports, rather than using llvm intrinsics directly')
   @no_wasm_backend('Wasm backend emits non-trapping float-to-int conversion')
   def test_binaryen_trap_mode(self):
     if not self.is_wasm(): return self.skip('wasm test')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7142,7 +7142,8 @@ int main(int argc, char **argv) {
     self.emcc_args += ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"']
     self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')
 
-  @no_wasm_backend
+  @no_wasm_backend('test uses calls to expected js imports, rather than using llvm intrinsics directly')
+  @no_wasm_backend('Wasm backend emits non-trapping float-to-int conversion')
   def test_binaryen_trap_mode(self):
     if not self.is_wasm(): return self.skip('wasm test')
     TRAP_OUTPUTS = ('trap', 'RuntimeError')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7142,6 +7142,7 @@ int main(int argc, char **argv) {
     self.emcc_args += ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"']
     self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')
 
+  @no_wasm_backend
   def test_binaryen_trap_mode(self):
     if not self.is_wasm(): return self.skip('wasm test')
     TRAP_OUTPUTS = ('trap', 'RuntimeError')


### PR DESCRIPTION
After https://github.com/llvm-mirror/llvm/commit/9f86840c1ccefbede8c0deeac9bb4f1a28608fc4, LLVM wass backend has two behaviors:

- When executing llc with `-mattr=+nontrapping-fptoint`:
It generates nontrapping version of instructions, those with :sat
varient.

- When executing llc with `-mattr=-nontrapping-fptoint`:
It generates trapping version of instructions, but it inserts
conditional checks around them so they don't trap and clamp to the
predefined value.

So it seems not very possible to support this trapping test including
three modes (allow, trap, and js) for wasm backend now.

Related: WebAssembly/binaryen#1168, #5863