### PR TITLE
EM_ASM varargs: using a format string

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1772,7 +1772,11 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   exported_implemented_functions = create_exported_implemented_functions_wasm(pre, forwarded_json, metadata, settings)
 
   asm_consts, asm_const_funcs = create_asm_consts_wasm(forwarded_json, metadata)
-  pre = pre.replace('// === Body ===', '// === Body ===\n' + '\nvar ASM_CONSTS = [' + ',\n '.join(asm_consts) + '];\n' + '\n'.join(asm_const_funcs) + '\n')
+  asm_consts_text = '\nvar ASM_CONSTS = [' + ',\n '.join(asm_consts) + '];\n'
+  asm_funcs_text = '\n'.join(asm_const_funcs) + '\n'
+
+  body_marker = '// === Body ==='
+  pre = pre.replace(body_marker, body_marker + '\n' + asm_consts_text + asstr(asm_funcs_text))
 
   outfile.write(pre)
   pre = None

--- a/emscripten.py
+++ b/emscripten.py
@@ -1963,25 +1963,29 @@ def create_asm_consts_wasm(forwarded_json, metadata):
     const = asstr(v[0])
     sigs = v[1]
     const = trim_asm_const_body(const)
-    const = '{ ' + const + ' }'
     args = []
-    arity = max(map(len, sigs)) - 1
+    max_arity = 16
+    arity = 0
+    for i in range(max_arity):
+      if ('$' + str(i)) in const:
+        arity = i + 1
     for i in range(arity):
       args.append('$' + str(i))
-    const = 'function(' + ', '.join(args) + ') ' + const
+    const = 'function(' + ', '.join(args) + ') {' + const + '}'
     asm_consts[int(k)] = const
     all_sigs += sigs
 
   asm_const_funcs = []
   for sig in set(all_sigs):
     forwarded_json['Functions']['libraryFunctions']['_emscripten_asm_const_' + sig] = 1
-    args = ['a%d' % i for i in range(len(sig)-1)]
-    all_args = ['code'] + args
     asm_const_funcs.append(r'''
-function _emscripten_asm_const_%s(%s) {
-return ASM_CONSTS[code](%s);
-}''' % (asstr(sig), ', '.join(all_args), ', '.join(args)))
-
+function _emscripten_asm_const_%s(code, nargs, argbuf) {
+  var args = [];
+  for (var i = 0; i < nargs; ++i) {
+    args.push(HEAPF64[(argbuf >> 3) + i]);
+  }
+  return ASM_CONSTS[code].apply(null, args);
+}''' % sig)
   return asm_consts, asm_const_funcs
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -1984,7 +1984,7 @@ def create_asm_consts_wasm(forwarded_json, metadata):
     forwarded_json['Functions']['libraryFunctions']['_emscripten_asm_const_' + sig] = 1
     asm_const_funcs.append(r'''
 function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
