### PR TITLE
Test running changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,6 @@ workflows:
       - test-d:
           requires:
             - build
-      - test-d2i:
-          requires:
-            - build
       - test-e:
           requires:
             - build
@@ -165,9 +162,6 @@ workflows:
           requires:
             - build
       - test-p:
-          requires:
-            - build
-      - test-p2i:
           requires:
             - build
       - test-qrst:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,7 @@ jobs:
   test-d:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=default.test_d* asm1.test_d* asm2.test_d* asm2f.test_d* asm2g.test_d* asm3.test_d*
-  test-d2i:
-    <<: *test-defaults
-    environment:
-      - TEST_TARGET=asm2i.test_d*
+      - TEST_TARGET=default.test_d* asm1.test_d* asm2.test_d* asm2g.test_d* asm3.test_d*
   test-e:
     <<: *test-defaults
     environment:
@@ -102,11 +98,7 @@ jobs:
   test-p:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=default.test_p* asm1.test_p* asm2.test_p* asm2f.test_p* asm2g.test_p* asm3.test_p*
-  test-p2i:
-    <<: *test-defaults
-    environment:
-      - TEST_TARGET=asm2i.test_p*
+      - TEST_TARGET=default.test_p* asm1.test_p* asm2.test_p* asm2g.test_p* asm3.test_p*
   test-qrst:
     <<: *test-defaults
     environment:
@@ -116,6 +108,22 @@ jobs:
     <<: *test-defaults
     environment:
       - TEST_TARGET=ALL.test_u* ALL.test_w* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*
+  test-binaryen0:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=binaryen0
+  test-binaryen1:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=binaryen1
+  test-binaryen2:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=binaryen2
+  test-binaryen3:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=binaryen3
 
 workflows:
   version: 2
@@ -166,5 +174,17 @@ workflows:
           requires:
             - build
       - test-uvwxyz:
+          requires:
+            - build
+      - test-binaryen0:
+          requires:
+            - build
+      - test-binaryen1:
+          requires:
+            - build
+      - test-binaryen2:
+          requires:
+            - build
+      - test-binaryen3:
           requires:
             - build

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -136,11 +136,11 @@ test_modes = [
   'asm1',
   'asm2',
   'asm3',
-  'asm2f',
   'asm2g',
-  'asm2i'
 ]
 nondefault_test_modes = [
+  'asm2f',
+  'asm2i',
   'binaryen0',
   'binaryen1',
   'binaryen2',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7350,10 +7350,7 @@ default = make_run("default", compiler=CLANG, emcc_args=["-s", "ASM_JS=2"])
 asm1 = make_run("asm1", compiler=CLANG, emcc_args=["-O1"])
 asm2 = make_run("asm2", compiler=CLANG, emcc_args=["-O2"])
 asm3 = make_run("asm3", compiler=CLANG, emcc_args=["-O3"])
-asm2f = make_run("asm2f", compiler=CLANG, emcc_args=["-Oz", "-s", "PRECISE_F32=1", "-s", "ALLOW_MEMORY_GROWTH=1"])
 asm2g = make_run("asm2g", compiler=CLANG, emcc_args=["-O2", "-g", "-s", "ASSERTIONS=1", "-s", "SAFE_HEAP=1"])
-asm2i = make_run("asm2i", compiler=CLANG, emcc_args=["-O2", '-s', 'EMTERPRETIFY=1'])
-#asm2m = make_run("asm2m", compiler=CLANG, emcc_args=["-O2", "--memory-init-file", "0", "-s", "MEM_INIT_METHOD=2", "-s", "ASSERTIONS=1"])
 
 # Main wasm test modes
 binaryen0 = make_run("binaryen0", compiler=CLANG, emcc_args=['-O0', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
@@ -7363,19 +7360,17 @@ binaryen3 = make_run("binaryen3", compiler=CLANG, emcc_args=['-O3', '-s', 'BINAR
 binaryens = make_run("binaryens", compiler=CLANG, emcc_args=['-Os', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
 binaryenz = make_run("binaryenz", compiler=CLANG, emcc_args=['-Oz', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"'])
 
-# Secondary wasm test modes
+# Secondary test modes - run directly when there is a specific need
+
+# asm.js
+asm2f = make_run("asm2f", compiler=CLANG, emcc_args=["-Oz", "-s", "PRECISE_F32=1", "-s", "ALLOW_MEMORY_GROWTH=1"])
+asm2i = make_run("asm2i", compiler=CLANG, emcc_args=["-O2", '-s', 'EMTERPRETIFY=1'])
+asm2nn = make_run("asm2nn", compiler=CLANG, emcc_args=["-O2"], env={"EMCC_NATIVE_OPTIMIZER": "0"})
+
+# wasm
 binaryen2jo = make_run("binaryen2jo", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'])
 binaryen3jo = make_run("binaryen3jo", compiler=CLANG, emcc_args=['-O3', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'])
 binaryen2s = make_run("binaryen2s", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'SAFE_HEAP=1'])
-
-# This tests the binaryen interpreter and its polyfill integration in the emscripten JS glue
 binaryen2_interpret = make_run("binaryen2_interpret", compiler=CLANG, emcc_args=['-O2', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
-
-
-#normalyen = make_run("normalyen", compiler=CLANG, emcc_args=['-O0', '-s', 'GLOBAL_BASE=1024']) # useful comparison to binaryen
-#spidaryen = make_run("binaryen", compiler=CLANG, emcc_args=['-O0', '-s', 'BINARYEN=1', '-s', 'BINARYEN_SCRIPTS="spidermonkify.py"'])
-
-# Legacy test modes -
-asm2nn = make_run("asm2nn", compiler=CLANG, emcc_args=["-O2"], env={"EMCC_NATIVE_OPTIMIZER": "0"})
 
 del T # T is just a shape for the specific subclasses, we don't test it itself


### PR DESCRIPTION
 * Don't run asm2f and asm2i by default. The former tests floats and memory growth in asm.js, which don't really matter any more, and the latter is emterpreter testing, which is very slow and we have basic coverage for in the other modes anyhow (when we change the emterpreter, we can run its full tests manually).
 * Start to run wasm tests on CircleCI, which we can now do thanks to using Node 8 which has wasm. Those tests seem to run in a reasonable time there.

Overall this should give us bot coverage of more important things (wasm over obscure asm.js things).