### PR TITLE
Fix stackAlloc test to handle adjacent/alignment-sized allocations

### DIFF
--- a/tests/core/stackAlloc.cpp
+++ b/tests/core/stackAlloc.cpp
@@ -15,8 +15,9 @@ int main() {
     assert((y - x)*(z - y) > 0, "allocations must be in the same direction");
     // no overlaps
     function notInRange(value, begin, end) {
-      if (begin < end) assert(!(value >= begin && value < end), value + " must not be in the range [" + [begin, end] + ")");
-      else assert(!(value <= begin && value > end), value + " must not be in the range [" + [begin, end] + ")");
+      function errormsg() { return value + " must not be in the range (" + begin + ", " + end + "]"; }
+      if (begin < end) assert(!(value >= begin && value < end), errormsg());
+      else assert(!(value <= begin && value > end), errormsg());
     }
     notInRange(x, y, y + direction*size);
     notInRange(x, z, z + direction*size);

--- a/tests/core/stackAlloc.cpp
+++ b/tests/core/stackAlloc.cpp
@@ -2,20 +2,21 @@
 
 int main() {
   EM_ASM({
-    var size = 100;
+    var size = 128;
     var before;
     before = stackSave();
     var x = stackAlloc(size);
     var y = stackAlloc(size);
     var direction = y > x ? 1 : -1;
+    assert(x % 16 == 0, "allocation must have 16-byte alignment");
     assert(x == Math.min(before, before + direction*size), "allocation must return the start of the range allocated");
     var z = stackAlloc(size);
     assert(x != y && y != z && x != z, "allocations must be unique");
     assert((y - x)*(z - y) > 0, "allocations must be in the same direction");
     // no overlaps
-    function notInRange(value, oneSide, otherSide) {
-      assert(!(Math.min(oneSide, otherSide) <= value &&
-               value <= Math.max(oneSide, otherSide)), value + " must not be in the range " + [oneSide, otherSide]);
+    function notInRange(value, begin, end) {
+      if (begin < end) assert(!(value >= begin && value < end), value + " must not be in the range [" + [begin, end] + ")");
+      else assert(!(value <= begin && value > end), value + " must not be in the range [" + [begin, end] + ")");
     }
     notInRange(x, y, y + direction*size);
     notInRange(x, z, z + direction*size);
@@ -26,4 +27,3 @@ int main() {
     Module['print']('ok.');
   });
 }
-


### PR DESCRIPTION
As written the assertion on the return value of x only works when the stack
growsp (because it assumes that any alignment padding will be at the top
of the allocation and not affect the returned value). Also the notInRange
function didn't allow allocations to be directly adjacent.