### PR TITLE
fix a JSDCE bug 

### DIFF
--- a/tests/optimizer/JSDCE-output.js
+++ b/tests/optimizer/JSDCE-output.js
@@ -27,4 +27,13 @@ function glue() {
  }
 }
 glue();
+function _glCreateShader() {
+ return 1;
+}
+function emulate() {
+ _glCreateShader = function _glCreateShader(shaderType) {
+  return glCreateShader();
+ };
+}
+emulate();
 

--- a/tests/optimizer/JSDCE.js
+++ b/tests/optimizer/JSDCE.js
@@ -58,4 +58,15 @@ function glue() {
   }
 }
 glue();
+// gl emulation style code
+function _glCreateShader() {
+ return 1;
+}
+function emulate() {
+  var saved = _glCreateShader;
+  _glCreateShader = function _glCreateShader(shaderType) { // the name here is just for show in stack traces!
+    return glCreateShader();
+  };
+}
+emulate();
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1787,8 +1787,9 @@ void *getBindBuffer() {
   return glBindBuffer;
 }
 ''')
-    for opts in [0, 1]:
-      self.btest('cubegeom_proc.c', reference='cubegeom.png', args=['-O' + str(opts), 'side.c', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
+    # also test -Os in wasm, which uses meta-dce, which should not break legacy gl emulation hacks
+    for opts in [[], ['-O1'], ['-Os', '-s', 'WASM=1']]:
+      self.btest('cubegeom_proc.c', reference='cubegeom.png', args=opts + ['side.c', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 
   def test_cubegeom_glew(self):
     self.btest('cubegeom_glew.c', reference='cubegeom.png', args=['-O2', '--closure', '1', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lGLEW', '-lSDL'])

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7872,7 +7872,8 @@ function JSDCE(ast, multipleIterations) {
       }
       isVarNameOrObjectKeys.push(false); // doesn't define a variable nor be an object literal
       if (type === 'defun' || type === 'function') {
-        if (node[1]) ensureData(scopes[scopes.length-1], node[1]).def = 1;
+        // defun names matter - function names (the y in var x = function y() {..}) are just for stack traces.
+        if (type === 'defun') ensureData(scopes[scopes.length-1], node[1]).def = 1;
         var scope = {};
         node[2].forEach(function(param) {
           ensureData(scope, param).def = 1;


### PR DESCRIPTION
We had a bug with function names: defined functions create a name in that scope, like a var, but '.. = function y()' does not do so, the name is just for stack traces and nothing more. This ended up removing code from GL emulation that was actually needed.