### PR TITLE
Add a directory-path for WASM on nodejs

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2025,10 +2025,19 @@ function integrateWasmJS() {
   // inputs
 
   var method = '{{{ BINARYEN_METHOD }}}';
+  var withDirName = function (p) {
+    if (ENVIRONMENT_IS_NODE) {
+      var path = require('path');
+      var programFile = process['argv'][1];
+      return path.join(path.dirname(programFile),p);
+    } else {
+      return p;
+    }
+  };
 
-  var wasmTextFile = '{{{ WASM_TEXT_FILE }}}';
-  var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
-  var asmjsCodeFile = '{{{ ASMJS_CODE_FILE }}}';
+  var wasmTextFile = withDirName('{{{ WASM_TEXT_FILE }}}');
+  var wasmBinaryFile = withDirName('{{{ WASM_BINARY_FILE }}}');
+  var asmjsCodeFile = withDirName('{{{ ASMJS_CODE_FILE }}}');
 
   if (typeof Module['locateFile'] === 'function') {
     wasmTextFile = Module['locateFile'](wasmTextFile);


### PR DESCRIPTION
Hi,

When we use a wasm option(-s WASM=1), emcc outputs main-js-program, wasm and asm-js files in the same directory. The main-js-program reads just the wasm and asm-js file-name which do not include the directory. 

When the compiling directory is different from the running directory,
the program does not work. 
We have to copy the wasm files to current working directory.
The sample code is below.

```
cd /tmp
emcc -o main.js main.c -s WASM=1
cd /home/hoge
node /tmp/main.js # wasm file does not exist in /home/hoge, so nodejs throws exception.
```

this PR adds a directory path for wasm files to be able to run main-js-program without copying.