### PR TITLE
fix envvar-related emcc link

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -321,3 +321,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * varkor <github@varkor.com>
 * Stuart Knightley <website@stuartk.com>
 * Amadeus Guo<gliheng@foxmail.com>
+* Nathan Froyd <froydnj@gmail.com> (copyright owned by Mozilla Foundation)

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -477,7 +477,7 @@ Environment variables
 	- ``EMMAKEN_CFLAGS``
 	- ``EMCC_DEBUG``
 
-Search for 'os.environ' in `emcc <https://github.com/kripken/emscripten/blob/master/emcc>`_ to see how these are used. The most interesting is possibly ``EMCC_DEBUG``, which forces the compiler to dump its build and temporary files to a temporary directory where they can be reviewed.
+Search for 'os.environ' in `emcc.py <https://github.com/kripken/emscripten/blob/master/emcc.py>`_ to see how these are used. The most interesting is possibly ``EMCC_DEBUG``, which forces the compiler to dump its build and temporary files to a temporary directory where they can be reviewed.
 
 
 .. todo:: In case we choose to document them properly in future, below are some of the :ref:`-s <emcc-s-option-value>` options that are documented in the site are listed below. Note that this is not exhaustive by any means:


### PR DESCRIPTION
The `emcc` reference page directs the reader to the source of `emcc` to understand how several environment variables affect `emcc`.  `emcc`, however, is merely a wrapper script for loading `emcc.py`.  While the reader is probably able to understand what the intention is, it would be better to point the reader to the correct place initially.