### PR TITLE
Multithreading 17/N: Sync performance.now()

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4015,6 +4015,11 @@ LibraryManager.library = {
                                "    var t = process['hrtime']();\n" +
                                "    return t[0] * 1e3 + t[1] / 1e6;\n" +
                                "  };\n" +
+#if USE_PTHREADS
+// Pthreads need their clocks synchronized to the execution of the main thread, so give them a special form of the function.
+                               "} else if (ENVIRONMENT_IS_PTHREAD) {\n" +
+                               "  _emscripten_get_now = function() { return performance['now']() - __performance_now_clock_drift; };\n" +
+#endif
                                "} else if (typeof dateNow !== 'undefined') {\n" +
                                "  _emscripten_get_now = dateNow;\n" +
                                "} else if (typeof self === 'object' && self['performance'] && typeof self['performance']['now'] === 'function') {\n" +

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -252,112 +252,115 @@ var LibraryPThread = {
       Module['print']('Preallocating ' + numWorkers + ' workers for a pthread spawn pool.');
 
       var numWorkersLoaded = 0;
+      var pthreadMainJs = 'pthread-main.js';
+      // Allow HTML module to configure the location where the 'pthread-main.js' file will be loaded from,
+      // either via Module.locateFile() function, or via Module.pthreadMainPrefixURL string. If neither
+      // of these are passed, then the default URL 'pthread-main.js' relative to the main html file is loaded.
+      if (typeof Module['locateFile'] === 'function') pthreadMainJs = Module['locateFile'](pthreadMainJs);
+      else if (Module['pthreadMainPrefixURL']) pthreadMainJs = Module['pthreadMainPrefixURL'] + pthreadMainJs;
+
       for (var i = 0; i < numWorkers; ++i) {
-        var pthreadMainJs = 'pthread-main.js';
-        // Allow HTML module to configure the location where the 'pthread-main.js' file will be loaded from,
-        // either via Module.locateFile() function, or via Module.pthreadMainPrefixURL string. If neither
-        // of these are passed, then the default URL 'pthread-main.js' relative to the main html file is loaded.
-        if (typeof Module['locateFile'] === 'function') pthreadMainJs = Module['locateFile'](pthreadMainJs);
-        else if (Module['pthreadMainPrefixURL']) pthreadMainJs = Module['pthreadMainPrefixURL'] + pthreadMainJs;
         var worker = new Worker(pthreadMainJs);
 
-        worker.onmessage = function(e) {
-          var d = e.data;
-          // TODO: Move the proxied call mechanism into a queue inside heap.
-          if (d.proxiedCall) {
-            var returnValue;
-            var funcTable = (d.func >= 0) ? proxiedFunctionTable : ASM_CONSTS;
-            var funcIdx = (d.func >= 0) ? d.func : (-1 - d.func);
-            PThread.currentProxiedOperationCallerThread = worker.pthread.threadInfoStruct; // Sometimes we need to backproxy events to the calling thread (e.g. HTML5 DOM events handlers such as emscripten_set_mousemove_callback()), so keep track in a globally accessible variable about the thread that initiated the proxying.
-            switch(d.proxiedCall & 31) {
-              case 1: returnValue = funcTable[funcIdx](); break;
-              case 2: returnValue = funcTable[funcIdx](d.p0); break;
-              case 3: returnValue = funcTable[funcIdx](d.p0, d.p1); break;
-              case 4: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2); break;
-              case 5: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3); break;
-              case 6: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4); break;
-              case 7: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5); break;
-              case 8: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6); break;
-              case 9: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7); break;
-              case 10: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7, d.p8); break;
-              default:
-                if (d.proxiedCall) {
-                  Module['printErr']("worker sent an unknown proxied call idx " + d.proxiedCall);
-                  console.error(e.data);
-                }
-                break;
+        (function(worker) {
+          worker.onmessage = function(e) {
+            var d = e.data;
+            // TODO: Move the proxied call mechanism into a queue inside heap.
+            if (d.proxiedCall) {
+              var returnValue;
+              var funcTable = (d.func >= 0) ? proxiedFunctionTable : ASM_CONSTS;
+              var funcIdx = (d.func >= 0) ? d.func : (-1 - d.func);
+              PThread.currentProxiedOperationCallerThread = worker.pthread.threadInfoStruct; // Sometimes we need to backproxy events to the calling thread (e.g. HTML5 DOM events handlers such as emscripten_set_mousemove_callback()), so keep track in a globally accessible variable about the thread that initiated the proxying.
+              switch(d.proxiedCall & 31) {
+                case 1: returnValue = funcTable[funcIdx](); break;
+                case 2: returnValue = funcTable[funcIdx](d.p0); break;
+                case 3: returnValue = funcTable[funcIdx](d.p0, d.p1); break;
+                case 4: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2); break;
+                case 5: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3); break;
+                case 6: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4); break;
+                case 7: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5); break;
+                case 8: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6); break;
+                case 9: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7); break;
+                case 10: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7, d.p8); break;
+                default:
+                  if (d.proxiedCall) {
+                    Module['printErr']("worker sent an unknown proxied call idx " + d.proxiedCall);
+                    console.error(e.data);
+                  }
+                  break;
+              }
+              if (d.returnValue) {
+                if (d.proxiedCall < 32) HEAP32[d.returnValue >> 2] = returnValue;
+                else HEAPF64[d.returnValue >> 3] = returnValue;
+              }
+              var waitAddress = d.waitAddress;
+              if (waitAddress) {
+                Atomics.store(HEAP32, waitAddress >> 2, 1);
+                Atomics.wake(HEAP32, waitAddress >> 2, 1);
+              }
+              return;
             }
