### PR TITLE
webidl_binder.py cleanup

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -497,10 +497,11 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
       if class_name != func_scope:
         # this function comes from an ancestor class; for operators, we must cast it
         cast_self = 'dynamic_cast<' + type_to_c(func_scope) + '>(' + cast_self + ')'
+      maybe_deref = '*' if sig[0] in interfaces else ''
       if '=' in operator:
-        call = '(*%s %s %s%s)' % (cast_self, operator, '*' if sig[0] in interfaces else '', args[0])
+        call = '(*%s %s %s%s)' % (cast_self, operator, maybe_deref, args[0])
       elif operator == '[]':
-        call = '((*%s)[%s%s])' % (cast_self, '*' if sig[0] in interfaces else '', args[0])
+        call = '((*%s)[%s%s])' % (cast_self, maybe_deref, args[0])
       else:
         raise Exception('unfamiliar operator ' + operator)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -591,12 +591,8 @@ for name in names:
 
   # Methods
 
-  seen_constructor = False # ensure a constructor, even for abstract base classes
-  for m in interface.members:
-    if m.identifier.name == name:
-      seen_constructor = True
-      break
-  if not seen_constructor:
+  # Ensure a constructor even if one is not specified.
+  if not any(m.identifier.name == name for m in interface.members):
     mid_js += ['function %s() { throw "cannot construct a %s, no constructor in IDL" }\n' % (name, name)]
     mid_js += build_constructor(name)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -375,11 +375,8 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
     body = ''
     pre_arg = []
 
-  for i in range(max_args):
-    arg = all_args[i]
-    if arg.type.isString() or arg.type.isArray():
-      body += '  ensureCache.prepare();\n'
-      break
+  if any(arg.type.isString() or arg.type.isArray() for arg in all_args):
+    body += '  ensureCache.prepare();\n'
 
   full_name = "%s::%s" % (class_name, func_name)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -526,7 +526,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
     if not constructor:
       if i == max_args:
         dec_args = ', '.join([type_to_cdec(raw[j]) + ' ' + args[j] for j in range(i)])
