### PR TITLE
addFunction support for Wasm backend

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -9,7 +9,7 @@ Not all changes are documented here. In particular, new features, user-oriented 
 
 Current Trunk
 -------------
- - Breaking change: `addFunction` is now supported on Wasm backend, but when being used on Wasm backend, you need to provide an additional second argument, a Wasm function signature string. Each character within a signature string represents a type. The first character represents the return type of a function, and remaining characters are for parameter types.
+ - Breaking change: `addFunction` is now supported on LLVM wasm backend, but when being used on the wasm backend, you need to provide an additional second argument, a Wasm function signature string. Each character within a signature string represents a type. The first character represents the return type of a function, and remaining characters are for parameter types.
     - 'v': void type
     - 'i': 32-bit integer type
     - 'j': 64-bit integer type (currently does not exist in JavaScript)

--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -9,6 +9,12 @@ Not all changes are documented here. In particular, new features, user-oriented 
 
 Current Trunk
 -------------
+ - Breaking change: `addFunction` is now supported on Wasm backend, but when being used on Wasm backend, you need to provide an additional second argument, a Wasm function signature string. Each character within a signature string represents a type. The first character represents the return type of a function, and remaining characters are for parameter types.
+    - 'v': void type
+    - 'i': 32-bit integer type
+    - 'j': 64-bit integer type (currently does not exist in JavaScript)
+    - 'f': 32-bit float type
+    - 'd': 64-bit float type
 
 v1.37.28: 01/08/2018
 --------------------

--- a/emscripten.py
+++ b/emscripten.py
@@ -1891,7 +1891,12 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
     ])
     debug_copy(base_wasm, 'base_wasm.wasm')
 
-    shared.check_call([wasm_emscripten_finalize, base_wasm, '-o', wasm])
+    shared.check_call([
+        wasm_emscripten_finalize,
+        base_wasm,
+        '--reserved-function-pointers=%d' %
+        shared.Settings.RESERVED_FUNCTION_POINTERS,
+        '-o', wasm])
     debug_copy(wasm, 'lld-emscripten-output.wasm')
 
     # TODO: This is gross. We currently read exports from the wast in order to
@@ -2126,7 +2131,7 @@ def create_s2wasm_args(temp_s):
   args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]
   args += ['--initial-memory=%d' % shared.Settings.TOTAL_MEMORY]
   args += ['--allow-memory-growth'] if shared.Settings.ALLOW_MEMORY_GROWTH else []
-  args += ['--reserved-function-pointers=%d' %
+  args += ['--emscripten-reserved-function-pointers=%d' %
            shared.Settings.RESERVED_FUNCTION_POINTERS]
   args += ['-l', libc_rt_lib]
   args += ['-l', compiler_rt_lib]

--- a/emscripten.py
+++ b/emscripten.py
@@ -520,7 +520,7 @@ def update_settings_glue(settings, metadata):
   settings['IMPLEMENTED_FUNCTIONS'] = metadata['implementedFunctions']
 
   # addFunction support
-  if settings['RESERVED_FUNCTION_POINTERS'] > 0:
+  if settings['WASM_BACKEND'] and settings['RESERVED_FUNCTION_POINTERS'] > 0:
     start_index = metadata['jsCallStartIndex']
     sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
     settings['JSCALL_START_INDEX'] = start_index

--- a/emscripten.py
+++ b/emscripten.py
@@ -1779,7 +1779,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   pre = None
 
   invoke_funcs = read_wast_invoke_imports(wast)
-#List of function signatures used in jsCall functions, e.g.['v', 'vi']
+  # List of function signatures used in jsCall functions, e.g.['v', 'vi']
   jscall_sigs = metadata.get('jsCallFuncType', [])
 
   try:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1779,7 +1779,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   pre = None
 
   invoke_funcs = read_wast_invoke_imports(wast)
-  # List of function signatures used in jsCall functions, e.g. ['v', 'vi']
+#List of function signatures used in jsCall functions, e.g.['v', 'vi']
   jscall_sigs = metadata.get('jsCallFuncType', [])
 
   try:
@@ -1877,8 +1877,8 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
     meta = basename + '.json'
     shared.check_call([
         wasm_link_metadata,
-        '--emscripten-reserved-function-pointers=%d' %
-        shared.Settings.RESERVED_FUNCTION_POINTERS,
+        ('--emscripten-reserved-function-pointers=%d' %
+         shared.Settings.RESERVED_FUNCTION_POINTERS),
         temp_o,
         '-o', meta])
     debug_copy(meta, 'lld-metadata.json')
@@ -1901,8 +1901,8 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
 
     shared.check_call([
         wasm_emscripten_finalize,
-        '--emscripten-reserved-function-pointers=%d' %
-        shared.Settings.RESERVED_FUNCTION_POINTERS,
+        ('--emscripten-reserved-function-pointers=%d' %
+         shared.Settings.RESERVED_FUNCTION_POINTERS),
         base_wasm,
         '-o', wasm])
     debug_copy(wasm, 'lld-emscripten-output.wasm')
@@ -2026,8 +2026,8 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata,
 
   jscall_funcs = ['jsCall_' + sig for sig in jscall_sigs]
 
-  send_items = basic_funcs + invoke_funcs + jscall_funcs + global_funcs + \
-               basic_vars + global_vars
+  send_items = (basic_funcs + invoke_funcs + jscall_funcs + global_funcs +
+                basic_vars + global_vars)
   def math_fix(g):
     return g if not g.startswith('Math_') else g.split('_')[1]
   return '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in send_items]) + ' }'
