### PR TITLE
Warn on failing to clear ports dir

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -560,7 +560,10 @@ class Ports(object):
 
   @staticmethod
   def erase():
-    shared.try_delete(Ports.get_dir())
+    dirname = Ports.get_dir()
+    shared.try_delete(dirname)
+    if os.path.exists(dirname):
+      logging.warning('could not delete ports dir %s - try to delete it manually' % dirname)
 
   @staticmethod
   def get_build_dir():


### PR DESCRIPTION
If clearing the ports dir fails, show a warning to the user. This can happen if e.g. the user lacks permissions to that directory, and if we don't show this warning, later ports operations may fail as well - when they do, we will suggest clearing ports, so putting the warning here should suffice.