### PR TITLE
SDL2 exporting fix

### DIFF
--- a/tests/sdl2_misc.c
+++ b/tests/sdl2_misc.c
@@ -1,0 +1,48 @@
+#include "SDL2/SDL.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include <emscripten.h>
+
+int main(int argc, char *argv[])
+{
+    SDL_Window *window;
+    SDL_Surface *surface;
+    SDL_Cursor *cursor;
+
+    if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) {
+        printf("Unable to initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    window = SDL_CreateWindow(
+        "sdl2_misc",
+        SDL_WINDOWPOS_UNDEFINED,
+        SDL_WINDOWPOS_UNDEFINED,
+        100,
+        100,
+        0
+    );
+
+    EM_ASM({
+      assert(document.title === 'sdl2_misc');
+    });
+    const char* intended = "a custom window title";
+    SDL_SetWindowTitle(window, intended);
+    const char* seen = SDL_GetWindowTitle(window);
+    if (strcmp(intended, seen) != 0) {
+        printf("Got a weird title back: %s\n", seen);
+        return 1;
+    }
+    EM_ASM({
+      assert(document.title === 'a custom window title');
+    });
+
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    REPORT_RESULT(1);
+
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2835,6 +2835,9 @@ window.close = function() {
     shutil.copyfile(path_from_root('tests', 'cursor.bmp'), os.path.join(self.get_dir(), 'cursor.bmp'))
     self.btest('sdl2_custom_cursor.c', expected='1', args=['--preload-file', 'cursor.bmp', '-s', 'USE_SDL=2'])
 
+  def test_sdl2_misc(self):
+    self.btest('sdl2_misc.c', expected='1', args=['-s', 'USE_SDL=2', '-O2'])
+
   def test_cocos2d_hello(self):
     from tools import system_libs
     cocos2d_root = os.path.join(system_libs.Ports.get_build_dir(), 'Cocos2d')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2836,7 +2836,13 @@ window.close = function() {
     self.btest('sdl2_custom_cursor.c', expected='1', args=['--preload-file', 'cursor.bmp', '-s', 'USE_SDL=2'])
 
   def test_sdl2_misc(self):
-    self.btest('sdl2_misc.c', expected='1', args=['-s', 'USE_SDL=2', '-O2'])
+    self.btest('sdl2_misc.c', expected='1', args=['-s', 'USE_SDL=2'])
+    print('also test building to object files first')
+    src = open(path_from_root('tests', 'sdl2_misc.c')).read()
+    open('test.c', 'w').write(self.with_report_result(src))
+    Popen([PYTHON, EMCC, 'test.c', '-s', 'USE_SDL=2', '-o', 'test.o']).communicate()
+    Popen([PYTHON, EMCC, 'test.o', '-s', 'USE_SDL=2', '-o', 'test.html']).communicate()
+    self.run_browser('test.html', '...', '/report_result?1')
 
   def test_cocos2d_hello(self):
     from tools import system_libs

--- a/tools/ports/sdl.py
+++ b/tools/ports/sdl.py
@@ -20,6 +20,9 @@ def get_with_configure(ports, settings, shared): # not currently used; no real n
 
 def get(ports, settings, shared):
   if settings.USE_SDL == 2:
+    # SDL2 uses some things on the Module object, make sure they are exported
+    settings.EXPORTED_RUNTIME_METHODS.append('Pointer_stringify')
+    # get the port
     ports.fetch_project('sdl2', 'https://github.com/emscripten-ports/SDL2/archive/' + TAG + '.zip', 'SDL2-' + TAG)
     def create():
       # we are rebuilding SDL, clear dependant projects so they copy in their includes to ours properly
@@ -56,7 +59,6 @@ def process_args(ports, args, settings, shared):
   elif settings.USE_SDL == 2:
     get(ports, settings, shared)
     args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2', 'include')]
-    settings.EXPORTED_RUNTIME_METHODS.append('Pointer_stringify')
   return args
 
 def show():


### PR DESCRIPTION
SDL2 needs to export some things by default, after the recent export-fewer-things changes. This only worked when compiling directly to an executable, but not with object files in the middle, as we didn't do this in the right place, see #5940 

The fix is to do this in `get()`, which is called at the right time. This PR also adds testing for both cases, and a bonus test for setting the window title.