### PR TITLE
De-runtime-ification

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -393,7 +393,7 @@ def create_module(function_table_sigs, metadata, settings,
 
   if settings['SIDE_MODULE']:
     module.append('''
-Runtime.registerFunctions(%(sigs)s, Module);
+registerFunctions(%(sigs)s, Module);
 ''' % { 'sigs': str(list(map(str, function_table_sigs))) })
 
   return module
@@ -564,7 +564,7 @@ def memory_and_global_initializers(pre, metadata, mem_init, settings):
                      mem_init=mem_init))
 
   if settings['SIDE_MODULE']:
-    pre = pre.replace('Runtime.GLOBAL_BASE', 'gb')
+    pre = pre.replace('GLOBAL_BASE', 'gb')
   if settings['SIDE_MODULE'] or settings['BINARYEN']:
     pre = pre.replace('{{{ STATIC_BUMP }}}', str(staticbump))
 
@@ -651,8 +651,8 @@ def get_implemented_functions(metadata):
 
 def proxy_debug_print(call_type, settings):
   if shared.Settings.PTHREADS_DEBUG:
-    if call_type == 'sync_on_main_thread_': return 'Runtime.warnOnce("sync proxying function " + code);';
-    elif call_type == 'async_on_main_thread_': return 'Runtime.warnOnce("async proxying function " + code);';
+    if call_type == 'sync_on_main_thread_': return 'warnOnce("sync proxying function " + code);';
+    elif call_type == 'async_on_main_thread_': return 'warnOnce("async proxying function " + code);';
   return ''
 
 def include_asm_consts(pre, forwarded_json, metadata, settings):
@@ -1151,9 +1151,8 @@ def create_asm_setup(debug_tables, function_table_data, metadata, settings):
     if not settings['EMULATED_FUNCTION_POINTERS']:
       asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size
   if settings['RELOCATABLE']:
-    asm_setup += 'var setTempRet0 = Runtime.setTempRet0, getTempRet0 = Runtime.getTempRet0;\n'
     if not settings['SIDE_MODULE']:
-      asm_setup += 'var gb = Runtime.GLOBAL_BASE, fb = 0;\n'
+      asm_setup += 'var gb = GLOBAL_BASE, fb = 0;\n'
     side = 'parent' if settings['SIDE_MODULE'] else ''
     def check(extern):
       if settings['ASSERTIONS']:
@@ -1616,7 +1615,7 @@ def create_runtime_library_overrides(settings):
   if not settings['RELOCATABLE']:
     overrides += ['setTempRet0', 'getTempRet0']
 
-  lines = ["Runtime.{0} = Module['{0}'];".format(func) for func in overrides]
+  lines = ["{0} = Module['{0}'];".format(func) for func in overrides]
   return '\n'.join(lines)
 
 
@@ -1995,15 +1994,15 @@ var asm = Module['asm'](%s, %s, buffer);
 STACKTOP = STACK_BASE + TOTAL_STACK;
 STACK_MAX = STACK_BASE;
 HEAP32[%d >> 2] = STACKTOP;
-Runtime.stackAlloc = Module['_stackAlloc'];
-Runtime.stackSave = Module['_stackSave'];
-Runtime.stackRestore = Module['_stackRestore'];
-Runtime.establishStackSpace = Module['establishStackSpace'];
+stackAlloc = Module['_stackAlloc'];
+stackSave = Module['_stackSave'];
+stackRestore = Module['_stackRestore'];
+establishStackSpace = Module['establishStackSpace'];
 ''' % shared.Settings.GLOBAL_BASE)
 
   module.append('''
-Runtime.setTempRet0 = Module['setTempRet0'];
-Runtime.getTempRet0 = Module['getTempRet0'];
+setTempRet0 = Module['setTempRet0'];
+getTempRet0 = Module['getTempRet0'];
 ''')
 
   module.append(invoke_wrappers)

--- a/emscripten.py
+++ b/emscripten.py
@@ -378,8 +378,6 @@ def create_module(function_table_sigs, metadata, settings,
 
   asm_end = create_asm_end(exports, settings)
 
-  runtime_library_overrides = create_runtime_library_overrides(settings)
-
   module = [
     asm_start,
     temp_float,
@@ -389,7 +387,7 @@ def create_module(function_table_sigs, metadata, settings,
     start_funcs_marker
   ] + runtime_funcs + funcs_js + ['\n  ',
     pre_tables, final_function_tables, asm_end,
-    '\n', receiving, ';\n', runtime_library_overrides]
+    '\n', receiving, ';\n']
 
   if settings['SIDE_MODULE']:
     module.append('''
@@ -1598,25 +1596,6 @@ def create_asm_end(exports, settings):
 ''' % (exports,
        'Module' + access_quote('asmGlobalArg'),
        'Module' + access_quote('asmLibraryArg'))
-
-
-def create_runtime_library_overrides(settings):
-  overrides = []
-  if not settings.get('SIDE_MODULE'):
-    overrides += [
-      'stackAlloc',
-      'stackSave',
-      'stackRestore',
-      'establishStackSpace',
-    ]
-    if settings['SAFE_HEAP']:
-      overrides.append('setDynamicTop')
-
-  if not settings['RELOCATABLE']:
-    overrides += ['setTempRet0', 'getTempRet0']
-
-  lines = ["{0} = Module['{0}'];".format(func) for func in overrides]
-  return '\n'.join(lines)
 
 
 def create_first_in_asm(settings):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1215,8 +1215,6 @@ def create_basic_funcs(function_table_sigs, settings):
   if settings['ASSERTIONS']:
     for sig in function_table_sigs:
       basic_funcs += ['nullFunc_' + sig]
-  if settings['RELOCATABLE']:
-    basic_funcs += ['setTempRet0', 'getTempRet0']
 
   for sig in function_table_sigs:
     basic_funcs.append('invoke_%s' % sig)
@@ -1275,8 +1273,6 @@ def create_asm_runtime_funcs(settings):
   funcs = []
   if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
     funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
-  if not settings['RELOCATABLE']:
-    funcs += ['setTempRet0', 'getTempRet0']
   if settings['SAFE_HEAP']:
     funcs += ['setDynamicTop']
   if settings['ONLY_MY_CODE']:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1215,6 +1215,8 @@ def create_basic_funcs(function_table_sigs, settings):
   if settings['ASSERTIONS']:
     for sig in function_table_sigs:
       basic_funcs += ['nullFunc_' + sig]
+  if settings['RELOCATABLE']:
+    basic_funcs += ['setTempRet0', 'getTempRet0']
 
   for sig in function_table_sigs:
     basic_funcs.append('invoke_%s' % sig)
@@ -1273,6 +1275,8 @@ def create_asm_runtime_funcs(settings):
   funcs = []
   if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
     funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
+  if not settings['RELOCATABLE']:
+    funcs += ['setTempRet0', 'getTempRet0']
   if settings['SAFE_HEAP']:
     funcs += ['setDynamicTop']
   if settings['ONLY_MY_CODE']:

--- a/emscripten.py
+++ b/emscripten.py
@@ -394,7 +394,7 @@ def create_module(function_table_sigs, metadata, settings,
 
   if settings['SIDE_MODULE']:
     module.append('''
