### PR TITLE
Fix test_demangle_stacks* in non-node.js

### DIFF
--- a/tests/core/test_demangle_stacks.cpp
+++ b/tests/core/test_demangle_stacks.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <emscripten.h>
+
 namespace NameSpace {
 class Class {
  public:
@@ -8,6 +10,9 @@ class Class {
   void Aborter(double x, char y, int *z) {
     volatile int w = 1;
     if (w) {
+      EM_ASM({
+        Module['print'](stackTrace());
+      });
       abort();
     }
   }


### PR DESCRIPTION
Don't depend on the vm's stack trace from an error, just print the stack trace ourselves.

The bots only test node, so we missed this.