### PR TITLE
Remove FUNCTION_POINTER_ALIGNMENT setting

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -809,7 +809,7 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
       body = list(map(receive, body))
     for j in range(settings['RESERVED_FUNCTION_POINTERS']):
       curr = 'jsCall_%s_%s' % (sig, j)
-      body[settings['FUNCTION_POINTER_ALIGNMENT'] * (1 + j)] = curr
+      body[1 + j] = curr
       implemented_functions.add(curr)
     Counter.next_item = 0
     def fix_item(item):

--- a/src/modules.js
+++ b/src/modules.js
@@ -27,7 +27,7 @@ var Types = {
   preciseI64MathUsed: (PRECISE_I64_MATH == 2)
 };
 
-var firstTableIndex = FUNCTION_POINTER_ALIGNMENT * RESERVED_FUNCTION_POINTERS + 1;
+var firstTableIndex = RESERVED_FUNCTION_POINTERS + 1;
 
 var Functions = {
   // All functions that will be implemented in this file. Maps id to signature

--- a/src/settings.js
+++ b/src/settings.js
@@ -228,12 +228,6 @@ var EMULATE_FUNCTION_POINTER_CASTS = 0; // Allows function pointers to be cast, 
                                         // call of an incorrect type with a runtime correction.
                                         // This adds overhead and should not be used normally.
                                         // It also forces ALIASING_FUNCTION_POINTERS to 0.
-var FUNCTION_POINTER_ALIGNMENT = 2; // Byte alignment of function pointers - we will fill the
-                                    // tables with zeros on aligned values. 1 means all values
-                                    // are aligned and all will be used (which is optimal).
-                                    // Sadly 1 breaks on &Class::method function pointer calls,
-                                    // which llvm assumes have the lower bit zero (see
-                                    // test_polymorph and issue #1692).
 
 var EXCEPTION_DEBUG = 0; // Print out exceptions in emscriptened code. Does not work in asm.js mode
 

--- a/src/support.js
+++ b/src/support.js
@@ -253,7 +253,7 @@ function addFunction(func) {
   for (var i = 0; i < functionPointers.length; i++) {
     if (!functionPointers[i]) {
       functionPointers[i] = func;
-      return {{{ FUNCTION_POINTER_ALIGNMENT }}}*(1 + i);
+      return 1 + i;
     }
   }
   throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';
@@ -282,7 +282,7 @@ function addFunction(func) {
 
 function removeFunction(index) {
 #if EMULATED_FUNCTION_POINTERS == 0
-  functionPointers[(index-{{{ FUNCTION_POINTER_ALIGNMENT }}})/{{{ FUNCTION_POINTER_ALIGNMENT }}}] = null;
+  functionPointers[index-1] = null;
 #else
   alignFunctionTables(); // XXX we should rely on this being an invariant
   var tables = getFunctionTables();


### PR DESCRIPTION
Closes #1692 and fixes #6068.
Should land with kripken/emscripten-fastcomp#212.