### PR TITLE
Use Node.js 8 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xf emsdk-portable.tar.gz
           pushd emsdk-portable
           ./emsdk update
-          ./emsdk install latest
+          ./emsdk install latest node-8.9.1-64bit
           ./emsdk activate latest
           popd
           echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> .emscripten


### PR DESCRIPTION
It seems #5910 does not, or at least do much less frequently, happen on Node.js 8. This PR forces Node 8 in CircleCI to prevent the problem.