### PR TITLE
Add support for OS-dependent decorators

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,9 +44,9 @@ def no_linux(note=''):
     return skip_if(f, 'is_linux', note)
   return decorated
 
-def no_mac(note=''):
+def no_osx(note=''):
   def decorated(f):
-    return skip_if(f, 'is_mac', note)
+    return skip_if(f, 'is_osx', note)
   return decorated
 
 def no_windows(note=''):
@@ -80,12 +80,11 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
   def is_wasm(self):
     return 'BINARYEN' in str(self.emcc_args) or self.is_wasm_backend()
   def is_linux(self):
-    # sys.platform is 'linux2' in Python 2.x and 'linux' in Python 3.x
-    return sys.platform.startsWith('linux')
-  def is_mac(self):
-    return sys.platform == 'darwin'
+    return LINUX
+  def is_osx(self):
+    return OSX
   def is_windows(self):
-    return sys.platform == 'win32'
+    return WINDOWS
 
   # Use closure in some tests for some additional coverage
   def maybe_closure(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4565,7 +4565,6 @@ def process(filename):
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')
     self.do_run_from_file(src, out)
 
-  @no_mac('NODERAWFS support on mac is flaky')
   @also_with_noderawfs
   def test_fs_writeFile(self, js_engines=None):
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=1'] # see issue 2334
@@ -4731,7 +4730,7 @@ def process(filename):
       if self.is_windows() and fs == 'NODEFS': Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on Windows including https://github.com/nodejs/node/issues/18014
-    if not self.is_mac() and not self.is_windows():
+    if not self.is_windows():
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-DNODERAWFS']
       if not os.geteuid(): # 0 if root
         Building.COMPILER_TEST_OPTS += ['-DSKIP_ACCESS_TESTS']

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -82,6 +82,7 @@ def path_from_root(*pathelems):
 
 WINDOWS = sys.platform.startswith('win')
 OSX = sys.platform == 'darwin'
+LINUX = sys.platform.startswith('linux')
 
 # This is a workaround for https://bugs.python.org/issue9400
 class Py2CalledProcessError(subprocess.CalledProcessError):


### PR DESCRIPTION
And replace the uses of [`WINDOWS` in tools/shared.py](https://github.com/kripken/emscripten/blob/e24661497247ecac78166b02e25e880e0ee14c9d/tools/shared.py#L83) with `self.is_windows()`.