### PR TITLE
Stack trace and heap cleanups

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -431,7 +431,7 @@ function abort(what) {
   EXITSTATUS = 1;
 
 #if ASSERTIONS == 0
-  throw 'abort(' + what + '). If this is unexpected, build with -s ASSERTIONS=1 which can give more information.';
+  throw 'abort(' + what + '). Build with -s ASSERTIONS=1 for more info.';
 #else
   var extra = '';
   var output = 'abort(' + what + ') at ' + stackTrace() + extra;

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -431,11 +431,9 @@ function abort(what) {
   EXITSTATUS = 1;
 
 #if ASSERTIONS == 0
-  var extra = '\nIf this abort() is unexpected, build with -s ASSERTIONS=1 which can give more information.';
+  throw 'abort(' + what + '). If this is unexpected, build with -s ASSERTIONS=1 which can give more information.';
 #else
   var extra = '';
-#endif
-
   var output = 'abort(' + what + ') at ' + stackTrace() + extra;
   if (abortDecorators) {
     abortDecorators.forEach(function(decorator) {
@@ -443,6 +441,7 @@ function abort(what) {
     });
   }
   throw output;
+#endif // ASSERTIONS
 }
 Module['abort'] = abort;
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1198,6 +1198,7 @@ if (Module['buffer']) {
 #if ASSERTIONS
   assert(buffer.byteLength === TOTAL_MEMORY);
 #endif // ASSERTIONS
+  Module['buffer'] = buffer;
 }
 updateGlobalBufferViews();
 #else // SPLIT_MEMORY
@@ -1491,17 +1492,6 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 HEAP16[1] = 0x6373;
 if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
 #endif
-
-Module['HEAP'] = HEAP;
-Module['buffer'] = buffer;
-Module['HEAP8'] = HEAP8;
-Module['HEAP16'] = HEAP16;
-Module['HEAP32'] = HEAP32;
-Module['HEAPU8'] = HEAPU8;
-Module['HEAPU16'] = HEAPU16;
-Module['HEAPU32'] = HEAPU32;
-Module['HEAPF32'] = HEAPF32;
-Module['HEAPF64'] = HEAPF64;
 
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {

--- a/tests/core/test_demangle_stacks_noassert.cpp
+++ b/tests/core/test_demangle_stacks_noassert.cpp
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace NameSpace {
+class Class {
+ public:
+  __attribute__((noinline))
+  void Aborter(double x, char y, int *z) {
+    volatile int w = 1;
+    if (w) {
+      abort();
+    }
+  }
+};
+}
+
+int main(int argc, char **argv) {
+  NameSpace::Class c;
+  c.Aborter(1.234, 'a', NULL);
+  return 0;
+}

--- a/tests/core/test_demangle_stacks_noassert.out
+++ b/tests/core/test_demangle_stacks_noassert.out
@@ -1,0 +1,1 @@
+Build with -s ASSERTIONS=1 for more info.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6043,12 +6043,12 @@ def process(filename):
     # Kill off the dead function, and check a code path using it aborts
     Settings.DEAD_FUNCTIONS = ['_unused']
     test('*2*')
-    test('abort(-1) at', args=['x'], no_build=True)
+    test('abort(', args=['x'], no_build=True)
 
     # Kill off a library function, check code aborts
     Settings.DEAD_FUNCTIONS = ['_printf']
-    test('abort(-1) at')
-    test('abort(-1) at', args=['x'], no_build=True)
+    test('abort(')
+    test('abort(', args=['x'], no_build=True)
 
   def test_pgo(self):
     if Settings.ASM_JS: return self.skip('PGO does not work in asm mode')
@@ -6296,10 +6296,13 @@ def process(filename):
 
   def test_demangle_stacks(self):
     Settings.DEMANGLE_SUPPORT = 1
+    Settings.ASSERTIONS = 1
     if '-O' in str(self.emcc_args):
       self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']
-
     self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks')
+    # without assertions, the stack is not printed
+    Settings.ASSERTIONS = 0
+    self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks_noassert')
 
   @no_emterpreter
   @no_wasm_backend('s2wasm does not generate symbol maps')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6300,9 +6300,10 @@ def process(filename):
     if '-O' in str(self.emcc_args):
       self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']
     self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks')
-    # without assertions, the stack is not printed
-    Settings.ASSERTIONS = 0
-    self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks_noassert')
+    if 'ASSERTIONS' not in str(self.emcc_args):
+      print('without assertions, the stack is not printed, but a message suggesting assertions is')
+      Settings.ASSERTIONS = 0
+      self.do_run_in_out_file_test('tests', 'core', 'test_demangle_stacks_noassert')
 
   @no_emterpreter
   @no_wasm_backend('s2wasm does not generate symbol maps')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -764,7 +764,7 @@ f.close()
       if moar_expected: self.assertContained(moar_expected, out)
 
     # fastcomp. all asm, so it can't just work with wrong sigs. but, ASSERTIONS=2 gives much better info to debug
-    test(['-O1'], 'If this abort() is unexpected, build with -s ASSERTIONS=1 which can give more information.') # no useful info, but does mention ASSERTIONS
+    test(['-O1'], 'Build with -s ASSERTIONS=1 for more info.') # no useful info, but does mention ASSERTIONS
     test(['-O1', '-s', 'ASSERTIONS=1'], '''Invalid function pointer called with signature 'v'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)
 Build with ASSERTIONS=2 for more info.
 ''') # some useful text
@@ -3665,7 +3665,7 @@ int main() {
                 if opts == 0:
                   assert 'Invalid function pointer called' in output, output
                 else:
-                  assert 'abort()' in output, output
+                  assert 'abort(' in output, output
 
   def test_aliased_func_pointers(self):
     open('src.cpp', 'w').write(r'''

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1411,7 +1411,6 @@ function hasSideEffects(node) { // this is 99% incomplete!
     case 'conditional': return hasSideEffects(node[1]) || hasSideEffects(node[2]) || hasSideEffects(node[3]);
     case 'function': case 'defun': return false;
     case 'object': return false;
-    case 'new': return false;
     default: return true;
   }
 }

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1411,6 +1411,7 @@ function hasSideEffects(node) { // this is 99% incomplete!
     case 'conditional': return hasSideEffects(node[1]) || hasSideEffects(node[2]) || hasSideEffects(node[3]);
     case 'function': case 'defun': return false;
     case 'object': return false;
+    case 'new': return false;
     default: return true;
   }
 }


### PR DESCRIPTION
 * Remove some unneeded code from heap creation.
 * In an `abort()`, do not attempt to show pretty stack traces without `ASSERTIONS`. When built without assertions, if we `abort()` we suggest `ASSERTIONS` in order to get more info.