### PR TITLE
Exit node.js with error status on unhandled promise rejections

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -137,6 +137,11 @@ if (ENVIRONMENT_IS_NODE) {
     }
   });
 #endif
+  // Currently node will swallow unhandled rejections, but this behavior is
+  // deprecated, and in the future it will exit with error status.
+  process['on']('unhandledRejection', function(reason, p) {
+    process['exit'](1);
+  });
 
   Module['inspect'] = function () { return '[Emscripten Module object]'; };
 }

--- a/src/shell.js
+++ b/src/shell.js
@@ -140,6 +140,7 @@ if (ENVIRONMENT_IS_NODE) {
   // Currently node will swallow unhandled rejections, but this behavior is
   // deprecated, and in the future it will exit with error status.
   process['on']('unhandledRejection', function(reason, p) {
+    Module['printErr']('node.js exiting due to unhandled promise rejection');
     process['exit'](1);
   });
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -140,7 +140,9 @@ if (ENVIRONMENT_IS_NODE) {
   // Currently node will swallow unhandled rejections, but this behavior is
   // deprecated, and in the future it will exit with error status.
   process['on']('unhandledRejection', function(reason, p) {
+#if ASSERTIONS
     Module['printErr']('node.js exiting due to unhandled promise rejection');
+#endif
     process['exit'](1);
   });
 


### PR DESCRIPTION
Currently node will swallow unhandled promise rejections and continue as
if no error occurred. Today it prints a deprecation warning when that
happens, and in the future it will exit with a non-zero status. That
behavior is what we want in any case, so until then, use the
unhandled promise rejection hook to get behavior to match other shells.