### PR TITLE
Eval elimination #6

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -182,25 +182,16 @@ var LibraryEmbind = {
   },
 
 
-  // from https://github.com/imvu/imvujs/blob/master/src/function.js
   $createNamedFunction__deps: ['$makeLegalFunctionName'],
-  $createNamedFunction: function(name, body) {
+  $createNamedFunction: function(name, func) {
     name = makeLegalFunctionName(name);
-#if NO_DYNAMIC_EXECUTION
-    return function() {
-      "use strict";
-      return body.apply(this, arguments);
+    // Non-standard Firefox feature
+    func.displayName = name;
+    // And this works in Chromium
+    func.toString = function () {
+      return 'function ' + name + ' () {}';
     };
-#else
-    /*jshint evil:true*/
-    return new Function(
-        "body",
-        "return function " + name + "() {\n" +
-        "    \"use strict\";" +
-        "    return body.apply(this, arguments);\n" +
-        "};\n"
-    )(body);
-#endif
+    return func;
   },
 
   embind_repr: function(v) {

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -44,13 +44,6 @@ var LibraryEmbind = {
     Module['getLiveInheritedInstances'] = getLiveInheritedInstances;
     Module['flushPendingDeletes'] = flushPendingDeletes;
     Module['setDelayFunction'] = setDelayFunction;
-#if IN_TEST_HARNESS
-#if NO_DYNAMIC_EXECUTION
-    // Without dynamic execution, dynamically created functions will have no
-    // names. This lets the test suite know that.
-    Module['NO_DYNAMIC_EXECUTION'] = true;
-#endif
-#endif
   },
 
   $throwInternalError__deps: ['$InternalError'],
@@ -185,6 +178,10 @@ var LibraryEmbind = {
   $createNamedFunction__deps: ['$makeLegalFunctionName'],
   $createNamedFunction: function(name, func) {
     name = makeLegalFunctionName(name);
+    // Make code that relies on `.name` property happy
+    Object.defineProperty(func, 'name', {
+      value: name
+    });
     // Non-standard Firefox feature
     func.displayName = name;
     // And this works in Chromium
@@ -848,7 +845,7 @@ var LibraryEmbind = {
 
 #if NO_DYNAMIC_EXECUTION
     var argsWired = new Array(argCount - 2);
-    return function() {
+    return createNamedFunction(humanName, function() {
       if (arguments.length !== argCount - 2) {
         throwBindingError('function ' + humanName + ' called with ' + arguments.length + ' arguments, expected ' + (argCount - 2) + ' args!');
       }
@@ -887,7 +884,7 @@ var LibraryEmbind = {
       if (returns) {
         return argTypes[0].fromWireType(rv);
       }
-    };
+    });
 #else
     var argsList = "";
     var argsListWired = "";

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -161,17 +161,16 @@ module({
         });
 
         test("setting and getting property on unrelated class throws error", function() {
-            var className = Module['NO_DYNAMIC_EXECUTION'] ? '' : 'HasTwoBases';
             var a = new cm.HasTwoBases;
             var e = assert.throws(cm.BindingError, function() {
                 Object.getOwnPropertyDescriptor(cm.HeldBySmartPtr.prototype, 'i').set.call(a, 10);
             });
-            assert.equal('HeldBySmartPtr.i setter incompatible with "this" of type ' + className, e.message);
+            assert.equal('HeldBySmartPtr.i setter incompatible with "this" of type HasTwoBases', e.message);
 
             var e = assert.throws(cm.BindingError, function() {
                 Object.getOwnPropertyDescriptor(cm.HeldBySmartPtr.prototype, 'i').get.call(a);
             });
-            assert.equal('HeldBySmartPtr.i getter incompatible with "this" of type ' + className, e.message);
+            assert.equal('HeldBySmartPtr.i getter incompatible with "this" of type HasTwoBases', e.message);
 
             a.delete();
         });
@@ -417,7 +416,7 @@ module({
             var e = cm.emval_test_take_and_return_std_string((new Int8Array([65, 66, 67, 68])).buffer);
             assert.equal('ABCD', e);
         });
-        
+
         test("can pass Uint8Array to std::basic_string<unsigned char>", function() {
             var e = cm.emval_test_take_and_return_std_basic_string_unsigned_char(new Uint8Array([65, 66, 67, 68]));
             assert.equal('ABCD', e);
@@ -1548,8 +1547,7 @@ module({
 
         test("smart pointer object has correct constructor name", function() {
             var e = new cm.HeldBySmartPtr(10, "foo");
-            var expectedName = Module['NO_DYNAMIC_EXECUTION'] ? "" : "HeldBySmartPtr";
-            assert.equal(expectedName, e.constructor.name);
+            assert.equal('HeldBySmartPtr', e.constructor.name);
             e.delete();
         });
 
@@ -1856,7 +1854,7 @@ module({
             assert.equal(10, instance.property);
             instance.delete();
         });
-        
+
         test("pass derived object to c++", function() {
             var Implementation = cm.AbstractClass.extend("Implementation", {
                 abstractMethod: function() {
@@ -2292,15 +2290,9 @@ module({
     });
 
     BaseFixture.extend("function names", function() {
-        if (Module['NO_DYNAMIC_EXECUTION']) {
-          assert.equal('', cm.ValHolder.name);
-          assert.equal('', cm.ValHolder.prototype.setVal.name);
-          assert.equal('', cm.ValHolder.makeConst.name);
-        } else {
-          assert.equal('ValHolder', cm.ValHolder.name);
-          assert.equal('ValHolder$setVal', cm.ValHolder.prototype.setVal.name);
-          assert.equal('ValHolder$makeConst', cm.ValHolder.makeConst.name);
-        }
+      assert.equal('ValHolder', cm.ValHolder.name);
+      assert.equal('ValHolder$setVal', cm.ValHolder.prototype.setVal.name);
+      assert.equal('ValHolder$makeConst', cm.ValHolder.makeConst.name);
     });
 
     BaseFixture.extend("constants", function() {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2133,7 +2133,6 @@ int f() {
     ]
     test_cases.extend([ (args[:] + ['-s', 'NO_DYNAMIC_EXECUTION=1'], status) for args, status in test_cases])
     test_cases.append((['--bind', '-O2', '--closure', '1'], False)) # closure compiler doesn't work with NO_DYNAMIC_EXECUTION=1
-    test_cases = [(args + ['-s', 'IN_TEST_HARNESS=1'], status) for args, status in test_cases]
 
     for args, fail in test_cases:
       print(args, fail)


### PR DESCRIPTION
Eliminate `new Function` use by overriding `toString` on function (and `displayName` property for Firefox), which makes it appear as named function in debugger regardless of original name or lack of it, also there is no call-time overhead.

Haven't tested other browsers, as I'm on Linux and never use anything besides Firefox and Chromium for debugging anyway.

This is also the first step for `NO_DYNAMIC_EXECUTION` elimination from #5911

Can be tested in any browser with following:
```javascript
function my_func () {}
console.log(my_func)
console.log(function () {})
function make_my_func (func) {
	func.displayName = 'my_func';
	func.toString = function () {return 'function my_func () {}'};
	return func;
}
console.log(make_my_func(function () {}))
```