### PR TITLE
Allocate main()'s arguments on the stack

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -178,10 +178,10 @@ Module['callMain'] = function callMain(args) {
   ensureInitRuntime();
 
   var argc = args.length+1;
-  var argv = _malloc((argc + 1) * {{{ Runtime.POINTER_SIZE }}});
-  HEAP32[argv >> 2] = allocateUTF8(Module['thisProgram']);
+  var argv = stackAlloc((argc + 1) * {{{ Runtime.POINTER_SIZE }}});
+  HEAP32[argv >> 2] = allocateUTF8OnStack(Module['thisProgram']);
   for (var i = 1; i < argc; i++) {
-    HEAP32[(argv >> 2) + i] = allocateUTF8(args[i - 1]);
+    HEAP32[(argv >> 2) + i] = allocateUTF8OnStack(args[i - 1]);
   }
   HEAP32[(argv >> 2) + argc] = 0;
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -751,6 +751,14 @@ function allocateUTF8(str) {
   return ret;
 }
 
+// Allocate stack space for a JS string, and write it there.
+function allocateUTF8OnStack(str) {
+  var size = lengthBytesUTF8(str) + 1;
+  var ret = stackAlloc(size);
+  stringToUTF8Array(str, HEAP8, ret, size);
+  return ret;
+}
+
 function demangle(func) {
 #if DEMANGLE_SUPPORT
   var __cxa_demangle_func = Module['___cxa_demangle'] || Module['__cxa_demangle'];

--- a/system/lib/split_malloc.cpp
+++ b/system/lib/split_malloc.cpp
@@ -229,6 +229,9 @@ void* calloc(size_t num, size_t size) {
 
 // very minimal sbrk, within one chunk
 void* sbrk(intptr_t increment) {
+  if (!initialized) {
+    init();
+  }
   const int SBRK_CHUNK = split_memory - 1024;
   static size_t start = -1;
   static size_t curr = 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -882,7 +882,7 @@ int main() {
   work(10);
   dump();
   struct mallinfo m2 = mallinfo();
-  assert(m1.arena == m2.arena && m1.uordblks == m2.uordblks);
+  assert(m1.uordblks == m2.uordblks);
   printf("ok.\n");
 }
 '''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7780,9 +7780,9 @@ int main() {
       ([],      25, ['abort', 'tempDoublePtr'], ['waka'],                  48213, 26, 19),
       (['-O1'], 20, ['abort', 'tempDoublePtr'], ['waka'],                  13460, 17, 17),
       (['-O2'], 20, ['abort', 'tempDoublePtr'], ['waka'],                  13381, 17, 17),
-      (['-O3'], 13, ['abort'],                  ['tempDoublePtr', 'waka'], 10165, 16,  3), # in -O3, -Os and -Oz we metadce
-      (['-Os'], 13, ['abort'],                  ['tempDoublePtr', 'waka'], 10091, 16,  3),
-      (['-Oz'], 13, ['abort'],                  ['tempDoublePtr', 'waka'], 10081, 16,  3),
+      (['-O3'],  7, ['abort'],                  ['tempDoublePtr', 'waka'],  2678, 10,  2), # in -O3, -Os and -Oz we metadce
+      (['-Os'],  7, ['abort'],                  ['tempDoublePtr', 'waka'],  2771, 10,  2),
+      (['-Oz'],  7, ['abort'],                  ['tempDoublePtr', 'waka'],  2765, 10,  2),
       # finally, check what happens when we export nothing. wasm should be almost empty
       (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                  0, [],                         ['tempDoublePtr', 'waka'],     8,  0,  0), # totally empty!


### PR DESCRIPTION
The stack is much more efficient and avoids pulling in malloc just for this.

This is a dramatic win for hello world, where it turns out malloc was in fact pulled in just for this. The wasm goes from 6,654 bytes to just 206 (the JS is still the bulk of the combined size, though, anyhow).