### PR TITLE
Provide a MODULARIZE_INSTANCE option

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -992,6 +992,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           'getMemory',
         ]
 
+      if shared.Settings.MODULARIZE_INSTANCE:
+        shared.Settings.MODULARIZE = 1
+
       if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
         shared.Settings.ALIASING_FUNCTION_POINTERS = 0
 
@@ -2462,11 +2465,15 @@ def modularize():
 %(src)s
 
   return %(EXPORT_NAME)s;
-};
+}%(instantiate)s;
 if (typeof module === "object" && module.exports) {
   module['exports'] = %(EXPORT_NAME)s;
 };
-''' % {"EXPORT_NAME": shared.Settings.EXPORT_NAME, "src": src})
+''' % {
+  'EXPORT_NAME': shared.Settings.EXPORT_NAME,
+  'src': src,
+  'instantiate': '()' if shared.Settings.MODULARIZE_INSTANCE else ''
+})
   f.close()
   if DEBUG: save_intermediate('modularized', 'js')
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -119,6 +119,7 @@ if (memoryInitializer) {
 #endif
 
 #if MODULARIZE
+#if MODULARIZE_INSTANCE == 0
 // Modularize mode returns a function, which can be called to
 // create instances. The instances provide a then() method,
 // must like a Promise, that receives a callback. The callback
@@ -141,6 +142,7 @@ Module['then'] = function(func) {
   }
   return Module;
 };
+#endif
 #endif
 
 /**

--- a/src/settings.js
+++ b/src/settings.js
@@ -569,6 +569,14 @@ var MODULARIZE = 0; // By default we emit all code in a straightforward way into
                     // to the onRuntimeInitialized callback (i.e., it waits for all
                     // necessary async events). It receives the instance as a parameter,
                     // for convenience.
+var MODULARIZE_INSTANCE = 0; // Similar to MODULARIZE, but while that mode exports a function,
+                             // with which you can create multiple instances, this option exports
+                             // a singleton instance. In other words, it's the same as if you
+                             // used MODULARIZE and did EXPORT_NAME = EXPORT_NAME() to create
+                             // the instance manually.
+                             // Note that the promise-like API MODULARIZE provides isn't
+                             // available here (since you arean't creating the instance
+                             // yourself).
 
 var BENCHMARK = 0; // If 1, will just time how long main() takes to execute, and not
                    // print out anything at all whatsoever. This is useful for benchmarking.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6862,23 +6862,30 @@ Module.printErr = Module['printErr'] = function(){};
           os.environ.pop('EMCC_DEBUG', None)
 
   def test_modularize_closure_pre(self):
-    # test that the combination of modularize + closure + pre-js works. in that mode,
-    # closure should not minify the Module object in a way that the pre-js cannot use it.
-    self.emcc_args += [
-      '--pre-js', path_from_root('tests', 'core', 'modularize_closure_pre.js'),
-      '--closure', '1',
-      '-s', 'MODULARIZE=1',
-      '-g1'
-    ]
-    def post(filename):
-      src = open(filename, 'a')
-      src.write('\n\n')
-      src.write('var TheModule = Module();\n')
-      src.close()
-    self.do_run(
-      open(path_from_root('tests', 'core', 'modularize_closure_pre.c')).read(),
-      open(path_from_root('tests', 'core', 'modularize_closure_pre.txt')).read(),
-      post_build=(None, post))
+    emcc_args = self.emcc_args[:]
+    for instance in [0, 1]:
+      print(instance)
+      # test that the combination of modularize + closure + pre-js works. in that mode,
+      # closure should not minify the Module object in a way that the pre-js cannot use it.
+      self.emcc_args = emcc_args + [
+        '--pre-js', path_from_root('tests', 'core', 'modularize_closure_pre.js'),
+        '--closure', '1',
+        '-g1'
+      ]
+      if not instance:
+        self.emcc_args += ['-s', 'MODULARIZE=1']
+      else:
+        self.emcc_args += ['-s', 'MODULARIZE_INSTANCE=1']
+      def post(filename):
+        src = open(filename, 'a')
+        src.write('\n\n')
+        if not instance:
+          src.write('var TheModule = Module();\n')
+        src.close()
+      self.do_run(
+        open(path_from_root('tests', 'core', 'modularize_closure_pre.c')).read(),
+        open(path_from_root('tests', 'core', 'modularize_closure_pre.txt')).read(),
+        post_build=(None, post))
 
   @no_emterpreter
   def test_exception_source_map(self):


### PR DESCRIPTION
Like MODULARIZE it wraps everything in a function, but it exports not that function but an instance of it. This is convenient because it can create the instance in exactly the right place, which otherwise the user would need to do (and it isn't always obvious how best to do it, as we found in binaryen.js).