### PR TITLE
Bump expected LLVM version for wasm backend to 7.0

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -398,7 +398,7 @@ actual_clang_version = None
 
 def expected_llvm_version():
   if get_llvm_target() == WASM_TARGET:
-    return "6.0"
+    return "7.0"
   else:
     return "4.0"
 


### PR DESCRIPTION
This silences the "LLVM version appears incorrect" warnings