### PR TITLE
Correct error for the random determinism test failure

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4834,7 +4834,7 @@ PORT: 3979
     if len(uniques) != 1:
       i = 0
       for unique in uniques:
-        open('unique_' + str(i) + '.js', 'w').write(unique)
+        open('unique_' + str(i) + '.js', 'wb').write(unique)
         i += 1
       assert 0, 'builds must be deterministic, see unique_X.js'
 


### PR DESCRIPTION
Now we read js+wasm as binary mode so we also have to write as binary mode.

That if branch is used only on test failure, but anyway we should generate unique_X.js correctly when failed.