### PR TITLE
Define WebAssembly.instantiateStreaming in the closure externs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -319,4 +319,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Erik Dubbelboer <erik@dubbelboer.com>
 * Sergey Tsatsulin <tsatsulin@gmail.com>
 * varkor <github@varkor.com>
-
+* Stuart Knightley <website@stuartk.com>

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -861,6 +861,12 @@ WebAssembly.RuntimeError = function() {};
  */
 WebAssembly.instantiate = function(moduleObject, importObject) {};
 /**
+ * @param {!Promise<!Response>} source
+ * @param {Object=} importObject
+ * @return {!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
+ */
+WebAssembly.instantiateStreaming = function(source, importObject) {};
+/**
  * @param {!BufferSource} bytes
  * @return {!Promise<!WebAssembly.Module>}
  */


### PR DESCRIPTION
As used in `preamble.js`.

This is needed so that closure compiler doesn't minify `instantiateStreaming`.