### PR TITLE
Fix format string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -317,4 +317,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * José Carlos Pujol <josecpujol(at)gmail.com>
 * Dannii Willis <curiousdannii@gmail.com>
 * Erik Dubbelboer <erik@dubbelboer.com>
+* Sergey Tsatsulin <tsatsulin@gmail.com>
 

--- a/emcc.py
+++ b/emcc.py
@@ -732,7 +732,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
         if not arg.startswith('-'):
           if not os.path.exists(arg):
-            exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
+            exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)' % (arg, arg))
 
           arg_ending = filename_type_ending(arg)
           if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs


### PR DESCRIPTION
This simple patch fixes the following error:

```
Traceback (most recent call last):
  File "/opt/emsdk/emscripten/incoming/emcc", line 13, in <module>
    emcc.run()
  File "/opt/emsdk//emscripten/incoming/emcc.py", line 735, in run
    exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)' % arg % arg)
TypeError: exit_with_error() takes exactly 1 argument (3 given)
```

This happens, for example, when object file does not exists.