### PR TITLE
Disable NODERAWFS tests on Mac

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4564,9 +4564,18 @@ def process(filename):
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')
     self.do_run_from_file(src, out)
 
-  @no_mac('NODERAWFS support on mac is flaky')
-  @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
+    self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
+    src = path_from_root('tests', 'fs', 'test_writeFile.cc')
+    out = path_from_root('tests', 'fs', 'test_writeFile.out')
+    self.do_run_from_file(src, out, js_engines=js_engines)
+
+  # NODERAWFS support for OSX is flaky, but it is not desirable to always
+  # disable test_fs_writeFile test, so we split the test into two.
+  # See issue 6121
+  @no_osx('NODERAWFS support on OSX is flaky')
+  @also_with_noderawfs
+  def test_fs_writeFile_noderawfs(self, js_engines=None):
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
     src = path_from_root('tests', 'fs', 'test_writeFile.cc')
     out = path_from_root('tests', 'fs', 'test_writeFile.out')
@@ -4730,7 +4739,7 @@ def process(filename):
       if self.is_windows() and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on Windows including https://github.com/nodejs/node/issues/18014
-    if not self.is_mac() and not self.is_windows():
+    if not self.is_osx() and not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-DNODERAWFS']
       if not os.geteuid(): # 0 if root
         Building.COMPILER_TEST_OPTS += ['-DSKIP_ACCESS_TESTS']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4624,9 +4624,9 @@ def process(filename):
 
   @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
-    if self.is_osx() and 'NODERAWFS=1' in self.emcc_args:
-      return self.skip('Skipping NODERAWFS part on OSX because NODERAWFS '
-                       'support on OSX is flaky')
+    if self.is_macos() and 'NODERAWFS=1' in self.emcc_args:
+      return self.skip('Skipping NODERAWFS part on macOS because NODERAWFS '
+                       'support on macOS is flaky')
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
     src = path_from_root('tests', 'fs', 'test_writeFile.cc')
     out = path_from_root('tests', 'fs', 'test_writeFile.out')
@@ -4790,7 +4790,7 @@ def process(filename):
       if self.is_windows() and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on Windows including https://github.com/nodejs/node/issues/18014
-    if not self.is_osx() and not self.is_windows():
+    if not self.is_macos() and not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-DNODERAWFS']
       if not os.geteuid(): # 0 if root
         Building.COMPILER_TEST_OPTS += ['-DSKIP_ACCESS_TESTS']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4565,7 +4565,7 @@ def process(filename):
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')
     self.do_run_from_file(src, out)
 
-  @no_mac('noderawfs support on mac is flaky')
+  @no_mac('NODERAWFS support on mac is flaky')
   @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
@@ -4721,7 +4721,7 @@ def process(filename):
     expected = open(path_from_root('tests', 'unistd', 'login.out'), 'r').read()
     self.do_run(src, expected)
 
-  @no_mac('noderawfs support on mac is flaky')
+  @no_mac('NODERAWFS support on mac is flaky')
   def test_unistd_unlink(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4624,9 +4624,6 @@ def process(filename):
 
   @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
-    if self.is_macos() and 'NODERAWFS=1' in self.emcc_args:
-      return self.skip('Skipping NODERAWFS part on macOS because NODERAWFS '
-                       'support on macOS is flaky')
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
     src = path_from_root('tests', 'fs', 'test_writeFile.cc')
     out = path_from_root('tests', 'fs', 'test_writeFile.out')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4564,18 +4564,11 @@ def process(filename):
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')
     self.do_run_from_file(src, out)
 
-  def test_fs_writeFile(self, js_engines=None):
-    self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
-    src = path_from_root('tests', 'fs', 'test_writeFile.cc')
-    out = path_from_root('tests', 'fs', 'test_writeFile.out')
-    self.do_run_from_file(src, out, js_engines=js_engines)
-
-  # NODERAWFS support for OSX is flaky, but it is not desirable to always
-  # disable test_fs_writeFile test, so we split the test into two.
-  # See issue 6121
-  @no_osx('NODERAWFS support on OSX is flaky')
   @also_with_noderawfs
-  def test_fs_writeFile_noderawfs(self, js_engines=None):
+  def test_fs_writeFile(self, js_engines=None):
+    if self.is_osx() and 'NODERAWFS=1' in self.emcc_args:
+      return self.skip('Skipping NODERAWFS part on OSX because NODERAWFS '
+                       'support on OSX is flaky')
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
     src = path_from_root('tests', 'fs', 'test_writeFile.cc')
     out = path_from_root('tests', 'fs', 'test_writeFile.out')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4636,7 +4636,7 @@ def process(filename):
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, expected, js_engines=[NODE_JS])
     # Node.js fs.chmod is nearly no-op on Windows
-    if not WINDOWS:
+    if not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts
       self.emcc_args += ['-s', 'NODERAWFS=1']
       self.do_run(src, expected, js_engines=[NODE_JS])
@@ -4687,7 +4687,7 @@ def process(filename):
       self.do_run(src, expected, js_engines=[NODE_JS])
 
   def test_unistd_truncate_noderawfs(self):
-    if WINDOWS:
+    if self.is_windows():
       return self.skip("Windows throws EPERM rather than EACCES or EINVAL")
     if not os.geteuid(): # 0 if root
       return self.skip("Root access invalidates this test by being able to write on readonly files")
@@ -4721,7 +4721,6 @@ def process(filename):
     expected = open(path_from_root('tests', 'unistd', 'login.out'), 'r').read()
     self.do_run(src, expected)
 
