### PR TITLE
test_other.py cleanups

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -21,6 +21,7 @@ class temp_directory(object):
   def __enter__(self):
     self.directory = tempfile.mkdtemp(prefix='emsripten_temp_', dir=TEMP_DIR)
     self.prev_cwd = os.getcwd()
+    os.chdir(self.directory)
     return self.directory
 
   def __exit__(self, type, value, traceback):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import multiprocessing, os, pipes, re, shutil, subprocess, sys
+import itertools
 import glob
 import tools.shared
 from tools.shared import *
@@ -7968,69 +7969,69 @@ int main() {
           subprocess.check_call([PYTHON, EMCC] + std + ['a.c', 'b.c'])
 
   def test_single_file(self):
-    for single_file_enabled in [True, False]:
-      for meminit1_enabled in [True, False]:
-        for debug_enabled in [True, False]:
-          for emterpreter_enabled in [True, False]:
-            for emterpreter_file_enabled in [True, False]:
-              for closure_enabled in [True, False]:
-                for wasm_enabled in [True, False]:
-                  for asmjs_fallback_enabled in [True, False]:
-                    # skip unhelpful option combinations
-                    if (
-                      (asmjs_fallback_enabled and not wasm_enabled) or
-                      (emterpreter_file_enabled and not emterpreter_enabled)
-                    ):
-                      continue
+    for (single_file_enabled,
+         meminit1_enabled,
+         debug_enabled,
+         emterpreter_enabled,
+         emterpreter_file_enabled,
+         closure_enabled,
+         wasm_enabled,
+         asmjs_fallback_enabled) in itertools.product([True, False], repeat=8):
+      # skip unhelpful option combinations
+      if (
+          (asmjs_fallback_enabled and not wasm_enabled) or
+          (emterpreter_file_enabled and not emterpreter_enabled)
+      ):
+        continue
 
-                    expect_asmjs_code = asmjs_fallback_enabled and wasm_enabled
-                    expect_emterpretify_file = emterpreter_file_enabled
-                    expect_meminit = (meminit1_enabled and not wasm_enabled) or (wasm_enabled and asmjs_fallback_enabled)
-                    expect_success = not (emterpreter_file_enabled and single_file_enabled)
-                    expect_wasm = wasm_enabled
-                    expect_wast = debug_enabled and wasm_enabled
+      expect_asmjs_code = asmjs_fallback_enabled and wasm_enabled
+      expect_emterpretify_file = emterpreter_file_enabled
+      expect_meminit = (meminit1_enabled and not wasm_enabled) or (wasm_enabled and asmjs_fallback_enabled)
+      expect_success = not (emterpreter_file_enabled and single_file_enabled)
+      expect_wasm = wasm_enabled
+      expect_wast = debug_enabled and wasm_enabled
 
-                    # currently, the emterpreter always fails with JS output since we do not preload the emterpreter file, which in non-HTML we would need to do manually
-                    should_run_js = expect_success and not emterpreter_enabled
+      # currently, the emterpreter always fails with JS output since we do not preload the emterpreter file, which in non-HTML we would need to do manually
+      should_run_js = expect_success and not emterpreter_enabled
 
-                    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c')]
+      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c')]
 
-                    if single_file_enabled:
-                      expect_asmjs_code = False
-                      expect_emterpretify_file = False
-                      expect_meminit = False
-                      expect_wasm = False
-                      expect_wast = False
-                      cmd += ['-s', 'SINGLE_FILE=1']
-                    if meminit1_enabled:
-                      cmd += ['--memory-init-file', '1']
-                    if debug_enabled:
-                      cmd += ['-g']
-                    if emterpreter_enabled:
-                      cmd += ['-s', 'EMTERPRETIFY=1']
-                    if emterpreter_file_enabled:
-                      cmd += ['-s', "EMTERPRETIFY_FILE='a.out.dat'"]
-                    if closure_enabled:
-                      cmd += ['--closure', '1']
-                    if wasm_enabled:
-                      method = 'interpret-binary'
-                      if asmjs_fallback_enabled:
-                        method += ',asmjs'
-                      cmd += ['-s', 'WASM=1', '-s', "BINARYEN_METHOD='" + method + "'"]
+      if single_file_enabled:
+        expect_asmjs_code = False
+        expect_emterpretify_file = False
+        expect_meminit = False
+        expect_wasm = False
+        expect_wast = False
+        cmd += ['-s', 'SINGLE_FILE=1']
+      if meminit1_enabled:
+        cmd += ['--memory-init-file', '1']
+      if debug_enabled:
+        cmd += ['-g']
+      if emterpreter_enabled:
+        cmd += ['-s', 'EMTERPRETIFY=1']
+      if emterpreter_file_enabled:
+        cmd += ['-s', "EMTERPRETIFY_FILE='a.out.dat'"]
+      if closure_enabled:
+        cmd += ['--closure', '1']
+      if wasm_enabled:
+        method = 'interpret-binary'
+        if asmjs_fallback_enabled:
+          method += ',asmjs'
+        cmd += ['-s', 'WASM=1', '-s', "BINARYEN_METHOD='" + method + "'"]
 
-                    print(' '.join(cmd))
-                    self.clear()
-                    proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-                    output, err = proc.communicate()
-                    print(os.listdir('.'))
-                    assert expect_success == (proc.returncode == 0)
-                    assert expect_asmjs_code == os.path.exists('a.out.asm.js')
-                    assert expect_emterpretify_file == os.path.exists('a.out.dat')
-                    assert expect_meminit == (os.path.exists('a.out.mem') or os.path.exists('a.out.js.mem'))
-                    assert expect_wasm == os.path.exists('a.out.wasm')
-                    assert expect_wast == os.path.exists('a.out.wast')
-                    if should_run_js:
-                      self.assertContained('hello, world!', run_js('a.out.js'))
+      print(' '.join(cmd))
+      self.clear()
+      proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+      output, err = proc.communicate()
+      print(os.listdir('.'))
+      assert expect_success == (proc.returncode == 0)
+      assert expect_asmjs_code == os.path.exists('a.out.asm.js')
+      assert expect_emterpretify_file == os.path.exists('a.out.dat')
+      assert expect_meminit == (os.path.exists('a.out.mem') or os.path.exists('a.out.js.mem'))
+      assert expect_wasm == os.path.exists('a.out.wasm')
+      assert expect_wast == os.path.exists('a.out.wast')
+      if should_run_js:
+        self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_emar_M(self):
     open('file1', 'w').write(' ')


### PR DESCRIPTION
The `temp_directory` changes are the interesting ones; the `test_single_file` change was thrown in for fun, and I can understand if you don't want it.  (There are other places that could use the `test_single_file` change, but I'm keeping it simple for the moment.)