### PR TITLE
Multithreading 16/N: test_pthread_global_data_initialization

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -55,7 +55,6 @@ var MEM_INIT_METHOD = 0; // How to represent the initial memory content.
                          // 1: create a *.mem file containing the binary data of the initial memory;
                          //    use the --memory-init-file command line switch to select this method
                          // 2: embed a string literal representing that initial memory data
-                         //    XXX this is known to have bugs on windows, see https://github.com/kripken/emscripten/pull/3326
 var TOTAL_STACK = 5*1024*1024; // The total stack size. There is no way to enlarge the stack, so this
                                // value must be large enough for the program's requirements. If
                                // assertions are on, we will assert on not exceeding this, otherwise,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3350,9 +3350,9 @@ window.close = function() {
 
   # Tests that spawning a new thread does not cause a reinitialization of the global data section of the application memory area.
   def test_pthread_global_data_initialization(self):
-    for mem_init_mode in [[], ['--memory-init-file', '0'], ['--memory-init-file', '1']]:
+    for mem_init_mode in [[], ['--memory-init-file', '0'], ['--memory-init-file', '1'], ['-s', 'MEM_INIT_METHOD=2']]:
       for args in [[], ['-O3']]:
-        self.btest(path_from_root('tests', 'pthread', 'test_pthread_global_data_initialization.c'), expected='20', args=args+mem_init_mode+['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'], also_wasm=False)
+        self.btest(path_from_root('tests', 'pthread', 'test_pthread_global_data_initialization.c'), expected='20', args=args+mem_init_mode+['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   # Test that emscripten_get_now() reports coherent wallclock times across all pthreads, instead of each pthread independently reporting wallclock times since the launch of that pthread.
   def test_pthread_clock_drift(self):


### PR DESCRIPTION
Revises test browser.test_pthread_global_data_initialization to cover Wasm and -s MEM_INIT_METHOD=2.

@kripken already cherry-picked the original fix earlier, but it looks like the test was not enabled for Wasm? (`also_wasm=False` was set), and `-s MEM_INIT_METHOD=2` was not being tested, so add those.