### PR TITLE
Don't include exceptions support code if exceptions are disabled

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4715,7 +4715,7 @@ function autoAddDeps(object, name) {
   }
 }
 
-if (DISABLE_EXCEPTION_CATCHING) {
+if (DISABLE_EXCEPTION_CATCHING == 1) {
   // sometimes exception-using code remains even when compiled without exceptions,
   // if LLVM couldn't eliminate it all. we still don't need it, even if it's here
   var EXCEPTIONS_SUPPORT_FUNCS = [
@@ -4726,7 +4726,9 @@ if (DISABLE_EXCEPTION_CATCHING) {
     '__gxx_personality_v0',
   ];
   EXCEPTIONS_SUPPORT_FUNCS.forEach(function(name) {
-    LibraryManager.library[name] = function(){}
+    LibraryManager.library[name] = function() {
+      {{{ makeThrow() }}}
+    };
     LibraryManager.library[name + '__deps'] = null;
   });
 }

--- a/src/library.js
+++ b/src/library.js
@@ -4715,3 +4715,19 @@ function autoAddDeps(object, name) {
   }
 }
 
+if (DISABLE_EXCEPTION_CATCHING) {
+  // sometimes exception-using code remains even when compiled without exceptions,
+  // if LLVM couldn't eliminate it all. we still don't need it, even if it's here
+  var EXCEPTIONS_SUPPORT_FUNCS = [
+    '__cxa_begin_catch',
+    '__cxa_end_catch',
+    '__cxa_allocate_exception',
+    '__cxa_free_exception',
+    '__gxx_personality_v0',
+  ];
+  EXCEPTIONS_SUPPORT_FUNCS.forEach(function(name) {
+    LibraryManager.library[name] = function(){}
+    LibraryManager.library[name + '__deps'] = null;
+  });
+}
+

--- a/src/library.js
+++ b/src/library.js
@@ -1287,6 +1287,9 @@ LibraryManager.library = {
   llvm_eh_typeid_for: function(type) {
     return type;
   },
+#if DISABLE_EXCEPTION_CATCHING
+  __cxa_begin_catch: function() {}, // without exceptions, just do nothing
+#else // DISABLE_EXCEPTION_CATCHING
   __cxa_begin_catch__deps: ['_ZSt18uncaught_exceptionv', '$EXCEPTIONS'],
   __cxa_begin_catch: function(ptr) {
     var info = EXCEPTIONS.infos[ptr];
@@ -1302,6 +1305,7 @@ LibraryManager.library = {
     EXCEPTIONS.addRef(EXCEPTIONS.deAdjust(ptr));
     return ptr;
   },
+#endif // DISABLE_EXCEPTION_CATCHING
   // We're done with a catch. Now, we can run the destructor if there is one
   // and free the exception. Note that if the dynCall on the destructor fails
   // due to calling apply on undefined, that means that the destructor is
@@ -1357,10 +1361,12 @@ LibraryManager.library = {
 
   terminate: '__cxa_call_unexpected',
 
+#if DISABLE_EXCEPTION_CATCHING == 0
+  // when exceptions are enabled, ensure we bring in all necessary support
   __gxx_personality_v0__deps: ['_ZSt18uncaught_exceptionv', '__cxa_find_matching_catch'],
+#endif // DISABLE_EXCEPTION_CATCHING
   __gxx_personality_v0: function() {
   },
-
   __gcc_personality_v0: function() {
   },
 

--- a/src/library.js
+++ b/src/library.js
@@ -1287,9 +1287,6 @@ LibraryManager.library = {
   llvm_eh_typeid_for: function(type) {
     return type;
   },
-#if DISABLE_EXCEPTION_CATCHING
-  __cxa_begin_catch: function() {}, // without exceptions, just do nothing
-#else // DISABLE_EXCEPTION_CATCHING
   __cxa_begin_catch__deps: ['_ZSt18uncaught_exceptionv', '$EXCEPTIONS'],
   __cxa_begin_catch: function(ptr) {
     var info = EXCEPTIONS.infos[ptr];
@@ -1305,7 +1302,6 @@ LibraryManager.library = {
     EXCEPTIONS.addRef(EXCEPTIONS.deAdjust(ptr));
     return ptr;
   },
-#endif // DISABLE_EXCEPTION_CATCHING
   // We're done with a catch. Now, we can run the destructor if there is one
   // and free the exception. Note that if the dynCall on the destructor fails
   // due to calling apply on undefined, that means that the destructor is
@@ -1361,12 +1357,10 @@ LibraryManager.library = {
 
   terminate: '__cxa_call_unexpected',
 
-#if DISABLE_EXCEPTION_CATCHING == 0
-  // when exceptions are enabled, ensure we bring in all necessary support
   __gxx_personality_v0__deps: ['_ZSt18uncaught_exceptionv', '__cxa_find_matching_catch'],
-#endif // DISABLE_EXCEPTION_CATCHING
   __gxx_personality_v0: function() {
   },
+
   __gcc_personality_v0: function() {
   },
 


### PR DESCRIPTION
Even if LLVM didn't manage to remove all the relevant calls, we don't need to include that code if exceptions are not supported in the build anyhow.