### PR TITLE
Rework EM_ASM for WebAssembly compilation

### DIFF
--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -1,35 +1,32 @@
 #ifndef __em_asm_h__
 #define __em_asm_h__
 
-// The wasm backend calls vararg functions by passing the variadic arguments as
-// an array on the stack. For EM_ASM's underlying functions, s2wasm needs to
-// translate them to emscripten_asm_const_[signature], but the expected
-// signature and arguments has been lost as part of the vararg buffer.
-// Therefore, we declare EM_ASM's implementing functions as non-variadic.
-
-#ifndef __asmjs
-#ifndef __cplusplus
-// In C, declare these as non-prototype declarations. This is obsolete K&R C
-// (that is still supported) that causes the C frontend to consider any calls
-// to them as valid, and avoids using the vararg calling convention.
-void emscripten_asm_const();
-int emscripten_asm_const_int();
-double emscripten_asm_const_double();
-#else
-// C++ interprets an empty parameter list as a function taking no arguments,
-// instead of a K&R C function declaration. Variadic templates are lowered as
-// non-vararg calls to the instantiated templated function, which we then
-// replace in s2wasm.
-template <typename... Args> void emscripten_asm_const(const char* code, Args...);
-template <typename... Args> int emscripten_asm_const_int(const char* code, Args...);
-template <typename... Args> double emscripten_asm_const_double(const char* code, Args...);
-#endif // __cplusplus
-#else // __asmjs
-// asmjs expects these to be vararg, so let them be vararg.
 #ifdef __cplusplus
 extern "C" {
 #endif
-void emscripten_asm_const(const char* code);
+
+#ifndef __asmjs
+#define _EA_COUNT_ARGS_EXP(a,b,c,d,e,n,...) n
+#define _EA_COUNT_ARGS(...) _EA_COUNT_ARGS_EXP(__VA_ARGS__,5,4,3,2,1,0)
+
+#define _EA_PROMOTE_ARGS_0()
+#define _EA_PROMOTE_ARGS_1(x, ...) (double)(x)
+#define _EA_PROMOTE_ARGS_2(x, ...) (double)(x), _EA_PROMOTE_ARGS_1(__VA_ARGS__)
+#define _EA_PROMOTE_ARGS_3(x, ...) (double)(x), _EA_PROMOTE_ARGS_2(__VA_ARGS__)
+#define _EA_PROMOTE_ARGS_4(x, ...) (double)(x), _EA_PROMOTE_ARGS_3(__VA_ARGS__)
+#define _EA_PROMOTE_ARGS_5(x, ...) (double)(x), _EA_PROMOTE_ARGS_4(__VA_ARGS__)
+#define _EA_PROMOTE_ARGS(...) \
+  _EA_CONCATENATE(_EA_PROMOTE_ARGS_,_EA_COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+#define _EA_PREP_ARGS(code, ...) \
+  #code, COUNT_ARGS(__VA_ARGS__), PROMOTE_ARGS(__VA_ARGS__)
+
+int emscripten_asm_const_int(const char* code, int nargs, ...);
+double emscripten_asm_const_double(const char* code, int nargs, ...);
+
+#else // __asmjs
+#define _EA_PREP_ARGS(code, ...) #code, ##__VA_ARGS__
+
 int emscripten_asm_const_int(const char* code, ...);
 double emscripten_asm_const_double(const char* code, ...);
 
@@ -38,25 +35,24 @@ double emscripten_asm_const_double_sync_on_main_thread(const char* code, ...);
 
 void emscripten_asm_const_async_on_main_thread(const char* code, ...);
 
+#endif // __asmjs
+
 #ifdef __cplusplus
 }
 #endif
-#endif // __asmjs
-
-void emscripten_asm_const(const char* code);
 
 // Note: If the code block in the EM_ASM() family of functions below contains a comma,
 // then wrap the whole code block inside parentheses (). See tests/core/test_em_asm_2.cpp
 // for example code snippets.
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns no value back.
-#define EM_ASM(code, ...) ((void)emscripten_asm_const_int(#code, ##__VA_ARGS__))
+#define EM_ASM(code, ...) ((void)emscripten_asm_const_int(_EA_PREP_ARGS(code, __VA_ARGS__)))
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns an integer back.
-#define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
+#define EM_ASM_INT(code, ...) emscripten_asm_const_int(_EA_PREP_ARGS(code, __VA_ARGS__))
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns a double back.
-#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code, ##__VA_ARGS__)
+#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(_EA_PREP_ARGS(code, __VA_ARGS__))
 
 // Runs the given JavaScript code synchronously on the main browser thread, and returns no value back.
 // Call this function for example to access DOM elements in a pthread/web worker. Avoid calling this


### PR DESCRIPTION
Currently, EM_ASM does something different on Wasm and asm.js - and sadly the Wasm behaviour is relying on a bug in Wasm's Clang.

@sunfishcode has (in principle) agreed with my request to fix Clang to be C-standards-compliant, but the current behaviour needs to stay until EM_ASM has been changed.

See https://bugs.llvm.org/show_bug.cgi?id=35385.

The problem is that EM_ASM uses a (legacy) "undeclared-arguments" C declaration of the form `int emscripten_asm_const_int()`, expecting that the Wasm compiler will treat it as varargs and push the arguments to the stack. Unfortunately that's a compiler bug - when fixed, the compiler should call the method directly with whatever arguments are supplied (ie it's treated by the C in the same way as a function without a prototype at all - another legacy C feature - and a non-varargs signature is deduced from the callsite arguments).

This PR outlines a possible approach. We declare a helper `int emscripten_asm_const_int(const char* code, int nargs, ...)`, and with some macro goodness we get the following:

```
    EM_ASM(example code, arg1, arg2);
=> expands to =>
    (void)emscripten_asm_const_int("example code", 2, (double)arg1, (double)arg2);
```

Would it be possible for someone to finish off the details, and make it work? In this PR I've just got the header changes, not the actual implementation.

I'm expecting that in s2wasm we can get rid of all the messy special-casing of the "emscripten_asm_" functions.

It should be simple just to add something like this to library.js (for Wasm only, asm.js can stay the same):

```
LibraryManager.library = {
  // ...
  "emscripten_asm_const_int" : function (code, nargs, stackPos) {
    var argDecls = [], argVals = [];
    for (var i = 1; i <= nargs; ++i) {
      argDecls.push("$" + i); // in the "code" string, args are named using $1, $2, ...
      argVals.push(getValue(stackPos, 'double'));
      stackPos += 8;
    }
    return eval("(function(" + argDecls.join(",") + ") { return " + code + " })(" + argVals.join(",") + ")");
  }
  // ...
```

I know it isn't beautiful to be using eval, but maybe we could go with that for the moment, as a way of getting the code string out of the Wasm blob? For asm.js, you're relying on having Clang itself perform special handling of the "emscripten_asm" functions in the JsBackend (it looks like the backend extracts the code string as metadata for emscripten.py to extract into the final output without eval) - but upstream Clang's Wasm backend can't have hacks like that for named emscripten functions.