### PR TITLE
Assertions cleanup, remove unnecessary work when they are disabled

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1136,12 +1136,11 @@ LibraryManager.library = {
   llvm_prefetch: function(){},
 
   __assert_fail: function(condition, filename, line, func) {
-    ABORT = true;
-    throw 'Assertion failed: ' + Pointer_stringify(condition) + ', at: ' + [filename ? Pointer_stringify(filename) : 'unknown filename', line, func ? Pointer_stringify(func) : 'unknown function'] + ' at ' + stackTrace();
+    abort('Assertion failed: ' + Pointer_stringify(condition) + ', at: ' + [filename ? Pointer_stringify(filename) : 'unknown filename', line, func ? Pointer_stringify(func) : 'unknown function']);
   },
 
   __assert_func: function(filename, line, func, condition) {
-    throw 'Assertion failed: ' + (condition ? Pointer_stringify(condition) : 'unknown condition') + ', at: ' + [filename ? Pointer_stringify(filename) : 'unknown filename', line, func ? Pointer_stringify(func) : 'unknown function'] + ' at ' + stackTrace();
+    abort('Assertion failed: ' + (condition ? Pointer_stringify(condition) : 'unknown condition') + ', at: ' + [filename ? Pointer_stringify(filename) : 'unknown filename', line, func ? Pointer_stringify(func) : 'unknown function']);
   },
 
   $EXCEPTIONS: {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1714,7 +1714,9 @@ if (!Math['trunc']) Math['trunc'] = function(x) {
 };
 Math.trunc = Math['trunc'];
 #else // LEGACY_VM_SUPPORT
+#if ASSERTIONS
 assert(Math['imul'] && Math['fround'] && Math['clz32'] && Math['trunc'], 'this is a legacy browser, build with LEGACY_VM_SUPPORT');
+#endif
 #endif // LEGACY_VM_SUPPORT
 
 var Math_abs = Math.abs;


### PR DESCRIPTION
Also use `abort` properly in C assertions handling (we forgot to set the `ABORT` var in one place, which `abort` does for us).