### PR TITLE
Run binaryen wasm-opt on wasm backend output

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1177,7 +1177,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
         # we run the optimizer during asm2wasm itself). use it, if not overridden
         if 'BINARYEN_PASSES' not in settings_key_changes:
-          shared.Settings.BINARYEN_PASSES = shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)
+          if options.opt_level > 0 or options.shrink_level > 0:
+            shared.Settings.BINARYEN_PASSES = shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)
 
         # to bootstrap struct_info, we need binaryen
         os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'

--- a/emcc.py
+++ b/emcc.py
@@ -707,8 +707,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           'BINARYEN_MEM_MAX': 'WASM_MEM_MAX',
           # TODO: change most (all?) other BINARYEN* names to WASM*
       }
+      settings_key_changes = set()
       def setting_sub(s):
         key, rest = s.split('=', 1)
+        settings_key_changes.add(key)
         return '='.join([settings_aliases.get(key, key), rest])
       settings_changes = list(map(setting_sub, settings_changes))
 
@@ -1171,6 +1173,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.WASM_BACKEND:
         options.js_opts = None
         shared.Settings.BINARYEN = shared.Settings.WASM = 1
+
+        # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
+        # we run the optimizer during asm2wasm itself). use it, if not overridden
+        if 'BINARYEN_PASSES' not in settings_key_changes:
+          shared.Settings.BINARYEN_PASSES = shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)
 
         # to bootstrap struct_info, we need binaryen
         os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'

--- a/emscripten.py
+++ b/emscripten.py
@@ -1983,16 +1983,11 @@ var stackRestore = Module['_stackRestore'];
 var establishStackSpace = Module['establishStackSpace'];
 ''' % shared.Settings.GLOBAL_BASE)
 
-  # the tempRet0 methods may have been implemented and exported already;
-  # if not, we still need them from JS
-  has_set = 'setTempRet0' in exported_implemented_functions
-  has_get = 'getTempRet0' in exported_implemented_functions
-  if not has_set and not has_get:
-    module.append('''
-var tempRet0 = 0;
-var setTempRet0 = function(x) { tempRet0 = x };
-var getTempRet0 = function() { return tempRet0 };
-''')
+  # some runtime functionality may not have been generated in
+  # the wasm; provide a JS shim for it
+  for name in ['setTempRet0', 'getTempRet0', 'stackSave', 'stackRestore', 'stackAlloc']:
+    if name not in exported_implemented_functions:
+      module.append('var %s;\n' % name)
 
   module.append(invoke_wrappers)
   return module

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -239,32 +239,24 @@ mergeInto(LibraryManager.library, {
         }
       },
       read: function (stream, buffer, offset, length, position) {
-        if (length === 0) return 0; // node errors on 0 length reads
-        // FIXME this is terrible.
-        var nbuffer = new Buffer(length);
-        var res;
+        // Node.js < 6 compatibility: node errors on 0 length reads
+        if (length === 0) return 0;
+        // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
+        var buf = Buffer.from ? Buffer.from(buffer.buffer) : new Buffer(buffer.buffer);
         try {
-          res = fs.readSync(stream.nfd, nbuffer, 0, length, position);
+          return fs.readSync(stream.nfd, buf, offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
-        if (res > 0) {
-          for (var i = 0; i < res; i++) {
-            buffer[offset + i] = nbuffer[i];
-          }
-        }
-        return res;
       },
       write: function (stream, buffer, offset, length, position) {
-        // FIXME this is terrible.
-        var nbuffer = new Buffer(buffer.subarray(offset, offset + length));
-        var res;
+        // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
+        var buf = Buffer.from ? Buffer.from(buffer.buffer) : new Buffer(buffer.buffer);
         try {
-          res = fs.writeSync(stream.nfd, nbuffer, 0, length, position);
+          return fs.writeSync(stream.nfd, buf, offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
-        return res;
       },
       llseek: function (stream, offset, whence) {
         var position = offset;


### PR DESCRIPTION
This proposes we run the binaryen optimizer on wasm-backend output. It makes that output 5-10% smaller. This came up again today when looking at the clang running in the browser demo, which is from the wasm backend, and part of the reason for the large size is not running binaryen opts.

Debatable whether this makes sense to do by default or not - in -O1 and above it shrinks the output but increases build time, it's a tradeoff - but I lean towards emcc doing what emits good code. That clang build is adding binaryen to the build process, but emcc could do it by default so other people don't miss it. Also, there is no change to the speed of -O0 builds for fast iteration.

This PR also contains some closure fixes I noticed when running the test suite locally. I'm surprised these weren't noticed on the bots, maybe they don't have java and so skip closure, I guess?