### PR TITLE
fix setting of `timezone` by `tzset()`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2084,7 +2084,12 @@ LibraryManager.library = {
     if (_tzset.called) return;
     _tzset.called = true;
 
-    {{{ makeSetValue(makeGlobalUse('_timezone'), '0', '-(new Date()).getTimezoneOffset() * 60', 'i32') }}};
+    // timezone is specified as seconds west of UTC ("The external variable
+    // `timezone` shall be set to the difference, in seconds, between
+    // Coordinated Universal Time (UTC) and local standard time."), the same
+    // as returned by getTimezoneOffset().
+    // See http://pubs.opengroup.org/onlinepubs/009695399/functions/tzset.html
+    {{{ makeSetValue(makeGlobalUse('_timezone'), '0', '(new Date()).getTimezoneOffset() * 60', 'i32') }}};
 
     var winter = new Date(2000, 0, 1);
     var summer = new Date(2000, 6, 1);


### PR DESCRIPTION
`timezone` and the value returned by `getTimezoneOffset()` are specified
in the same way, so there's no need to negate the value returned
here.  (Compare the glibc extension field `tm_gmtoff` to `struct tm`,
which is specified as seconds east of UTC, which would require a
negation.)

Fix noticed by @brion, partially addresses #5652.