-  var sig = UTF8ToString(sig_ptr);
+  var sig = AsciiToString(sig_ptr);
   var args = [];
   var align_to = function(ptr, align) {
     return (ptr+align-1) & ~(align-1);

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -1,35 +1,85 @@
 #ifndef __em_asm_h__
 #define __em_asm_h__
 
-// The wasm backend calls vararg functions by passing the variadic arguments as
-// an array on the stack. For EM_ASM's underlying functions, s2wasm needs to
-// translate them to emscripten_asm_const_[signature], but the expected
-// signature and arguments has been lost as part of the vararg buffer.
-// Therefore, we declare EM_ASM's implementing functions as non-variadic.
-
-#ifndef __asmjs
-#ifndef __cplusplus
-// In C, declare these as non-prototype declarations. This is obsolete K&R C
-// (that is still supported) that causes the C frontend to consider any calls
-// to them as valid, and avoids using the vararg calling convention.
-void emscripten_asm_const();
-int emscripten_asm_const_int();
-double emscripten_asm_const_double();
-#else
-// C++ interprets an empty parameter list as a function taking no arguments,
-// instead of a K&R C function declaration. Variadic templates are lowered as
-// non-vararg calls to the instantiated templated function, which we then
-// replace in s2wasm.
-template <typename... Args> void emscripten_asm_const(const char* code, Args...);
-template <typename... Args> int emscripten_asm_const_int(const char* code, Args...);
-template <typename... Args> double emscripten_asm_const_double(const char* code, Args...);
-#endif // __cplusplus
-#else // __asmjs
-// asmjs expects these to be vararg, so let them be vararg.
 #ifdef __cplusplus
 extern "C" {
-#endif
-void emscripten_asm_const(const char* code);
+#endif // __cplusplus
+
+#ifndef __asmjs
+// When calling EM_ASM functions, we're calling out to JS. JS only has doubles
+// natively, so we can convert all C types to double before the call. By
+// converting all arguments to double, we can store them in a vararg buffer,
+// and we only need to pass the number of args in order to read them in JS.
+
+// When converting arguments to double, we need to:
+//   - upcast floats to doubles, so we have consistent bit widths
+//   - convert ints to doubles (via f64.convert_s/i32 and such)
+//   - cast pointers to ints, and then convert (C disallows direct pointer to
+//     double conversions)
+// We can use the generic selection C11 feature (that clang supports pre-C11
+// as an extension) to decide at compile time what operations to apply.
+// Unfortunately each branch needs to compile for all possible types, even
+// though only one is selected. Fortunately, we can use a function inside the
+// _Generic expression, and use that do do our conversion.
+// All pointer types should go through the default case.
+#define _EM_ASM_CAST(x) _Generic((x), \
+    float: _em_asm_cast_double, \
+    double: _em_asm_cast_double, \
+    int: _em_asm_cast_int, \
+    unsigned: _em_asm_cast_uint, \
+    long: _em_asm_cast_int, \
+    unsigned long: _em_asm_cast_uint, \
+    default: _em_asm_cast_ptr)(x)
+inline double _em_asm_cast_double(double x) {
+  return x;
+}
+inline double _em_asm_cast_int(long x) {
+  return (double)x;
+}
+inline double _em_asm_cast_uint(unsigned long x) {
+  return (double)x;
+}
+inline double _em_asm_cast_ptr(const void* x) {
+  return (double)(long)x;
+}
+
+// This indirection is needed to allow us to concatenate computed results, e.g.
+//   #define BAR(N) _EM_ASM_CONCATENATE(FOO_, N)
+//   BAR(3) // rewritten to BAR_3
+// whereas using ## or _EM_ASM_CONCATENATE_ directly would result in BAR_N
+#define _EM_ASM_CONCATENATE(a, b) _EM_ASM_CONCATENATE_(a, b)
+#define _EM_ASM_CONCATENATE_(a, b) a##b
+
+// Counts arguments. We use $$ as a sentinel value to enable using ##__VA_ARGS__
+// which omits a comma in the event that we have 0 arguments passed, which is
+// necessary to keep the count correct.
+// TODO(jgravelle): increase the max number of args to 32 or so
+#define _EM_ASM_COUNT_ARGS_EXP(_$,_0,_1,_2,_3,_4,n,...) n
+#define _EM_ASM_COUNT_ARGS(...) _EM_ASM_COUNT_ARGS_EXP($$,##__VA_ARGS__,5,4,3,2,1,0)
+
+// Promote each argument to double. We lead with commas to avoid adding a comma
+// in the 0-argument case, which messes up the argument parsing.
+// Note that we omit a comma separating calls to _EM_ASM_PROMOTE_ARGS as well.
+#define _EM_ASM_PROMOTE_ARGS_0(x, ...)
+#define _EM_ASM_PROMOTE_ARGS_1(x, ...) , _EM_ASM_CAST(x)
+#define _EM_ASM_PROMOTE_ARGS_2(x, ...) , _EM_ASM_CAST(x) _EM_ASM_PROMOTE_ARGS_1(__VA_ARGS__)
+#define _EM_ASM_PROMOTE_ARGS_3(x, ...) , _EM_ASM_CAST(x) _EM_ASM_PROMOTE_ARGS_2(__VA_ARGS__)
+#define _EM_ASM_PROMOTE_ARGS_4(x, ...) , _EM_ASM_CAST(x) _EM_ASM_PROMOTE_ARGS_3(__VA_ARGS__)
+#define _EM_ASM_PROMOTE_ARGS_5(x, ...) , _EM_ASM_CAST(x) _EM_ASM_PROMOTE_ARGS_4(__VA_ARGS__)
+#define _EM_ASM_PROMOTE_ARGS(N, ...) \
+  _EM_ASM_CONCATENATE(_EM_ASM_PROMOTE_ARGS_,N)(__VA_ARGS__)
+
+#define _EM_ASM_PREP_ARGS(...) \
+  , _EM_ASM_COUNT_ARGS(__VA_ARGS__) \
+    _EM_ASM_PROMOTE_ARGS(_EM_ASM_COUNT_ARGS(__VA_ARGS__), ##__VA_ARGS__)
+
+void emscripten_asm_const(const char* code, int num_args, ...);
+int emscripten_asm_const_int(const char* code, int num_args, ...);
+double emscripten_asm_const_double(const char* code, int num_args, ...);
+
+#else // __asmjs
+#define _EM_ASM_PREP_ARGS(...) , ##__VA_ARGS__
+
 int emscripten_asm_const_int(const char* code, ...);
 double emscripten_asm_const_double(const char* code, ...);
 
@@ -38,25 +88,24 @@ double emscripten_asm_const_double_sync_on_main_thread(const char* code, ...);
 
 void emscripten_asm_const_async_on_main_thread(const char* code, ...);
 
-#ifdef __cplusplus
-}
-#endif
 #endif // __asmjs
 
-void emscripten_asm_const(const char* code);
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 // Note: If the code block in the EM_ASM() family of functions below contains a comma,
 // then wrap the whole code block inside parentheses (). See tests/core/test_em_asm_2.cpp
 // for example code snippets.
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns no value back.
-#define EM_ASM(code, ...) ((void)emscripten_asm_const_int(#code, ##__VA_ARGS__))
+#define EM_ASM(code, ...) ((void)emscripten_asm_const_int(#code _EM_ASM_PREP_ARGS(__VA_ARGS__)))
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns an integer back.
-#define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code, ##__VA_ARGS__)
+#define EM_ASM_INT(code, ...) emscripten_asm_const_int(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
 
 // Runs the given JavaScript code on the calling thread (synchronously), and returns a double back.
-#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code, ##__VA_ARGS__)
+#define EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
 
 // Runs the given JavaScript code synchronously on the main browser thread, and returns no value back.
 // Call this function for example to access DOM elements in a pthread/web worker. Avoid calling this
@@ -65,29 +114,29 @@ void emscripten_asm_const(const char* code);
 // code blocks to call in succession, it will likely be much faster to coalesce all the calls to a single
 // MAIN_THREAD_EM_ASM() block. If you do not need synchronization nor a return value back, consider using
 // the function MAIN_THREAD_ASYNC_EM_ASM() instead, which will not block.
-#define MAIN_THREAD_EM_ASM(code, ...) ((void)emscripten_asm_const_int_sync_on_main_thread(#code, ##__VA_ARGS__))
+#define MAIN_THREAD_EM_ASM(code, ...) ((void)emscripten_asm_const_int_sync_on_main_thread(#code _EM_ASM_PREP_ARGS(__VA_ARGS__)))
 
 // Runs the given JavaScript code synchronously on the main browser thread, and returns an integer back.
 // The same considerations apply as with MAIN_THREAD_EM_ASM().
-#define MAIN_THREAD_EM_ASM_INT(code, ...) emscripten_asm_const_int_sync_on_main_thread(#code, ##__VA_ARGS__)
+#define MAIN_THREAD_EM_ASM_INT(code, ...) emscripten_asm_const_int_sync_on_main_thread(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
 
 // Runs the given JavaScript code synchronously on the main browser thread, and returns a double back.
 // The same considerations apply as with MAIN_THREAD_EM_ASM().
-#define MAIN_THREAD_EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double_sync_on_main_thread(#code, ##__VA_ARGS__)
+#define MAIN_THREAD_EM_ASM_DOUBLE(code, ...) emscripten_asm_const_double_sync_on_main_thread(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
 
 // Asynchronously dispatches the given JavaScript code to be run on the main browser thread.
 // If the calling thread is the main browser thread, then the specified JavaScript code is executed
 // synchronously. Otherwise an event will be queued on the main browser thread to execute the call
 // later (think postMessage()), and this call will immediately return without waiting. Be sure to
 // guard any accesses to shared memory on the heap inside the JavaScript code with appropriate locking.
-#define MAIN_THREAD_ASYNC_EM_ASM(code, ...) ((void)emscripten_asm_const_async_on_main_thread(#code, ##__VA_ARGS__))
+#define MAIN_THREAD_ASYNC_EM_ASM(code, ...) ((void)emscripten_asm_const_async_on_main_thread(#code _EM_ASM_PREP_ARGS(__VA_ARGS__)))
 
 // Old forms for compatibility, no need to use these.
 // Replace EM_ASM_, EM_ASM_ARGS and EM_ASM_INT_V with EM_ASM_INT,
 // and EM_ASM_DOUBLE_V with EM_ASM_DOUBLE.
-#define EM_ASM_(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
-#define EM_ASM_ARGS(code, ...) emscripten_asm_const_int(#code, __VA_ARGS__)
-#define EM_ASM_INT_V(code) emscripten_asm_const_int(#code)
-#define EM_ASM_DOUBLE_V(code) emscripten_asm_const_double(#code)
+#define EM_ASM_(code, ...) emscripten_asm_const_int(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
+#define EM_ASM_ARGS(code, ...) emscripten_asm_const_int(#code _EM_ASM_PREP_ARGS(__VA_ARGS__))
+#define EM_ASM_INT_V(code) EM_ASM_INT(#code)
+#define EM_ASM_DOUBLE_V(code) EM_ASM_DOUBLE(#code)
 
 #endif // __em_asm_h__

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -35,9 +35,9 @@
 // Counts arguments. We use $$ as a sentinel value to enable using ##__VA_ARGS__
 // which omits a comma in the event that we have 0 arguments passed, which is
 // necessary to keep the count correct.
-// TODO(jgravelle): increase the max number of args to 32 or so
-#define _EM_ASM_COUNT_ARGS_EXP(_$,_0,_1,_2,_3,_4,n,...) n
-#define _EM_ASM_COUNT_ARGS(...) _EM_ASM_COUNT_ARGS_EXP($$,##__VA_ARGS__,5,4,3,2,1,0)
+#define _EM_ASM_COUNT_ARGS_EXP(_$,_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,n,...) n
+#define _EM_ASM_COUNT_ARGS(...) \
+    _EM_ASM_COUNT_ARGS_EXP($$,##__VA_ARGS__,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0)
 
 // Promote each argument to double. We lead with commas to avoid adding a comma
 // in the 0-argument case, which messes up the argument parsing.
@@ -48,6 +48,17 @@
 #define _EM_ASM_ARG_SIGS_3(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_2(__VA_ARGS__)
 #define _EM_ASM_ARG_SIGS_4(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_3(__VA_ARGS__)
 #define _EM_ASM_ARG_SIGS_5(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_4(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_6(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_5(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_7(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_6(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_8(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_7(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_9(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_8(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_10(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_9(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_11(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_10(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_12(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_11(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_13(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_12(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_14(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_13(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_15(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_14(__VA_ARGS__)
+#define _EM_ASM_ARG_SIGS_16(x, ...) _EM_ASM_SIG_CHAR(x), _EM_ASM_ARG_SIGS_15(__VA_ARGS__)
 #define _EM_ASM_ARG_SIGS_(N, ...) \
     ((char[]){ _EM_ASM_CONCATENATE(_EM_ASM_ARG_SIGS_,N)(__VA_ARGS__) '\0' })
 

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -1,7 +1,7 @@
 #ifndef __em_asm_h__
 #define __em_asm_h__
 
-#ifndef __asmjs
+#ifndef __asmjs__
 // In wasm backend, we need to call the emscripten_asm_const_* functions with
 // the C vararg calling convention, because we will call it with a variety of
 // arguments, but need to generate a coherent import for the wasm module before
@@ -122,7 +122,7 @@ double emscripten_asm_const_double(const char* code, const char* arg_sigs, ...);
 }
 #endif // __cplusplus
 
-#else // __asmjs
+#else // __asmjs__
 
 #ifdef __cplusplus
 extern "C" {
@@ -142,7 +142,7 @@ void emscripten_asm_const_async_on_main_thread(const char* code, ...);
 }
 #endif // __cplusplus
 
-#endif // __asmjs
+#endif // __asmjs__
 
 
 // Note: If the code block in the EM_ASM() family of functions below contains a comma,

--- a/tests/core/test_em_asm_unicode.cpp
+++ b/tests/core/test_em_asm_unicode.cpp
@@ -1,0 +1,5 @@
+#include <emscripten.h>
+
+int main() {
+  EM_ASM( Module.print("hello world…") );
+}

--- a/tests/core/test_em_asm_unicode.out
+++ b/tests/core/test_em_asm_unicode.out
@@ -1,0 +1,1 @@
+hello world…

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1683,13 +1683,8 @@ int main(int argc, char **argv) {
     self.do_run_in_out_file_test('tests', 'core', 'test_main_thread_async_em_asm', force_c=True)
 
   def test_em_asm_unicode(self):
-    self.do_run(r'''
-#include <emscripten.h>
-
-int main() {
-  EM_ASM( Module.print("hello world…") );
-}
-''', 'hello world…')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_unicode')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_unicode', force_c=True)
 
   def test_em_asm_unused_arguments(self):
     src = r'''


### PR DESCRIPTION
Hopefully this is commented well enough to explain what's going on, but essentially instead of converting everything to double and passing in a count, this leaves every arg as-is, and passes in a signature string that we can read in JS.
I'm trying to do more complete shenaniganry to try and get a `constexpr char*` in c++ and it's... nontrivial. For now I'm using `std::string` and relying on RAII to handle the dynamic allocation in an expression-y context. The wasm that generates is... not great.
This is primarily motivated by test_em_asm_parameter_pack, but should be a very general mechanism (and should generalize to i64s down the line).