-            if (d.returnValue) {
-              if (d.proxiedCall < 32) HEAP32[d.returnValue >> 2] = returnValue;
-              else HEAPF64[d.returnValue >> 3] = returnValue;
-            }
-            var waitAddress = d.waitAddress;
-            if (waitAddress) {
-              Atomics.store(HEAP32, waitAddress >> 2, 1);
-              Atomics.wake(HEAP32, waitAddress >> 2, 1);
-            }
-            return;
-          }
 
-          // If this message is intended to a recipient that is not the main thread, forward it to the target thread.
-          if (d.targetThread && d.targetThread != _pthread_self()) {
-            var thread = PThread.pthreads[d.targetThread];
-            if (thread) {
-              thread.worker.postMessage(e.data, d.transferList);
+            // If this message is intended to a recipient that is not the main thread, forward it to the target thread.
+            if (d.targetThread && d.targetThread != _pthread_self()) {
+              var thread = PThread.pthreads[d.targetThread];
+              if (thread) {
+                thread.worker.postMessage(e.data, d.transferList);
+              } else {
+                console.error('Internal error! Worker sent a message "' + d.cmd + '" to target pthread ' + d.targetThread + ', but that thread no longer exists!');
+              }
+              return;
+            }
+
+            if (d.cmd === 'processQueuedMainThreadWork') {
+              // TODO: Must post message to main Emscripten thread in PROXY_TO_WORKER mode.
+              _emscripten_main_thread_process_queued_calls();
+            } else if (d.cmd === 'spawnThread') {
+              __spawn_thread(e.data);
+            } else if (d.cmd === 'cleanupThread') {
+              __cleanup_thread(d.thread);
+            } else if (d.cmd === 'killThread') {
+              __kill_thread(d.thread);
+            } else if (d.cmd === 'cancelThread') {
+              __cancel_thread(d.thread);
+            } else if (d.cmd === 'loaded') {
+              worker.loaded = true;
+              // If this Worker is already pending to start running a thread, launch the thread now
+              if (worker.runPthread) {
+                worker.runPthread();
+                delete worker.runPthread;
+              }
+              ++numWorkersLoaded;
+              if (numWorkersLoaded === numWorkers && onFinishedLoading) {
+                onFinishedLoading();
+              }
+            } else if (d.cmd === 'print') {
+              Module['print']('Thread ' + d.threadId + ': ' + d.text);
+            } else if (d.cmd === 'printErr') {
+              Module['printErr']('Thread ' + d.threadId + ': ' + d.text);
+            } else if (d.cmd === 'alert') {
+              alert('Thread ' + d.threadId + ': ' + d.text);
+            } else if (d.cmd === 'exit') {
+              // currently no-op
+            } else if (d.cmd === 'cancelDone') {
+              PThread.freeThreadData(worker.pthread);
+              worker.pthread = undefined; // Detach the worker from the pthread object, and return it to the worker pool as an unused worker.
+              PThread.unusedWorkerPool.push(worker);
+              // TODO: Free if detached.
+              PThread.runningWorkers.splice(PThread.runningWorkers.indexOf(worker.pthread), 1); // Not a running Worker anymore.
+            } else if (d.cmd === 'objectTransfer') {
+              PThread.receiveObjectTransfer(e.data);
+            } else if (e.data.target === 'setimmediate') {
+              worker.postMessage(e.data); // Worker wants to postMessage() to itself to implement setImmediate() emulation.
             } else {
-              console.error('Internal error! Worker sent a message "' + d.cmd + '" to target pthread ' + d.targetThread + ', but that thread no longer exists!');
+              Module['printErr']("worker sent an unknown command " + d.cmd);
             }
-            return;
-          }
+          };
 
