### PR TITLE
fix metadce + async bug

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -644,6 +644,13 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
       funcs += ['setTempRet0', 'getTempRet0']
     if not (settings['BINARYEN'] and settings['SIDE_MODULE']):
       funcs += ['setThrew']
+    if settings['EMTERPRETIFY']:
+      funcs += ['emterpret']
+      if settings['EMTERPRETIFY_ASYNC']:
+        funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore']
+    if settings['ASYNCIFY']:
+      funcs += ['setAsync']
+
   return sorted(set(funcs))
 
 
@@ -1253,8 +1260,6 @@ def create_basic_vars(exported_implemented_functions, forwarded_json, metadata, 
 def create_exports(exported_implemented_functions, in_table, function_table_data, metadata, settings):
   quote = quoter(settings)
   asm_runtime_funcs = create_asm_runtime_funcs(settings)
-  if need_asyncify(exported_implemented_functions):
-    asm_runtime_funcs.append('setAsync')
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data, settings)
   if settings['EMULATED_FUNCTION_POINTERS']:
     all_exported += in_table
@@ -1281,10 +1286,6 @@ def create_asm_runtime_funcs(settings):
     funcs += ['setDynamicTop']
   if settings['ONLY_MY_CODE']:
     funcs = []
-  if settings.get('EMTERPRETIFY'):
-    funcs += ['emterpret']
-    if settings.get('EMTERPRETIFY_ASYNC'):
-      funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore']
   return funcs
 
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -54,7 +54,7 @@ mergeInto(LibraryManager.library, {
 
   emscripten_sleep__deps: ['emscripten_async_resume', '$Browser'],
   emscripten_sleep: function(ms) {
-    Module['asm'].setAsync(); // tell the scheduler that we have a callback on hold
+    Module['setAsync'](); // tell the scheduler that we have a callback on hold
     Browser.safeSetTimeout(_emscripten_async_resume, ms);
   },
 
@@ -196,7 +196,7 @@ mergeInto(LibraryManager.library, {
     var _url = Pointer_stringify(url);
     var _file = Pointer_stringify(file);
     _file = PATH.resolve(FS.cwd(), _file);
-    Module['asm'].setAsync();
+    Module['setAsync']();
     Module['noExitRuntime'] = true;
     var destinationDirectory = PATH.dirname(_file);
     FS.createPreloadedFile(
@@ -255,7 +255,7 @@ mergeInto(LibraryManager.library, {
     setState: function(s) {
       this.ensureInit();
       this.state = s;
-      Module['asm'].setAsyncState(s);
+      Module['setAsyncState'](s);
     },
     handle: function(doAsyncOp, yieldDuring) {
       Module['noExitRuntime'] = true;


### PR DESCRIPTION
This breakage was not noticed until the js engine filter change in #5931 

This patch also simplifies the async logic, with less hacks - just add the extra functions to `exported_implemented_functions`, in one place, and then use them normally on Module, instead of hackishly using the `asm` object.