-registerFunctions(%(sigs)s, Module);
+parentModule['registerFunctions'](%(sigs)s, Module);
 ''' % { 'sigs': str(list(map(str, function_table_sigs))) })
 
   return module

--- a/emscripten.py
+++ b/emscripten.py
@@ -143,6 +143,9 @@ def parse_backend_output(backend_output, DEBUG):
   metadata_raw = backend_output[metadata_split+len(metadata_split_marker):]
   mem_init = backend_output[end_funcs+len(end_funcs_marker):metadata_split]
 
+  # we no longer use the "Runtime" object. TODO: stop emiting it in the backend
+  mem_init = mem_init.replace('Runtime.', '')
+
   try:
     #if DEBUG: print >> sys.stderr, "METAraw", metadata_raw
     metadata = json.loads(metadata_raw, object_pairs_hook=OrderedDict)

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -485,7 +485,7 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #if FETCH_DEBUG
     console.log('fetch: operation success. e: ' + e);
 #endif
-    if (onsuccess && Runtime.dynCall) Module['dynCall_vi'](onsuccess, fetch);
+    if (onsuccess && typeof dynCall === 'function') Module['dynCall_vi'](onsuccess, fetch);
     else if (successcb) successcb(fetch);
   };
 
@@ -497,21 +497,21 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #if FETCH_DEBUG
       console.log('fetch: IndexedDB store succeeded.');
 #endif
-      if (onsuccess && Runtime.dynCall) Module['dynCall_vi'](onsuccess, fetch);
+      if (onsuccess && typeof dynCall === 'function') Module['dynCall_vi'](onsuccess, fetch);
       else if (successcb) successcb(fetch);
     };
     var storeError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
       console.error('fetch: IndexedDB store failed.');
 #endif
-      if (onsuccess && Runtime.dynCall) Module['dynCall_vi'](onsuccess, fetch);
+      if (onsuccess && typeof dynCall === 'function') Module['dynCall_vi'](onsuccess, fetch);
       else if (successcb) successcb(fetch);
     };
     __emscripten_fetch_cache_data(Fetch.dbInstance, fetch, xhr.response, storeSuccess, storeError);
   };
 
   var reportProgress = function(fetch, xhr, e) {
-    if (onprogress && Runtime.dynCall) Module['dynCall_vi'](onprogress, fetch);
+    if (onprogress && typeof dynCall === 'function') Module['dynCall_vi'](onprogress, fetch);
     else if (progresscb) progresscb(fetch);
   };
 
@@ -519,7 +519,7 @@ function emscripten_start_fetch(fetch, successcb, errorcb, progresscb) {
 #if FETCH_DEBUG
     console.error('fetch: operation failed: ' + e);
 #endif
-    if (onerror && Runtime.dynCall) Module['dynCall_vi'](onerror, fetch);
+    if (onerror && typeof dynCall === 'function') Module['dynCall_vi'](onerror, fetch);
     else if (errorcb) errorcb(fetch);
   };
 

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1025,6 +1025,9 @@ var VoidPtr;
 
 // Various Emscripten-specific global variables
 
+/**
+ * @suppress {duplicate}
+ */
 var tempRet0;
 var tempI64;
 var tempDouble;

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -67,8 +67,13 @@ function JSify(data, functionsOnly) {
 
     var shellParts = read(shellFile).split('{{BODY}}');
     print(processMacros(preprocess(shellParts[0], shellFile)));
-    var preFile = BUILD_AS_SHARED_LIB || SIDE_MODULE ? 'preamble_sharedlib.js' : 'preamble.js';
-    var pre = processMacros(preprocess(read(preFile).replace('{{RUNTIME}}', getRuntime()), preFile));
+    var pre;
+    if (BUILD_AS_SHARED_LIB || SIDE_MODULE) {
+      pre = processMacros(preprocess(read('preamble_sharedlib.js'), 'preamble_sharedlib.js'));
+    } else {
+      pre = processMacros(preprocess(read('support.js'), 'support.js')) +
+            processMacros(preprocess(read('preamble.js'), 'preamble.js'));
+    }
     print(pre);
   }
 
@@ -114,8 +119,8 @@ function JSify(data, functionsOnly) {
     // name the function; overwrite if it's already named
     snippet = snippet.replace(/function(?:\s+([^(]+))?\s*\(/, 'function ' + finalName + '(');
     if (LIBRARY_DEBUG && !LibraryManager.library[ident + '__asm']) {
-      snippet = snippet.replace('{', '{ var ret = (function() { if (Runtime.debug) Module.printErr("[library call:' + finalName + ': " + Array.prototype.slice.call(arguments).map(Runtime.prettyPrint) + "]"); ');
-      snippet = snippet.substr(0, snippet.length-1) + '}).apply(this, arguments); if (Runtime.debug && typeof ret !== "undefined") Module.printErr("  [     return:" + Runtime.prettyPrint(ret)); return ret; \n}';
+      snippet = snippet.replace('{', '{ var ret = (function() { if (runtimeDebug) Module.printErr("[library call:' + finalName + ': " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]"); ');
+      snippet = snippet.substr(0, snippet.length-1) + '}).apply(this, arguments); if (runtimeDebug && typeof ret !== "undefined") Module.printErr("  [     return:" + prettyPrint(ret)); return ret; \n}';
     }
     return snippet;
   }
@@ -130,7 +135,7 @@ function JSify(data, functionsOnly) {
     }
 
     var func = "function _emscripten_" + (sync ? '' : 'a') + 'sync_run_in_browser_thread_' + sig + '(func' + argsList(sig.length-1) + ') {\n';
-    if (sync) func += '  var waitAddress = Runtime.stackSave();\n';
+    if (sync) func += '  var waitAddress = stackSave();\n';
 
     function sizeofType(t) {
       switch(t) {
@@ -421,10 +426,10 @@ function JSify(data, functionsOnly) {
         Variables.generatedGlobalBase = true;
         // Globals are done, here is the rest of static memory
         if (!SIDE_MODULE) {
-          print('STATIC_BASE = Runtime.GLOBAL_BASE;\n');
+          print('STATIC_BASE = GLOBAL_BASE;\n');
           print('STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
         } else {
-          print('gb = Runtime.alignMemory(getMemory({{{ STATIC_BUMP }}}, ' + MAX_GLOBAL_ALIGN + ' || 1));\n');
+          print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}}, ' + MAX_GLOBAL_ALIGN + ' || 1));\n');
           print('// STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n'); // comment as metadata only
         }
         if (BINARYEN) {
@@ -461,7 +466,7 @@ function JSify(data, functionsOnly) {
         if (USE_PTHREADS) {
           print('if (!ENVIRONMENT_IS_PTHREAD) {') // Pthreads should not initialize memory again, since it's shared with the main thread.
         }
-        print('/* memory initializer */ ' + makePointer(memoryInitialization, null, 'ALLOC_NONE', 'i8', 'Runtime.GLOBAL_BASE' + (SIDE_MODULE ? '+H_BASE' : ''), true));
+        print('/* memory initializer */ ' + makePointer(memoryInitialization, null, 'ALLOC_NONE', 'i8', 'GLOBAL_BASE' + (SIDE_MODULE ? '+H_BASE' : ''), true));
         if (USE_PTHREADS) {
           print('}')
         }
@@ -472,7 +477,7 @@ function JSify(data, functionsOnly) {
       if (!BUILD_AS_SHARED_LIB && !SIDE_MODULE) {
         if (USE_PTHREADS) {
           print('var tempDoublePtr;\n');
-          print('if (!ENVIRONMENT_IS_PTHREAD) tempDoublePtr = Runtime.alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
+          print('if (!ENVIRONMENT_IS_PTHREAD) tempDoublePtr = alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
         } else {
           print('var tempDoublePtr = ' + makeStaticAlloc(8) + '\n');
         }
@@ -519,11 +524,11 @@ function JSify(data, functionsOnly) {
         for(i in proxiedFunctionInvokers) print(proxiedFunctionInvokers[i]+'\n');
         print('if (!ENVIRONMENT_IS_PTHREAD) {\n // Only main thread initializes these, pthreads copy them over at thread worker init time (in pthread-main.js)');
       }
-      print('DYNAMICTOP_PTR = Runtime.staticAlloc(4);\n');
-      print('STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);\n');
-      if (STACK_START > 0) print('if (STACKTOP < ' + STACK_START + ') STACK_BASE = STACKTOP = Runtime.alignMemory(' + STACK_START + ');\n');
+      print('DYNAMICTOP_PTR = staticAlloc(4);\n');
+      print('STACK_BASE = STACKTOP = alignMemory(STATICTOP);\n');
+      if (STACK_START > 0) print('if (STACKTOP < ' + STACK_START + ') STACK_BASE = STACKTOP = alignMemory(' + STACK_START + ');\n');
       print('STACK_MAX = STACK_BASE + TOTAL_STACK;\n');
-      print('DYNAMIC_BASE = Runtime.alignMemory(STACK_MAX);\n');
+      print('DYNAMIC_BASE = alignMemory(STACK_MAX);\n');
       print('HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;\n');
       print('staticSealed = true; // seal the static portion of memory\n');
       if (ASSERTIONS) print('assert(DYNAMIC_BASE < TOTAL_MEMORY, "TOTAL_MEMORY not big enough for stack");\n');

--- a/src/library.js
+++ b/src/library.js
@@ -2005,7 +2005,7 @@ LibraryManager.library = {
     var dst = (summerOffset != winterOffset && date.getTimezoneOffset() == Math.min(winterOffset, summerOffset))|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_isdst, 'dst', 'i32') }}};
 
-    var zonePtr = {{{ makeGetValue(makeGlobalUse('_tzname'), 'dst ? Runtime.QUANTUM_SIZE : 0', 'i32') }}};
+    var zonePtr = {{{ makeGetValue(makeGlobalUse('_tzname'), 'dst ? ' + Runtime.QUANTUM_SIZE + ' : 0', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_zone, 'zonePtr', 'i32') }}};
 
     return tmPtr;

--- a/src/library.js
+++ b/src/library.js
@@ -4176,7 +4176,7 @@ LibraryManager.library = {
   emscripten_log: function(flags, varargs) {
     // Extract the (optionally-existing) printf format specifier field from varargs.
     var format = {{{ makeGetValue('varargs', '0', 'i32', undefined, undefined, true) }}};
-    varargs += Math.max(getNativeFieldSize('i32'), getAlignSize('i32', null, true));
+    varargs += {{{ Math.max(Runtime.getNativeFieldSize('i32'), Runtime.getAlignSize('i32', null, true)) }}};
     var str = '';
     if (format) {
       var result = __formatString(format, varargs);

--- a/src/library.js
+++ b/src/library.js
@@ -565,14 +565,14 @@ LibraryManager.library = {
      * not an issue.
      */
 #if ASSERTIONS == 2
-    Runtime.warnOnce('using stub malloc (reference it from C to have the real one included)');
+    warnOnce('using stub malloc (reference it from C to have the real one included)');
 #endif
-    var ptr = Runtime.dynamicAlloc(bytes + 8);
+    var ptr = dynamicAlloc(bytes + 8);
     return (ptr+8) & 0xFFFFFFF8;
   },
   free: function() {
 #if ASSERTIONS == 2
-    Runtime.warnOnce('using stub free (reference it from C to have the real one included)');
+    warnOnce('using stub free (reference it from C to have the real one included)');
 #endif
 },
 
@@ -598,7 +598,7 @@ LibraryManager.library = {
   atexit: function(func, arg) {
 #if ASSERTIONS
 #if NO_EXIT_RUNTIME == 1
-    Runtime.warnOnce('atexit() called, but NO_EXIT_RUNTIME is set, so atexits() will not be called. set NO_EXIT_RUNTIME to 0 (see the FAQ)');
+    warnOnce('atexit() called, but NO_EXIT_RUNTIME is set, so atexits() will not be called. set NO_EXIT_RUNTIME to 0 (see the FAQ)');
 #endif
 #endif
     __ATEXIT__.unshift({ func: func, arg: arg });
@@ -641,7 +641,7 @@ LibraryManager.library = {
       ENV['_'] = Module['thisProgram'];
       // Allocate memory.
       poolPtr = allocate(TOTAL_ENV_SIZE, 'i8', ALLOC_STATIC);
-      envPtr = allocate(MAX_ENV_VALUES * {{{ Runtime.QUANTUM_SIZE }}},
+      envPtr = allocate(MAX_ENV_VALUES * {{{ Runtime.POINTER_SIZE }}},
                         'i8*', ALLOC_STATIC);
       {{{ makeSetValue('envPtr', '0', 'poolPtr', 'i8*') }}};
       {{{ makeSetValue(makeGlobalUse('_environ'), 0, 'envPtr', 'i8*') }}};
@@ -1432,14 +1432,14 @@ LibraryManager.library = {
     if (!self.LLVM_SAVEDSTACKS) {
       self.LLVM_SAVEDSTACKS = [];
     }
-    self.LLVM_SAVEDSTACKS.push(Runtime.stackSave());
+    self.LLVM_SAVEDSTACKS.push(stackSave());
     return self.LLVM_SAVEDSTACKS.length-1;
   },
   llvm_stackrestore: function(p) {
     var self = _llvm_stacksave;
     var ret = self.LLVM_SAVEDSTACKS[p];
     self.LLVM_SAVEDSTACKS.splice(p, 1);
-    Runtime.stackRestore(ret);
+    stackRestore(ret);
   },
 
   __cxa_pure_virtual: function() {
@@ -1707,12 +1707,12 @@ LibraryManager.library = {
         var lib_data = FS.readFile(filename, { encoding: 'binary' });
         if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
         //Module.printErr('libfile ' + filename + ' size: ' + lib_data.length);
-        lib_module = Runtime.loadWebAssemblyModule(lib_data);
+        lib_module = loadWebAssemblyModule(lib_data);
 #else
         // the shared library is a JS file, which we eval
         var lib_data = FS.readFile(filename, { encoding: 'utf8' });
         lib_module = eval(lib_data)(
-          Runtime.alignFunctionTables(),
+          alignFunctionTables(),
           Module
         );
 #endif
@@ -1813,7 +1813,7 @@ LibraryManager.library = {
       } else {
         var result = lib.module[symbol];
         if (typeof result == 'function') {
-          result = Runtime.addFunction(result);
+          result = addFunction(result);
           //Module.printErr('adding function dlsym result for ' + symbol + ' => ' + result);
           lib.cached_functions = result;
         }
@@ -2052,9 +2052,9 @@ LibraryManager.library = {
 
   ctime_r__deps: ['localtime_r', 'asctime_r'],
   ctime_r: function(time, buf) {
-    var stack = Runtime.stackSave();
-    var rv = _asctime_r(_localtime_r(time, Runtime.stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
-    Runtime.stackRestore(stack);
+    var stack = stackSave();
+    var rv = _asctime_r(_localtime_r(time, stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
+    stackRestore(stack);
     return rv;
   },
 
@@ -4048,7 +4048,7 @@ LibraryManager.library = {
 
     // If user requested to see the original source stack, but no source map information is available, just fall back to showing the JS stack.
     if (flags & 8/*EM_LOG_C_STACK*/ && typeof emscripten_source_map === 'undefined') {
-      Runtime.warnOnce('Source map information is not available, emscripten_log with EM_LOG_C_STACK will be ignored. Build with "--pre-js $EMSCRIPTEN/src/emscripten-source-map.min.js" linker flag to add source map loading to code.');
+      warnOnce('Source map information is not available, emscripten_log with EM_LOG_C_STACK will be ignored. Build with "--pre-js $EMSCRIPTEN/src/emscripten-source-map.min.js" linker flag to add source map loading to code.');
       flags ^= 8/*EM_LOG_C_STACK*/;
       flags |= 16/*EM_LOG_JS_STACK*/;
     }
@@ -4176,7 +4176,7 @@ LibraryManager.library = {
   emscripten_log: function(flags, varargs) {
     // Extract the (optionally-existing) printf format specifier field from varargs.
     var format = {{{ makeGetValue('varargs', '0', 'i32', undefined, undefined, true) }}};
-    varargs += Math.max(Runtime.getNativeFieldSize('i32'), Runtime.getAlignSize('i32', null, true));
+    varargs += Math.max(getNativeFieldSize('i32'), getAlignSize('i32', null, true));
     var str = '';
     if (format) {
       var result = __formatString(format, varargs);
@@ -4190,7 +4190,7 @@ LibraryManager.library = {
   emscripten_get_compiler_setting: function(name) {
     name = Pointer_stringify(name);
 
-    var ret = Runtime.getCompilerSetting(name);
+    var ret = getCompilerSetting(name);
     if (typeof ret === 'number') return ret;
 
     if (!_emscripten_get_compiler_setting.cache) _emscripten_get_compiler_setting.cache = {};

--- a/src/library_bootstrap_structInfo.js
+++ b/src/library_bootstrap_structInfo.js
@@ -22,16 +22,16 @@ LibraryManager.library = {
     if (!self.called) {
       HEAP32[DYNAMICTOP_PTR>>2] = alignUp(HEAP32[DYNAMICTOP_PTR>>2], 16777216); // make sure we start out aligned
       self.called = true;
-      assert(Runtime.dynamicAlloc);
-      self.alloc = Runtime.dynamicAlloc;
-      Runtime.dynamicAlloc = function() { abort('cannot dynamically allocate, sbrk now has control') };
+      assert(dynamicAlloc);
+      self.alloc = dynamicAlloc;
+      dynamicAlloc = function() { abort('cannot dynamically allocate, sbrk now has control') };
     }
     var ret = HEAP32[DYNAMICTOP_PTR>>2];
     if (bytes != 0) self.alloc(bytes);
     return ret;  // Previous break location.
   },
   malloc: function(x) {
-    return Runtime.dynamicAlloc(x);
+    return dynamicAlloc(x);
   },
 };
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -122,7 +122,7 @@ var LibraryBrowser = {
               b = new Blob([(new Uint8Array(byteArray)).buffer], { type: Browser.getMimetype(name) });
             }
           } catch(e) {
-            Runtime.warnOnce('Blob constructor present but fails: ' + e + '; falling back to blob builder');
+            warnOnce('Blob constructor present but fails: ' + e + '; falling back to blob builder');
           }
         }
         if (!b) {
@@ -743,9 +743,9 @@ var LibraryBrowser = {
     _file = PATH.resolve(FS.cwd(), _file);
     function doCallback(callback) {
       if (callback) {
-        var stack = Runtime.stackSave();
+        var stack = stackSave();
         Module['dynCall_vi'](callback, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK));
-        Runtime.stackRestore(stack);
+        stackRestore(stack);
       }
     }
     var destinationDirectory = PATH.dirname(_file);
@@ -817,9 +817,9 @@ var LibraryBrowser = {
 
         FS.createDataFile( _file.substr(0, index), _file.substr(index + 1), new Uint8Array(http.response), true, true, false);
         if (onload) {
-          var stack = Runtime.stackSave();
+          var stack = stackSave();
           Module['dynCall_viii'](onload, handle, arg, allocate(intArrayFromString(_file), 'i8', ALLOC_STACK));
-          Runtime.stackRestore(stack);
+          stackRestore(stack);
         }
       } else {
         if (onerror) Module['dynCall_viii'](onerror, handle, arg, http.status);
@@ -1002,8 +1002,8 @@ var LibraryBrowser = {
 
   // TODO: currently not callable from a pthread, but immediately calls onerror() if not on main thread.
   emscripten_async_load_script: function(url, onload, onerror) {
-    onload = Runtime.getFuncWrapper(onload, 'v');
-    onerror = Runtime.getFuncWrapper(onerror, 'v');
+    onload = getFuncWrapper(onload, 'v');
+    onerror = getFuncWrapper(onerror, 'v');
 
 #if USE_PTHREADS
     if (ENVIRONMENT_IS_PTHREAD) {
@@ -1251,7 +1251,7 @@ var LibraryBrowser = {
     Module['noExitRuntime'] = true;
 
     function wrapper() {
-      Runtime.getFuncWrapper(func, 'vi')(arg);
+      getFuncWrapper(func, 'vi')(arg);
     }
 
     if (millis >= 0) {
@@ -1272,7 +1272,7 @@ var LibraryBrowser = {
   emscripten_force_exit: function(status) {
 #if NO_EXIT_RUNTIME
 #if ASSERTIONS
-    Runtime.warnOnce('emscripten_force_exit cannot actually shut down the runtime, as the build has NO_EXIT_RUNTIME set');
+    warnOnce('emscripten_force_exit cannot actually shut down the runtime, as the build has NO_EXIT_RUNTIME set');
 #endif
 #endif
     Module['noExitRuntime'] = false;
@@ -1377,7 +1377,7 @@ var LibraryBrowser = {
     if (callback) {
       callbackId = info.callbacks.length;
       info.callbacks.push({
-        func: Runtime.getFuncWrapper(callback, 'viii'),
+        func: getFuncWrapper(callback, 'viii'),
         arg: arg
       });
       info.awaited++;

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -555,13 +555,13 @@ var LibraryBrowser = {
         
         // check if SDL is available
         if (typeof SDL != "undefined") {
-        	Browser.mouseX = SDL.mouseX + Browser.mouseMovementX;
-        	Browser.mouseY = SDL.mouseY + Browser.mouseMovementY;
+          Browser.mouseX = SDL.mouseX + Browser.mouseMovementX;
+          Browser.mouseY = SDL.mouseY + Browser.mouseMovementY;
         } else {
-        	// just add the mouse delta to the current absolut mouse position
-        	// FIXME: ideally this should be clamped against the canvas size and zero
-        	Browser.mouseX += Browser.mouseMovementX;
-        	Browser.mouseY += Browser.mouseMovementY;
+          // just add the mouse delta to the current absolut mouse position
+          // FIXME: ideally this should be clamped against the canvas size and zero
+          Browser.mouseX += Browser.mouseMovementX;
+          Browser.mouseY += Browser.mouseMovementY;
         }        
       } else {
         // Otherwise, calculate the movement based on the changes
@@ -659,9 +659,9 @@ var LibraryBrowser = {
     setFullscreenCanvasSize: function() {
       // check if SDL is available   
       if (typeof SDL != "undefined") {
-      	var flags = {{{ makeGetValue('SDL.screen+Runtime.QUANTUM_SIZE*0', '0', 'i32', 0, 1) }}};
-      	flags = flags | 0x00800000; // set SDL_FULLSCREEN flag
-      	{{{ makeSetValue('SDL.screen+Runtime.QUANTUM_SIZE*0', '0', 'flags', 'i32') }}}
+        var flags = {{{ makeGetValue('SDL.screen', '0', 'i32', 0, 1) }}};
+        flags = flags | 0x00800000; // set SDL_FULLSCREEN flag
+        {{{ makeSetValue('SDL.screen', '0', 'flags', 'i32') }}}
       }
       Browser.updateResizeListeners();
     },
@@ -669,9 +669,9 @@ var LibraryBrowser = {
     setWindowedCanvasSize: function() {
       // check if SDL is available       
       if (typeof SDL != "undefined") {
-      	var flags = {{{ makeGetValue('SDL.screen+Runtime.QUANTUM_SIZE*0', '0', 'i32', 0, 1) }}};
-      	flags = flags & ~0x00800000; // clear SDL_FULLSCREEN flag
-      	{{{ makeSetValue('SDL.screen+Runtime.QUANTUM_SIZE*0', '0', 'flags', 'i32') }}}
+        var flags = {{{ makeGetValue('SDL.screen', '0', 'i32', 0, 1) }}};
+        flags = flags & ~0x00800000; // clear SDL_FULLSCREEN flag
+        {{{ makeSetValue('SDL.screen', '0', 'flags', 'i32') }}}
       }
       Browser.updateResizeListeners();
     },

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7275,7 +7275,7 @@ var LibraryGL = {
   glTexCoord3f: function() { throw 'glTexCoord3f: TODO' },
   glGetTexLevelParameteriv: function() { throw 'glGetTexLevelParameteriv: TODO' },
 
-  glShadeModel: function() { Runtime.warnOnce('TODO: glShadeModel') },
+  glShadeModel: function() { warnOnce('TODO: glShadeModel') },
 
   // Open GLES1.1 compatibility
 

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2464,7 +2464,7 @@ var LibraryGL = {
     // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15
     timeoutLo = timeoutLo >>> 0;
     timeoutHi = timeoutHi >>> 0;
-    var timeout = (timeoutLo == 0xFFFFFFFF && timeoutHi == 0xFFFFFFFF) ? -1 : Runtime.makeBigInt(timeoutLo, timeoutHi, true);
+    var timeout = (timeoutLo == 0xFFFFFFFF && timeoutHi == 0xFFFFFFFF) ? -1 : makeBigInt(timeoutLo, timeoutHi, true);
     return GLctx.clientWaitSync(GL.syncs[sync], flags, timeout);
   },
 
@@ -2473,7 +2473,7 @@ var LibraryGL = {
     // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
     timeoutLo = timeoutLo >>> 0;
     timeoutHi = timeoutHi >>> 0;
-    var timeout = (timeoutLo == 0xFFFFFFFF && timeoutHi == 0xFFFFFFFF) ? -1 : Runtime.makeBigInt(timeoutLo, timeoutHi, true);
+    var timeout = (timeoutLo == 0xFFFFFFFF && timeoutHi == 0xFFFFFFFF) ? -1 : makeBigInt(timeoutLo, timeoutHi, true);
     GLctx.waitSync(GL.syncs[sync], flags, timeout);
   },
 
@@ -5933,7 +5933,7 @@ var LibraryGL = {
 #if ASSERTIONS
         if (!useCurrProgram) {
           if (GLImmediate.TexEnvJIT.getTexUnitType(i) == 0) {
-             Runtime.warnOnce("GL_TEXTURE" + i + " coords are supplied, but that texture unit is disabled in the fixed-function pipeline.");
+             warnOnce("GL_TEXTURE" + i + " coords are supplied, but that texture unit is disabled in the fixed-function pipeline.");
           }
         }
 #endif
@@ -6539,7 +6539,7 @@ var LibraryGL = {
       if (!GLImmediate.modifiedClientAttributes) {
 #if GL_ASSERTIONS
         if ((GLImmediate.stride & 3) != 0) {
-          Runtime.warnOnce('Warning: Rendering from client side vertex arrays where stride (' + GLImmediate.stride + ') is not a multiple of four! This is not currently supported!');
+          warnOnce('Warning: Rendering from client side vertex arrays where stride (' + GLImmediate.stride + ') is not a multiple of four! This is not currently supported!');
         }
 #endif
         GLImmediate.vertexCounter = (GLImmediate.stride * count) / 4; // XXX assuming float
@@ -6585,7 +6585,7 @@ var LibraryGL = {
         // The immediate-mode glBegin()/glEnd() vertex submission gets automatically generated in appropriate layout,
         // so never need to come down this path if that was used.
 #if GL_ASSERTIONS
-        Runtime.warnOnce('Rendering from planar client-side vertex arrays. This is a very slow emulation path! Use interleaved vertex arrays for best performance.');
+        warnOnce('Rendering from planar client-side vertex arrays. This is a very slow emulation path! Use interleaved vertex arrays for best performance.');
 #endif
         if (!GLImmediate.restrideBuffer) GLImmediate.restrideBuffer = _malloc(GL.MAX_TEMP_BUFFER_SIZE);
         var start = GLImmediate.restrideBuffer;
@@ -6637,7 +6637,7 @@ var LibraryGL = {
       if (!beginEnd) {
 #if GL_ASSERTIONS
         if ((GLImmediate.stride & 3) != 0) {
-          Runtime.warnOnce('Warning: Rendering from client side vertex arrays where stride (' + GLImmediate.stride + ') is not a multiple of four! This is not currently supported!');
+          warnOnce('Warning: Rendering from client side vertex arrays where stride (' + GLImmediate.stride + ') is not a multiple of four! This is not currently supported!');
         }
 #endif
         GLImmediate.vertexCounter = (GLImmediate.stride * count) / 4; // XXX assuming float
@@ -7264,9 +7264,9 @@ var LibraryGL = {
 
   glTexGeni: function() { throw 'glTexGeni: TODO' },
   glTexGenfv: function() { throw 'glTexGenfv: TODO' },
-  glTexEnvi: function() { Runtime.warnOnce('glTexEnvi: TODO') },
-  glTexEnvf: function() { Runtime.warnOnce('glTexEnvf: TODO') },
-  glTexEnvfv: function() { Runtime.warnOnce('glTexEnvfv: TODO') },
+  glTexEnvi: function() { warnOnce('glTexEnvi: TODO') },
+  glTexEnvf: function() { warnOnce('glTexEnvf: TODO') },
+  glTexEnvfv: function() { warnOnce('glTexEnvfv: TODO') },
 
   glGetTexEnviv: function(target, pname, param) { throw 'GL emulation not initialized!'; },
   glGetTexEnvfv: function(target, pname, param) { throw 'GL emulation not initialized!'; },

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1703,7 +1703,7 @@ var LibraryGLFW = {
     for (var i in arg) {
       str += 'i';
     }
-    Runtime.dynCall(str, fun, arg);
+    dynCall(str, fun, arg);
     // One single thread
     return 0;
   },

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -184,13 +184,13 @@ var LibraryOpenAL = {
             audioSrc.noteOn(startTime);
 #if OPENAL_DEBUG
             if (offset > 0.0) {
-              Runtime.warnOnce('The current browser does not support AudioBufferSourceNode.start(when, offset); method, so cannot play back audio with an offset '+startOffset+' secs! Audio glitches will occur!');
+              warnOnce('The current browser does not support AudioBufferSourceNode.start(when, offset); method, so cannot play back audio with an offset '+startOffset+' secs! Audio glitches will occur!');
             }
 #endif
           }
 #if OPENAL_DEBUG
           else {
-            Runtime.warnOnce('Unable to start AudioBufferSourceNode playback! Not supported by the browser?');
+            warnOnce('Unable to start AudioBufferSourceNode playback! Not supported by the browser?');
           }
 
           console.log('scheduleSourceAudio() queuing buffer ' + buf.id + ' for source ' + src.id + ' at ' + startTime + ' (offset by ' + startOffset + ')');
@@ -473,7 +473,7 @@ var LibraryOpenAL = {
         listener.positionZ.value = listener._position[2];
       } else {
 #if OPENAL_DEBUG
-        Runtime.warnOnce('Listener position attributes are not present, falling back to setPosition()');
+        warnOnce('Listener position attributes are not present, falling back to setPosition()');
 #endif
         listener.setPosition(listener._position[0], listener._position[1], listener._position[2]);
       }
@@ -486,7 +486,7 @@ var LibraryOpenAL = {
         listener.upZ.value = listener._up[2];
       } else {
 #if OPENAL_DEBUG
-        Runtime.warnOnce('Listener orientation attributes are not present, falling back to setOrientation()');
+        warnOnce('Listener orientation attributes are not present, falling back to setOrientation()');
 #endif
         listener.setOrientation(
           listener._direction[0], listener._direction[1], listener._direction[2],
@@ -598,7 +598,7 @@ var LibraryOpenAL = {
         panner.positionZ.value = posZ;
       } else {
 #if OPENAL_DEBUG
-        Runtime.warnOnce('Panner position attributes are not present, falling back to setPosition()');
+        warnOnce('Panner position attributes are not present, falling back to setPosition()');
 #endif
         panner.setPosition(posX, posY, posZ);
       }
@@ -608,7 +608,7 @@ var LibraryOpenAL = {
         panner.orientationZ.value = dirZ;
       } else {
 #if OPENAL_DEBUG
-        Runtime.warnOnce('Panner orientation attributes are not present, falling back to setOrientation()');
+        warnOnce('Panner orientation attributes are not present, falling back to setOrientation()');
 #endif
         panner.setOrientation(dirX, dirY, dirZ);
       }
@@ -1347,7 +1347,7 @@ var LibraryOpenAL = {
           return;
         }
 #if OPENAL_DEBUG
-        Runtime.warnOnce('AL_MIN_GAIN is not currently supported');
+        warnOnce('AL_MIN_GAIN is not currently supported');
 #endif
         src.minGain = value;
         break;
@@ -1360,7 +1360,7 @@ var LibraryOpenAL = {
           return;
         }
 #if OPENAL_DEBUG
-        Runtime.warnOnce('AL_MAX_GAIN is not currently supported');
+        warnOnce('AL_MAX_GAIN is not currently supported');
 #endif
         src.maxGain = value;
         break;
@@ -3377,7 +3377,7 @@ var LibraryOpenAL = {
   alDopplerVelocity__proxy: 'sync',
   alDopplerVelocity__sig: 'vi',
   alDopplerVelocity: function(value) {
-    Runtime.warnOnce('alDopplerVelocity() is deprecated, and only kept for compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
+    warnOnce('alDopplerVelocity() is deprecated, and only kept for compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     if (!AL.currentCtx) {
 #if OPENAL_DEBUG
       console.error('alDopplerVelocity() called without a valid context');

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -295,7 +295,7 @@ var LibraryPThreadStub = {
     var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
     var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
     {{{ makeSetValue('ptr', 0, '_i64Add(l, h, vall, valh)', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'Runtime["getTempRet0"]()', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'getTempRet0()', 'i32') }}};
     {{{ makeStructuralReturn(['l', 'h']) }}};
   },
 
@@ -304,7 +304,7 @@ var LibraryPThreadStub = {
     var l = {{{ makeGetValue('ptr', 0, 'i32') }}};
     var h = {{{ makeGetValue('ptr', 4, 'i32') }}};
     {{{ makeSetValue('ptr', 0, '_i64Subtract(l, h, vall, valh)', 'i32') }}};
-    {{{ makeSetValue('ptr', 4, 'Runtime["getTempRet0"]()', 'i32') }}};
+    {{{ makeSetValue('ptr', 4, 'getTempRet0()', 'i32') }}};
     {{{ makeStructuralReturn(['l', 'h']) }}};
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -302,7 +302,7 @@ var LibrarySDL = {
       // Canvas screens are always RGBA.
       var format = {{{ makeGetValue('fmt', C_STRUCTS.SDL_PixelFormat.format, 'i32') }}};
       if (format != {{{ cDefine('SDL_PIXELFORMAT_RGBA8888') }}}) {
-        Runtime.warnOnce('Unsupported pixel format!');
+        warnOnce('Unsupported pixel format!');
       }
 #endif
     },
@@ -514,7 +514,7 @@ var LibrarySDL = {
       dstData.ctx.globalAlpha = oldAlpha;
       if (dst != SDL.screen) {
         // XXX As in IMG_Load, for compatibility we write out |pixels|
-        Runtime.warnOnce('WARNING: copying canvas data to memory for compatibility');
+        warnOnce('WARNING: copying canvas data to memory for compatibility');
         _SDL_LockSurface(dst);
         dstData.locked--; // The surface is not actually locked in this hack
       }
@@ -1379,7 +1379,7 @@ var LibrarySDL = {
   SDL_GetVideoInfo__sig: 'i',
   SDL_GetVideoInfo: function() {
     // %struct.SDL_VideoInfo = type { i32, i32, %struct.SDL_PixelFormat*, i32, i32 } - 5 fields of quantum size
-    var ret = _malloc(5*Runtime.QUANTUM_SIZE);
+    var ret = _malloc(5 * {{{ Runtime.QUANTUM_SIZE }}});
     {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*0', '0', '0', 'i32') }}}; // TODO
     {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*1', '0', '0', 'i32') }}}; // TODO
     {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*2', '0', '0', 'void*') }}};
@@ -2010,7 +2010,7 @@ var LibrarySDL = {
     // SetColorKey assigns one color to be rendered as transparent. I don't
     // think the canvas API allows for anything like this, and iterating through
     // each pixel to replace that color seems prohibitively expensive.
-    Runtime.warnOnce('SDL_SetColorKey is a no-op for performance reasons');
+    warnOnce('SDL_SetColorKey is a no-op for performance reasons');
     return 0;
   },
 
@@ -2257,7 +2257,7 @@ var LibrarySDL = {
         var raw = callStbImage('stbi_load_from_memory', [rwops.bytes, rwops.count]);
         if (!raw) return 0;
 #else
-        Runtime.warnOnce('Only file names that have been preloaded are supported for IMG_Load_RW. Consider using STB_IMAGE=1 if you want synchronous image decoding (see settings.js), or package files with --use-preload-plugins');
+        warnOnce('Only file names that have been preloaded are supported for IMG_Load_RW. Consider using STB_IMAGE=1 if you want synchronous image decoding (see settings.js), or package files with --use-preload-plugins');
         return 0;
 #endif
       }
@@ -2277,8 +2277,8 @@ var LibrarySDL = {
           var raw = callStbImage('stbi_load', [name]);
           if (!raw) return 0;
 #else
-          Runtime.warnOnce('Cannot find preloaded image ' + filename);
-          Runtime.warnOnce('Cannot find preloaded image ' + filename + '. Consider using STB_IMAGE=1 if you want synchronous image decoding (see settings.js), or package files with --use-preload-plugins');
+          warnOnce('Cannot find preloaded image ' + filename);
+          warnOnce('Cannot find preloaded image ' + filename + '. Consider using STB_IMAGE=1 if you want synchronous image decoding (see settings.js), or package files with --use-preload-plugins');
           return 0;
 #endif
         } else if (Module['freePreloadedMediaOnUse']) {
@@ -2751,7 +2751,7 @@ var LibrarySDL = {
       var raw = Module["preloadedAudios"][filename];
       if (!raw) {
         if (raw === null) Module.printErr('Trying to reuse preloaded audio, but freePreloadedMediaOnUse is set!');
-        if (!Module.noAudioDecoding) Runtime.warnOnce('Cannot find preloaded audio ' + filename);
+        if (!Module.noAudioDecoding) warnOnce('Cannot find preloaded audio ' + filename);
 
         // see if we can read the file-contents from the in-memory FS
         try {
@@ -2916,7 +2916,7 @@ var LibrarySDL = {
     }
     audio['onended'] = function SDL_audio_onended() { // TODO: cache these
       if (channelInfo.audio == this) { channelInfo.audio.paused = true; channelInfo.audio = null; }
-      if (SDL.channelFinished) Runtime.getFuncWrapper(SDL.channelFinished, 'vi')(channel);
+      if (SDL.channelFinished) getFuncWrapper(SDL.channelFinished, 'vi')(channel);
     }
     channelInfo.audio = audio;
     // TODO: handle N loops. Behavior matches Mix_PlayMusic
@@ -2941,7 +2941,7 @@ var LibrarySDL = {
         info.audio = null;
       }
       if (SDL.channelFinished) {
-        Runtime.getFuncWrapper(SDL.channelFinished, 'vi')(channel);
+        getFuncWrapper(SDL.channelFinished, 'vi')(channel);
       }
     }
     if (channel != -1) {
@@ -3679,7 +3679,7 @@ var LibrarySDL = {
   SDL_CondWaitTimeout: function() { throw 'SDL_CondWaitTimeout: TODO' },
   SDL_WM_IconifyWindow: function() { throw 'SDL_WM_IconifyWindow TODO' },
 
-  Mix_SetPostMix: function() { Runtime.warnOnce('Mix_SetPostMix: TODO') },
+  Mix_SetPostMix: function() { warnOnce('Mix_SetPostMix: TODO') },
 
   Mix_VolumeChunk: function(chunk, volume) { throw 'Mix_VolumeChunk: TODO' },
   Mix_SetPosition: function(channel, angle, distance) { throw 'Mix_SetPosition: TODO' },

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1380,11 +1380,11 @@ var LibrarySDL = {
   SDL_GetVideoInfo: function() {
     // %struct.SDL_VideoInfo = type { i32, i32, %struct.SDL_PixelFormat*, i32, i32 } - 5 fields of quantum size
     var ret = _malloc(5 * {{{ Runtime.QUANTUM_SIZE }}});
-    {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*0', '0', '0', 'i32') }}}; // TODO
-    {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*1', '0', '0', 'i32') }}}; // TODO
-    {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*2', '0', '0', 'void*') }}};
-    {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*3', '0', 'Module["canvas"].width', 'i32') }}};
-    {{{ makeSetValue('ret+Runtime.QUANTUM_SIZE*4', '0', 'Module["canvas"].height', 'i32') }}};
+    {{{ makeSetValue('ret+' + (Runtime.QUANTUM_SIZE*0), '0', '0', 'i32') }}}; // TODO
+    {{{ makeSetValue('ret+' + (Runtime.QUANTUM_SIZE*1), '0', '0', 'i32') }}}; // TODO
+    {{{ makeSetValue('ret+' + (Runtime.QUANTUM_SIZE*2), '0', '0', 'void*') }}};
+    {{{ makeSetValue('ret+' + (Runtime.QUANTUM_SIZE*3), '0', 'Module["canvas"].width', 'i32') }}};
+    {{{ makeSetValue('ret+' + (Runtime.QUANTUM_SIZE*4), '0', 'Module["canvas"].height', 'i32') }}};
     return ret;
   },
 

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -91,7 +91,7 @@ var funs = {
 #endif
   ___setErrNo(ERRNO_CODES.ENOSYS);
 #if ASSERTIONS
-      Runtime.warnOnce('raise() returning an error as we do not support it');
+    warnOnce('raise() returning an error as we do not support it');
 #endif
     return -1;
   },
@@ -131,7 +131,7 @@ var funs = {
     // in most cases siglongjmp will be called later.
 
     // siglongjmp can be called very many times, so don't flood the stderr.
-    Runtime.warnOnce("Calling longjmp() instead of siglongjmp()");
+    warnOnce("Calling longjmp() instead of siglongjmp()");
     _longjmp(env, value);
   },
 #else

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -714,10 +714,10 @@ mergeInto(LibraryManager.library, {
     function _callback(data) {
       try {
         if (event === 'error') {
-          var sp = Runtime.stackSave();
+          var sp = stackSave();
           var msg = allocate(intArrayFromString(data[2]), 'i8', ALLOC_STACK);
           Module['dynCall_viiii'](callback, data[0], data[1], msg, userData);
-          Runtime.stackRestore(sp);
+          stackRestore(sp);
         } else {
           Module['dynCall_vii'](callback, data, userData);
         }

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -147,11 +147,11 @@ var LibraryWebVR = {
     var displayIterationFunc;
     if (typeof arg !== 'undefined') {
       displayIterationFunc = function() {
-        Runtime.dynCall('vi', func, [arg]);
+        dynCall('vi', func, [arg]);
       };
     } else {
       displayIterationFunc = function() {
-        Runtime.dynCall('v', func);
+        dynCall('v', func);
       };
     }
 
@@ -257,7 +257,7 @@ var LibraryWebVR = {
 
     display.requestPresent(layerInit).then(function() {
       if (!func) return;
-      Runtime.dynCall('vi', func, [userData]);
+      dynCall('vi', func, [userData]);
     });
 
     return 1;

--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -15,7 +15,7 @@ var emscriptenMemoryProfiler = {
   // If allocateStatistics = true, then all callstacks that have recorded more than the following number of allocations will be printed to html page.
   allocateStatisticsNumcallsMinReported: 100,
 
-  // If true, we hook into Runtime.stackAlloc to be able to catch better estimate of the maximum used STACK space.
+  // If true, we hook into stackAlloc to be able to catch better estimate of the maximum used STACK space.
   // You might only ever want to set this to false for performance reasons. Since stack allocations may occur often, this might impact performance.
   hookStackAlloc: true,
 
@@ -167,12 +167,12 @@ var emscriptenMemoryProfiler = {
 
     if (this.hookStackAlloc) {
       // Inject stack allocator.
-      var prevStackAlloc = Runtime.stackAlloc;
+      var prevStackAlloc = stackAlloc;
       function hookedStackAlloc(size) {
         emscriptenMemoryProfiler.stackTopWatermark = Math.max(emscriptenMemoryProfiler.stackTopWatermark, STACKTOP + size);
         return prevStackAlloc(size);
       }
-      Runtime.stackAlloc = hookedStackAlloc;
+      stackAlloc = hookedStackAlloc;
     }
 
     memoryprofiler = document.getElementById('memoryprofiler');

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1313,7 +1313,7 @@ function makeStructuralReturn(values, inAsm) {
   return 'return ' + asmCoercion(values.slice(1).map(function(value) {
     i++;
     if (!inAsm) {
-      return 'Runtime.setTempRet' + i + '(' + value + ')';
+      return 'setTempRet' + i + '(' + value + ')';
     }
     if (i === 0) {
       return makeSetTempRet0(value)

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1473,3 +1473,14 @@ function makeStaticAlloc(size) {
   return 'STATICTOP; STATICTOP += ' + size + ';';
 }
 
+function makeRetainedCompilerSettings() {
+  var blacklist = set('STRUCT_INFO');
+  var ret = {};
+  for (var x in this) {
+    try {
+      if (x[0] !== '_' && !(x in blacklist) && x == x.toUpperCase() && (typeof this[x] === 'number' || typeof this[x] === 'string' || this.isArray())) ret[x] = this[x];
+    } catch(e){}
+  }
+  return ret;
+}
+

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -31,7 +31,7 @@ if (memoryInitializer) (function(s) {
   assert(crc === 0, "memory initializer checksum");
 #endif
   for (i = 0; i < n; ++i) {
-    HEAPU8[Runtime.GLOBAL_BASE + i] = s.charCodeAt(i);
+    HEAPU8[GLOBAL_BASE + i] = s.charCodeAt(i);
   }
 })(memoryInitializer);
 #else
@@ -47,17 +47,17 @@ if (memoryInitializer) {
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
     var data = Module['readBinary'](memoryInitializer);
-    HEAPU8.set(data, Runtime.GLOBAL_BASE);
+    HEAPU8.set(data, GLOBAL_BASE);
   } else {
     addRunDependency('memory initializer');
     var applyMemoryInitializer = function(data) {
       if (data.byteLength) data = new Uint8Array(data);
 #if ASSERTIONS
       for (var i = 0; i < data.length; i++) {
-        assert(HEAPU8[Runtime.GLOBAL_BASE + i] === 0, "area for memory initializer should not have been touched before it's loaded");
+        assert(HEAPU8[GLOBAL_BASE + i] === 0, "area for memory initializer should not have been touched before it's loaded");
       }
 #endif
-      HEAPU8.set(data, Runtime.GLOBAL_BASE);
+      HEAPU8.set(data, GLOBAL_BASE);
       // Delete the typed array that contains the large blob of the memory initializer request response so that
       // we won't keep unnecessary memory lying around. However, keep the XHR object itself alive so that e.g.
       // its .status field can still be accessed later.
@@ -352,7 +352,7 @@ function exit(status, implicit) {
     Module['print'] = print;
     Module['printErr'] = printErr;
     if (has) {
-      Runtime.warnOnce('stdio streams had content in them that was not flushed. you should set NO_EXIT_RUNTIME to 0 (see the FAQ), or make sure to emit a newline when you printf etc.');
+      warnOnce('stdio streams had content in them that was not flushed. you should set NO_EXIT_RUNTIME to 0 (see the FAQ), or make sure to emit a newline when you printf etc.');
     }
   }
 #endif // NO_EXIT_RUNTIME

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -301,7 +301,7 @@ document.styleSheets = [{
 document.URL = 'http://worker.not.yet.ready.wait.for.window.onload?fake';
 
 function Audio() {
-  Runtime.warnOnce('faking Audio elements, no actual sound will play');
+  warnOnce('faking Audio elements, no actual sound will play');
 }
 Audio.prototype = new EventListener();
 Object.defineProperty(Audio.prototype, 'src', {
@@ -319,7 +319,7 @@ Audio.prototype.cloneNode = function() {
 }
 
 function AudioContext() {
-  Runtime.warnOnce('faking WebAudio elements, no actual sound will play');
+  warnOnce('faking WebAudio elements, no actual sound will play');
   function makeNode() {
     return {
       connect: function(){},

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -119,7 +119,7 @@ this.onmessage = function(e) {
       STACK_MAX = STACK_BASE + e.data.stackSize;
       assert(STACK_BASE != 0);
       assert(STACK_MAX > STACK_BASE);
-      Runtime.establishStackSpace(e.data.stackBase, e.data.stackBase + e.data.stackSize);
+      establishStackSpace(e.data.stackBase, e.data.stackBase + e.data.stackSize);
       var result = 0;
 //#if STACK_OVERFLOW_CHECK
       if (typeof writeStackCookie === 'function') writeStackCookie();

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -628,12 +628,3 @@ function reSign(value, bits, ignore) {
   return value;
 }
 
-if (RETAIN_COMPILER_SETTINGS) {
-  var blacklist = set('STRUCT_INFO');
-  for (var x in this) {
-    try {
-      if (x[0] !== '_' && !(x in blacklist) && x == x.toUpperCase() && (typeof this[x] === 'number' || typeof this[x] === 'string' || this.isArray())) Runtime.compilerSettings[x] = this[x];
-    } catch(e){}
-  }
-}
-

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -626,12 +626,6 @@ function reSign(value, bits, ignore) {
   return value;
 }
 
-// The address globals begin at. Very low in memory, for code size and optimization opportunities.
-// Above 0 is static memory, starting with globals.
-// Then the stack.
-// Then 'dynamic' memory for sbrk.
-Runtime.GLOBAL_BASE = {{{ GLOBAL_BASE }}};
-
 if (RETAIN_COMPILER_SETTINGS) {
   var blacklist = set('STRUCT_INFO');
   for (var x in this) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -572,6 +572,8 @@ Runtime.dynamicAlloc = unInline('dynamicAlloc', ['size'], false);
 Runtime.alignMemory = unInline('alignMemory', ['size', 'quantum'], true);
 Runtime.makeBigInt = unInline('makeBigInt', ['low', 'high', 'unsigned'], true);
 
+Runtime.POINTER_SIZE = 4;
+
 if (MAIN_MODULE || SIDE_MODULE) {
   Runtime.tempRet0 = 0;
   Runtime.getTempRet0 = function() {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,119 +1,5 @@
 //"use strict";
 
-// Implementation details for the 'runtime environment' we generate in
-// JavaScript. The Runtime object itself is used both during compilation,
-// and is available at runtime (dynamic compilation). The RuntimeGenerator
-// helps to create the Runtime object (written so that the Runtime object
-// itself is as optimized as possible - no unneeded runtime checks).
-
-var RuntimeGenerator = {
-  alloc: function(size, type, sep, ignoreAlign) {
-    sep = sep || ';';
-    var ret = type + 'TOP';
-    ret += sep + type + 'TOP = (' + type + 'TOP + ' + size + ')|0';
-    if ({{{ STACK_ALIGN }}} > 1 && !ignoreAlign) {
-      ret += sep + RuntimeGenerator.alignMemory(type + 'TOP', {{{ STACK_ALIGN }}});
-    }
-    return ret;
-  },
-
-  // An allocation that lives as long as the current function call
-  stackAlloc: function(size, sep) {
-    sep = sep || ';';
-    var ret = RuntimeGenerator.alloc(size, 'STACK', sep, (isNumber(size) && parseInt(size) % {{{ STACK_ALIGN }}} == 0));
-    if (ASSERTIONS || STACK_OVERFLOW_CHECK >= 2) {
-      ret += sep + '(assert(' + asmCoercion('(STACKTOP|0) < (STACK_MAX|0)', 'i32') + ')|0)';
-    }
-    return ret;
-  },
-
-  stackEnter: function(initial, force) {
-    if (initial === 0 && SKIP_STACK_IN_SMALL && !force) return '';
-    var ret = 'var sp=0;sp=STACKTOP';
-    if (initial > 0) ret += ';STACKTOP=(STACKTOP+' + initial + ')|0';
-    assert(initial % Runtime.STACK_ALIGN == 0);
-    if (ASSERTIONS && Runtime.STACK_ALIGN == 4) {
-      ret += '; (assert(' + asmCoercion('!(STACKTOP&3)', 'i32') + ')|0)';
-    }
-    if (ASSERTIONS) {
-      ret += '; (assert(' + asmCoercion('(STACKTOP|0) < (STACK_MAX|0)', 'i32') + ')|0)';
-    }
-    return ret;
-  },
-
-  stackExit: function(initial, force) {
-    if (initial === 0 && SKIP_STACK_IN_SMALL && !force) return '';
-    return 'STACKTOP=sp';
-  },
-
-  // An allocation that cannot normally be free'd (except through sbrk, which once
-  // called, takes control of STATICTOP)
-  staticAlloc: function(size) {
-    if (ASSERTIONS) size = '(assert(!staticSealed),' + size + ')'; // static area must not be sealed
-#if USE_PTHREADS
-    if (typeof ENVIRONMENT_IS_PTHREAD !== 'undefined' && ENVIRONMENT_IS_PTHREAD) throw 'Runtime.staticAlloc is not available in pthreads!'; // This is because each worker has its own copy of STATICTOP, of which main thread is authoritative.
-#endif
-    var ret = RuntimeGenerator.alloc(size, 'STATIC');
-    return ret;
-  },
-
-  // allocation on the top of memory, adjusted dynamically by sbrk
-  dynamicAlloc: function(size) {
-    var ret = '';
-    if (ASSERTIONS) ret += 'assert(DYNAMICTOP_PTR);'; // dynamic area must be ready
-    ret += 'var ret = HEAP32[DYNAMICTOP_PTR>>2];'
-      + 'var end = (((ret + size + 15)|0) & -16);'
-      + 'HEAP32[DYNAMICTOP_PTR>>2] = end;'
-      + 'if (end >= TOTAL_MEMORY) {'
-      +   'var success = enlargeMemory();'
-      +     'if (!success) {'
-      +       'HEAP32[DYNAMICTOP_PTR>>2] = ret;'
-      +       'return 0;'
-      +    '}'
-      +  '}'
-      + 'return ret;';
-    return ret;
-  },
-
-  forceAlign: function(target, quantum) {
-    quantum = quantum || {{{ QUANTUM_SIZE }}};
-    if (quantum == 1) return target;
-    if (isNumber(target) && isNumber(quantum)) {
-      return Math.ceil(target/quantum)*quantum;
-    } else if (isNumber(quantum) && isPowerOfTwo(quantum)) {
-      return '(((' +target + ')+' + (quantum-1) + ')&' + -quantum + ')';
-    }
-    return 'Math.ceil((' + target + ')/' + quantum + ')*' + quantum;
-  },
-
-  alignMemory: function(target, quantum) {
-    if (typeof quantum !== 'number') {
-      quantum = '(quantum ? quantum : {{{ STACK_ALIGN }}})';
-    }
-    return target + ' = ' + RuntimeGenerator.forceAlign(target, quantum);
-  },
-
-  // Given two 32-bit unsigned parts of an emulated 64-bit number, combine them into a JS number (double).
-  // Rounding is inevitable if the number is large. This is a particular problem for small negative numbers
-  // (-1 will be rounded!), so handle negatives separately and carefully
-  makeBigInt: function(low, high, unsigned) {
-    var unsignedRet = '(' + asmCoercion(makeSignOp(low, 'i32', 'un', 1, 1), 'double') + '+(' + asmCoercion(makeSignOp(high, 'i32', 'un', 1, 1), 'double') + '*' + asmEnsureFloat(4294967296, 'double') + '))';
-    var signedRet = '(' + asmCoercion(makeSignOp(low, 'i32', 'un', 1, 1), 'double') + '+(' + asmCoercion(makeSignOp(high, 'i32', 're', 1, 1), 'double') + '*' + asmEnsureFloat(4294967296, 'double') + '))';
-    if (typeof unsigned === 'string') return '(' + unsigned + ' ? ' + unsignedRet + ' : ' + signedRet + ')';
-    return unsigned ? unsignedRet : signedRet;
-  }
-};
-
-function unInline(name_, params, isExpression) {
-  if (isExpression) {
-    var src = '(function(' + params + ') { var ret = ' + RuntimeGenerator[name_].apply(null, params) + '; return ret; })';
-  } else {
-    var src = '(function(' + params + ') { ' + RuntimeGenerator[name_].apply(null, params) + '})';
-  }
-  var ret = eval(src);
-  return ret;
-}
-
 var Compiletime = {
   isPointerType: isPointerType,
   isStructType: isStructType,
@@ -126,47 +12,40 @@ var Compiletime = {
   FLOAT_TYPES: set('float', 'double'),
 };
 
-var Runtime = {
-  // When a 64 bit long is returned from a compiled function the least significant
-  // 32 bit word is passed in the return value, but the most significant 32 bit
-  // word is placed in tempRet0. This provides an accessor for that value.
-  setTempRet0: function(value) {
-    tempRet0 = value;
-    return value;
-  },
-  getTempRet0: function() {
-    return tempRet0;
-  },
-  stackSave: function() {
-    return STACKTOP;
-  },
-  stackRestore: function(stackTop) {
-    STACKTOP = stackTop;
-  },
+// code used both at compile time and runtime is defined here, then put on
+// the Runtime object for compile time and support.js for the generated code
 
-  //! Returns the size of a type, as C/C++ would have it (in 32-bit), in bytes.
-  //! @param type The type, by name.
-  getNativeTypeSize: function(type) {
-    switch (type) {
-      case 'i1': case 'i8': return 1;
-      case 'i16': return 2;
-      case 'i32': return 4;
-      case 'i64': return 8;
-      case 'float': return 4;
-      case 'double': return 8;
-      default: {
-        if (type[type.length-1] === '*') {
-          return Runtime.QUANTUM_SIZE; // A pointer
-        } else if (type[0] === 'i') {
-          var bits = parseInt(type.substr(1));
-          assert(bits % 8 === 0);
-          return bits/8;
-        } else {
-          return 0;
-        }
+function getNativeTypeSize(type) {
+  switch (type) {
+    case 'i1': case 'i8': return 1;
+    case 'i16': return 2;
+    case 'i32': return 4;
+    case 'i64': return 8;
+    case 'float': return 4;
+    case 'double': return 8;
+    default: {
+      if (type[type.length-1] === '*') {
+        return 4; // A pointer
+      } else if (type[0] === 'i') {
+        var bits = parseInt(type.substr(1));
+        assert(bits % 8 === 0);
+        return bits / 8;
+      } else {
+        return 0;
       }
     }
-  },
+  }
+}
+
+function alignMemory(size, factor) {
+  if (!factor) factor = STACK_ALIGN; // stack alignment (16-byte) by default
+  var ret = size = Math.ceil(size / factor) * factor;
+  return ret;
+}
+
+var Runtime = {
+  getNativeTypeSize: getNativeTypeSize,
+  alignMemory: alignMemory,
 
   //! Returns the size of a structure field, as C/C++ would have it (in 32-bit,
   //! for now).
@@ -176,21 +55,7 @@ var Runtime = {
   },
 
   STACK_ALIGN: {{{ STACK_ALIGN }}},
-
-  // This must be called before reading a double or i64 vararg. It will bump the pointer properly.
-  // It also does an assert on i32 values, so it's nice to call it before all varargs calls.
-  prepVararg: function(ptr, type) {
-    if (type === 'double' || type === 'i64') {
-      // move so the load is aligned
-      if (ptr & 7) {
-        assert((ptr & 7) === 4);
-        ptr += 4;
-      }
-    } else {
-      assert((ptr & 3) === 0);
-    }
-    return ptr;
-  },
+  POINTER_SIZE: 4,
 
   // type can be a native type or a struct (or null, for structs we only look at size here)
   getAlignSize: function(type, size, vararg) {
@@ -198,407 +63,8 @@ var Runtime = {
     if (!vararg && (type == 'i64' || type == 'double')) return 8;
     if (!type) return Math.min(size, 8); // align structures internally to 64 bits
     return Math.min(size || (type ? Runtime.getNativeFieldSize(type) : 0), Runtime.QUANTUM_SIZE);
-  },
-
-  dynCall: function(sig, ptr, args) {
-    if (args && args.length) {
-#if ASSERTIONS
-      assert(args.length == sig.length-1);
-#endif
-#if ASSERTIONS
-      assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
-#endif
-      return Module['dynCall_' + sig].apply(null, [ptr].concat(args));
-    } else {
-#if ASSERTIONS
-      assert(sig.length == 1);
-#endif
-#if ASSERTIONS
-      assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
-#endif
-      return Module['dynCall_' + sig].call(null, ptr);
-    }
-  },
-
-#if EMULATED_FUNCTION_POINTERS
-  getFunctionTables: function(module) {
-    if (!module) module = Module;
-    var tables = {};
-    for (var t in module) {
-      if (/^FUNCTION_TABLE_.*/.test(t)) {
-        var table = module[t];
-        if (typeof table === 'object') tables[t.substr('FUNCTION_TABLE_'.length)] = table;
-      }
-    }
-    return tables;
-  },
-
-  alignFunctionTables: function(module) {
-    var tables = Runtime.getFunctionTables(module);
-    var maxx = 0;
-    for (var sig in tables) {
-      maxx = Math.max(maxx, tables[sig].length);
-    }
-    assert(maxx >= 0);
-    for (var sig in tables) {
-      var table = tables[sig];
-      while (table.length < maxx) table.push(0);
-    }
-    return maxx;
-  },
-
-  registerFunctions: function(sigs, newModule) {
-    sigs.forEach(function(sig) {
-      if (!Module['FUNCTION_TABLE_' + sig]) {
-        Module['FUNCTION_TABLE_' + sig] = [];
-      }
-    });
-    var oldMaxx = Runtime.alignFunctionTables(); // align the new tables we may have just added
-    var newMaxx = Runtime.alignFunctionTables(newModule);
-    var maxx = oldMaxx + newMaxx;
-    sigs.forEach(function(sig) {
-      var newTable = newModule['FUNCTION_TABLE_' + sig];
-      var oldTable = Module['FUNCTION_TABLE_' + sig];
-      assert(newTable !== oldTable);
-      assert(oldTable.length === oldMaxx);
-      for (var i = 0; i < newTable.length; i++) {
-        oldTable.push(newTable[i]);
-      }
-      assert(oldTable.length === maxx);
-    });
-    assert(maxx === Runtime.alignFunctionTables()); // align the ones we didn't touch
-  },
-#endif
-
-  functionPointers: new Array(RESERVED_FUNCTION_POINTERS),
-
-  addFunction: function(func) {
-#if EMULATED_FUNCTION_POINTERS == 0
-    for (var i = 0; i < Runtime.functionPointers.length; i++) {
-      if (!Runtime.functionPointers[i]) {
-        Runtime.functionPointers[i] = func;
-        return {{{ FUNCTION_POINTER_ALIGNMENT }}}*(1 + i);
-      }
-    }
-    throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';
-#else
-#if BINARYEN
-    // we can simply appent to the wasm table
-    var table = Module['wasmTable'];
-    var ret = table.length;
-    table.grow(1);
-    table.set(ret, func);
-    return ret;
-#else
-    Runtime.alignFunctionTables(); // XXX we should rely on this being an invariant
-    var tables = Runtime.getFunctionTables();
-    var ret = -1;
-    for (var sig in tables) {
-      var table = tables[sig];
-      if (ret < 0) ret = table.length;
-      else assert(ret === table.length);
-      table.push(func);
-    }
-    return ret;
-#endif
-#endif
-  },
-
-  removeFunction: function(index) {
-#if EMULATED_FUNCTION_POINTERS == 0
-    Runtime.functionPointers[(index-{{{ FUNCTION_POINTER_ALIGNMENT }}})/{{{ FUNCTION_POINTER_ALIGNMENT }}}] = null;
-#else
-    Runtime.alignFunctionTables(); // XXX we should rely on this being an invariant
-    var tables = Runtime.getFunctionTables();
-    for (var sig in tables) {
-      tables[sig][index] = null;
-    }
-#endif
-  },
-
-#if RELOCATABLE
-  loadedDynamicLibraries: [],
-
-  loadDynamicLibrary: function(lib) {
-    var libModule;
-#if BINARYEN
-    var bin;
-    if (lib.buffer) {
-      // we were provided the binary, in a typed array
-      bin = lib;
-    } else {
-      // load the binary synchronously
-      bin = Module['readBinary'](lib);
-    }
-    libModule = Runtime.loadWebAssemblyModule(bin);
-#else
-    var src = Module['read'](lib);
-    libModule = eval(src)(
-      Runtime.alignFunctionTables(),
-      Module
-    );
-#endif
-    // add symbols into global namespace TODO: weak linking etc.
-    for (var sym in libModule) {
-      if (!Module.hasOwnProperty(sym)) {
-        Module[sym] = libModule[sym];
-      }
-#if ASSERTIONS == 2
-      else if (sym[0] === '_') {
-        var curr = Module[sym], next = libModule[sym];
-        // don't warn on functions - might be odr, linkonce_odr, etc.
-        if (!(typeof curr === 'function' && typeof next === 'function')) {
-          Module.printErr("warning: trying to dynamically load symbol '" + sym + "' (from '" + lib + "') that already exists (duplicate symbol? or weak linking, which isn't supported yet?)"); // + [curr, ' vs ', next]);
-        }
-      }
-#endif
-    }
-    Runtime.loadedDynamicLibraries.push(libModule);
-  },
-
-#if BINARYEN
-  // Loads a side module from binary data
-  loadWebAssemblyModule: function(binary) {
-    var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
-    assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0wasm
-    // we should see the dylink section right after the magic number and wasm version
-    assert(binary[8] === 0, 'need the dylink section to be first')
-    var next = 9;
-    function getLEB() {
-      var ret = 0;
-      var mul = 1;
-      while (1) {
-        var byte = binary[next++];
-        ret += ((byte & 0x7f) * mul);
-        mul *= 0x80;
-        if (!(byte & 0x80)) break;
-      }
-      return ret;
-    }
-    var sectionSize = getLEB();
-    assert(binary[next] === 6);                 next++; // size of "dylink" string
-    assert(binary[next] === 'd'.charCodeAt(0)); next++;
-    assert(binary[next] === 'y'.charCodeAt(0)); next++;
-    assert(binary[next] === 'l'.charCodeAt(0)); next++;
-    assert(binary[next] === 'i'.charCodeAt(0)); next++;
-    assert(binary[next] === 'n'.charCodeAt(0)); next++;
-    assert(binary[next] === 'k'.charCodeAt(0)); next++;
-    var memorySize = getLEB();
-    var tableSize = getLEB();
-    var env = Module['asmLibraryArg'];
-    // TODO: use only memoryBase and tableBase, need to update asm.js backend
-    var table = Module['wasmTable'];
-    var oldTableSize = table.length;
-    env['memoryBase'] = env['gb'] = Runtime.alignMemory(getMemory(memorySize + Runtime.STACK_ALIGN), Runtime.STACK_ALIGN); // TODO: add to cleanups
-    env['tableBase'] = env['fb'] = oldTableSize;
-    var originalTable = table;
-    table.grow(tableSize);
-    assert(table === originalTable);
-    // zero-initialize memory and table TODO: in some cases we can tell it is already zero initialized
-    for (var i = env['memoryBase']; i < env['memoryBase'] + memorySize; i++) {
-      HEAP8[i] = 0;
-    }
-    for (var i = env['tableBase']; i < env['tableBase'] + tableSize; i++) {
-      table.set(i, null);
-    }
-    // copy currently exported symbols so the new module can import them
-    for (var x in Module) {
-      if (!(x in env)) {
-        env[x] = Module[x];
-      }
-    }
-    var info = {
-      global: {
-        'NaN': NaN,
-        'Infinity': Infinity,
-        'Math': Math
-      },
-      env: env
-    };
-#if ASSERTIONS
-    var oldTable = [];
-    for (var i = 0; i < oldTableSize; i++) {
-      oldTable.push(table.get(i));
-    }
-#endif
-    // create a module from the instance
-    var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), info);
-#if ASSERTIONS
-    // the table should be unchanged
-    assert(table === originalTable);
-    assert(table === Module['wasmTable']);
-    if (instance.exports['table']) {
-      assert(table === instance.exports['table']);
-    }
-    // the old part of the table should be unchanged
-    for (var i = 0; i < oldTableSize; i++) {
-      assert(table.get(i) === oldTable[i], 'old table entries must remain the same');
-    }
-    // verify that the new table region was filled in
-    for (var i = 0; i < tableSize; i++) {
-      assert(table.get(oldTableSize + i) !== undefined, 'table entry was not filled in');
-    }
-#endif
-    var exports = {};
-    for (var e in instance.exports) {
-      var value = instance.exports[e];
-      if (typeof value === 'number') {
-        // relocate it - modules export the absolute value, they can't relocate before they export
-        value = value + env['memoryBase'];
-      }
-      exports[e] = value;
-    }
-    // initialize the module
-    var init = exports['__post_instantiate'];
-    if (init) {
-      if (runtimeInitialized) {
-        init();
-      } else {
-        // we aren't ready to run compiled code yet
-        __ATINIT__.push(init);
-      }
-    }
-    return exports;
-  },
-#endif
-#endif
-
-  warnOnce: function(text) {
-    if (!Runtime.warnOnce.shown) Runtime.warnOnce.shown = {};
-    if (!Runtime.warnOnce.shown[text]) {
-      Runtime.warnOnce.shown[text] = 1;
-      Module.printErr(text);
-    }
-  },
-
-  funcWrappers: {},
-
-  getFuncWrapper: function(func, sig) {
-    if (!func) return; // on null pointer, return undefined
-    assert(sig);
-    if (!Runtime.funcWrappers[sig]) {
-      Runtime.funcWrappers[sig] = {};
-    }
-    var sigCache = Runtime.funcWrappers[sig];
-    if (!sigCache[func]) {
-      // optimize away arguments usage in common cases
-      if (sig.length === 1) {
-        sigCache[func] = function dynCall_wrapper() {
-          return Runtime.dynCall(sig, func);
-        };
-      } else if (sig.length === 2) {
-        sigCache[func] = function dynCall_wrapper(arg) {
-          return Runtime.dynCall(sig, func, [arg]);
-        };
-      } else {
-        // general case
-        sigCache[func] = function dynCall_wrapper() {
-          return Runtime.dynCall(sig, func, Array.prototype.slice.call(arguments));
-        };
-      }
-    }
-    return sigCache[func];
-  },
-
-#if RETAIN_COMPILER_SETTINGS
-  compilerSettings: {},
-#endif
-
-  getCompilerSetting: function(name) {
-#if RETAIN_COMPILER_SETTINGS == 0
-    throw 'You must build with -s RETAIN_COMPILER_SETTINGS=1 for Runtime.getCompilerSetting or emscripten_get_compiler_setting to work';
-#else
-    if (!(name in Runtime.compilerSettings)) return 'invalid compiler setting: ' + name;
-    return Runtime.compilerSettings[name];
-#endif
-  },
-
-#if RUNTIME_DEBUG
-  debug: true, // Switch to false at runtime to disable logging at the right times
-
-  printObjectList: [],
-
-  prettyPrint: function(arg) {
-    if (typeof arg == 'undefined') return '!UNDEFINED!';
-    if (typeof arg == 'boolean') arg = arg + 0;
-    if (!arg) return arg;
-    var index = Runtime.printObjectList.indexOf(arg);
-    if (index >= 0) return '<' + arg + '|' + index + '>';
-    if (arg.toString() == '[object HTMLImageElement]') {
-      return arg + '\n\n';
-    }
-    if (arg.byteLength) {
-      return '{' + Array.prototype.slice.call(arg, 0, Math.min(arg.length, 400)) + '}'; // Useful for correct arrays, less so for compiled arrays, see the code below for that
-      var buf = new ArrayBuffer(32);
-      var i8buf = new Int8Array(buf);
-      var i16buf = new Int16Array(buf);
-      var f32buf = new Float32Array(buf);
-      switch(arg.toString()) {
-        case '[object Uint8Array]':
-          i8buf.set(arg.subarray(0, 32));
-          break;
-        case '[object Float32Array]':
-          f32buf.set(arg.subarray(0, 5));
-          break;
-        case '[object Uint16Array]':
-          i16buf.set(arg.subarray(0, 16));
-          break;
-        default:
-          alert('unknown array for debugging: ' + arg);
-          throw 'see alert';
-      }
-      var ret = '{' + arg.byteLength + ':\n';
-      var arr = Array.prototype.slice.call(i8buf);
-      ret += 'i8:' + arr.toString().replace(/,/g, ',') + '\n';
-      arr = Array.prototype.slice.call(f32buf, 0, 8);
-      ret += 'f32:' + arr.toString().replace(/,/g, ',') + '}';
-      return ret;
-    }
-    if (typeof arg == 'object') {
-      Runtime.printObjectList.push(arg);
-      return '<' + arg + '|' + (Runtime.printObjectList.length-1) + '>';
-    }
-    if (typeof arg == 'number') {
-      if (arg > 0) return '0x' + arg.toString(16) + ' (' + arg + ')';
-    }
-    return arg;
   }
-#endif
 };
-
-Runtime.stackAlloc = unInline('stackAlloc', ['size'], true);
-Runtime.staticAlloc = unInline('staticAlloc', ['size'], true);
-Runtime.dynamicAlloc = unInline('dynamicAlloc', ['size'], false);
-Runtime.alignMemory = unInline('alignMemory', ['size', 'quantum'], true);
-Runtime.makeBigInt = unInline('makeBigInt', ['low', 'high', 'unsigned'], true);
-
-Runtime.POINTER_SIZE = 4;
-
-if (MAIN_MODULE || SIDE_MODULE) {
-  Runtime.tempRet0 = 0;
-  Runtime.getTempRet0 = function() {
-    return Runtime.tempRet0;
-  };
-  Runtime.setTempRet0 = function(x) {
-    Runtime.tempRet0 = x;
-    return x;
-  };
-}
-
-function getRuntime() {
-  var ret = 'var Runtime = {\n';
-  for (i in Runtime) {
-    var item = Runtime[i];
-    ret += '  ' + i + ': ';
-    if (typeof item === 'function') {
-      ret += item.toString();
-    } else {
-      ret += JSON.stringify(item);
-    }
-    ret += ',\n';
-  }
-  return ret + '  __dummy__: 0\n}\n';
-}
 
 // Additional runtime elements, that need preprocessing
 

--- a/src/support.js
+++ b/src/support.js
@@ -436,6 +436,13 @@ var getTempRet0 = function() {
 }
 #endif // RELOCATABLE
 
+// FIXME backwards compatibility layer for ports. Support some Runtime.*
+//       for now, fix it there, then remove it from here. That way we
+//       can minimize any period of breakage.
+var Runtime = {
+  dynCall: dynCall // for SDL2 port
+};
+
 // The address globals begin at. Very low in memory, for code size and optimization opportunities.
 // Above 0 is static memory, starting with globals.
 // Then the stack.

--- a/src/support.js
+++ b/src/support.js
@@ -1,0 +1,375 @@
+// {{PREAMBLE_ADDITIONS}}
+
+var STACK_ALIGN = {{{ STACK_ALIGN }}};
+
+// stack management and other functionality that is provided by the compiled code
+var stackSave, stackRestore, stackAlloc, setTempRet0, getTempRet0;
+#if ASSERTIONS
+stackSave = stackRestore = stackAlloc = setTempRet0 = getTempRet0 = function() {
+  abort('cannot use the stack before compiled code is ready to run, and has provided stack access');
+};
+#endif
+
+function staticAlloc(size) {
+  assert(!staticSealed);
+  var ret = STATICTOP;
+  STATICTOP = (STATICTOP + size + 15) & -16;
+  return ret;
+}
+
+function dynamicAlloc(size) {
+  assert(DYNAMICTOP_PTR);
+  var ret = HEAP32[DYNAMICTOP_PTR>>2];
+  var end = (ret + size + 15) & -16;
+  HEAP32[DYNAMICTOP_PTR>>2] = end;
+  if (end >= TOTAL_MEMORY) {
+    var success = enlargeMemory();
+    if (!success) {
+      HEAP32[DYNAMICTOP_PTR>>2] = ret;
+      return 0;
+    }
+  }
+  return ret;
+}
+
+function alignMemory(size, factor) {
+  if (!factor) factor = STACK_ALIGN; // stack alignment (16-byte) by default
+  var ret = size = Math.ceil(size / factor) * factor;
+  return ret;
+}
+
+function getNativeTypeSize(type) {
+  switch (type) {
+    case 'i1': case 'i8': return 1;
+    case 'i16': return 2;
+    case 'i32': return 4;
+    case 'i64': return 8;
+    case 'float': return 4;
+    case 'double': return 8;
+    default: {
+      if (type[type.length-1] === '*') {
+        return 4; // A pointer
+      } else if (type[0] === 'i') {
+        var bits = parseInt(type.substr(1));
+        assert(bits % 8 === 0);
+        return bits / 8;
+      } else {
+        return 0;
+      }
+    }
+  }
+}
+
+function warnOnce(text) {
+  if (!warnOnce.shown) warnOnce.shown = {};
+  if (!warnOnce.shown[text]) {
+    warnOnce.shown[text] = 1;
+    Module.printErr(text);
+  }
+}
+
+#if RELOCATABLE
+var loadedDynamicLibraries = [];
+
+function loadDynamicLibrary(lib) {
+  var libModule;
+#if BINARYEN
+  var bin;
+  if (lib.buffer) {
+    // we were provided the binary, in a typed array
+    bin = lib;
+  } else {
+    // load the binary synchronously
+    bin = Module['readBinary'](lib);
+  }
+  libModule = loadWebAssemblyModule(bin);
+#else
+  var src = Module['read'](lib);
+  libModule = eval(src)(
+    alignFunctionTables(),
+    Module
+  );
+#endif
+  // add symbols into global namespace TODO: weak linking etc.
+  for (var sym in libModule) {
+    if (!Module.hasOwnProperty(sym)) {
+      Module[sym] = libModule[sym];
+    }
+#if ASSERTIONS == 2
+    else if (sym[0] === '_') {
+      var curr = Module[sym], next = libModule[sym];
+      // don't warn on functions - might be odr, linkonce_odr, etc.
+      if (!(typeof curr === 'function' && typeof next === 'function')) {
+        Module.printErr("warning: trying to dynamically load symbol '" + sym + "' (from '" + lib + "') that already exists (duplicate symbol? or weak linking, which isn't supported yet?)"); // + [curr, ' vs ', next]);
+      }
+    }
+#endif
+  }
+  loadedDynamicLibraries.push(libModule);
+}
+
+#if BINARYEN
+// Loads a side module from binary data
+function loadWebAssemblyModule(binary) {
+  var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
+  assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0wasm
+  // we should see the dylink section right after the magic number and wasm version
+  assert(binary[8] === 0, 'need the dylink section to be first')
+  var next = 9;
+  function getLEB() {
+    var ret = 0;
+    var mul = 1;
+    while (1) {
+      var byte = binary[next++];
+      ret += ((byte & 0x7f) * mul);
+      mul *= 0x80;
+      if (!(byte & 0x80)) break;
+    }
+    return ret;
+  }
+  var sectionSize = getLEB();
+  assert(binary[next] === 6);                 next++; // size of "dylink" string
+  assert(binary[next] === 'd'.charCodeAt(0)); next++;
+  assert(binary[next] === 'y'.charCodeAt(0)); next++;
+  assert(binary[next] === 'l'.charCodeAt(0)); next++;
+  assert(binary[next] === 'i'.charCodeAt(0)); next++;
+  assert(binary[next] === 'n'.charCodeAt(0)); next++;
+  assert(binary[next] === 'k'.charCodeAt(0)); next++;
+  var memorySize = getLEB();
+  var tableSize = getLEB();
+  var env = Module['asmLibraryArg'];
+  // TODO: use only memoryBase and tableBase, need to update asm.js backend
+  var table = Module['wasmTable'];
+  var oldTableSize = table.length;
+  env['memoryBase'] = env['gb'] = alignMemory(getMemory(memorySize + STACK_ALIGN), STACK_ALIGN); // TODO: add to cleanups
+  env['tableBase'] = env['fb'] = oldTableSize;
+  var originalTable = table;
+  table.grow(tableSize);
+  assert(table === originalTable);
+  // zero-initialize memory and table TODO: in some cases we can tell it is already zero initialized
+  for (var i = env['memoryBase']; i < env['memoryBase'] + memorySize; i++) {
+    HEAP8[i] = 0;
+  }
+  for (var i = env['tableBase']; i < env['tableBase'] + tableSize; i++) {
+    table.set(i, null);
+  }
+  // copy currently exported symbols so the new module can import them
+  for (var x in Module) {
+    if (!(x in env)) {
+      env[x] = Module[x];
+    }
+  }
+  var info = {
+    global: {
+      'NaN': NaN,
+      'Infinity': Infinity,
+      'Math': Math
+    },
+    env: env
+  };
+#if ASSERTIONS
+  var oldTable = [];
+  for (var i = 0; i < oldTableSize; i++) {
+    oldTable.push(table.get(i));
+  }
+#endif
+  // create a module from the instance
+  var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), info);
+#if ASSERTIONS
+  // the table should be unchanged
+  assert(table === originalTable);
+  assert(table === Module['wasmTable']);
+  if (instance.exports['table']) {
+    assert(table === instance.exports['table']);
+  }
+  // the old part of the table should be unchanged
+  for (var i = 0; i < oldTableSize; i++) {
+    assert(table.get(i) === oldTable[i], 'old table entries must remain the same');
+  }
+  // verify that the new table region was filled in
+  for (var i = 0; i < tableSize; i++) {
+    assert(table.get(oldTableSize + i) !== undefined, 'table entry was not filled in');
+  }
+#endif
+  var exports = {};
+  for (var e in instance.exports) {
+    var value = instance.exports[e];
+    if (typeof value === 'number') {
+      // relocate it - modules export the absolute value, they can't relocate before they export
+      value = value + env['memoryBase'];
+    }
+    exports[e] = value;
+  }
+  // initialize the module
+  var init = exports['__post_instantiate'];
+  if (init) {
+    if (runtimeInitialized) {
+      init();
+    } else {
+      // we aren't ready to run compiled code yet
+      __ATINIT__.push(init);
+    }
+  }
+  return exports;
+}
+#endif // BINARYEN
+#endif // RELOCATABLE
+
+#if EMULATED_FUNCTION_POINTERS
+function getFunctionTables(module) {
+  if (!module) module = Module;
+  var tables = {};
+  for (var t in module) {
+    if (/^FUNCTION_TABLE_.*/.test(t)) {
+      var table = module[t];
+      if (typeof table === 'object') tables[t.substr('FUNCTION_TABLE_'.length)] = table;
+    }
+  }
+  return tables;
+}
+
+function alignFunctionTables(module) {
+  var tables = getFunctionTables(module);
+  var maxx = 0;
+  for (var sig in tables) {
+    maxx = Math.max(maxx, tables[sig].length);
+  }
+  assert(maxx >= 0);
+  for (var sig in tables) {
+    var table = tables[sig];
+    while (table.length < maxx) table.push(0);
+  }
+  return maxx;
+},
+
+function registerFunctions(sigs, newModule) {
+  sigs.forEach(function(sig) {
+    if (!Module['FUNCTION_TABLE_' + sig]) {
+      Module['FUNCTION_TABLE_' + sig] = [];
+    }
+  });
+  var oldMaxx = alignFunctionTables(); // align the new tables we may have just added
+  var newMaxx = alignFunctionTables(newModule);
+  var maxx = oldMaxx + newMaxx;
+  sigs.forEach(function(sig) {
+    var newTable = newModule['FUNCTION_TABLE_' + sig];
+    var oldTable = Module['FUNCTION_TABLE_' + sig];
+    assert(newTable !== oldTable);
+    assert(oldTable.length === oldMaxx);
+    for (var i = 0; i < newTable.length; i++) {
+      oldTable.push(newTable[i]);
+    }
+    assert(oldTable.length === maxx);
+  });
+  assert(maxx === alignFunctionTables()); // align the ones we didn't touch
+},
+#endif
+
+var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
+
+function addFunction(func) {
+#if EMULATED_FUNCTION_POINTERS == 0
+  for (var i = 0; i < functionPointers.length; i++) {
+    if (!functionPointers[i]) {
+      functionPointers[i] = func;
+      return {{{ FUNCTION_POINTER_ALIGNMENT }}}*(1 + i);
+    }
+  }
+  throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';
+#else
+#if BINARYEN
+  // we can simply appent to the wasm table
+  var table = Module['wasmTable'];
+  var ret = table.length;
+  table.grow(1);
+  table.set(ret, func);
+  return ret;
+#else
+  alignFunctionTables(); // XXX we should rely on this being an invariant
+  var tables = getFunctionTables();
+  var ret = -1;
+  for (var sig in tables) {
+    var table = tables[sig];
+    if (ret < 0) ret = table.length;
+    else assert(ret === table.length);
+    table.push(func);
+  }
+  return ret;
+#endif
+#endif
+}
+
+function removeFunction(index) {
+#if EMULATED_FUNCTION_POINTERS == 0
+  functionPointers[(index-{{{ FUNCTION_POINTER_ALIGNMENT }}})/{{{ FUNCTION_POINTER_ALIGNMENT }}}] = null;
+#else
+  alignFunctionTables(); // XXX we should rely on this being an invariant
+  var tables = getFunctionTables();
+  for (var sig in tables) {
+    tables[sig][index] = null;
+  }
+#endif
+}
+
+#if RUNTIME_DEBUG
+var runtimeDebug = true; // Switch to false at runtime to disable logging at the right times
+
+var printObjectList = [];
+
+function prettyPrint(arg) {
+  if (typeof arg == 'undefined') return '!UNDEFINED!';
+  if (typeof arg == 'boolean') arg = arg + 0;
+  if (!arg) return arg;
+  var index = Runtime.printObjectList.indexOf(arg);
+  if (index >= 0) return '<' + arg + '|' + index + '>';
+  if (arg.toString() == '[object HTMLImageElement]') {
+    return arg + '\n\n';
+  }
+  if (arg.byteLength) {
+    return '{' + Array.prototype.slice.call(arg, 0, Math.min(arg.length, 400)) + '}'; // Useful for correct arrays, less so for compiled arrays, see the code below for that
+    var buf = new ArrayBuffer(32);
+    var i8buf = new Int8Array(buf);
+    var i16buf = new Int16Array(buf);
+    var f32buf = new Float32Array(buf);
+    switch(arg.toString()) {
+      case '[object Uint8Array]':
+        i8buf.set(arg.subarray(0, 32));
+        break;
+      case '[object Float32Array]':
+        f32buf.set(arg.subarray(0, 5));
+        break;
+      case '[object Uint16Array]':
+        i16buf.set(arg.subarray(0, 16));
+        break;
+      default:
+        alert('unknown array for debugging: ' + arg);
+        throw 'see alert';
+    }
+    var ret = '{' + arg.byteLength + ':\n';
+    var arr = Array.prototype.slice.call(i8buf);
+    ret += 'i8:' + arr.toString().replace(/,/g, ',') + '\n';
+    arr = Array.prototype.slice.call(f32buf, 0, 8);
+    ret += 'f32:' + arr.toString().replace(/,/g, ',') + '}';
+    return ret;
+  }
+  if (typeof arg == 'object') {
+    Runtime.printObjectList.push(arg);
+    return '<' + arg + '|' + (Runtime.printObjectList.length-1) + '>';
+  }
+  if (typeof arg == 'number') {
+    if (arg > 0) return '0x' + arg.toString(16) + ' (' + arg + ')';
+  }
+  return arg;
+}
+#endif
+
+// The address globals begin at. Very low in memory, for code size and optimization opportunities.
+// Above 0 is static memory, starting with globals.
+// Then the stack.
+// Then 'dynamic' memory for sbrk.
+var GLOBAL_BASE = {{{ GLOBAL_BASE }}};
+
+#if RELOCATABLE
+GLOBAL_BASE = alignMemory(GLOBAL_BASE, {{{ MAX_GLOBAL_ALIGN || 1 }}});
+#endif
+

--- a/src/support.js
+++ b/src/support.js
@@ -436,6 +436,21 @@ var getTempRet0 = function() {
 }
 #endif // RELOCATABLE
 
+#if RETAIN_COMPILER_SETTINGS
+var compilerSettings = {{{ JSON.stringify(makeRetainedCompilerSettings()) }}} ;
+
+function getCompilerSetting(name) {
+  if (!(name in compilerSettings)) return 'invalid compiler setting: ' + name;
+  return compilerSettings[name];
+}
+#else // RETAIN_COMPILER_SETTINGS
+#if ASSERTIONS
+function getCompilerSetting(name) {
+  throw 'You must build with -s RETAIN_COMPILER_SETTINGS=1 for Runtime.getCompilerSetting or emscripten_get_compiler_setting to work';
+}
+#endif // ASSERTIONS
+#endif // RETAIN_COMPILER_SETTINGS
+
 // FIXME backwards compatibility layer for ports. Support some Runtime.*
 //       for now, fix it there, then remove it from here. That way we
 //       can minimize any period of breakage.

--- a/src/support.js
+++ b/src/support.js
@@ -32,33 +32,9 @@ function dynamicAlloc(size) {
   return ret;
 }
 
-function alignMemory(size, factor) {
-  if (!factor) factor = STACK_ALIGN; // stack alignment (16-byte) by default
-  var ret = size = Math.ceil(size / factor) * factor;
-  return ret;
-}
+{{{ alignMemory }}}
 
-function getNativeTypeSize(type) {
-  switch (type) {
-    case 'i1': case 'i8': return 1;
-    case 'i16': return 2;
-    case 'i32': return 4;
-    case 'i64': return 8;
-    case 'float': return 4;
-    case 'double': return 8;
-    default: {
-      if (type[type.length-1] === '*') {
-        return 4; // A pointer
-      } else if (type[0] === 'i') {
-        var bits = parseInt(type.substr(1));
-        assert(bits % 8 === 0);
-        return bits / 8;
-      } else {
-        return 0;
-      }
-    }
-  }
-}
+{{{ getNativeTypeSize }}}
 
 function warnOnce(text) {
   if (!warnOnce.shown) warnOnce.shown = {};

--- a/src/support.js
+++ b/src/support.js
@@ -451,11 +451,17 @@ function getCompilerSetting(name) {
 #endif // ASSERTIONS
 #endif // RETAIN_COMPILER_SETTINGS
 
-// FIXME backwards compatibility layer for ports. Support some Runtime.*
-//       for now, fix it there, then remove it from here. That way we
-//       can minimize any period of breakage.
 var Runtime = {
-  dynCall: dynCall // for SDL2 port
+  // FIXME backwards compatibility layer for ports. Support some Runtime.*
+  //       for now, fix it there, then remove it from here. That way we
+  //       can minimize any period of breakage.
+  dynCall: dynCall, // for SDL2 port
+#if ASSERTIONS
+  // helpful errors
+  getTempRet0: function() { abort('getTempRet0() is now a top-level function, after removing the Runtime object. Remove "Runtime."') },
+  staticAlloc: function() { abort('staticAlloc() is now a top-level function, after removing the Runtime object. Remove "Runtime."') },
+  stackAlloc: function() { abort('stackAlloc() is now a top-level function, after removing the Runtime object. Remove "Runtime."') },
+#endif
 };
 
 // The address globals begin at. Very low in memory, for code size and optimization opportunities.

--- a/src/support.js
+++ b/src/support.js
@@ -242,6 +242,8 @@ function alignFunctionTables(module) {
   return maxx;
 }
 
+#if RELOCATABLE
+// register functions from a new module being loaded
 function registerFunctions(sigs, newModule) {
   sigs.forEach(function(sig) {
     if (!Module['FUNCTION_TABLE_' + sig]) {
@@ -263,7 +265,10 @@ function registerFunctions(sigs, newModule) {
   });
   assert(maxx === alignFunctionTables()); // align the ones we didn't touch
 }
-#endif
+// export this so side modules can use it
+Module['registerFunctions'] = registerFunctions;
+#endif // RELOCATABLE
+#endif // EMULATED_FUNCTION_POINTERS
 
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 

--- a/src/support.js
+++ b/src/support.js
@@ -2,9 +2,9 @@
 
 var STACK_ALIGN = {{{ STACK_ALIGN }}};
 
-// stack management and other functionality that is provided by the compiled code
-var stackSave, stackRestore, stackAlloc, setTempRet0, getTempRet0;
 #if ASSERTIONS
+// stack management, and other functionality that is provided by the compiled code,
+// should not be used before it is ready
 stackSave = stackRestore = stackAlloc = setTempRet0 = getTempRet0 = function() {
   abort('cannot use the stack before compiled code is ready to run, and has provided stack access');
 };

--- a/src/support.js
+++ b/src/support.js
@@ -387,6 +387,21 @@ function dynCall(sig, ptr, args) {
   }
 }
 
+#if RELOCATABLE
+// tempRet0 is normally handled in the module. but in relocatable code,
+// we need to share a single one among all the modules, so they all call
+// out.
+var tempRet0 = 0;
+
+function setTempRet0(value) {
+  tempRet0 = value;
+}
+
+function getTempRet0() {
+  return tempRet0;
+}
+#endif // RELOCATABLE
+
 // The address globals begin at. Very low in memory, for code size and optimization opportunities.
 // Above 0 is static memory, starting with globals.
 // Then the stack.

--- a/src/support.js
+++ b/src/support.js
@@ -398,11 +398,11 @@ function dynCall(sig, ptr, args) {
 // out.
 var tempRet0 = 0;
 
-function setTempRet0(value) {
+var setTempRet0 = function(value) {
   tempRet0 = value;
 }
 
-function getTempRet0() {
+var getTempRet0 = function() {
   return tempRet0;
 }
 #endif // RELOCATABLE

--- a/src/support.js
+++ b/src/support.js
@@ -240,7 +240,7 @@ function alignFunctionTables(module) {
     while (table.length < maxx) table.push(0);
   }
   return maxx;
-},
+}
 
 function registerFunctions(sigs, newModule) {
   sigs.forEach(function(sig) {
@@ -262,7 +262,7 @@ function registerFunctions(sigs, newModule) {
     assert(oldTable.length === maxx);
   });
   assert(maxx === alignFunctionTables()); // align the ones we didn't touch
-},
+}
 #endif
 
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
@@ -362,6 +362,30 @@ function prettyPrint(arg) {
   return arg;
 }
 #endif
+
+function makeBigInt(low, high, unsigned) {
+  return unsigned ? ((+((low>>>0)))+((+((high>>>0)))*4294967296.0)) : ((+((low>>>0)))+((+((high|0)))*4294967296.0));
+}
+
+function dynCall(sig, ptr, args) {
+  if (args && args.length) {
+#if ASSERTIONS
+    assert(args.length == sig.length-1);
+#endif
+#if ASSERTIONS
+    assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
+#endif
+    return Module['dynCall_' + sig].apply(null, [ptr].concat(args));
+  } else {
+#if ASSERTIONS
+    assert(sig.length == 1);
+#endif
+#if ASSERTIONS
+    assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
+#endif
+    return Module['dynCall_' + sig].call(null, ptr);
+  }
+}
 
 // The address globals begin at. Very low in memory, for code size and optimization opportunities.
 // Above 0 is static memory, starting with globals.

--- a/tests/core/test_runtime_stacksave.c
+++ b/tests/core/test_runtime_stacksave.c
@@ -2,8 +2,8 @@
 #include <assert.h>
 
 int main() {
-  int x = EM_ASM_INT({ return Runtime.stackSave(); });
-  int y = EM_ASM_INT({ return Runtime.stackSave(); });
+  int x = EM_ASM_INT({ return stackSave(); });
+  int y = EM_ASM_INT({ return stackSave(); });
   EM_ASM_INT({ Module.print($0); }, &x);
   EM_ASM_INT({ Module.print($0); }, &y);
   assert(x == y);

--- a/tests/interop/test_add_function.cpp
+++ b/tests/interop/test_add_function.cpp
@@ -7,7 +7,9 @@ int main(int argc, char **argv) {
   printf("fp: %d\n", fp);
   void (*f)(int) = reinterpret_cast<void (*)(int)>(fp);
   f(7);
-  EM_ASM(Module['Runtime']['removeFunction']($0), f);
+  EM_ASM({
+    removeFunction($0)
+  }, f);
   printf("ok\n");
   return 0;
 }

--- a/tests/interop/test_add_function_post.js
+++ b/tests/interop/test_add_function_post.js
@@ -1,4 +1,4 @@
-var newFuncPtr = Runtime.addFunction(function(num) {
+var newFuncPtr = addFunction(function(num) {
     Module['print']('Hello ' + num + ' from JS!');
 });
 Module['callMain']([newFuncPtr.toString()]);

--- a/tests/return64bit/testbind.js
+++ b/tests/return64bit/testbind.js
@@ -9,7 +9,7 @@ var Module = {
 
 Module['runtest'] = function() {
     var low = _test();
-    var high = Runtime.getTempRet0();
+    var high = getTempRet0();
 
     console.log("low = " + low);
     console.log("high = " + high);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3257,13 +3257,13 @@ Module = {
         printf("main\n");
         EM_ASM({
           // make the function table sizes a non-power-of-two
-          Runtime.alignFunctionTables();
+          alignFunctionTables();
           Module['FUNCTION_TABLE_v'].push(0, 0, 0, 0, 0);
-          var newSize = Runtime.alignFunctionTables();
+          var newSize = alignFunctionTables();
           //Module.print('new size of function tables: ' + newSize);
           // when masked, the two function pointers 1 and 2 should not happen to fall back to the right place
           assert(((newSize+1) & 3) !== 1 || ((newSize+2) & 3) !== 2);
-          Runtime.loadDynamicLibrary('liblib.so');
+          loadDynamicLibrary('liblib.so');
         });
         volatilevoidfunc f;
         f = (volatilevoidfunc)left1;
@@ -3765,7 +3765,7 @@ Module = {
       extern int bsideg;
       int main() {
         EM_ASM({
-          Runtime.loadDynamicLibrary('third.js'); // hyper-dynamic! works at least for functions (and consts not used in same block)
+          loadDynamicLibrary('third.js'); // hyper-dynamic! works at least for functions (and consts not used in same block)
         });
         printf("sidef: %d, sideg: %d.\n", sidef(), sideg);
         printf("bsidef: %d.\n", bsidef());
@@ -6255,8 +6255,8 @@ def process(filename):
 
     int main() {
       EM_ASM({
-        Runtime.getFuncWrapper($0, 'vi')(0);
-        Runtime.getFuncWrapper($1, 'vii')(0, 0);
+        getFuncWrapper($0, 'vi')(0);
+        getFuncWrapper($1, 'vii')(0, 0);
       }, func1, func2);
       return 0;
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1563,7 +1563,10 @@ def process(filename):
   def test_emscripten_get_compiler_setting(self):
     test_path = path_from_root('tests', 'core', 'emscripten_get_compiler_setting')
     src, output = (test_path + s for s in ('.c', '.out'))
+    old = Settings.ASSERTIONS
+    Settings.ASSERTIONS = 1 # with assertions, a nice message is shown
     self.do_run(open(src).read(), 'You must build with -s RETAIN_COMPILER_SETTINGS=1')
+    Settings.ASSERTIONS = old
     Settings.RETAIN_COMPILER_SETTINGS = 1
     self.do_run(open(src).read(), open(output).read().replace('waka', EMSCRIPTEN_VERSION))
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7758,11 +7758,11 @@ int main() {
         ([],      25, ['abort', 'tempDoublePtr'], ['waka']),
         (['-O1'], 20, ['abort', 'tempDoublePtr'], ['waka']),
         (['-O2'], 20, ['abort', 'tempDoublePtr'], ['waka']),
-        (['-O3'], 14, ['abort'], ['tempDoublePtr', 'waka']), # in -O3, -Os and -Oz we metadce
-        (['-Os'], 14, ['abort'], ['tempDoublePtr', 'waka']),
-        (['-Oz'], 14, ['abort'], ['tempDoublePtr', 'waka']),
+        (['-O3'], 13, ['abort'], ['tempDoublePtr', 'waka']), # in -O3, -Os and -Oz we metadce
+        (['-Os'], 13, ['abort'], ['tempDoublePtr', 'waka']),
+        (['-Oz'], 13, ['abort'], ['tempDoublePtr', 'waka']),
         # finally, check what happens when we export pretty much nothing. wasm should be almost  empty
-        (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]', '-s', 'EXPORTED_RUNTIME_METHODS=[]'], 2, ['STACKTOP'], ['tempDoublePtr', 'waka']),
+        (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]', '-s', 'EXPORTED_RUNTIME_METHODS=[]'], 1, ['STACKTOP'], ['tempDoublePtr', 'waka']),
       ]:
       print(args, expected_len, expected_exists, expected_not_exists)
       subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'WASM=1', '-g2'])

--- a/tools/asm_module.py
+++ b/tools/asm_module.py
@@ -89,7 +89,7 @@ class AsmModule():
   def relocate_into(self, main):
     # heap initializer
     if self.staticbump > 0:
-      new_mem_init = self.mem_init_js[:self.mem_init_js.rfind(', ')] + ', Runtime.GLOBAL_BASE+%d)' % main.staticbump
+      new_mem_init = self.mem_init_js[:self.mem_init_js.rfind(', ')] + ', GLOBAL_BASE+%d)' % main.staticbump
       main.set_pre_js(main.staticbump + self.staticbump, new_mem_init)
 
     # Find function name replacements TODO: do not rename duplicate names with duplicate contents, just merge them

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2269,7 +2269,7 @@ class Building(object):
       if os.environ.get('EMCC_CLOSURE_ARGS'):
         args += shlex.split(os.environ.get('EMCC_CLOSURE_ARGS'))
       logging.debug('closure compiler: ' + ' '.join(args))
-      process = run_process(args, stdout=PIPE, stderr=STDOUT)
+      process = run_process(args, stdout=PIPE, stderr=STDOUT, check=False)
       if process.returncode != 0 or not os.path.exists(filename + '.cc.js'):
         raise Exception('closure compiler error: ' + process.stdout + ' (rc: %d)' % process.returncode)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2596,7 +2596,7 @@ class JS(object):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
     ret = '''function%s(%s) {
-    %functionPointers[index](%s);
+    %sfunctionPointers[index](%s);
 }''' % ((' jsCall_' + sig) if named else '', args, 'return ' if sig[0] != 'v' else '', fnargs)
     return ret
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2483,7 +2483,7 @@ class FilenameReplacementStrings:
   ASMJS_CODE_FILE = '{{{ FILENAME_REPLACEMENT_STRINGS_ASMJS_CODE_FILE }}}'
 
 class JS(object):
-  memory_initializer_pattern = '/\* memory initializer \*/ allocate\(\[([\d, ]*)\], "i8", ALLOC_NONE, ([\d+Runtime\.GLOBAL_BASEHgb]+)\);'
+  memory_initializer_pattern = '/\* memory initializer \*/ allocate\(\[([\d, ]*)\], "i8", ALLOC_NONE, ([\d+\.GLOBAL_BASEHgb]+)\);'
   no_memory_initializer_pattern = '/\* no memory initializer \*/'
 
   memory_staticbump_pattern = 'STATICTOP = STATIC_BASE \+ (\d+);'
@@ -2596,7 +2596,7 @@ class JS(object):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
     ret = '''function%s(%s) {
-    %sRuntime.functionPointers[index](%s);
+    %functionPointers[index](%s);
 }''' % ((' jsCall_' + sig) if named else '', args, 'return ' if sig[0] != 'v' else '', fnargs)
     return ret
 


### PR DESCRIPTION
This removes the `Runtime` object from the generated code. Much of it was not needed at all, the rest is moved into plain JS functions in a new `support.js` file (which is easier for DCE to remove). This is something @juj suggested we do, and it helps with the goal of shrinking JS - this reduces code from a few % in something like libc++ to 15% in small hello world type things.

The history here is that in the early days I thought we'd have a coherent `Runtime` object, and it would be used at both compile time and execution time, sharing code between them. But with asm.js and wasm, we've been doing less and less in JS anyhow, so `Runtime` has made less and less sense. Also it turns out there are just a handful of methods we need both at compile time and execution time, at this point.

Another old idea was that we need to generate the runtime support dynamically, since we supported weird things like `QUANTUM=1` (ints and pointers take one memory address location). That's why we had `RuntimeGenerator` and all that. But again, with asm.js and wasm, we really just support one type of memory, the plain C style. So it's easier to just write out those methods in `support.js` instead of generating them from a flexible template. This simplification may also help us in the future with more modularization of our runtime code (ES6 modules, etc.).

Breakage-wise, this does affect anyone that used anything on `Runtime` in a manual way: `Runtime.X` needs to change to just `X`. The `Runtime` object is sort of an internal implementation detail, so hopefully few people ever used it, but still, there's a risk. There are helper messages in assertions mode with some of the more likely candidates, hopefully that will help. Overall, I think this is unavoidable refactoring, and hopefully any inconvenience will be minor.