@@ -2195,8 +2195,8 @@ def add_metadata_from_wast(metadata, wast):
       if import_type == 'memory':
         continue
       elif import_type == 'func':
-        if not import_name.startswith('invoke_') and \
-           not import_name.startswith('jsCall_'):
+        if (not import_name.startswith('invoke_') and
+            not import_name.startswith('jsCall_')):
           metadata['declares'].append(import_name)
       elif import_type == 'global':
         metadata['externs'].append('_' + import_name)

--- a/emscripten.py
+++ b/emscripten.py
@@ -519,10 +519,12 @@ def update_settings_glue(settings, metadata):
   settings['MAX_GLOBAL_ALIGN'] = metadata['maxGlobalAlign']
   settings['IMPLEMENTED_FUNCTIONS'] = metadata['implementedFunctions']
 
-  # addFunction support
+  # addFunction support for Wasm backend
   if settings['WASM_BACKEND'] and settings['RESERVED_FUNCTION_POINTERS'] > 0:
     start_index = metadata['jsCallStartIndex']
+    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2order {'v': 0, 'ii': 1}
     sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
+    # Index in the Wasm function table in which jsCall thunk function starts
     settings['JSCALL_START_INDEX'] = start_index
     settings['JSCALL_SIG_ORDER'] = sig2order
 
@@ -1777,6 +1779,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   pre = None
 
   invoke_funcs = read_wast_invoke_imports(wast)
+  # List of function signatures used in jsCall functions, e.g. ['v', 'vi']
   jscall_sigs = metadata.get('jsCallFuncType', [])
 
   try:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1901,6 +1901,7 @@ def read_metadata_wast(wast, DEBUG):
   parts = output.split('\n;; METADATA:')
   assert len(parts) == 2
   metadata_raw = parts[1]
+  print(metadata_raw)
   return create_metadata_wasm(metadata_raw, wast, DEBUG)
 
 
@@ -2050,7 +2051,7 @@ var asm = Module['asm'](%s, %s, buffer);
      'Module' + access_quote('asmLibraryArg'),
      receiving)]
 
