### PR TITLE
Fix spidermonkey shell Module.printErr detection

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -267,9 +267,9 @@ else {
 }
 #endif // ASSERTIONS
 
-// prefer print/printErr if they exist, as they are the best supported in shells (printErr goes
-// to stderr properly, etc.)
-Module['print'] = typeof print !== 'undefined' ? print : (typeof console !== 'undefined' ? console.log : null);
+// console.log is checked first, as 'print' on the web will open a print dialogue
+// printErr is preferable to console.warn (works better in shells)
+Module['print'] = typeof console !== 'undefined' ? console.log : (typeof print !== 'undefined' ? print : null);
 Module['printErr'] = typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn) || Module['print']);
 
 // *** Environment setup code ***

--- a/src/shell.js
+++ b/src/shell.js
@@ -272,11 +272,11 @@ if (typeof console !== 'undefined') {
   Module['printErr'] = console.warn;
 } else if (typeof print !== 'undefined') {
   Module['print'] = print;
-  if (typeof printErr !== 'undefined') Module['printErr'] = printErr;
-} else {
-  Module['print'] = {};
 }
-if (!Module['printErr']) Module['printErr'] = Module['print'];
+if (!Module['printErr']) {
+  if (typeof printErr !== 'undefined') Module['printErr'] = printErr;
+  else Module['printErr'] = Module['print'];
+}
 
 // *** Environment setup code ***
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -273,10 +273,7 @@ if (typeof console !== 'undefined') {
 } else if (typeof print !== 'undefined') {
   Module['print'] = print;
 }
-if (!Module['printErr']) {
-  if (typeof printErr !== 'undefined') Module['printErr'] = printErr;
-  else Module['printErr'] = Module['print'];
-}
+Module['printErr'] = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : Module['print']);
 
 // *** Environment setup code ***
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -267,13 +267,10 @@ else {
 }
 #endif // ASSERTIONS
 
-if (typeof console !== 'undefined') {
-  Module['print'] = console.log;
-  Module['printErr'] = console.warn;
-} else if (typeof print !== 'undefined') {
-  Module['print'] = print;
-}
-Module['printErr'] = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : Module['print']);
+// prefer print/printErr if they exist, as they are the best supported in shells (printErr goes
+// to stderr properly, etc.)
+Module['print'] = typeof print !== 'undefined' ? print : (typeof console !== 'undefined' ? console.log : null);
+Module['printErr'] = typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn) || Module['print']);
 
 // *** Environment setup code ***
 


### PR DESCRIPTION
It has `console.log` but not `console.warn`, so it needs to find and use printErr.