### PR TITLE
Runtime exports

### DIFF
--- a/src/arrayUtils.js
+++ b/src/arrayUtils.js
@@ -1,5 +1,3 @@
-// All functions here should be maybeExported from jsifier.js
-
 /** @type {function(string, boolean=, number=)} */
 function intArrayFromString(stringy, dontAddNull, length) {
   var len = length > 0 ? length : lengthBytesUTF8(stringy)+1;

--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -1,5 +1,3 @@
-// All functions here should be maybeExported from jsifier.js
-
 // Copied from https://github.com/strophe/strophejs/blob/e06d027/src/polyfills.js#L149
 
 // This code was written by Tyler Akins and has been placed in the

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -541,15 +541,9 @@ function JSify(data, functionsOnly) {
     print('var ASSERTIONS = ' + !!ASSERTIONS + ';\n');
 
     print(preprocess(read('arrayUtils.js')));
-    // Export all arrayUtils.js functions
-    print(maybeExport('intArrayFromString'));
-    print(maybeExport('intArrayToString'));
 
     if (SUPPORT_BASE64_EMBEDDING) {
       print(preprocess(read('base64Utils.js')));
-      // Export all base64Utils.js functions
-      print(maybeExport('intArrayFromBase64'));
-      print(maybeExport('tryParseAsDataURI'));
     }
 
     if (asmLibraryFunctions.length > 0) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -290,42 +290,116 @@ function isExportedByForceFilesystem(name) {
          name === 'removeRunDependency';
 }
 
-// optionally export something.
-// in ASSERTIONS mode we show a useful error if it is used without
-// being exported. how we show the message depends on whether it's
-// a function (almost all of them) or a number.
-function maybeExport(name, isNumber) {
-  // if requested to be exported, export it
-  if (name in EXPORTED_RUNTIME_METHODS_SET) {
-    var exported = name;
-    if (isFSPrefixed(exported)) {
-      // this is a filesystem value, FS.x exported as FS_x
-      exported = 'FS.' + exported.substr(3);
+// export parts of the JS runtime that the user asked for
+function exportRuntime() {
+  // optionally export something.
+  // in ASSERTIONS mode we show a useful error if it is used without
+  // being exported. how we show the message depends on whether it's
+  // a function (almost all of them) or a number.
+  function maybeExport(name, isNumber) {
+    // if requested to be exported, export it
+    if (name in EXPORTED_RUNTIME_METHODS_SET) {
+      var exported = name;
+      if (isFSPrefixed(exported)) {
+        // this is a filesystem value, FS.x exported as FS_x
+        exported = 'FS.' + exported.substr(3);
+      }
+      return 'Module["' + name + '"] = ' + exported + ';';
     }
-    return 'Module["' + name + '"] = ' + exported + ';';
+    // do not export it. but if ASSERTIONS, emit a
+    // stub with an error, so the user gets a message
+    // if it is used, that they should export it
+    if (ASSERTIONS) {
+      // check if it already exists, to support EXPORT_ALL and other cases
+      // (we could optimize this, but in ASSERTIONS mode code size doesn't
+      // matter anyhow)
+      var extra = '';
+      if (isExportedByForceFilesystem(name)) {
+        extra = '. Alternatively, forcing filesystem support (-s FORCE_FILESYSTEM=1) can export this for you';
+      }
+      if (!isNumber) {
+        return 'if (!Module["' + name + '"]) Module["' + name + '"] = function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") };';
+      } else {
+        return 'if (!Module["' + name + '"]) Object.defineProperty(Module, "' + name + '", { get: function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") } });';
+      }
+    }
+    return '';
   }
-  // do not export it. but if ASSERTIONS, emit a
-  // stub with an error, so the user gets a message
-  // if it is used, that they should export it
-  if (ASSERTIONS) {
-    // check if it already exists, to support EXPORT_ALL and other cases
-    // (we could optimize this, but in ASSERTIONS mode code size doesn't
-    // matter anyhow)
-    var extra = '';
-    if (isExportedByForceFilesystem(name)) {
-      extra = '. Alternatively, forcing filesystem support (-s FORCE_FILESYSTEM=1) can export this for you';
-    }
-    if (!isNumber) {
-      return 'if (!Module["' + name + '"]) Module["' + name + '"] = function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") };';
-    } else {
-      return 'if (!Module["' + name + '"]) Object.defineProperty(Module, "' + name + '", { get: function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") } });';
-    }
-  }
-  return '';
-}
 
-function maybeExportNumber(name) {
-  return maybeExport(name, true);
+  function maybeExportNumber(name) {
+    return maybeExport(name, true);
+  }
+
+  // All possible runtime elements to export
+  var runtimeElements = [
+    'intArrayFromString',
+    'intArrayToString',
+    'ccall',
+    'cwrap',
+    'setValue',
+    'getValue',
+    'allocate',
+    'getMemory',
+    'Pointer_stringify',
+    'AsciiToString',
+    'stringToAscii',
+    'UTF8ArrayToString',
+    'UTF8ToString',
+    'stringToUTF8Array',
+    'stringToUTF8',
+    'UTF16ToString',
+    'stringToUTF16',
+    'lengthBytesUTF16',
+    'UTF32ToString',
+    'stringToUTF32',
+    'lengthBytesUTF32',
+    'stackTrace',
+    'addOnPreRun',
+    'addOnInit',
+    'addOnPreMain',
+    'addOnExit',
+    'addOnPostRun',
+    'writeStringToMemory',
+    'writeArrayToMemory',
+    'writeAsciiToMemory',
+    'addRunDependency',
+    'removeRunDependency',
+    'FS',
+    'FS_createFolder',
+    'FS_createPath',
+    'FS_createDataFile',
+    'FS_createPreloadedFile',
+    'FS_createLazyFile',
+    'FS_createLink',
+    'FS_createDevice',
+    'FS_unlink',
+    'GL',
+  ];
+  if (SUPPORT_BASE64_EMBEDDING) {
+    runtimeElements.push('intArrayFromBase64');
+    runtimeElements.push('tryParseAsDataURI');
+  }
+  var runtimeNumbers = [
+    'ALLOC_NORMAL',
+    'ALLOC_STACK',
+    'ALLOC_STATIC',
+    'ALLOC_DYNAMIC',
+    'ALLOC_NONE',
+  ];
+  if (ASSERTIONS) {
+    // check all exported things exist, warn about typos
+    for (var name in EXPORTED_RUNTIME_METHODS_SET) {
+      if (runtimeElements.indexOf(name) < 0 &&
+          runtimeNumbers.indexOf(name) < 0) {
+        printErr('warning: invalid item (maybe a typo?) in EXPORTED_RUNTIME_METHODS: ' + name);
+      }
+    }
+  }
+  return runtimeElements.map(function(name) {
+    return maybeExport(name);
+  }).join('\n') + runtimeNumbers.map(function(name) {
+    return maybeExportNumber(name);
+  }).join('\n');
 }
 
 var PassManager = {

--- a/src/modules.js
+++ b/src/modules.js
@@ -374,6 +374,22 @@ function exportRuntime() {
     'FS_createDevice',
     'FS_unlink',
     'GL',
+    'staticAlloc',
+    'dynamicAlloc',
+    'warnOnce',
+    'loadDynamicLibrary',
+    'loadWebAssemblyModule',
+    'getLEB',
+    'getFunctionTables',
+    'alignFunctionTables',
+    'registerFunctions',
+    'addFunction',
+    'removeFunction',
+    'getFuncWrapper',
+    'prettyPrint',
+    'makeBigInt',
+    'dynCall',
+    'getCompilerSetting',
   ];
   if (SUPPORT_BASE64_EMBEDDING) {
     runtimeElements.push('intArrayFromBase64');

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -3,17 +3,7 @@
 
 Module['asm'] = asm;
 
-{{{ maybeExport('FS') }}}
-{{{ maybeExport('FS_createFolder') }}}
-{{{ maybeExport('FS_createPath') }}}
-{{{ maybeExport('FS_createDataFile') }}}
-{{{ maybeExport('FS_createPreloadedFile') }}}
-{{{ maybeExport('FS_createLazyFile') }}}
-{{{ maybeExport('FS_createLink') }}}
-{{{ maybeExport('FS_createDevice') }}}
-{{{ maybeExport('FS_unlink') }}}
-
-{{{ maybeExport('GL') }}}
+{{{ exportRuntime() }}}
 
 #if MEM_INIT_IN_WASM == 0
 #if MEM_INIT_METHOD == 2

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -199,9 +199,6 @@ function cwrap (ident, returnType, argTypes) {
   }
 }
 
-{{{ maybeExport("ccall") }}}
-{{{ maybeExport("cwrap") }}}
-
 /** @type {function(number, number, string, boolean=)} */
 function setValue(ptr, value, type, noSafe) {
   type = type || 'i8';
@@ -234,7 +231,6 @@ function setValue(ptr, value, type, noSafe) {
   }
 #endif
 }
-{{{ maybeExport("setValue") }}}
 
 /** @type {function(number, string, boolean=)} */
 function getValue(ptr, type, noSafe) {
@@ -269,18 +265,12 @@ function getValue(ptr, type, noSafe) {
 #endif
   return null;
 }
-{{{ maybeExport("getValue") }}}
 
 var ALLOC_NORMAL = 0; // Tries to use _malloc()
 var ALLOC_STACK = 1; // Lives for the duration of the current function call
 var ALLOC_STATIC = 2; // Cannot be freed
 var ALLOC_DYNAMIC = 3; // Cannot be freed except through sbrk
 var ALLOC_NONE = 4; // Do not allocate
-{{{ maybeExportNumber('ALLOC_NORMAL') }}}
-{{{ maybeExportNumber('ALLOC_STACK') }}}
-{{{ maybeExportNumber('ALLOC_STATIC') }}}
-{{{ maybeExportNumber('ALLOC_DYNAMIC') }}}
-{{{ maybeExportNumber('ALLOC_NONE') }}}
 
 // allocate(): This is for internal use. You can use it yourself as well, but the interface
 //             is a little tricky (see docs right below). The reason is that it is optimized
@@ -366,7 +356,6 @@ function allocate(slab, types, allocator, ptr) {
 
   return ret;
 }
-{{{ maybeExport('allocate') }}}
 
 // Allocate memory during any stage of startup - static memory early on, dynamic memory later, malloc when ready
 function getMemory(size) {
@@ -374,7 +363,6 @@ function getMemory(size) {
   if (!runtimeInitialized) return dynamicAlloc(size);
   return _malloc(size);
 }
-{{{ maybeExport('getMemory') }}}
 
 /** @type {function(number, number=)} */
 function Pointer_stringify(ptr, length) {
@@ -411,7 +399,6 @@ function Pointer_stringify(ptr, length) {
   }
   return UTF8ToString(ptr);
 }
-{{{ maybeExport('Pointer_stringify') }}}
 
 // Given a pointer 'ptr' to a null-terminated ASCII-encoded string in the emscripten HEAP, returns
 // a copy of that string as a Javascript String object.
@@ -424,7 +411,6 @@ function AsciiToString(ptr) {
     str += String.fromCharCode(ch);
   }
 }
-{{{ maybeExport('AsciiToString') }}}
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in ASCII form. The copy will require at most str.length+1 bytes of space in the HEAP.
@@ -432,7 +418,6 @@ function AsciiToString(ptr) {
 function stringToAscii(str, outPtr) {
   return writeAsciiToMemory(str, outPtr, false);
 }
-{{{ maybeExport('stringToAscii') }}}
 
 // Given a pointer 'ptr' to a null-terminated UTF8-encoded string in the given array that contains uint8 values, returns
 // a copy of that string as a Javascript String object.
@@ -489,7 +474,6 @@ function UTF8ArrayToString(u8Array, idx) {
   }
 #endif
 }
-{{{ maybeExport('UTF8ArrayToString') }}}
 
 // Given a pointer 'ptr' to a null-terminated UTF8-encoded string in the emscripten HEAP, returns
 // a copy of that string as a Javascript String object.
@@ -497,7 +481,6 @@ function UTF8ArrayToString(u8Array, idx) {
 function UTF8ToString(ptr) {
   return UTF8ArrayToString({{{ heapAndOffset('HEAPU8', 'ptr') }}});
 }
-{{{ maybeExport('UTF8ToString') }}}
 
 // Copies the given Javascript String object 'str' to the given byte array at address 'outIdx',
 // encoded in UTF8 form and null-terminated. The copy will require at most str.length*4+1 bytes of space in the HEAP.
@@ -562,7 +545,6 @@ function stringToUTF8Array(str, outU8Array, outIdx, maxBytesToWrite) {
   outU8Array[outIdx] = 0;
   return outIdx - startIdx;
 }
-{{{ maybeExport('stringToUTF8Array') }}}
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in UTF8 form. The copy will require at most str.length*4+1 bytes of space in the HEAP.
@@ -575,7 +557,6 @@ function stringToUTF8(str, outPtr, maxBytesToWrite) {
 #endif
   return stringToUTF8Array(str, {{{ heapAndOffset('HEAPU8', 'outPtr') }}}, maxBytesToWrite);
 }
-{{{ maybeExport('stringToUTF8') }}}
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF8 byte array, EXCLUDING the null terminator byte.
 
@@ -602,7 +583,6 @@ function lengthBytesUTF8(str) {
   }
   return len;
 }
-{{{ maybeExport('lengthBytesUTF8') }}}
 
 // Given a pointer 'ptr' to a null-terminated UTF16LE-encoded string in the emscripten HEAP, returns
 // a copy of that string as a Javascript String object.
@@ -638,7 +618,6 @@ function UTF16ToString(ptr) {
   }
 #endif
 }
-{{{ maybeExport('UTF16ToString') }}}
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in UTF16 form. The copy will require at most str.length*4+2 bytes of space in the HEAP.
@@ -676,14 +655,12 @@ function stringToUTF16(str, outPtr, maxBytesToWrite) {
   {{{ makeSetValue('outPtr', 0, 0, 'i16') }}};
   return outPtr - startPtr;
 }
-{{{ maybeExport('stringToUTF16') }}}
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF16 byte array, EXCLUDING the null terminator byte.
 
 function lengthBytesUTF16(str) {
   return str.length*2;
 }
-{{{ maybeExport('lengthBytesUTF16') }}}
 
 function UTF32ToString(ptr) {
 #if ASSERTIONS
@@ -707,7 +684,6 @@ function UTF32ToString(ptr) {
     }
   }
 }
-{{{ maybeExport('UTF32ToString') }}}
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in UTF32 form. The copy will require at most str.length*4+4 bytes of space in the HEAP.
@@ -750,7 +726,6 @@ function stringToUTF32(str, outPtr, maxBytesToWrite) {
   {{{ makeSetValue('outPtr', 0, 0, 'i32') }}};
   return outPtr - startPtr;
 }
-{{{ maybeExport('stringToUTF32') }}}
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF16 byte array, EXCLUDING the null terminator byte.
 
@@ -766,7 +741,6 @@ function lengthBytesUTF32(str) {
 
   return len;
 }
-{{{ maybeExport('lengthBytesUTF32') }}}
 
 function demangle(func) {
 #if DEMANGLE_SUPPORT
@@ -841,7 +815,6 @@ function stackTrace() {
   if (Module['extraStackTrace']) js += '\n' + Module['extraStackTrace']();
   return demangleAll(js);
 }
-{{{ maybeExport('stackTrace') }}}
 
 // Memory management
 
@@ -1607,27 +1580,22 @@ function postRun() {
 function addOnPreRun(cb) {
   __ATPRERUN__.unshift(cb);
 }
-{{{ maybeExport('addOnPreRun') }}}
 
 function addOnInit(cb) {
   __ATINIT__.unshift(cb);
 }
-{{{ maybeExport('addOnInit') }}}
 
 function addOnPreMain(cb) {
   __ATMAIN__.unshift(cb);
 }
-{{{ maybeExport('addOnPreMain') }}}
 
 function addOnExit(cb) {
   __ATEXIT__.unshift(cb);
 }
-{{{ maybeExport('addOnExit') }}}
 
 function addOnPostRun(cb) {
   __ATPOSTRUN__.unshift(cb);
 }
-{{{ maybeExport('addOnPostRun') }}}
 
 // Deprecated: This function should not be called because it is unsafe and does not provide
 // a maximum length limit of how many bytes it is allowed to write. Prefer calling the
@@ -1648,7 +1616,6 @@ function writeStringToMemory(string, buffer, dontAddNull) {
   stringToUTF8(string, buffer, Infinity);
   if (dontAddNull) HEAP8[end] = lastChar; // Restore the value under the null character.
 }
-{{{ maybeExport('writeStringToMemory') }}}
 
 function writeArrayToMemory(array, buffer) {
 #if ASSERTIONS
@@ -1656,7 +1623,6 @@ function writeArrayToMemory(array, buffer) {
 #endif
   HEAP8.set(array, buffer);
 }
-{{{ maybeExport('writeArrayToMemory') }}}
 
 function writeAsciiToMemory(str, buffer, dontAddNull) {
   for (var i = 0; i < str.length; ++i) {
@@ -1668,7 +1634,6 @@ function writeAsciiToMemory(str, buffer, dontAddNull) {
   // Null-terminate the pointer to the HEAP.
   if (!dontAddNull) {{{ makeSetValue('buffer', 0, 0, 'i8') }}};
 }
-{{{ maybeExport('writeAsciiToMemory') }}}
 
 {{{ unSign }}}
 {{{ reSign }}}
@@ -1805,7 +1770,6 @@ function addRunDependency(id) {
   }
 #endif
 }
-{{{ maybeExport('addRunDependency') }}}
 
 function removeRunDependency(id) {
   runDependencies--;
@@ -1832,7 +1796,6 @@ function removeRunDependency(id) {
     }
   }
 }
-{{{ maybeExport('removeRunDependency') }}}
 
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data

--- a/tests/core/dyncall.c
+++ b/tests/core/dyncall.c
@@ -8,7 +8,14 @@ void waka(int x, int y, int z) {
 
 int main() {
   EM_ASM({
+#if EXPORTED
+    // test for additional things being exported
+    assert(Module['addFunction']);
+    // the main test here
+    Module['dynCall']('viii', $0, [1, 4, 9]);
+#else
     dynCall('viii', $0, [1, 4, 9]);
+#endif
   }, &waka);
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5973,6 +5973,10 @@ def process(filename):
 
   def test_dyncall(self):
     self.do_run_in_out_file_test('tests', 'core', 'dyncall')
+    # test dyncall (and other runtime methods in support.js) can be exported
+    self.emcc_args += ['-DEXPORTED']
+    Settings.EXTRA_EXPORTED_RUNTIME_METHODS = ['dynCall', 'addFunction']
+    self.do_run_in_out_file_test('tests', 'core', 'dyncall')
 
   def test_getValue_setValue(self):
     # these used to be exported, but no longer are by default


### PR DESCRIPTION
The recent runtime refactoring did not add support for exporting the methods that were moved out of `Runtime.`. This fixes that, and refactors that exporting code to a single convenient location. It also adds a warning if an invalid item is asked to be exported.