-  # wasm backend stack goes down, and is stored in the first global var location
+# wasm backend stack goes down, and is stored in the first global var location
   module.append('''
 STACKTOP = STACK_BASE + TOTAL_STACK;
 STACK_MAX = STACK_BASE;
@@ -2109,6 +2110,8 @@ def create_s2wasm_args(temp_s):
   args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]
   args += ['--initial-memory=%d' % shared.Settings.TOTAL_MEMORY]
   args += ['--allow-memory-growth'] if shared.Settings.ALLOW_MEMORY_GROWTH else []
+  args += ['--reserved-function-pointers=%d' %
+           shared.Settings.RESERVED_FUNCTION_POINTERS]
   args += ['-l', libc_rt_lib]
   args += ['-l', compiler_rt_lib]
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -522,11 +522,11 @@ def update_settings_glue(settings, metadata):
   # addFunction support for Wasm backend
   if settings['WASM_BACKEND'] and settings['RESERVED_FUNCTION_POINTERS'] > 0:
     start_index = metadata['jsCallStartIndex']
-    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2order {'v': 0, 'ii': 1}
-    sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
+    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2index{'v': 0, 'ii': 1}
+    sig2index = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
     # Index in the Wasm function table in which jsCall thunk function starts
     settings['JSCALL_START_INDEX'] = start_index
-    settings['JSCALL_SIG_ORDER'] = sig2order
+    settings['JSCALL_SIG_TO_SIG_INDEX'] = sig2index
 
 
 def compile_settings(compiler_engine, settings, libraries, temp_files):

--- a/emscripten.py
+++ b/emscripten.py
@@ -520,10 +520,11 @@ def update_settings_glue(settings, metadata):
   settings['IMPLEMENTED_FUNCTIONS'] = metadata['implementedFunctions']
 
   # addFunction support
-  start_index = metadata['jsCallStartIndex']
-  sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
-  settings['JSCALL_START_INDEX'] = start_index
-  settings['JSCALL_SIG_ORDER'] = sig2order
+  if settings['RESERVED_FUNCTION_POINTERS'] > 0:
+    start_index = metadata['jsCallStartIndex']
+    sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
+    settings['JSCALL_START_INDEX'] = start_index
+    settings['JSCALL_SIG_ORDER'] = sig2order
 
 
 def compile_settings(compiler_engine, settings, libraries, temp_files):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1872,7 +1872,12 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
     wasm = basename + '.wasm'
     base_wasm = basename + '.lld.wasm'
     meta = basename + '.json'
-    shared.check_call([wasm_link_metadata, temp_o, '-o', meta])
+    shared.check_call([
+        wasm_link_metadata,
+        '--emscripten-reserved-function-pointers=%d' %
+        shared.Settings.RESERVED_FUNCTION_POINTERS,
+        temp_o,
+        '-o', meta])
     debug_copy(meta, 'lld-metadata.json')
 
     libc_rt_lib = shared.Cache.get('wasm_libc_rt.a', wasm_rt_fail('wasm_libc_rt.a'), 'a')
@@ -1893,9 +1898,9 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
 
     shared.check_call([
         wasm_emscripten_finalize,
-        base_wasm,
-        '--reserved-function-pointers=%d' %
+        '--emscripten-reserved-function-pointers=%d' %
         shared.Settings.RESERVED_FUNCTION_POINTERS,
+        base_wasm,
         '-o', wasm])
     debug_copy(wasm, 'lld-emscripten-output.wasm')
 
@@ -2226,8 +2231,8 @@ def create_invoke_wrappers(invoke_funcs):
 
 def create_jscall_funcs(sigs):
   jscall_funcs = ''
-  for sig in sigs:
-    jscall_funcs += '\n' + shared.JS.make_jscall(sig) + '\n'
+  for i, sig in enumerate(sigs):
+    jscall_funcs += '\n' + shared.JS.make_jscall(sig, i) + '\n'
   return jscall_funcs
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -519,6 +519,13 @@ def update_settings_glue(settings, metadata):
   settings['MAX_GLOBAL_ALIGN'] = metadata['maxGlobalAlign']
   settings['IMPLEMENTED_FUNCTIONS'] = metadata['implementedFunctions']
 
+  # addFunction support
+  sig2index = {}
+  start_index = metadata['jsCallStartIndex']
+  for i, sig in enumerate(metadata['jsCallFuncType']):
+    sig2index[sig] = start_index + i * settings['RESERVED_FUNCTION_POINTERS']
+  settings['JSCALL_SIG_TO_INDEX'] = sig2index
+
 
 def compile_settings(compiler_engine, settings, libraries, temp_files):
   # Save settings to a file to work around v8 issue 1579

--- a/emscripten.py
+++ b/emscripten.py
@@ -2170,7 +2170,8 @@ def add_metadata_from_wast(metadata, wast):
       if import_type == 'memory':
         continue
       elif import_type == 'func':
-        if not import_name.startswith('invoke_'):
+        if not import_name.startswith('invoke_') and \
+           not import_name.startswith('jsCall_'):
           metadata['declares'].append(import_name)
       elif import_type == 'global':
         metadata['externs'].append('_' + import_name)

--- a/emscripten.py
+++ b/emscripten.py
@@ -522,11 +522,11 @@ def update_settings_glue(settings, metadata):
   # addFunction support for Wasm backend
   if settings['WASM_BACKEND'] and settings['RESERVED_FUNCTION_POINTERS'] > 0:
     start_index = metadata['jsCallStartIndex']
-    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2index{'v': 0, 'ii': 1}
-    sig2index = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
+    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2order{'v': 0, 'ii': 1}
+    sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
     # Index in the Wasm function table in which jsCall thunk function starts
     settings['JSCALL_START_INDEX'] = start_index
-    settings['JSCALL_SIG_TO_SIG_INDEX'] = sig2index
+    settings['JSCALL_SIG_ORDER'] = sig2order
 
 
 def compile_settings(compiler_engine, settings, libraries, temp_files):

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -596,7 +596,7 @@ space for 20 functions to be added::
 
     emcc ... -s RESERVED_FUNCTION_POINTERS=20 ...
 
-.. note:: When using ``addFunction`` on Wasm backend, you need to provide
+.. note:: When using ``addFunction`` on LLVM wasm backend, you need to provide
    an additional second argument, a Wasm function signature string. Each
    character within a signature string represents a type. The first character
    represents the return type of a function, and remaining characters are for

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -609,6 +609,7 @@ space for 20 functions to be added::
    For example, if you add a function that takes an integer and does not return
    anything, you can do
    ``addFunction(your_function, 'vi');``
+   See tests/interop/test_add_function_post.js for an example.
 
 
 .. _interacting-with-code-access-memory:

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -596,6 +596,21 @@ space for 20 functions to be added::
 
     emcc ... -s RESERVED_FUNCTION_POINTERS=20 ...
 
+.. note:: When using ``addFunction`` on Wasm backend, you need to provide
+   an additional second argument, a Wasm function signature string. Each
+   character within a signature string represents a type. The first character
+   represents the return type of a function, and remaining characters are for
+   parameter types.
+   - 'v': void type
+   - 'i': 32-bit integer type
+   - 'j': 64-bit integer type (currently does not exist in JavaScript)
+   - 'f': 32-bit float type
+   - 'd': 64-bit float type
+   For example, if you add a function that takes an integer and does not return
+   anything, you can do
+   ``addFunction(your_function, 'vi');``
+
+
 .. _interacting-with-code-access-memory:
 
 Access memory from JavaScript

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -37,6 +37,9 @@ var NEED_ALL_ASM2WASM_IMPORTS = BINARYEN_METHOD != 'native-wasm' || BINARYEN_TRA
 // the current compilation unit.
 var HAS_MAIN = ('_main' in IMPLEMENTED_FUNCTIONS) || MAIN_MODULE || SIDE_MODULE;
 
+var WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS =
+  WASM_BACKEND && RESERVED_FUNCTION_POINTERS;
+
 // JSifier
 function JSify(data, functionsOnly) {
   var mainPass = !functionsOnly;

--- a/src/support.js
+++ b/src/support.js
@@ -246,11 +246,22 @@ Module['registerFunctions'] = registerFunctions;
 #endif // RELOCATABLE
 #endif // EMULATED_FUNCTION_POINTERS
 
+#if WASM_BACKEND
+var functionPointers = new Array({{{ numSigs * RESERVED_FUNCTION_POINTERS }}});
+
+function addFunction(func, sig) {
+#else
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 
 function addFunction(func) {
+#endif
 #if EMULATED_FUNCTION_POINTERS == 0
-  for (var i = 0; i < functionPointers.length; i++) {
+#if WASN_BACKEND
+  var start = sigindex * RESERVED_FUNCTION_POINTERS;
+#else
+  var start = 0;
+#endif
+  for (var i = start; i < start + RESERVED_FUNCTION_POINTERS; i++) {
     if (!functionPointers[i]) {
       functionPointers[i] = func;
       return 1 + i;

--- a/src/support.js
+++ b/src/support.js
@@ -247,7 +247,9 @@ Module['registerFunctions'] = registerFunctions;
 #endif // EMULATED_FUNCTION_POINTERS
 
 #if WASM_BACKEND
-var functionPointers = new Array({{{ numSigs * RESERVED_FUNCTION_POINTERS }}});
+var jsCallSig2Index = {{{ JSON.stringify(JSCALL_SIG_TO_INDEX) }}};
+var jsCallNumSigs = Object.keys(jsCall_sig2index).length;
+var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
 
 function addFunction(func, sig) {
 #else
@@ -256,8 +258,8 @@ var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 function addFunction(func) {
 #endif
 #if EMULATED_FUNCTION_POINTERS == 0
-#if WASN_BACKEND
-  var start = sigindex * RESERVED_FUNCTION_POINTERS;
+#if WASM_BACKEND
+  var start = jsCallSig2Index[sig];
 #else
   var start = 0;
 #endif

--- a/src/support.js
+++ b/src/support.js
@@ -247,26 +247,28 @@ Module['registerFunctions'] = registerFunctions;
 #endif // EMULATED_FUNCTION_POINTERS
 
 #if WASM_BACKEND
-var jsCallSig2Index = {{{ JSON.stringify(JSCALL_SIG_TO_INDEX) }}};
-var jsCallNumSigs = Object.keys(jsCallSig2Index).length;
+var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
+var jsCallSigOrder = {{{ JSON.stringify(JSCALL_SIG_ORDER) }}};
+var jsCallNumSigs = Object.keys(jsCallSigOrder).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
 
 function addFunction(func, sig) {
 #else
+var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 
 function addFunction(func) {
 #endif
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
-  var start = jsCallSig2Index[sig];
+  var base = jsCallSigOrder[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
 #else
-  var start = 0;
+  var base = 0;
 #endif
-  for (var i = start; i < start + RESERVED_FUNCTION_POINTERS; i++) {
+  for (var i = base; i < base + {{{ RESERVED_FUNCTION_POINTERS }}}; i++) {
     if (!functionPointers[i]) {
       functionPointers[i] = func;
-      return 1 + i;
+      return jsCallStartIndex + i;
     }
   }
   throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';

--- a/src/support.js
+++ b/src/support.js
@@ -248,7 +248,7 @@ Module['registerFunctions'] = registerFunctions;
 
 #if WASM_BACKEND
 var jsCallSig2Index = {{{ JSON.stringify(JSCALL_SIG_TO_INDEX) }}};
-var jsCallNumSigs = Object.keys(jsCall_sig2index).length;
+var jsCallNumSigs = Object.keys(jsCallSig2Index).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
 
 function addFunction(func, sig) {

--- a/src/support.js
+++ b/src/support.js
@@ -246,6 +246,28 @@ Module['registerFunctions'] = registerFunctions;
 #endif // RELOCATABLE
 #endif // EMULATED_FUNCTION_POINTERS
 
+// TODO Currently logical operations like '#if a && b' or '#if a || b' are not
+// supported, so the code below contains duplicate parts, as in the pattern
+// below:
+//
+// #if WASM BACKEND
+// #if RESERVED_FUNCTION_POINTERS
+// TASK 1
+// #else
+// TASK 2
+// #endif
+// #else
+// TASK 2
+// #endif
+//
+// When the logical operations become supported, change the code to this:
+//
+// #if WASM_BACKEND && RESERVED_FUNCTION_POINTERS
+// TASK 1
+// #else
+// TASK 2
+// #endif
+
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS
 var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
@@ -261,11 +283,7 @@ var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 #endif
 
-#if WASM_BACKEND
 function addFunction(func, sig) {
-#else
-function addFunction(func) {
-#endif
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS

--- a/src/support.js
+++ b/src/support.js
@@ -272,8 +272,8 @@ Module['registerFunctions'] = registerFunctions;
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS
 var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
-var jsCallSigIndex = {{{ JSON.stringify(JSCALL_SIG_TO_SIG_INDEX) }}};
-var jsCallNumSigs = Object.keys(jsCallSigIndex).length;
+var jsCallSigOrder = {{{ JSON.stringify(JSCALL_SIG_ORDER) }}};
+var jsCallNumSigs = Object.keys(jsCallSigOrder).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
 #else // RESERVED_FUNCTION_POINTERS == 0
 var jsCallStartIndex = 1;
@@ -289,7 +289,7 @@ function addFunction(func, sig) {
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS
-  var base = jsCallSigIndex[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
+  var base = jsCallSigOrder[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
 #else // RESERVED_FUNCTION_POINTERS == 0
   var base = 0;
 #endif // RESERVED_FUNCTION_POINTERS
@@ -328,7 +328,7 @@ function addFunction(func, sig) {
 
 function removeFunction(index) {
 #if EMULATED_FUNCTION_POINTERS == 0
-  functionPointers[index-1] = null;
+  functionPointers[index-jsCallStartIndex] = null;
 #else
   alignFunctionTables(); // XXX we should rely on this being an invariant
   var tables = getFunctionTables();

--- a/src/support.js
+++ b/src/support.js
@@ -286,6 +286,17 @@ var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 
 // 'sig' parameter is only used in LLVM wasm backend
 function addFunction(func, sig) {
+#if WASM_BACKEND
+  assert(typeof sig !== 'undefined',
+         'Second argument of addFunction should be a wasm function signature ' +
+         'string');
+#endif // WASM_BACKEND
+#if ASSERTIONS
+  if (typeof sig === 'undefined') {
+    Module.printErr('Warning: addFunction: Provide a wasm function signature ' +
+                    'string as a second argument');
+  }
+#endif // ASSERTIONS
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS

--- a/src/support.js
+++ b/src/support.js
@@ -247,21 +247,32 @@ Module['registerFunctions'] = registerFunctions;
 #endif // EMULATED_FUNCTION_POINTERS
 
 #if WASM_BACKEND
+#if RESERVED_FUNCTION_POINTERS
 var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
 var jsCallSigOrder = {{{ JSON.stringify(JSCALL_SIG_ORDER) }}};
 var jsCallNumSigs = Object.keys(jsCallSigOrder).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
-
-function addFunction(func, sig) {
 #else
 var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
+#endif
+#else
+var jsCallStartIndex = 1;
+var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
+#endif
 
+#if WASM_BACKEND
+function addFunction(func, sig) {
+#else
 function addFunction(func) {
 #endif
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
+#if RESERVED_FUNCTION_POINTERS
   var base = jsCallSigOrder[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
+#else
+  var base = 0;
+#endif
 #else
   var base = 0;
 #endif

--- a/src/support.js
+++ b/src/support.js
@@ -246,45 +246,17 @@ Module['registerFunctions'] = registerFunctions;
 #endif // RELOCATABLE
 #endif // EMULATED_FUNCTION_POINTERS
 
-#if 0
-// TODO Currently logical operations like '#if a && b' or '#if a || b' are not
-// supported, so the code below contains duplicate parts, as in the pattern
-// below:
-//
-// #if WASM BACKEND
-// #if RESERVED_FUNCTION_POINTERS
-// [TASK 1]
-// #else
-// [TASK 2]
-// #endif
-// #else
-// [TASK 2]
-// #endif
-//
-// When the logical operations become supported, change the code to this:
-//
-// #if WASM_BACKEND && RESERVED_FUNCTION_POINTERS
-// [TASK 1]
-// #else
-// [TASK 2]
-// #endif
-#endif
-#if WASM_BACKEND
-#if RESERVED_FUNCTION_POINTERS
+#if WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS
 var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
 var jsCallSigOrder = {{{ JSON.stringify(JSCALL_SIG_ORDER) }}};
 var jsCallNumSigs = Object.keys(jsCallSigOrder).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
-#else // RESERVED_FUNCTION_POINTERS == 0
+#else // WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS == 0
 var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
-#endif // RESERVED_FUNCTION_POINTERS
-#else // WASM_BACKEND == 0
-var jsCallStartIndex = 1;
-var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
-#endif // WASM_BACKEND
+#endif // WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS
 
-// 'sig' parameter is only used in LLVM wasm backend
+// 'sig' parameter is only used on LLVM wasm backend
 function addFunction(func, sig) {
 #if WASM_BACKEND
   assert(typeof sig !== 'undefined',
@@ -298,15 +270,11 @@ function addFunction(func, sig) {
   }
 #endif // ASSERTIONS
 #if EMULATED_FUNCTION_POINTERS == 0
-#if WASM_BACKEND
-#if RESERVED_FUNCTION_POINTERS
+#if WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS
   var base = jsCallSigOrder[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
-#else // RESERVED_FUNCTION_POINTERS == 0
+#else // WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS == 0
   var base = 0;
-#endif // RESERVED_FUNCTION_POINTERS
-#else // WASM_BACKEND == 0
-  var base = 0;
-#endif // WASM_BACKEND
+#endif // WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS
   for (var i = base; i < base + {{{ RESERVED_FUNCTION_POINTERS }}}; i++) {
     if (!functionPointers[i]) {
       functionPointers[i] = func;

--- a/src/support.js
+++ b/src/support.js
@@ -246,54 +246,56 @@ Module['registerFunctions'] = registerFunctions;
 #endif // RELOCATABLE
 #endif // EMULATED_FUNCTION_POINTERS
 
+#if 0
 // TODO Currently logical operations like '#if a && b' or '#if a || b' are not
 // supported, so the code below contains duplicate parts, as in the pattern
 // below:
 //
 // #if WASM BACKEND
 // #if RESERVED_FUNCTION_POINTERS
-// TASK 1
+// [TASK 1]
 // #else
-// TASK 2
+// [TASK 2]
 // #endif
 // #else
-// TASK 2
+// [TASK 2]
 // #endif
 //
 // When the logical operations become supported, change the code to this:
 //
 // #if WASM_BACKEND && RESERVED_FUNCTION_POINTERS
-// TASK 1
+// [TASK 1]
 // #else
-// TASK 2
+// [TASK 2]
 // #endif
-
+#endif
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS
 var jsCallStartIndex = {{{ JSCALL_START_INDEX }}};
-var jsCallSigOrder = {{{ JSON.stringify(JSCALL_SIG_ORDER) }}};
-var jsCallNumSigs = Object.keys(jsCallSigOrder).length;
+var jsCallSigIndex = {{{ JSON.stringify(JSCALL_SIG_TO_SIG_INDEX) }}};
+var jsCallNumSigs = Object.keys(jsCallSigIndex).length;
 var functionPointers = new Array(jsCallNumSigs * {{{ RESERVED_FUNCTION_POINTERS }}});
-#else
+#else // RESERVED_FUNCTION_POINTERS == 0
 var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
-#endif
-#else
+#endif // RESERVED_FUNCTION_POINTERS
+#else // WASM_BACKEND == 0
 var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
-#endif
+#endif // WASM_BACKEND
 
+// 'sig' parameter is only used in LLVM wasm backend
 function addFunction(func, sig) {
 #if EMULATED_FUNCTION_POINTERS == 0
 #if WASM_BACKEND
 #if RESERVED_FUNCTION_POINTERS
-  var base = jsCallSigOrder[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
-#else
+  var base = jsCallSigIndex[sig] * {{{ RESERVED_FUNCTION_POINTERS }}};
+#else // RESERVED_FUNCTION_POINTERS == 0
   var base = 0;
-#endif
-#else
+#endif // RESERVED_FUNCTION_POINTERS
+#else // WASM_BACKEND == 0
   var base = 0;
-#endif
+#endif // WASM_BACKEND
   for (var i = base; i < base + {{{ RESERVED_FUNCTION_POINTERS }}}; i++) {
     if (!functionPointers[i]) {
       functionPointers[i] = func;

--- a/tests/interop/test_add_function_post.js
+++ b/tests/interop/test_add_function_post.js
@@ -1,4 +1,4 @@
 var newFuncPtr = addFunction(function(num) {
     Module['print']('Hello ' + num + ' from JS!');
-});
+}, 'vi');
 Module['callMain']([newFuncPtr.toString()]);

--- a/tests/interop/test_add_function_post_asmjs.js
+++ b/tests/interop/test_add_function_post_asmjs.js
@@ -1,4 +1,0 @@
-var newFuncPtr = addFunction(function(num) {
-    Module['print']('Hello ' + num + ' from JS!');
-});
-Module['callMain']([newFuncPtr.toString()]);

--- a/tests/interop/test_add_function_post_asmjs.js
+++ b/tests/interop/test_add_function_post_asmjs.js
@@ -1,0 +1,4 @@
+var newFuncPtr = addFunction(function(num) {
+    Module['print']('Hello ' + num + ' from JS!');
+});
+Module['callMain']([newFuncPtr.toString()]);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6424,7 +6424,10 @@ def process(filename):
     test_path = path_from_root('tests', 'interop')
     src, expected = (os.path.join(test_path, s) for s in ('test_add_function.cpp', 'test_add_function.out'))
 
-    post_js = os.path.join(test_path, 'test_add_function_post.js')
+    if Settings.WASM_BACKEND:
+      post_js = os.path.join(test_path, 'test_add_function_post.js')
+    else:
+      post_js = os.path.join(test_path, 'test_add_function_post_asmjs.js')
     self.emcc_args += ['--post-js', post_js]
     self.do_run_from_file(src, expected)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6432,7 +6432,7 @@ def process(filename):
       Settings.RESERVED_FUNCTION_POINTERS = 0
       self.do_run(open(src).read(), '''Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.''')
       generated = open('src.cpp.o.js').read()
-      assert 'jsCall' not in generated
+      assert 'jsCall_' not in generated
       Settings.RESERVED_FUNCTION_POINTERS = 1
 
       Settings.ALIASING_FUNCTION_POINTERS = 1 - Settings.ALIASING_FUNCTION_POINTERS # flip the test

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6417,7 +6417,6 @@ def process(filename):
     assert '_exported_func_from_response_file_1' in open('src.cpp.o.js').read()
 
   @sync
-  @no_wasm_backend('no jsCall function pointers are created for wasm backend')
   def test_add_function(self):
     Settings.INVOKE_RUN = 0
     Settings.RESERVED_FUNCTION_POINTERS = 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6424,10 +6424,7 @@ def process(filename):
     test_path = path_from_root('tests', 'interop')
     src, expected = (os.path.join(test_path, s) for s in ('test_add_function.cpp', 'test_add_function.out'))
 
-    if Settings.WASM_BACKEND:
-      post_js = os.path.join(test_path, 'test_add_function_post.js')
-    else:
-      post_js = os.path.join(test_path, 'test_add_function_post_asmjs.js')
+    post_js = os.path.join(test_path, 'test_add_function_post.js')
     self.emcc_args += ['--post-js', post_js]
     self.do_run_from_file(src, expected)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,12 +2526,16 @@ class JS(object):
     return ret
 
   @staticmethod
-  def make_jscall(sig, named=True):
+  def make_jscall(sig, order, named=True):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
+    if Settings.WASM_BACKEND:
+      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * order)
+    else:
+      index = 'index'
     ret = '''function%s(%s) {
-    %sfunctionPointers[index](%s);
-}''' % ((' jsCall_' + sig) if named else '', args, 'return ' if sig[0] != 'v' else '', fnargs)
+    %sfunctionPointers[%s](%s);
+}''' % ((' jsCall_' + sig) if named else '', args, 'return ' if sig[0] != 'v' else '', index, fnargs)
     return ret
 
   @staticmethod

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2529,6 +2529,17 @@ class JS(object):
   def make_jscall(sig, order, named=True):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
+    # While asm.js/fastcomp's addFunction support preallocates
+    # Settings.RESERVED_FUNCTION_POINTERS slots in functionPointers array, on
+    # the Wasm backend we reserve that number of slots for each possible
+    # function signature, so it is (Settings.RESERVED_FUNCTION_POINTERS * # of
+    # indirectly called function signatures) slots in total. So the index to
+    # functionPointers array should be adjusted according to the order of the
+    # function signature. The reason we do this is Wasm has a single unified
+    # function table while asm.js maintains separate function table per
+    # signature.
+    # e.g. When there are three possible function signature, ['v', 'ii', 'ff'],
+    # the 'order' parameter will be 0 for 'v', 1 for 'ii', and so on.
     if Settings.WASM_BACKEND:
       index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * order)
     else:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,7 +2526,7 @@ class JS(object):
     return ret
 
   @staticmethod
