### PR TITLE
fix_IGNORE_CLOSURE_COMPILER_ERRORS_on_Windows

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2194,8 +2194,7 @@ class Building(object):
         args.append('--externs')
         args.append(extern)
       if Settings.IGNORE_CLOSURE_COMPILER_ERRORS:
-        args.append('--jscomp_off')
-        args.append('*')
+        args.append('--jscomp_off=*')
       if pretty: args += ['--formatting', 'PRETTY_PRINT']
       if os.environ.get('EMCC_CLOSURE_ARGS'):
         args += shlex.split(os.environ.get('EMCC_CLOSURE_ARGS'))


### PR DESCRIPTION
Fix Closure parameter -s IGNORE_CLOSURE_COMPILER_ERRORS=1 to work on Windows. Fixes other.test_IGNORE_CLOSURE_COMPILER_ERRORS on Windows.

On Windows command line, a standalone `*` gets expanded out to all files in the current directory, and as result, the first form of command line would fail the test with the following error

```
DEBUG:root:java.lang.NullPointerException: No warning class for name: a.out.js.mem
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:864)
        at com.google.javascript.jscomp.DiagnosticGroups.setWarningLevel(DiagnosticGroups.java:732)
        at com.google.javascript.jscomp.AbstractCommandLineRunner.setWarningGuardOptions(AbstractCommandLineRunner.java:321)
        at com.google.javascript.jscomp.AbstractCommandLineRunner.setRunOptions(AbstractCommandLineRunner.java:336)
        at com.google.javascript.jscomp.AbstractCommandLineRunner.doRun(AbstractCommandLineRunner.java:1046)
        at com.google.javascript.jscomp.AbstractCommandLineRunner.run(AbstractCommandLineRunner.java:499)
        at com.google.javascript.jscomp.CommandLineRunner.main(CommandLineRunner.java:1968)
```