-          if (d.cmd === 'processQueuedMainThreadWork') {
-            // TODO: Must post message to main Emscripten thread in PROXY_TO_WORKER mode.
-            _emscripten_main_thread_process_queued_calls();
-          } else if (d.cmd === 'spawnThread') {
-            __spawn_thread(e.data);
-          } else if (d.cmd === 'cleanupThread') {
-            __cleanup_thread(d.thread);
-          } else if (d.cmd === 'killThread') {
-            __kill_thread(d.thread);
-          } else if (d.cmd === 'cancelThread') {
-            __cancel_thread(d.thread);
-          } else if (d.cmd === 'loaded') {
-            worker.loaded = true;
-            // If this Worker is already pending to start running a thread, launch the thread now
-            if (worker.runPthread) {
-              worker.runPthread();
-              delete worker.runPthread;
-            }
-            ++numWorkersLoaded;
-            if (numWorkersLoaded === numWorkers && onFinishedLoading) {
-              onFinishedLoading();
-            }
-          } else if (d.cmd === 'print') {
-            Module['print']('Thread ' + d.threadId + ': ' + d.text);
-          } else if (d.cmd === 'printErr') {
-            Module['printErr']('Thread ' + d.threadId + ': ' + d.text);
-          } else if (d.cmd === 'alert') {
-            alert('Thread ' + d.threadId + ': ' + d.text);
-          } else if (d.cmd === 'exit') {
-            // currently no-op
-          } else if (d.cmd === 'cancelDone') {
-            PThread.freeThreadData(worker.pthread);
-            worker.pthread = undefined; // Detach the worker from the pthread object, and return it to the worker pool as an unused worker.
-            PThread.unusedWorkerPool.push(worker);
-            // TODO: Free if detached.
-            PThread.runningWorkers.splice(PThread.runningWorkers.indexOf(worker.pthread), 1); // Not a running Worker anymore.
-          } else if (d.cmd === 'objectTransfer') {
-            PThread.receiveObjectTransfer(e.data);
-          } else if (e.data.target === 'setimmediate') {
-            worker.postMessage(e.data); // Worker wants to postMessage() to itself to implement setImmediate() emulation.
-          } else {
-            Module['printErr']("worker sent an unknown command " + d.cmd);
-          }
-        };
-
-        worker.onerror = function(e) {
-          Module['printErr']('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
-        };
+          worker.onerror = function(e) {
+            Module['printErr']('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+          };
+        }(worker));
 
         // Allocate tempDoublePtr for the worker. This is done here on the worker's behalf, since we may need to do this statically
         // if the runtime has not been loaded yet, etc. - so we just use getMemory, which is main-thread only.

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -23,6 +23,12 @@ var DYNAMIC_BASE = 0;
 
 var ENVIRONMENT_IS_PTHREAD = true;
 
+// performance.now() is specced to return a wallclock time in msecs since that Web Worker/main thread launched. However for pthreads this can cause
+// subtle problems in emscripten_get_now() as this essentially would measure time from pthread_create(), meaning that the clocks between each threads
+// would be wildly out of sync. Therefore sync all pthreads to the clock on the main browser thread, so that different threads see a somewhat
+// coherent clock across each of them (+/- 0.1msecs in testing)
+var __performance_now_clock_drift = 0;
+
 // Cannot use console.log or console.error in a web worker, since that would risk a browser deadlock! https://bugzilla.mozilla.org/show_bug.cgi?id=1049091
 // Therefore implement custom logging facility for threads running in a worker, which queue the messages to main thread to print.
 var Module = {};
@@ -106,6 +112,7 @@ this.onmessage = function(e) {
     } else if (e.data.cmd === 'objectTransfer') {
       PThread.receiveObjectTransfer(e.data);
     } else if (e.data.cmd === 'run') { // This worker was idle, and now should start executing its pthread entry point.
+    __performance_now_clock_drift = performance.now() - e.data.time; // Sync up to the clock of the main thread.
       threadInfoStruct = e.data.threadInfoStruct;
       __register_pthread_ptr(threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0); // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
       assert(threadInfoStruct);
@@ -126,17 +133,18 @@ this.onmessage = function(e) {
 //#endif
 
       PThread.receiveObjectTransfer(e.data);
-
       PThread.setThreadStatus(_pthread_self(), 1/*EM_THREAD_STATUS_RUNNING*/);
 
       try {
-        // HACK: Some code in the wild has instead signatures of form 'void *ThreadMain()', which seems to be ok in native code.
-        // To emulate supporting both in test suites, use the following form. This is brittle!
-        if (typeof Module['asm']['dynCall_ii'] !== 'undefined') {
-          result = Module['asm'].dynCall_ii(e.data.start_routine, e.data.arg); // pthread entry points are always of signature 'void *ThreadMain(void *arg)'
-        } else {
-          result = Module['asm'].dynCall_i(e.data.start_routine); // as a hack, try signature 'i' as fallback.
-        }
+      // pthread entry points are always of signature 'void *ThreadMain(void *arg)'
+      // Native codebases sometimes spawn threads with other thread entry point signatures,
+      // such as void ThreadMain(void *arg), void *ThreadMain(), or void ThreadMain().
+      // That is not acceptable per C/C++ specification, but x86 compiler ABI extensions
+      // enable that to work. If you find the following line to crash, either change the signature
+      // to "proper" void *ThreadMain(void *arg) form, or try linking with the Emscripten linker
+      // flag -s EMULATE_FUNCTION_POINTER_CASTS=1 to add in emulation for this x86 ABI extension.
+      result = Module['asm'].dynCall_ii(e.data.start_routine, e.data.arg);
+
 //#if STACK_OVERFLOW_CHECK
         if (typeof checkStackCookie === 'function') checkStackCookie();
 //#endif
@@ -163,6 +171,10 @@ this.onmessage = function(e) {
       }
     } else if (e.data.target === 'setimmediate') {
       // no-op
+    } else if (e.data.cmd === 'processThreadQueue') {
+      if (threadInfoStruct) { // If this thread is actually running?
+        _emscripten_current_thread_process_queued_calls();
+      }
     } else {
       Module['printErr']('pthread-main.js received unknown command ' + e.data.cmd);
       console.error(e.data);

--- a/tests/pthread/test_pthread_clock_drift.cpp
+++ b/tests/pthread/test_pthread_clock_drift.cpp
@@ -1,0 +1,55 @@
+#include <pthread.h>
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <math.h>
+
+volatile int threadStarted = 0;
+volatile int timeReceived = 0;
+volatile double mainThreadTime;
+
+void wait(volatile int *address)
+{
+	int state = emscripten_atomic_load_u32((void*)address);
+	while(state == 0)
+		state = emscripten_atomic_load_u32((void*)address);
+}
+
+void wake(volatile int *address)
+{
+	emscripten_atomic_store_u32((void*)address, 1);
+}
+
+void *thread_main(void *arg)
+{
+	wake(&threadStarted);
+	wait(&timeReceived);
+	double pthreadTime = emscripten_get_now();
+	double timeDifference = pthreadTime - mainThreadTime;
+	printf("Time difference between pthread and main thread is %f msecs.\n", timeDifference);
+
+#ifdef REPORT_RESULT
+	REPORT_RESULT(fabs(timeDifference) < 200); // The time difference here should be well less than 1 msec, but test against 200msecs to be super-sure.
+#endif
+	return 0;
+}
+
+void busy_sleep(double msecs)
+{
+	double end = emscripten_get_now() + msecs;
+	while(emscripten_get_now() < end)
+		;
+}
+
+int main()
+{
+	// Cause a one second delay between main() and pthread start that might have a chance to drift the wallclocks on emscripten_get_now().
+	busy_sleep(1000);
+
+	pthread_t thread;
+	pthread_create(&thread, NULL, thread_main, NULL);
+	wait(&threadStarted);
+	mainThreadTime = emscripten_get_now();
+	wake(&timeReceived);
+
+	EM_ASM(Module['noExitRuntime']=true);
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3354,6 +3354,10 @@ window.close = function() {
       for args in [[], ['-O3']]:
         self.btest(path_from_root('tests', 'pthread', 'test_pthread_global_data_initialization.c'), expected='20', args=args+mem_init_mode+['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'], also_wasm=False)
 
+  # Test that emscripten_get_now() reports coherent wallclock times across all pthreads, instead of each pthread independently reporting wallclock times since the launch of that pthread.
+  def test_pthread_clock_drift(self):
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_clock_drift.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
   # test atomicrmw i64
   def test_atomicrmw_i64(self):
     Popen([PYTHON, EMCC, path_from_root('tests', 'atomicrmw_i64.ll'), '-s', 'USE_PTHREADS=1', '-s', 'IN_TEST_HARNESS=1', '-o', 'test.html']).communicate()


### PR DESCRIPTION
Synchronize `emscripten_get_now()` to return values that are comparable across threads. Otherwise each thread would return time compared to the start of each worker hosting a thread, causing extremely subtle bugs in multithreaded task timing code.

One might ask "why don't we spec `emscripten_get_now()` to count time from 0 from each pthread start" - the reasons for this is are:
 - workers are reused to host multiple pthreads. If one pthread quits, the worker is not killed but will stay around. `performance.now()` returns time counting from 0 from the start of that worker, and not the start of the pthread. Also, workers can be pooled up front with `-s PTHREAD_POOL_SIZE=x`, and the time from Worker launching to worker having compiled and loaded asm.js/wasm code for execution is nontrivial, so if we wanted to have a model that counted from start of each pthread, we'd still have to compute an offset to account for all of these deltas.
 - in other platforms there has not ever existed a wallclock timing function that was not thread coherent (to my knowledge), so a thread incoherent timing function would be a first, and all codebases would likely have to work through this gotcha specifically for the web. We could entertain a `emscripten_thread_coherent_get_now()` which was a synchronized variant and keep the default one unsynchronized, but that feels like leading a path towards a "best practices" tip "remember that `emscripten_get_now()` is broken, always use `emscripten_thread_coherent_get_now()`".

We could perhaps have a `-s THREAD_COHERENT_EMSCRIPTEN_GET_NOW=0/1` flag that was default enabled, but for users that know they don't need it, they could disable it for a tiny code size win; but that might be premature for now, so opting to just do this by default in multithreaded builds, and keep it off from singlethreaded build mode.