### PR TITLE
Node.js: require at least 4.1.1

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -506,7 +506,7 @@ def check_fastcomp():
     logging.warning('could not check fastcomp: %s' % str(e))
     return True
 
-EXPECTED_NODE_VERSION = (0,8,0)
+EXPECTED_NODE_VERSION = (4, 1, 1)
 
 def check_node_version():
   jsrun.check_engine(NODE_JS)


### PR DESCRIPTION
The current expected version 0.8.0 is too low. This PR requires 4.1.1 which is what emsdk provided before.