### PR TITLE
Remove the asmGlobal if not using asm.js

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1289,6 +1289,9 @@ def function_tables(function_table_data, settings):
 
 
 def create_the_global(metadata, settings):
+  # the global is only needed for asm.js
+  if settings['WASM'] and settings['BINARYEN_METHOD'] == 'native-wasm':
+    return '{}'
   fundamentals = ['Math']
   fundamentals += ['Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Float32Array', 'Float64Array']
   fundamentals += ['NaN', 'Infinity']
@@ -1509,7 +1512,7 @@ def create_asm_start_pre(asm_setup, the_global, sending, metadata, settings):
   access_quote = access_quoter(settings)
 
   shared_array_buffer = ''
-  if settings['USE_PTHREADS']:
+  if settings['USE_PTHREADS'] and not settings['WASM']:
     shared_array_buffer = "Module.asmGlobalArg['Atomics'] = Atomics;"
 
   module_get = 'Module{access} = {val};'
@@ -1963,7 +1966,7 @@ def create_module_wasm(sending, receiving, invoke_funcs, settings):
 
   the_global = '{}'
 
-  if settings['USE_PTHREADS']:
+  if settings['USE_PTHREADS'] and not settings['WASM']:
     shared_array_buffer = "if (typeof SharedArrayBuffer !== 'undefined') Module.asmGlobalArg['Atomics'] = Atomics;"
   else:
     shared_array_buffer = ''

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2209,7 +2209,7 @@ function integrateWasmJS() {
       'NaN': NaN,
       'Infinity': Infinity
     };
-    info['global.Math'] = global.Math;
+    info['global.Math'] = Math;
     info['env'] = env;
     // handle a generated wasm instance, receiving its exports and
     // performing other necessary setup
@@ -2431,7 +2431,9 @@ function integrateWasmJS() {
   // doesn't need to care that it is wasm or olyfilled wasm or asm.js.
 
   Module['asm'] = function(global, env, providedBuffer) {
+#if BINARYEN_METHOD != 'native-wasm'
     global = fixImports(global);
+#endif
     env = fixImports(env);
 
     // import table

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -408,7 +408,11 @@ var Runtime = {
       }
     }
     var info = {
-      global: Module['asmGlobalArg'],
+      global: {
+        'NaN': NaN,
+        'Infinity': Infinity,
+        'Math': Math
+      },
       env: env
     };
 #if ASSERTIONS


### PR DESCRIPTION
It is fairly large and contains imports like Int8Array, etc. If we're just doing wasm, we don't need it.