-        js_call_args = ', '.join(['%s%s' % (('(int)' if sig[j] in interfaces else '') + ('&' if raw[j].getExtendedAttribute('Ref') or raw[j].getExtendedAttribute('Value') else ''), args[j]) for j in range(i)])
+        js_call_args = ', '.join(['%s%s' % (('(int)' if sig[j] in interfaces else '') + take_addr_if_nonpointer(raw[j]), args[j]) for j in range(i)])
 
         js_impl_methods += [r'''  %s %s(%s) {
     %sEM_ASM_%s({

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -405,7 +405,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
       # Print type info in comments.
       body += "  /* %s <%s> [%s] */\n" % (js_arg, arg.type.name, inner)
 
-      # Wrap asserts with existance check when argument is optional.
+      # Wrap asserts with existence check when argument is optional.
       if all_checks and optional: body += "if(typeof {0} !== 'undefined' && {0} !== null) {{\n".format(js_arg)
       # Special case argument types.
       if arg.type.isNumeric():

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -76,9 +76,8 @@ mid_c += [r'''
 extern "C" {
 ''']
 
-def emit_constructor(name):
-  global mid_js
-  mid_js += [r'''%s.prototype = %s;
+def build_constructor(name):
+  return [r'''%s.prototype = %s;
 %s.prototype.constructor = %s;
 %s.prototype.__class__ = %s;
 %s.__cache__ = {};
@@ -93,7 +92,7 @@ function WrapperObject() {
 }
 ''']
 
-emit_constructor('WrapperObject')
+mid_js += build_constructor('WrapperObject')
 
 mid_js += ['''
 function getCache(__class__) {
@@ -601,7 +600,7 @@ for name in names:
       break
   if not seen_constructor:
     mid_js += ['function %s() { throw "cannot construct a %s, no constructor in IDL" }\n' % (name, name)]
-    emit_constructor(name)
+    mid_js += build_constructor(name)
 
   for m in interface.members:
     if not m.isMethod(): continue
@@ -639,7 +638,7 @@ for name in names:
                     const=m.getExtendedAttribute('Const'))
     mid_js += [';\n']
     if constructor:
-      emit_constructor(name)
+      mid_js += build_constructor(name)
 
   for m in interface.members:
     if not m.isAttr(): continue

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -569,8 +569,7 @@ for child, parent in implements.items():
     else:
       parent = None
 
-names = list(interfaces.keys())
-names.sort(key=lambda x: nodeHeight.get(x, 0), reverse=True)
+names = sorted(interfaces.keys(), key=lambda x: nodeHeight.get(x, 0), reverse=True)
 
 for name in names:
   interface = interfaces[name]

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -381,12 +381,11 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
 
   full_name = "%s::%s" % (class_name, func_name)
 
-  for i in range(max_args):
+  for i, arg in enumerate(all_args):
     if i >= min_args:
       optional = True
     else:
       optional = False
-    arg = all_args[i]
     do_default = False
     # Filter out arguments we don't know how to parse. Fast casing only common cases.
     compatible_arg = isinstance(arg, Dummy) or (isinstance(arg, WebIDL.IDLArgument) and arg.optional is False)

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -77,12 +77,13 @@ extern "C" {
 ''']
 
 def build_constructor(name):
-  return [r'''%s.prototype = %s;
-%s.prototype.constructor = %s;
-%s.prototype.__class__ = %s;
-%s.__cache__ = {};
-Module['%s'] = %s;
-''' % (name, 'Object.create(%s.prototype)' % (implements[name][0] if implements.get(name) else 'WrapperObject'), name, name, name, name, name, name, name)]
+  implementing_name = implements[name][0] if implements.get(name) else 'WrapperObject'
+  return [r'''{name}.prototype = Object.create({implementing}.prototype);
+{name}.prototype.constructor = {name};
+{name}.prototype.__class__ = {name};
+{name}.__cache__ = {{}};
+Module['{name}'] = {name};
+'''.format(name=name, implementing=implementing_name)]
 
 
 mid_js += ['''

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -716,23 +716,24 @@ for name, enum in enums.items():
   deferred_js += ['\n', '// ' + name + '\n']
   for value in enum.values():
     function_id = "%s_%s" % (name, value.split('::')[-1])
-    mid_c += [r'''%s EMSCRIPTEN_KEEPALIVE emscripten_enum_%s() {
+    function_id = 'emscripten_enum_%s' % function_id
+    mid_c += [r'''%s EMSCRIPTEN_KEEPALIVE %s() {
   return %s;
 }
 ''' % (name, function_id, value)]
     symbols = value.split('::')
     if len(symbols) == 1:
       identifier = symbols[0]
-      deferred_js += ["Module['%s'] = _emscripten_enum_%s();\n" % (identifier, function_id)]
+      deferred_js += ["Module['%s'] = _%s();\n" % (identifier, function_id)]
     elif len(symbols) == 2:
       [namespace, identifier] = symbols
       if namespace in interfaces:
         # namespace is a class
-        deferred_js += ["Module['%s']['%s'] = _emscripten_enum_%s();\n" % \
+        deferred_js += ["Module['%s']['%s'] = _%s();\n" % \
                   (namespace, identifier, function_id)]
       else:
         # namespace is a namespace, so the enums get collapsed into the top level namespace.
-        deferred_js += ["Module['%s'] = _emscripten_enum_%s();\n" % (identifier, function_id)]
+        deferred_js += ["Module['%s'] = _%s();\n" % (identifier, function_id)]
     else:
       raise Exception("Illegal enum value %s" % value)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -749,12 +749,10 @@ mid_js += ['''
 
 # Write
 
-c = open(output_base + '.cpp', 'w')
-for x in pre_c: c.write(x)
-for x in mid_c: c.write(x)
-c.close()
+with open(output_base + '.cpp', 'w') as c:
+  for x in pre_c: c.write(x)
+  for x in mid_c: c.write(x)
 
-js = open(output_base + '.js', 'w')
-for x in mid_js: js.write(x)
-js.close()
+with open(output_base + '.js', 'w') as js:
+  for x in mid_js: js.write(x)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -273,39 +273,43 @@ def full_typename(arg):
 
 def type_to_c(t, non_pointing=False):
   #print 'to c ', t
+  def base_type_to_c(t):
+    if t == 'Long':
+      ret = 'int'
+    elif t == 'UnsignedLong':
+      ret = 'unsigned int'
+    elif t == 'Short':
+      ret = 'short'
+    elif t == 'UnsignedShort':
+      ret = 'unsigned short'
+    elif t == 'Byte':
+      ret = 'char'
+    elif t == 'Octet':
+      ret = 'unsigned char'
+    elif t == 'Void':
+      ret = 'void'
+    elif t == 'String':
+      ret = 'char*'
+    elif t == 'Float':
+      ret = 'float'
+    elif t == 'Double':
+      ret = 'double'
+    elif t == 'Boolean':
+      ret = 'bool'
+    elif t == 'Any' or t == 'VoidPtr':
+      ret = 'void*'
+    elif t in interfaces:
+      ret = (interfaces[t].getExtendedAttribute('Prefix') or [''])[0] + t + ('' if non_pointing else '*')
+    else:
+      ret = t
+    return ret
+
   t = t.replace(' (Wrapper)', '')
   suffix = ''
   if '[]' in t:
     suffix = '*'
     t = t.replace('[]', '')
-  if t == 'Long':
-    ret = 'int'
-  elif t == 'UnsignedLong':
-    ret = 'unsigned int'
-  elif t == 'Short':
-    ret = 'short'
-  elif t == 'UnsignedShort':
-    ret = 'unsigned short'
-  elif t == 'Byte':
-    ret = 'char'
-  elif t == 'Octet':
-    ret = 'unsigned char'
-  elif t == 'Void':
-    ret = 'void'
-  elif t == 'String':
-    ret = 'char*'
-  elif t == 'Float':
-    ret = 'float'
-  elif t == 'Double':
-    ret = 'double'
-  elif t == 'Boolean':
-    ret = 'bool'
-  elif t == 'Any' or t == 'VoidPtr':
-    ret = 'void*'
-  elif t in interfaces:
-    ret = (interfaces[t].getExtendedAttribute('Prefix') or [''])[0] + t + ('' if non_pointing else '*')
-  else:
-    ret = t
+  ret = base_type_to_c(t)
   return ret + suffix
 
 def take_addr_if_nonpointer(m):

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -305,12 +305,9 @@ def type_to_c(t, non_pointing=False):
     return ret
 
   t = t.replace(' (Wrapper)', '')
-  suffix = ''
   if '[]' in t:
-    suffix = '*'
-    t = t.replace('[]', '')
-  ret = base_type_to_c(t)
-  return ret + suffix
+    return base_type_to_c(t.replace('[]', '')) + '*'
+  return base_type_to_c(t)
 
 def take_addr_if_nonpointer(m):
   if m.getExtendedAttribute('Ref') or m.getExtendedAttribute('Value'):

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -338,7 +338,6 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
   min_args = min(sigs.keys())
   max_args = max(sigs.keys())
 
-  c_names = {}
   all_args = sigs.get(max_args)
 
   if DEBUG:
@@ -454,6 +453,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
         elif arg_type == 'Double':
           body += "  if (typeof arg%d == 'object') { arg%d = ensureFloat64(arg%d); }\n" % (i, i, i)
 
+  c_names = {}
   for i in range(min_args, max_args):
     c_names[i] = 'emscripten_bind_%s_%d' % (bindings_name, i)
     body += '  if (arg%d === undefined) { %s%s(%s)%s%s }\n' % (i, call_prefix, '_' + c_names[i], ', '.join(pre_arg + args[:i]), call_postfix, '' if 'return ' in call_prefix else '; ' + (cache or ' ') + 'return')


### PR DESCRIPTION
These are a collection of small changes I noticed while reading through `webidl_binder.py`.  They don't make the code significantly smaller, but I'd like to think they make it more readable in most places.

A real cleanup would work on separating things out into separate functions, but I'm saving that for another time.