### PR TITLE
Clean up JS optimizer traversal

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -191,6 +191,7 @@ function traverseChildren(node, traverse, pre, post) {
   if (node[0] === 'var') {
     // don't traverse the names, just the values
     var children = node[1];
+    if (!Array.isArray(children)) return;
     for (var i = 0; i < children.length; i++) {
       var subnode = children[i];
       if (subnode.length === 2) {
@@ -205,6 +206,7 @@ function traverseChildren(node, traverse, pre, post) {
   } else if (node[0] === 'object') {
     // don't traverse the names, just the values
     var children = node[1];
+    if (!Array.isArray(children)) return;
     for (var i = 0; i < children.length; i++) {
       var subnode = children[i];
       var value = subnode[1];

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -188,12 +188,41 @@ function srcToExp(src) {
 // Traverses the children of a node. If the traverse function returns an object,
 // replaces the child. If it returns true, stop the traversal and return true.
 function traverseChildren(node, traverse, pre, post) {
-  for (var i = 0; i < node.length; i++) {
-    var subnode = node[i];
-    if (Array.isArray(subnode)) {
-      var subresult = traverse(subnode, pre, post);
-      if (subresult === true) return true;
-      if (subresult !== null && typeof subresult === 'object') node[i] = subresult;
+  if (node[0] === 'var') {
+    // don't traverse the names, just the values
+    var children = node[1];
+    for (var i = 0; i < children.length; i++) {
+      var subnode = children[i];
+      if (subnode.length === 2) {
+        var value = subnode[1];
+        if (Array.isArray(value)) {
+          var subresult = traverse(value, pre, post);
+          if (subresult === true) return true;
+          if (subresult !== null && typeof subresult === 'object') subnode[1] = subresult;
+        }
+      }
+    }
+  } else if (node[0] === 'object') {
+    // don't traverse the names, just the values
+    var children = node[1];
+    for (var i = 0; i < children.length; i++) {
+      var subnode = children[i];
+      var value = subnode[1];
+      if (Array.isArray(value)) {
+        var subresult = traverse(value, pre, post);
+        if (subresult === true) return true;
+        if (subresult !== null && typeof subresult === 'object') subnode[1] = subresult;
+      }
+    }
+  } else {
+    // generic traversal
+    for (var i = 0; i < node.length; i++) {
+      var subnode = node[i];
+      if (Array.isArray(subnode)) {
+        var subresult = traverse(subnode, pre, post);
+        if (subresult === true) return true;
+        if (subresult !== null && typeof subresult === 'object') node[i] = subresult;
+      }
     }
   }
 }
@@ -4704,7 +4733,12 @@ var FAST_ELIMINATION_BINARIES = setUnion(setUnion(USEFUL_BINARY_OPS, COMPARE_OPS
 
 function measureSize(ast) {
   var size = 0;
-  traverse(ast, function() {
+  traverse(ast, function(node, type) {
+    // FIXME backwards compatibility: measure var internal node too. this
+    //       affects the 'outline' test.
+    if (type === 'var') {
+      size += node[1].length;
+    }
     size++;
   });
   return size;
@@ -7846,31 +7880,17 @@ function JSDCE(ast, multipleIterations) {
       });
       return ast;
     }
-    var isVarNameOrObjectKeys = [];
-    // isVarNameOrObjectKeys is a stack which saves the state the node is defining a variable or in an object literal.
-    // the second argument `type` passed into the callback function called by traverse() could be a variable name or object key name.
-    // You cannot distinguish the `type` is a real type or not without isVarNameOrObjectKeys.
-    // ex.) var name = true;          // `type` can be 'name'
-    //      var obj = { defun: true } // `type` can be 'defun'
     traverse(ast, function(node, type) {
-      if (isVarNameOrObjectKeys[isVarNameOrObjectKeys.length - 1]) { // check parent node defines a variable or is an object literal
-        // `type` is a variable name or an object key name
-        isVarNameOrObjectKeys.push(false); // doesn't define a variable nor be an object literal
-        return;
-      }
       if (type === 'var') {
         node[1].forEach(function(varItem, j) {
           var name = varItem[0];
           ensureData(scopes[scopes.length-1], name).def = 1;
         });
-        isVarNameOrObjectKeys.push(true); // this `node` defines a varible
         return;
       }
       if (type === 'object') {
-        isVarNameOrObjectKeys.push(true); // this `node` is an object literal
         return;
       }
-      isVarNameOrObjectKeys.push(false); // doesn't define a variable nor be an object literal
       if (type === 'defun' || type === 'function') {
         if (node[1]) ensureData(scopes[scopes.length-1], node[1]).def = 1;
         var scope = {};
@@ -7885,8 +7905,6 @@ function JSDCE(ast, multipleIterations) {
         ensureData(scopes[scopes.length-1], node[1]).use = 1;
       }
     }, function(node, type) {
-      isVarNameOrObjectKeys.pop();
-      if (isVarNameOrObjectKeys[isVarNameOrObjectKeys.length - 1]) return; // `type` is a variable name or an object key name
       if (type === 'defun' || type === 'function') {
         var scope = scopes.pop();
         var names = set();


### PR DESCRIPTION
Don't traverse the internal structure of var and object, which led us to horrible workarounds in JSDCE. Skip those internal nodes, so that traversal only traverses actual nodes, as intended, and remove those  workarounds.

This was always incorrect, but never noticed until JSDCE since our opts run on asm.js, which doesn't have objects etc. And with JSDCE we temporarily worked around it.

This fix will make future optimizations similar to JSDCE easier, which we need to get the full benefit out of metadce (since it needs to scan the JS).