### PR TITLE
Use emsdk update-tags on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
           tar -xf emsdk-portable.tar.gz
           pushd emsdk-portable
-          ./emsdk update
+          ./emsdk update-tags
           ./emsdk install latest
           ./emsdk activate latest
           popd

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /root/ \
  && wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
  && tar -xf emsdk-portable.tar.gz \
  && pushd emsdk-portable \
- && ./emsdk update \
+ && ./emsdk update-tags \
  && ./emsdk install latest \
  && ./emsdk activate latest \
  && popd \


### PR DESCRIPTION
CI always newly downloads emsdk so no need to update emsdk scripts.