-  @no_mac('NODERAWFS support on mac is flaky')
   def test_unistd_unlink(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
@@ -4729,10 +4728,10 @@ def process(filename):
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       # symlinks on node.js on Windows require administrative privileges, so skip testing those bits on that combination.
-      if WINDOWS and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
+      if self.is_windows() and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on Windows including https://github.com/nodejs/node/issues/18014
-    if not WINDOWS:
+    if not self.mac() and not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-DNODERAWFS']
       if not os.geteuid(): # 0 if root
         Building.COMPILER_TEST_OPTS += ['-DSKIP_ACCESS_TESTS']
@@ -4745,7 +4744,7 @@ def process(filename):
     src = open(path_from_root('tests', 'unistd', 'links.c'), 'r').read()
     expected = open(path_from_root('tests', 'unistd', 'links.out'), 'r').read()
     for fs in ['MEMFS', 'NODEFS']:
-      if WINDOWS and fs == 'NODEFS':
+      if self.is_windows() and fs == 'NODEFS':
         print('Skipping NODEFS part of this test for test_unistd_links on Windows, since it would require administrative privileges.', file=sys.stderr)
         # Also, other detected discrepancies if you do end up running this test on NODEFS:
         # test expects /, but Windows gives \ as path slashes.
@@ -4755,7 +4754,7 @@ def process(filename):
       self.do_run(src, expected, js_engines=[NODE_JS])
 
   def test_unistd_symlink_on_nodefs(self):
-    if WINDOWS:
+    if self.is_windows():
       return self.skip('Skipping NODEFS part of this test for test_unistd_symlink_on_nodefs on Windows, since it would require administrative privileges.')
       # Also, other detected discrepancies if you do end up running this test on NODEFS:
       # test expects /, but Windows gives \ as path slashes.
@@ -5490,7 +5489,7 @@ return malloc(size);
                             os.path.join('objs', '.libs', 'libfreetype.a'))
 
   def test_freetype(self):
-    if WINDOWS: return self.skip('test_freetype uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
+    if self.is_windows(): return self.skip('test_freetype uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
     assert 'asm2g' in test_modes
     if self.run_name == 'asm2g':
       Settings.ALIASING_FUNCTION_POINTERS = 1 - Settings.ALIASING_FUNCTION_POINTERS # flip for some more coverage here
@@ -5579,7 +5578,7 @@ def process(filename):
     if self.run_name == 'asm2g':
       self.emcc_args += ['-g4'] # more source maps coverage
 
-    use_cmake_configure = WINDOWS
+    use_cmake_configure = self.is_windows()
     if use_cmake_configure:
       make_args = []
       configure = [PYTHON, path_from_root('emcmake'), 'cmake', '.', '-DBUILD_SHARED_LIBS=OFF']
@@ -5601,7 +5600,7 @@ def process(filename):
     for use_cmake in [False, True]: # If false, use a configure script to configure Bullet build.
       print('cmake', use_cmake)
       # Windows cannot run configure sh scripts.
-      if WINDOWS and not use_cmake:
+      if self.is_windows() and not use_cmake:
         continue
 
       Settings.ASSERTIONS = 2 if use_cmake else asserts # extra testing for ASSERTIONS == 2
@@ -5632,7 +5631,7 @@ def process(filename):
 
   @sync
   def test_poppler(self):
-    if WINDOWS: return self.skip('test_poppler depends on freetype, which uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
+    if self.is_windows(): return self.skip('test_poppler depends on freetype, which uses a ./configure script to build and therefore currently only runs on Linux and OS X.')
 
     def test():
       Building.COMPILER_TEST_OPTS += [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,21 @@ def no_wasm_backend(note=''):
     return skip_if(f, 'is_wasm_backend', note)
   return decorated
 
+def no_linux(note=''):
+  def decorated(f):
+    return skip_if(f, 'is_linux', note)
+  return decorated
+
+def no_mac(note=''):
+  def decorated(f):
+    return skip_if(f, 'is_mac', note)
+  return decorated
+
+def no_windows(note=''):
+  def decorated(f):
+    return skip_if(f, 'is_windows', note)
+  return decorated
+
 # Async wasm compilation can't work in some tests, they are set up synchronously
 def sync(f):
   def decorated(self):
@@ -64,6 +79,13 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
     return 'SPLIT_MEMORY=' in str(self.emcc_args)
   def is_wasm(self):
     return 'BINARYEN' in str(self.emcc_args) or self.is_wasm_backend()
+  def is_linux(self):
+    # sys.platform is 'linux2' in Python 2.x and 'linux' in Python 3.x
+    return sys.platform.startsWith('linux')
+  def is_mac(self):
+    return sys.platform == 'darwin'
+  def is_windows(self):
+    return sys.platform == 'win32'
 
   # Use closure in some tests for some additional coverage
   def maybe_closure(self):
@@ -4543,6 +4565,7 @@ def process(filename):
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')
     self.do_run_from_file(src, out)
 
+  @no_mac('noderawfs support on mac is flaky')
   @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
@@ -4698,6 +4721,7 @@ def process(filename):
     expected = open(path_from_root('tests', 'unistd', 'login.out'), 'r').read()
     self.do_run(src, expected)
 
+  @no_mac('noderawfs support on mac is flaky')
   def test_unistd_unlink(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4731,7 +4731,7 @@ def process(filename):
       if self.is_windows() and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on Windows including https://github.com/nodejs/node/issues/18014
-    if not self.mac() and not self.is_windows():
+    if not self.is_mac() and not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-DNODERAWFS']
       if not os.geteuid(): # 0 if root
         Building.COMPILER_TEST_OPTS += ['-DSKIP_ACCESS_TESTS']


### PR DESCRIPTION
NODERAWFS support added by #6008 seems to be still flaky on Mac. (Not sure about Windows. Out waterfall bots have other problems at the moment so they can't test this)

Also add support for platform-dependent tests.