### PR TITLE
Add llvm.minnum.f(32|64) and llvm.maxnum.f(32|64) intrinsics

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -318,4 +318,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dannii Willis <curiousdannii@gmail.com>
 * Erik Dubbelboer <erik@dubbelboer.com>
 * Sergey Tsatsulin <tsatsulin@gmail.com>
+* varkor <github@varkor.com>
 

--- a/src/library.js
+++ b/src/library.js
@@ -1582,6 +1582,10 @@ LibraryManager.library = {
   llvm_floor_f64: 'Math_floor',
   llvm_round_f32: 'Math_round',
   llvm_round_f64: 'Math_round',
+  llvm_minnum_f32: 'Math_min',
+  llvm_minnum_f64: 'Math_min',
+  llvm_maxnum_f32: 'Math_max',
+  llvm_maxnum_f64: 'Math_max',
 
   llvm_exp2_f32: function(x) {
     return Math.pow(2, x);
@@ -4372,8 +4376,6 @@ LibraryManager.library = {
   llvm_dbg_value: true,
   llvm_debugtrap: true,
   llvm_ctlz_i32: true,
-  llvm_maxnum_f32: true,
-  llvm_maxnum_f64: true,
   emscripten_asm_const: true,
   emscripten_asm_const_int: true,
   emscripten_asm_const_double: true,

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1735,6 +1735,7 @@ var Math_imul = Math.imul;
 var Math_fround = Math.fround;
 var Math_round = Math.round;
 var Math_min = Math.min;
+var Math_max = Math.max;
 var Math_clz32 = Math.clz32;
 var Math_trunc = Math.trunc;
 

--- a/tests/core/test_llvm_intrinsics.cpp
+++ b/tests/core/test_llvm_intrinsics.cpp
@@ -37,6 +37,10 @@ extern double llvm_copysign_f64(double x, double y);
 
 extern double llvm_round_f64(double x);
 extern float llvm_round_f32(float x);
+extern float llvm_minnum_f32(float x, float y);
+extern double llvm_minnum_f64(double x, double y);
+extern float llvm_maxnum_f32(float x, float y);
+extern double llvm_maxnum_f64(double x, double y);
 }
 
 int main(void) {
@@ -135,6 +139,16 @@ int main(void) {
   printf("llvm_round_f32 %.1f\n", llvm_round_f32(42));
   printf("llvm_round_f32 %.1f\n", llvm_round_f32(-20.5));
   printf("llvm_round_f32 %.1f\n", llvm_round_f32(-20.51));
+
+  printf("llvm_minnum_f32 %.1f\n", llvm_minnum_f32(5.7, 10.2));
+  printf("llvm_minnum_f32 %.1f\n", llvm_minnum_f32(8.5, 2.3));
+  printf("llvm_minnum_f64 %.1f\n", llvm_minnum_f64(5.7, 10.2));
+  printf("llvm_minnum_f64 %.1f\n", llvm_minnum_f64(8.5, 2.3));
+
+  printf("llvm_maxnum_f32 %.1f\n", llvm_maxnum_f32(5.7, 10.2));
+  printf("llvm_maxnum_f32 %.1f\n", llvm_maxnum_f32(8.5, 2.3));
+  printf("llvm_maxnum_f64 %.1f\n", llvm_maxnum_f64(5.7, 10.2));
+  printf("llvm_maxnum_f64 %.1f\n", llvm_maxnum_f64(8.5, 2.3));
 
   printf("llvm_copysign_f32 %.1f\n", llvm_copysign_f32(-1.2, 3.4));
   printf("llvm_copysign_f32 %.1f\n", llvm_copysign_f32(5.6, -7.8));

--- a/tests/core/test_llvm_intrinsics.out
+++ b/tests/core/test_llvm_intrinsics.out
@@ -69,6 +69,14 @@ llvm_round_f32 21.0
 llvm_round_f32 42.0
 llvm_round_f32 -20.0
 llvm_round_f32 -21.0
+llvm_minnum_f32 5.7
+llvm_minnum_f32 2.3
+llvm_minnum_f64 5.7
+llvm_minnum_f64 2.3
+llvm_maxnum_f32 10.2
+llvm_maxnum_f32 8.5
+llvm_maxnum_f64 10.2
+llvm_maxnum_f64 8.5
 llvm_copysign_f32 1.2
 llvm_copysign_f32 -5.6
 llvm_copysign_f32 -1.3


### PR DESCRIPTION
This fixes #5976. I’m using https://github.com/kripken/emscripten/pull/4353 as a model.