### PR TITLE
Use emsdk master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
       - run: |
           apt-get update
           apt-get install -y python cmake
-          wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
-          tar -xf emsdk-portable.tar.gz
-          pushd emsdk-portable
+          wget https://github.com/juj/emsdk/archive/master.tar.gz
+          tar -xf master.tar.gz
+          pushd emsdk-master
           ./emsdk update-tags
           ./emsdk install latest
           ./emsdk activate latest
@@ -46,7 +46,7 @@ jobs:
           root: ~/
           # Must be relative path from root
           paths:
-            - emsdk-portable/
+            - emsdk-master/
             - .emscripten_cache/
             - .emscripten_ports/
             - .emscripten

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN cd /root/ \
  && apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless \
  && pip install --upgrade pip \
  && pip install lit \
- && wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
- && tar -xf emsdk-portable.tar.gz \
- && pushd emsdk-portable \
+ && wget https://github.com/juj/emsdk/archive/master.tar.gz \
+ && tar -xf master.tar.gz \
+ && pushd emsdk-master \
  && ./emsdk update-tags \
  && ./emsdk install latest \
  && ./emsdk activate latest \


### PR DESCRIPTION
To get latest changes instantly, including the new default tool Node.js 8.

Should fix #5910 but not sure exactly why. Possibly related with https://github.com/nodejs/node/issues/3370?