### PR TITLE
Followups for eval-removal 1 (#5751)

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -1,3 +1,30 @@
+#if SIDE_MODULE == 0
+// The Module object: Our interface to the outside world. We import
+// and export values on it. There are various ways Module can be used:
+// 1. Not defined. We create it here
+// 2. A function parameter, function(Module) { ..generated code.. }
+// 3. pre-run appended it, var Module = {}; ..generated code..
+// 4. External script tag defines var Module.
+// We need to check if Module already exists (e.g. case 3 above).
+// Substitution will be replaced with actual code on later stage of the build,
+// this way Closure Compiler will not mangle it (e.g. case 4. above).
+// Note that if you want to run closure, and also to use Module
+// after the generated code, you will need to define   var Module = {};
+// before the code. Then that object will be used in the code, and you
+// can continue to use Module afterwards as well.
+#if USE_CLOSURE_COMPILER
+// if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
+var Module;
+if (!Module) Module = "__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__";
+#else
+var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : {};
+#endif // USE_CLOSURE_COMPILER
+#endif // SIDE_MODULE
+
+// --pre-jses are emitted after the Module integration code, so that they can
+// refer to Module (if they choose; they can also define Module)
+// {{PRE_JSES}}
+
 // Sometimes an existing Module object exists with properties
 // meant to overwrite the default module functionality. Here
 // we collect those properties and reapply _after_ we configure

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6762,8 +6762,7 @@ Module.printErr = Module['printErr'] = function(){};
       '--pre-js', path_from_root('tests', 'core', 'modularize_closure_pre.js'),
       '--closure', '1',
       '-s', 'MODULARIZE=1',
-      '-g1',
-      '-O2'
+      '-g1'
     ]
     def post(filename):
       src = open(filename, 'a')


### PR DESCRIPTION
Some minor followups for that PR:

 * add module integration code in shell.js, to avoid writing the js in emcc.py (which is at its maximum size this early in the compilation process, possibly hundreds of MB) just to add it, which is a little slower (a few %).
 * do not force -O2 in test_modularize_closure_pre: while we won't have closure if -O0 or -O1, it's useful to see that the situation in that test passes in those modes as well
 * fix an existing regression bug with debugging stuff like this, improper use of 'final' in emcc, which led to incorrect logging of temp files (if a method calls save_intermediate(), it must modify the global 'final' var, as that method reads it). in particular we logged the modularize temp file incorrectly.
