### PR TITLE
Test calling abort() before an EmterpreterAsync function resumes

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7168,10 +7168,10 @@ mergeInto(LibraryManager.library, {
     EmterpreterAsync.handle(function(resume) {
       setTimeout(function() {
         abort();
-      }, 50);
-      setTimeout(function() {
-        resume();
-      }, 100);
+        setTimeout(function() {
+          resume();
+        }, 10);
+      }, 10);
     });
   }
 });


### PR DESCRIPTION
Follow on to #5816, #6060