### PR TITLE
Reduce core count to 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ test-defaults: &test-defaults
         apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless
         pip install --upgrade pip
         pip install lit
-        EMCC_CORES=8 python emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple
+        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple
 
 version: 2
 jobs:
@@ -38,7 +38,7 @@ jobs:
           popd
           echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> .emscripten
           echo BINARYEN_ROOT="''" >> .emscripten
-          EMCC_CORES=8 python2 emscripten/embuilder.py build ALL
+          EMCC_CORES=4 python2 emscripten/embuilder.py build ALL
           python2 emscripten/tests/runner.py test_hello_world
 
       - persist_to_workspace:


### PR DESCRIPTION
...to prevent `test_failing_alloc` failure. See https://github.com/kripken/emscripten/pull/5842#issuecomment-348075209

The actual performance shouldn't decrease as the actual assigned core count is 2, although I've seen slight performance increase when `EMCC_CORES=4` over `EMCC_CORES=2`.