### PR TITLE
fix test_add_function, which should use quotes on accessing Module objects

### DIFF
--- a/tests/interop/test_add_function_post.js
+++ b/tests/interop/test_add_function_post.js
@@ -1,4 +1,4 @@
 var newFuncPtr = Runtime.addFunction(function(num) {
-    Module.print('Hello ' + num + ' from JS!');
+    Module['print']('Hello ' + num + ' from JS!');
 });
-Module.callMain([newFuncPtr.toString()]);
+Module['callMain']([newFuncPtr.toString()]);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6209,7 +6209,6 @@ def process(filename):
     assert 'asm2' in test_modes
     if self.run_name == 'asm2':
       print('closure')
-      self.banned_js_engines = [NODE_JS] # weird global handling in node
       self.emcc_args += ['--closure', '1']
       self.do_run_from_file(src, expected)
 


### PR DESCRIPTION
(for closure to work). Also enable it on node.js, which apparently was disabled due to older versions of node having issues.