### PR TITLE
NODEFS: Do not create new memory space when read/write

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -240,27 +240,18 @@ mergeInto(LibraryManager.library, {
       },
       read: function (stream, buffer, offset, length, position) {
         if (length === 0) return 0; // node errors on 0 length reads
-        // FIXME this is terrible.
-        var nbuffer = new Buffer(length);
         var res;
         try {
-          res = fs.readSync(stream.nfd, nbuffer, 0, length, position);
+          res = fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
-        }
-        if (res > 0) {
-          for (var i = 0; i < res; i++) {
-            buffer[offset + i] = nbuffer[i];
-          }
         }
         return res;
       },
       write: function (stream, buffer, offset, length, position) {
-        // FIXME this is terrible.
-        var nbuffer = new Buffer(buffer.subarray(offset, offset + length));
         var res;
         try {
-          res = fs.writeSync(stream.nfd, nbuffer, 0, length, position);
+          res = fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -240,22 +240,18 @@ mergeInto(LibraryManager.library, {
       },
       read: function (stream, buffer, offset, length, position) {
         if (length === 0) return 0; // node errors on 0 length reads
-        var res;
         try {
-          res = fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
+          return fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
-        return res;
       },
       write: function (stream, buffer, offset, length, position) {
-        var res;
         try {
-          res = fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
+          return fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
-        return res;
       },
       llseek: function (stream, offset, whence) {
         var position = offset;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -239,16 +239,21 @@ mergeInto(LibraryManager.library, {
         }
       },
       read: function (stream, buffer, offset, length, position) {
-        if (length === 0) return 0; // node errors on 0 length reads
+        // Node.js < 6 compatibility: node errors on 0 length reads
+        if (length === 0) return 0;
+        // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
+        var buf = Buffer.from ? Buffer.from(buffer.buffer) : new Buffer(buffer.buffer);
         try {
-          return fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
+          return fs.readSync(stream.nfd, buf, offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       write: function (stream, buffer, offset, length, position) {
+        // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
+        var buf = Buffer.from ? Buffer.from(buffer.buffer) : new Buffer(buffer.buffer);
         try {
-          return fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
+          return fs.writeSync(stream.nfd, buf, offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }


### PR DESCRIPTION
`Buffer` in Node.js is a subclass of `Uint8Array` and thus is a view for `ArrayBuffer`. Therefore we can use it as a proxy.

Note that this breaks compatibility for Node.js < 4.5 because `Buffer.from` didn't support `ArrayBuffer` back then. (We can instead use [deprecated `new Buffer`](https://nodejs.org/docs/latest/api/buffer.html#buffer_new_buffer_arraybuffer_byteoffset_length) but should we?)