### PR TITLE
Skip CI breakage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
     environment:
       - TEST_TARGET=other.test_n* other.test_o* other.test_p* other.test_q* other.test_r* other.test_s* other.test_t* other.test_u* other.test_v* other.test_w* other.test_x* other.test_y* other.test_z* skip:other.test_native_link_error_message
       # TODO: remove skips after fastcomp update on travis for 1.37.23
+  test-browser:
     <<: *test-defaults
     environment:
       - TEST_TARGET=browser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ test-defaults: &test-defaults
         apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless
         pip install --upgrade pip
         pip install lit
-        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:default.test_simd_sitofp skip:default.test_simd3
-        # TODO: remove `other.test_emcc_v skip:default.test_simd_sitofp skip:default.test_simd3` after fastcomp update on travis for 1.37.23
+        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET
 
 version: 2
 jobs:
@@ -55,12 +54,14 @@ jobs:
   test-other-am:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=other.test_a* other.test_b* other.test_c* other.test_d* other.test_e* other.test_f* other.test_g* other.test_h* other.test_i* other.test_j* other.test_k* other.test_l* other.test_m*
+      - TEST_TARGET=other.test_a* other.test_b* other.test_c* other.test_d* other.test_e* other.test_f* other.test_g* other.test_h* other.test_i* other.test_j* other.test_k* other.test_l* other.test_m* skip:other.test_bad_triple skip:other.test_emcc_v
+      # TODO: remove skips after fastcomp update on travis for 1.37.23
+
   test-other-nz:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=other.test_n* other.test_o* other.test_p* other.test_q* other.test_r* other.test_s* other.test_t* other.test_u* other.test_v* other.test_w* other.test_x* other.test_y* other.test_z*
-  test-browser:
+      - TEST_TARGET=other.test_n* other.test_o* other.test_p* other.test_q* other.test_r* other.test_s* other.test_t* other.test_u* other.test_v* other.test_w* other.test_x* other.test_y* other.test_z* skip:other.test_native_link_error_message
+      # TODO: remove skips after fastcomp update on travis for 1.37.23
     <<: *test-defaults
     environment:
       - TEST_TARGET=browser
@@ -108,7 +109,8 @@ jobs:
   test-qrst:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t*
+      - TEST_TARGET=ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t* skip:default.test_simd_sitofp skip:default.test_simd3 skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full
+      # TODO: remove skips after fastcomp update on travis for 1.37.23
   test-uvwxyz:
     <<: *test-defaults
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ test-defaults: &test-defaults
         apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless
         pip install --upgrade pip
         pip install lit
-        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple
+        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:default.test_simd_sitofp skip:default.test_simd3
+        # TODO: remove `other.test_emcc_v skip:default.test_simd_sitofp skip:default.test_simd3` after fastcomp update on travis for 1.37.23
 
 version: 2
 jobs:
@@ -107,8 +108,7 @@ jobs:
   test-qrst:
     <<: *test-defaults
     environment:
-      # TODO: remove `skip:default.test_simd_sitofp skip:default.test_simd3` after fastcomp update on travis for 1.37.23
-      - TEST_TARGET=ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t* skip:default.test_simd_sitofp skip:default.test_simd3 
+      - TEST_TARGET=ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t*
   test-uvwxyz:
     <<: *test-defaults
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /root/ \
 
 ARG TEST_TARGET
 RUN export EMSCRIPTEN_BROWSER=0 \
- && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:default.test_simd_sitofp skip:default.test_simd3
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:default.test_simd_sitofp skip:default.test_simd3 skip:other.test_emcc_v
 
-# TODO: remove  skip:default.test_simd_sitofp skip:default.test_simd3  after fastcomp update on travis for 1.37.23
+# TODO: remove  skip:default.test_simd_sitofp skip:default.test_simd3 skip:other.test_emcc_v  after fastcomp update on travis for 1.37.23
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -51,6 +51,15 @@ class clean_write_access_to_canonical_temp_dir(object):
       self.clean_emcc_files_in_temp_dir()
 
 class other(RunnerCore):
+  def test_emcc_v(self):
+    for compiler in [EMCC, EMXX]:
+      # -v, without input files
+      output = Popen([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE).communicate()
+      self.assertContained('''clang version %s.0 ''' % expected_llvm_version(), output[1].replace('\r', ''), output[1].replace('\r', ''))
+      self.assertContained('''GNU''', output[0])
+      self.assertNotContained('this is dangerous', output[0])
+      self.assertNotContained('this is dangerous', output[1])
+
   def test_emcc(self):
     for compiler in [EMCC, EMXX]:
       shortcompiler = os.path.basename(compiler)
@@ -64,13 +73,6 @@ class other(RunnerCore):
 This is free and open source software under the MIT license.
 There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ''', output)
-
-      # -v, without input files
-      output = Popen([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE).communicate()
-      self.assertContained('''clang version %s.0 ''' % expected_llvm_version(), output[1].replace('\r', ''), output[1].replace('\r', ''))
-      self.assertContained('''GNU''', output[0])
-      self.assertNotContained('this is dangerous', output[0])
-      self.assertNotContained('this is dangerous', output[1])
 
       # --help
       output = Popen([PYTHON, compiler, '--help'], stdout=PIPE, stderr=PIPE).communicate()


### PR DESCRIPTION
Split out the part of other.test_emcc that checks for a version mismatch, which currently fails on CI since it uses 1.37.22 instead of 1.37.23. Disable that test on CI for now.

I also merged the skip lists, which were in two places for CircleCI - was there a reason for that I am missing?