-  def make_jscall(sig, order, named=True):
+  def make_jscall(sig, sig_index, named=True):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
     # While asm.js/fastcomp's addFunction support preallocates
@@ -2539,9 +2539,9 @@ class JS(object):
     # function table while asm.js maintains separate function table per
     # signature.
     # e.g. When there are three possible function signature, ['v', 'ii', 'ff'],
-    # the 'order' parameter will be 0 for 'v', 1 for 'ii', and so on.
+    # the 'sig_index' parameter will be 0 for 'v', 1 for 'ii', and so on.
     if Settings.WASM_BACKEND:
-      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * order)
+      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * sig_index)
     else:
       index = 'index'
     ret = '''function%s(%s) {

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,7 +2526,7 @@ class JS(object):
     return ret
 
   @staticmethod
-  def make_jscall(sig, sig_index, named=True):
+  def make_jscall(sig, sig_order, named=True):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
     # While asm.js/fastcomp's addFunction support preallocates
@@ -2539,9 +2539,9 @@ class JS(object):
     # function table while asm.js maintains separate function table per
     # signature.
     # e.g. When there are three possible function signature, ['v', 'ii', 'ff'],
-    # the 'sig_index' parameter will be 0 for 'v', 1 for 'ii', and so on.
+    # the 'sig_order' parameter will be 0 for 'v', 1 for 'ii', and so on.
     if Settings.WASM_BACKEND:
-      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * sig_index)
+      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * sig_order)
     else:
       index = 'index'
     ret = '''function%s(%s) {

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,7 +2526,7 @@ class JS(object):
     return ret
 
   @staticmethod
-  def make_jscall(sig, sig_order, named=True):
+  def make_jscall(sig, sig_order=0, named=True):
     fnargs = ','.join(['a' + str(i) for i in range(1, len(sig))])
     args = 'index' + (',' if fnargs else '') + fnargs
     # While asm.js/fastcomp's addFunction support preallocates


### PR DESCRIPTION
This introduces a breaking change; when using `addFunction` on Wasm backend, you should provide an additional second argument, a Wasm function signature string. See changelog for details.

Should land after WebAssembly/binaryen#1395. Closes #5673 and closes #6100.