### PR TITLE
Run the optimize_syscalls code in emscripten.py for the wasm backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1728,6 +1728,10 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
     wast = build_wasm(temp_files, infile, outfile, settings, DEBUG)
     metadata = read_metadata_wast(wast, DEBUG)
 
+  # optimize syscalls
+
+  optimize_syscalls(metadata['declares'], settings, DEBUG)
+
   # js compiler
 
   if DEBUG: logging.debug('emscript: js compiler glue')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2253,6 +2253,9 @@ class Building(object):
     for item in graph:
       if 'export' in item:
         export = item['export']
+        # wasm backend's exports are prefixed differently inside the wasm
+        if Settings.WASM_BACKEND:
+          export = '_' + export
         if export in Building.user_requested_exports or Settings.EXPORT_ALL:
           item['root'] = True
     if Settings.WASM_BACKEND:


### PR DESCRIPTION
This makes hello world type programs 5x smaller, by avoiding linking in all the filesystem support code in js and wasm.
