### PR TITLE
Allow Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 defaults: &defaults
   docker:
     - image: buildpack-deps:xenial
+      environment:
+        LANG: C.UTF-8
   working_directory: ~/
 
 test-defaults: &test-defaults
@@ -14,10 +16,10 @@ test-defaults: &test-defaults
 
     - run: |
         apt-get update
-        apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless
-        pip install --upgrade pip
-        pip install lit
-        EMCC_CORES=4 python emscripten/tests/runner.py $TEST_TARGET
+        apt-get install -y python3 python3-pip cmake build-essential openjdk-9-jre-headless
+        pip3 install --upgrade pip
+        pip3 install lit
+        EMCC_CORES=4 python3 emscripten/tests/runner.py $TEST_TARGET
 
 version: 2
 jobs:
@@ -28,7 +30,7 @@ jobs:
           path: emscripten/
       - run: |
           apt-get update
-          apt-get install -y python cmake
+          apt-get install -y python3 cmake
           wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
           tar -xf emsdk-portable.tar.gz
           pushd emsdk-portable
@@ -38,8 +40,8 @@ jobs:
           popd
           echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> .emscripten
           echo BINARYEN_ROOT="''" >> .emscripten
-          EMCC_CORES=4 python2 emscripten/embuilder.py build ALL
-          python2 emscripten/tests/runner.py test_hello_world
+          EMCC_CORES=4 python3 emscripten/embuilder.py build ALL
+          python3 emscripten/tests/runner.py test_hello_world
 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory

--- a/em++
+++ b/em++
@@ -9,13 +9,8 @@ import sys
 
 sys.argv += ['--emscripten-cxx']
 
-if sys.version_info.major == 2:
-  if __name__ == '__main__':
-    ToolchainProfiler.record_process_start()
-    import emcc
-    emcc.run()
-    sys.exit(0)
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))
+if __name__ == '__main__':
+  ToolchainProfiler.record_process_start()
+  import emcc
+  emcc.run()
+  sys.exit(0)

--- a/em++.py
+++ b/em++.py
@@ -7,11 +7,6 @@ import sys
 
 sys.argv += ['--emscripten-cxx']
 
-if sys.version_info.major == 2:
-  import emcc
-  if __name__ == '__main__':
-    emcc.run()
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))
+import emcc
+if __name__ == '__main__':
+  emcc.run()

--- a/emar
+++ b/emar
@@ -6,13 +6,8 @@ from tools.toolchain_profiler import ToolchainProfiler
 
 import sys
 
-if sys.version_info.major == 2:
-  if __name__ == '__main__':
-    ToolchainProfiler.record_process_start()
-    import emar
-    emar.run()
-    sys.exit(0)
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emar.py')] + sys.argv[1:]))
+if __name__ == '__main__':
+  ToolchainProfiler.record_process_start()
+  import emar
+  emar.run()
+  sys.exit(0)

--- a/emcc
+++ b/emcc
@@ -6,13 +6,8 @@ from tools.toolchain_profiler import ToolchainProfiler
 
 import sys
 
-if sys.version_info.major == 2:
-  if __name__ == '__main__':
-    ToolchainProfiler.record_process_start()
-    import emcc
-    emcc.run()
-    sys.exit(0)
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc.py')] + sys.argv[1:]))
+if __name__ == '__main__':
+  ToolchainProfiler.record_process_start()
+  import emcc
+  emcc.run()
+  sys.exit(0)

--- a/emcmake
+++ b/emcmake
@@ -7,11 +7,6 @@ import sys
 
 
 
-if sys.version_info.major == 2:
-  import emcmake
-  if __name__ == '__main__':
-    emcmake.run()
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcmake.py')] + sys.argv[1:]))
+import emcmake
+if __name__ == '__main__':
+  emcmake.run()

--- a/emconfigure
+++ b/emconfigure
@@ -7,11 +7,6 @@ import sys
 
 
 
-if sys.version_info.major == 2:
-  import emconfigure
-  if __name__ == '__main__':
-    emconfigure.run()
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emconfigure.py')] + sys.argv[1:]))
+import emconfigure
+if __name__ == '__main__':
+  emconfigure.run()

--- a/emmake
+++ b/emmake
@@ -8,13 +8,8 @@ import sys
 
 
 
-if sys.version_info.major == 2:
-  if __name__ == '__main__':
-    ToolchainProfiler.record_process_start()
-    import emmake
-    emmake.run()
-    sys.exit(0)
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emmake.py')] + sys.argv[1:]))
+if __name__ == '__main__':
+  ToolchainProfiler.record_process_start()
+  import emmake
+  emmake.run()
+  sys.exit(0)

--- a/emrun
+++ b/emrun
@@ -4,11 +4,6 @@
 
 import sys
 
-if sys.version_info.major == 2:
-  if __name__ == '__main__':
-    import emrun
-    sys.exit(emrun.main())
-else:
-  import os, subprocess
-  if __name__ == '__main__':
-    sys.exit(subprocess.call(['python2', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emrun.py')] + sys.argv[1:]))
+if __name__ == '__main__':
+  import emrun
+  sys.exit(emrun.main())

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -521,6 +521,10 @@ def check_node_version():
     logging.warning('cannot check node version: %s',  e)
     return False
 
+def check_python_version():
+  if sys.version_info.major > 2:
+    logging.warning('Python 3 support is experimental')
+
 def check_closure_compiler():
   try:
     subprocess.call([JAVA, '-version'], stdout=PIPE, stderr=PIPE)
@@ -610,6 +614,7 @@ def check_sanity(force=False):
     # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
     check_llvm_version()
     check_node_version()
+    check_python_version()
 
     if os.environ.get('EMCC_FAST_COMPILER') == '0':
       logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2340,11 +2340,11 @@ class Building(object):
     cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm-metadce'), '--graph-file=' + temp, wasm_file, '-o', wasm_file]
     if debug_info:
       cmd += ['-g']
-    out = subprocess.check_output(cmd)
+    out = run_process(cmd, stdout=PIPE).stdout
     # find the unused things in js
     unused = []
     PREFIX = 'unused: '
-    for line in out.split(os.linesep):
+    for line in out.split('\n'):
       if line.startswith(PREFIX):
         name = line.replace(PREFIX, '').strip()
         unused.append(name)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2168,7 +2168,7 @@ class Building(object):
       subprocess.check_call(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes, stdout=open(next, 'w'))
       return next
     else:
-      return subprocess.check_output(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes)
+      return run_process(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes, stdout=PIPE).stdout
 
   # evals ctors. if binaryen_bin is provided, it is the dir of the binaryen tool for this, and we are in wasm mode
   @staticmethod


### PR DESCRIPTION
Fixes #5950.

(This includes #5946 to pass CI, you may want to review it first)

This PR:

1. uses default Python executable
2. warns if Python version > 2