### PR TITLE
Port coroutines to EMTERPRETIFY_ASYNC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -647,7 +647,7 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
     if settings['EMTERPRETIFY']:
       funcs += ['emterpret']
       if settings['EMTERPRETIFY_ASYNC']:
-        funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore']
+        funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore', 'getEmtStackMax', 'setEmtStackMax']
     if settings['ASYNCIFY']:
       funcs += ['setAsync']
 
@@ -1419,6 +1419,13 @@ function emtStackSave() {
 function emtStackRestore(x) {
   x = x | 0;
   EMTSTACKTOP = x;
+}
+function getEmtStackMax() {
+  return EMT_STACK_MAX | 0;
+}
+function setEmtStackMax(x) {
+  x = x | 0;
+  EMT_STACK_MAX = x;
 }
 ''' if settings['EMTERPRETIFY_ASYNC'] else '') + '''
 function setThrew(threw, value) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -455,6 +455,7 @@ mergeInto(LibraryManager.library, {
     var temp = 0, func = 0, funcArg = 0, coroutine_not_finished = 0;
 
     // switch context
+    // TODO Save EMTSTACKTOP to EMTSTACK_BASE during startup and use it instead
     {{{ makeSetValueAsm('coroutine', 0, 'EMTSTACKTOP', 'i32') }}};
     temp = Module['emtStackSave']();
     {{{ makeSetValueAsm('coroutine', 4, 'temp', 'i32') }}};

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -417,10 +417,10 @@ mergeInto(LibraryManager.library, {
    * Layout of an EMTERPRETIFY_ASYNC coroutine structure:
    *
    *  0 callee's EMTSTACKTOP
-   *  4 callee's EMTSTACKTOP from Module['asm']
+   *  4 callee's EMTSTACKTOP from the compiled code
    *  8 callee's EMT_STACK_MAX
    * 12 my EMTSTACKTOP
-   * 16 my EMTSTACKTOP from Module['asm']
+   * 16 my EMTSTACKTOP from the compiled code
    * 20 my EMT_STACK_MAX
    * 24 coroutine function (0 if already started)
    * 28 coroutine arg
@@ -456,14 +456,14 @@ mergeInto(LibraryManager.library, {
 
     // switch context
     {{{ makeSetValueAsm('coroutine', 0, 'EMTSTACKTOP', 'i32') }}};
-    temp = Module['asm'].emtStackSave();
+    temp = Module['emtStackSave']();
     {{{ makeSetValueAsm('coroutine', 4, 'temp', 'i32') }}};
-    temp = Module['asm'].getEmtStackMax();
+    temp = Module['getEmtStackMax']();
     {{{ makeSetValueAsm('coroutine', 8, 'temp', 'i32') }}};
 
     EMTSTACKTOP = {{{ makeGetValueAsm('coroutine', 12, 'i32') }}};
-    Module['asm'].emtStackRestore({{{ makeGetValueAsm('coroutine', 16, 'i32') }}});
-    Module['asm'].setEmtStackMax({{{ makeGetValueAsm('coroutine', 20, 'i32') }}});
+    Module['emtStackRestore']({{{ makeGetValueAsm('coroutine', 16, 'i32') }}});
+    Module['setEmtStackMax']({{{ makeGetValueAsm('coroutine', 20, 'i32') }}});
 
     func = {{{ makeGetValueAsm('coroutine', 24, 'i32') }}};
     if (func !== 0) {
@@ -474,21 +474,21 @@ mergeInto(LibraryManager.library, {
       {{{ makeDynCall('vi') }}}(func, funcArg);
     } else {
       EmterpreterAsync.setState(2);
-      Module['asm'].emterpret({{{ makeGetValue('EMTSTACKTOP', 0, 'i32')}}});
+      Module['emterpret']({{{ makeGetValue('EMTSTACKTOP', 0, 'i32')}}});
     }
     coroutine_not_finished = EmterpreterAsync.state !== 0;
     EmterpreterAsync.setState(0);
 
     // switch context
     {{{ makeSetValueAsm('coroutine', 12, 'EMTSTACKTOP', 'i32') }}}; // cannot change?
-    temp = Module['asm'].emtStackSave();
+    temp = Module['emtStackSave']();
     {{{ makeSetValueAsm('coroutine', 16, 'temp', 'i32') }}};
-    temp = Module['asm'].getEmtStackMax();
+    temp = Module['getEmtStackMax']();
     {{{ makeSetValueAsm('coroutine', 20, 'temp', 'i32') }}}; // cannot change?
 
     EMTSTACKTOP = {{{ makeGetValueAsm('coroutine', 0, 'i32') }}};
-    Module['asm'].emtStackRestore({{{ makeGetValueAsm('coroutine', 4, 'i32') }}});
-    Module['asm'].setEmtStackMax({{{ makeGetValueAsm('coroutine', 8, 'i32') }}});
+    Module['emtStackRestore']({{{ makeGetValueAsm('coroutine', 4, 'i32') }}});
+    Module['setEmtStackMax']({{{ makeGetValueAsm('coroutine', 8, 'i32') }}});
 
     if (!coroutine_not_finished) {
       _free(coroutine);

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -131,7 +131,7 @@ mergeInto(LibraryManager.library, {
 
     if ((stack_size|0) <= 0) stack_size = 4096;
 
-    coroutine = _malloc(stack_size)|0;
+    coroutine = _malloc((stack_size + 32)|0)|0;
     {{{ makeSetValueAsm('coroutine', 12, 0, 'i32') }}}; 
     {{{ makeSetValueAsm('coroutine', 16, '(coroutine+32)', 'i32') }}};
     {{{ makeSetValueAsm('coroutine', 20, 'stack_size', 'i32') }}};

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -262,8 +262,8 @@ mergeInto(LibraryManager.library, {
       if (EmterpreterAsync.state === 0) {
         // save the stack we want to resume. this lets other code run in between
         // XXX this assumes that this stack top never ever leak! exceptions might violate that
-        var stack = new Int32Array(HEAP32.subarray(EMTSTACKTOP>>2, Module['asm'].emtStackSave()>>2));
-        var stacktop = Module['asm'].stackSave();
+        var stack = new Int32Array(HEAP32.subarray(EMTSTACKTOP>>2, Module['emtStackSave']()>>2));
+        var stacktop = Module['stackSave']();
 
         var resumedCallbacksForYield = false;
         function resumeCallbacksForYield() {
@@ -300,7 +300,7 @@ mergeInto(LibraryManager.library, {
           // copy the stack back in and resume
           HEAP32.set(stack, EMTSTACKTOP>>2);
 #if ASSERTIONS
-          assert(stacktop === Module['asm'].stackSave()); // nothing should have modified the stack meanwhile
+          assert(stacktop === Module['stackSave']()); // nothing should have modified the stack meanwhile
 #endif
           EmterpreterAsync.setState(2);
           // Resume the main loop
@@ -309,7 +309,7 @@ mergeInto(LibraryManager.library, {
           }
           assert(!EmterpreterAsync.postAsync);
           EmterpreterAsync.postAsync = post || null;
-          Module['asm'].emterpret(stack[0]); // pc of the first function, from which we can reconstruct the rest, is at position 0 on the stack
+          Module['emterpret'](stack[0]); // pc of the first function, from which we can reconstruct the rest, is at position 0 on the stack
           if (!yieldDuring && EmterpreterAsync.state === 0) {
             // if we did *not* do another async operation, then we know that nothing is conceptually on the stack now, and we can re-allow async callbacks as well as run the queued ones right now
             Browser.resumeAsyncCallbacks();

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -120,7 +120,7 @@ mergeInto(LibraryManager.library, {
  * 32 my stack:
  *    ...
  */
-  emscripten_coroutine_create__sig: 'iii',
+  emscripten_coroutine_create__sig: 'iiii',
   emscripten_coroutine_create__asm: true,
   emscripten_coroutine_create__deps: ['malloc', 'emscripten_alloc_async_context'],
   emscripten_coroutine_create: function(f, arg, stack_size) {
@@ -427,7 +427,7 @@ mergeInto(LibraryManager.library, {
    * 32 my stack:
    *    ...
    */
-  emscripten_coroutine_create__sig: 'iii',
+  emscripten_coroutine_create__sig: 'iiii',
   emscripten_coroutine_create__asm: true,
   emscripten_coroutine_create__deps: ['malloc'],
   emscripten_coroutine_create: function(f, arg, stack_size) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7249,7 +7249,7 @@ int main() {
     self.emcc_args += ['--js-library', 'lib.js']
     self.do_run(src, 'Hello')
 
-  def test_coroutine(self):
+  def do_test_coroutine(self, additional_settings):
     Settings.NO_EXIT_RUNTIME = 0 # needs to flush stdio streams
     src = r'''
 #include <stdio.h>
@@ -7293,8 +7293,15 @@ int main(int argc, char **argv) {
     return 0;
 }
 '''
-    Settings.ASYNCIFY = 1
+    for (k, v) in additional_settings.items():
+      Settings.__setattr__(k, v)
     self.do_run(src, '*0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
+
+  def test_coroutine_asyncify(self):
+    self.do_test_coroutine({'ASYNCIFY': 1})
+
+  def test_coroutine_emterpretify_async(self):
+    self.do_test_coroutine({'EMTERPRETIFY': 1, 'EMTERPRETIFY_ASYNC': 1})
 
   @no_emterpreter
   @no_wasm_backend('EMTERPRETIFY causes JSOptimizer to run, which is disallowed')

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -61,7 +61,7 @@ sys.argv = list(filter(handle_arg, sys.argv))
 
 # consts
 
-BLACKLIST = set(['_malloc', '_free', '_memcpy', '_memmove', '_memset', '_strlen', 'stackAlloc', 'setThrew', 'stackRestore', 'setTempRet0', 'getTempRet0', 'stackSave', '_emscripten_autodebug_double', '_emscripten_autodebug_float', '_emscripten_autodebug_i8', '_emscripten_autodebug_i16', '_emscripten_autodebug_i32', '_emscripten_autodebug_i64', '_strncpy', '_strcpy', '_strcat', '_saveSetjmp', '_testSetjmp', '_emscripten_replace_memory', '_bitshift64Shl', '_bitshift64Ashr', '_bitshift64Lshr', 'setAsyncState', 'emtStackSave', 'emtStackRestore'])
+BLACKLIST = set(['_malloc', '_free', '_memcpy', '_memmove', '_memset', '_strlen', 'stackAlloc', 'setThrew', 'stackRestore', 'setTempRet0', 'getTempRet0', 'stackSave', '_emscripten_autodebug_double', '_emscripten_autodebug_float', '_emscripten_autodebug_i8', '_emscripten_autodebug_i16', '_emscripten_autodebug_i32', '_emscripten_autodebug_i64', '_strncpy', '_strcpy', '_strcat', '_saveSetjmp', '_testSetjmp', '_emscripten_replace_memory', '_bitshift64Shl', '_bitshift64Ashr', '_bitshift64Lshr', 'setAsyncState', 'emtStackSave', 'emtStackRestore', 'getEmtStackMax', 'setEmtStackMax'])
 WHITELIST = []
 
 SYNC_FUNCS = set(['_emscripten_sleep', '_emscripten_sleep_with_yield', '_emscripten_wget_data', '_emscripten_idb_load', '_emscripten_idb_store', '_emscripten_idb_delete'])


### PR DESCRIPTION
This code is merely a rewritten coroutine support code from `ASYNCIFY`. It definitely needs review, but it passes the test for coroutine implementation `test_coroutine` (I have splitted it into two tests: one for `ASYNCIFY` and one for `EMTERPRETER_ASYNC`, respectively) and it even seems to work in real project.