### PR TITLE
Enable test_headless for node.js

### DIFF
--- a/src/headless.js
+++ b/src/headless.js
@@ -284,11 +284,13 @@ var screen = { // XXX these values may need to be adjusted
   availWidth: 2100,
   availHeight: 1283,
 };
-var console = {
-  log: function(x) {
-    print(x);
-  },
-};
+if (typeof console === "undefined") {
+  console = {
+    log: function(x) {
+      print(x);
+    }
+  };
+}
 var MozBlobBuilder = function() {
   this.data = new Uint8Array(0);
   this.append = function(buffer) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2346,11 +2346,9 @@ seeked= file.
     assert crunch_time < os.stat('ship.crn').st_mtime, 'Crunch was changed'
 
   def test_headless(self):
-    if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey due to node limitations (Uint8ClampedArray etc.)')
-
     shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'example.png'))
     Popen([PYTHON, EMCC, path_from_root('tests', 'sdl_headless.c'), '-s', 'HEADLESS=1']).communicate()
-    output = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE, stderr=PIPE)
+    output = run_js('a.out.js', stderr=PIPE)
     assert '''Init: 0
 Font: 0x1
 Sum: 0


### PR DESCRIPTION
The test runs well on Node.js so this PR enables it.

Fixes a problem that `var console` conflicts with native Node.js console API.