### PR TITLE
NODERAWFS writeFile append mode fix for macOS

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1219,9 +1219,9 @@ mergeInto(LibraryManager.library, {
       if (typeof data === 'string') {
         var buf = new Uint8Array(lengthBytesUTF8(data)+1);
         var actualNumBytes = stringToUTF8Array(data, buf, 0, buf.length);
-        FS.write(stream, buf, 0, actualNumBytes, 0, opts.canOwn);
+        FS.write(stream, buf, 0, actualNumBytes, void 0, opts.canOwn);
       } else if (ArrayBuffer.isView(data)) {
-        FS.write(stream, data, 0, data.byteLength, 0, opts.canOwn);
+        FS.write(stream, data, 0, data.byteLength, void 0, opts.canOwn);
       } else {
         throw new Error('Unsupported data type');
       }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1109,7 +1109,7 @@ mergeInto(LibraryManager.library, {
       if (!stream.stream_ops.read) {
         throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }
-      var seeking = position != null;
+      var seeking = typeof position !== 'undefined';
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
@@ -1136,7 +1136,7 @@ mergeInto(LibraryManager.library, {
         // seek to the end before writing in append mode
         FS.llseek(stream, 0, {{{ cDefine('SEEK_END') }}});
       }
-      var seeking = position != null;
+      var seeking = typeof position !== 'undefined';
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
@@ -1219,9 +1219,9 @@ mergeInto(LibraryManager.library, {
       if (typeof data === 'string') {
         var buf = new Uint8Array(lengthBytesUTF8(data)+1);
         var actualNumBytes = stringToUTF8Array(data, buf, 0, buf.length);
-        FS.write(stream, buf, 0, actualNumBytes, void 0, opts.canOwn);
+        FS.write(stream, buf, 0, actualNumBytes, undefined, opts.canOwn);
       } else if (ArrayBuffer.isView(data)) {
-        FS.write(stream, data, 0, data.byteLength, void 0, opts.canOwn);
+        FS.write(stream, data, 0, data.byteLength, undefined, opts.canOwn);
       } else {
         throw new Error('Unsupported data type');
       }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1134,7 +1134,7 @@ mergeInto(LibraryManager.library, {
       }
       if (stream.flags & {{{ cDefine('O_APPEND') }}}) {
         // seek to the end before writing in append mode
-        position = FS.llseek(stream, 0, {{{ cDefine('SEEK_END') }}});
+        FS.llseek(stream, 0, {{{ cDefine('SEEK_END') }}});
       }
       var seeking = position != null;
       if (!seeking) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1109,10 +1109,9 @@ mergeInto(LibraryManager.library, {
       if (!stream.stream_ops.read) {
         throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }
-      var seeking = true;
-      if (typeof position === 'undefined') {
+      var seeking = position != null;
+      if (!seeking) {
         position = stream.position;
-        seeking = false;
       } else if (!stream.seekable) {
         throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
       }
@@ -1137,10 +1136,9 @@ mergeInto(LibraryManager.library, {
         // seek to the end before writing in append mode
         position = FS.llseek(stream, 0, {{{ cDefine('SEEK_END') }}});
       }
-      var seeking = true;
-      if (typeof position === 'undefined') {
+      var seeking = position != null;
+      if (!seeking) {
         position = stream.position;
-        seeking = false;
       } else if (!stream.seekable) {
         throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
       }

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -43,10 +43,10 @@ mergeInto(LibraryManager.library, {
     ftruncate: function() { fs.ftruncateSync.apply(void 0, arguments); },
     utime: function() { fs.utimesSync.apply(void 0, arguments); },
     open: function(path, flags, mode, suggestFD) {
-      if (typeof flags === "number") {
-        flags = NODEFS.flagsForNode(flags)
+      if (typeof flags === "string") {
+        flags = VFS.modeStringToFlags(flags)
       }
-      var nfd = fs.openSync(path, flags, mode);
+      var nfd = fs.openSync(path, NODEFS.flagsForNode(flags), mode);
       var fd = suggestFD != null ? suggestFD : FS.nextfd(nfd);
       var stream = { fd: fd, nfd: nfd, position: 0, path: path, flags: flags };
       FS.streams[fd] = stream;

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -94,7 +94,7 @@ mergeInto(LibraryManager.library, {
       }
       if (stream.flags & +"{{{ cDefine('O_APPEND') }}}") {
         // seek to the end before writing in append mode
-        position = FS.llseek(stream, 0, +"{{{ cDefine('SEEK_END') }}}");
+        FS.llseek(stream, 0, +"{{{ cDefine('SEEK_END') }}}");
       }
       var bytesWritten = fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
       // update position marker when non-seeking

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -82,12 +82,9 @@ mergeInto(LibraryManager.library, {
         // this stream is created by in-memory filesystem
         return VFS.read(stream, buffer, offset, length, position);
       }
-      var seeking = true;
-      if (typeof position === 'undefined') {
-        seeking = false;
-      }
       var bytesRead = fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
-      if (!seeking) stream.position += bytesRead;
+      // update position marker when non-seeking
+      if (position == null) stream.position += bytesRead;
       return bytesRead;
     },
     write: function(stream, buffer, offset, length, position) {
@@ -99,12 +96,9 @@ mergeInto(LibraryManager.library, {
         // seek to the end before writing in append mode
         position = FS.llseek(stream, 0, +"{{{ cDefine('SEEK_END') }}}");
       }
-      var seeking = true;
-      if (typeof position === 'undefined') {
-        seeking = false;
-      }
       var bytesWritten = fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
-      if (!seeking) stream.position += bytesWritten;
+      // update position marker when non-seeking
+      if (position == null) stream.position += bytesWritten;
       return bytesWritten;
     },
     allocate: function() {

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -84,7 +84,7 @@ mergeInto(LibraryManager.library, {
       }
       var bytesRead = fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
       // update position marker when non-seeking
-      if (position == null) stream.position += bytesRead;
+      if (typeof position === 'undefined') stream.position += bytesRead;
       return bytesRead;
     },
     write: function(stream, buffer, offset, length, position) {
@@ -98,7 +98,7 @@ mergeInto(LibraryManager.library, {
       }
       var bytesWritten = fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
       // update position marker when non-seeking
-      if (position == null) stream.position += bytesWritten;
+      if (typeof position === 'undefined') stream.position += bytesWritten;
       return bytesWritten;
     },
     allocate: function() {

--- a/tests/fs/test_llseek.c
+++ b/tests/fs/test_llseek.c
@@ -1,0 +1,17 @@
+#include <emscripten/emscripten.h>
+
+int main()
+{
+  EM_ASM(
+    FS.writeFile('testfile', 'a=1\nb=2\n');
+    var stream = FS.open('testfile', 'a');
+    fd = FS.write(stream, new Uint8Array([99, 61, 51]) /* c=3 */, 0, 3);
+
+    if (FS.llseek(stream, 0, 1 /* SEEK_CUR */) === 11) {
+      console.log("success");
+    }
+    FS.close(stream);
+  );
+
+  return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4683,6 +4683,12 @@ def process(filename):
       }
     ''', 'at Object.write', js_engines=js_engines, post_build=post) # engines has different error stack format
 
+  @also_with_noderawfs
+  def test_fs_llseek(self, js_engines=None):
+    Settings.FORCE_FILESYSTEM = 1
+    src = open(path_from_root('tests', 'fs', 'test_llseek.c'), 'r').read()
+    self.do_run(src, 'success', force_c=True, js_engines=js_engines)
+
   def test_unistd_access(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]


### PR DESCRIPTION
cc: @aheejin 

This PR fixes seek position bug where `writeFile` always explicitly passes `0` as position value.

I'm not 100% sure this will fix the macOS writeFile error, but by some help from my friends I found that the `position` argument passed to `fs.write` is ignored on other OSes while is not on macOS. So I think this fix will help, but I need help to confirm it.