### PR TITLE
Don't quit the FS when checking for unflushed stream content in assertions mode

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -19,7 +19,7 @@ mergeInto(LibraryManager.library, {
   $FS: {
     root: null,
     mounts: [],
-    devices: [null],
+    devices: {},
     streams: [],
     nextInode: 1,
     nameTable: null,

--- a/tests/fs_after_main.cpp
+++ b/tests/fs_after_main.cpp
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+
+// test file operations after main() exits
+
+#define NAME "file.cpp"
+
+EMSCRIPTEN_KEEPALIVE
+extern "C" void finish(void*) {
+  EM_ASM({
+    var printed = Module['extraSecretBuffer'].split('Iteration').length - 1;
+    console.log(printed);
+    assert(printed == 5, 'should have printed 5 iterations');
+  });
+  printf("Test passed.\n");
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}
+
+EMSCRIPTEN_KEEPALIVE
+extern "C" void looper() {
+  // exiting main should not cause any weirdness with file opening
+  printf("Iteration\n");
+  FILE* f = fopen("/dev/stdin", "rb");
+  if (!f) {
+    printf("Test failed.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT(1);
+#endif
+  }
+  fclose(f);
+}
+
+int main() {
+  EM_ASM({
+    (function() {
+      // exiting main should not cause any weirdness with printing
+      var realPrint = Module['print'];
+      Module['extraSecretBuffer'] = '';
+      Module['print'] = function(x) {
+        Module['extraSecretBuffer'] += x;
+        realPrint(x);
+      };
+    })();
+  });
+  printf("Start\n");
+  FILE* f = fopen(NAME, "wb");
+  fclose(f);
+  printf("Looping...\n");
+  EM_ASM({
+    Module['print']('js');
+    var counter = 0;
+    function looper() {
+      Module['print']('js looping');
+      Module['_looper']();
+      counter++;
+      if (counter < 5) {
+        Module['print']('js queueing');
+        setTimeout(looper, 1);
+      } else {
+        Module['print']('js finishing');
+        setTimeout(Module['_finish'], 1);
+      }
+    }
+    looper();
+  });
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1699,6 +1699,10 @@ keydown(100);keyup(100); // trigger the end
     for args in [[], ['--proxy-to-worker'], ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1']]:
       self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=args)
 
+  def test_fs_after_main(self):
+    for args in [[], ['-O1']]:
+      self.btest('fs_after_main.cpp', '0', args=args)
+
   def test_sdl_quit(self):
     self.btest('sdl_quit.c', '1', args=['-lSDL', '-lGL'])
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3307,6 +3307,12 @@ int main() {
         exit = 1-no_exit
         assert (no_exit and assertions) == ('atexit() called, but NO_EXIT_RUNTIME is set, so atexits() will not be called. set NO_EXIT_RUNTIME to 0' in output), 'warning should be shown'
 
+  def test_fs_after_main(self):
+    for args in [[], ['-O1']]:
+      print(args)
+      run_process([PYTHON, EMCC, path_from_root('tests', 'fs_after_main.cpp')])
+      self.assertContained('Test passed.', run_js('a.out.js', engine=NODE_JS))
+
   def test_os_oz(self):
     if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
     try:


### PR DESCRIPTION
Instead, flush the proper streams carefully, as it is possible to notice if the FS was quit. Add test (that failed before) in node and browser.

Also, `FS.devices` is used as a map, define it as one (to avoid JS engines allocating a flat array).