### PR TITLE
Multithreading 21/N: DEFAULT_PTHREAD_STACK_SIZE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -876,7 +876,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         key, value = change.split('=', 1)
 
         # In those settings fields that represent amount of memory, translate suffixes to multiples of 1024.
-        if key in ['TOTAL_STACK', 'TOTAL_MEMORY', 'GL_MAX_TEMP_BUFFER_SIZE', 'SPLIT_MEMORY', 'WASM_MEM_MAX']:
+        if key in ['TOTAL_STACK', 'TOTAL_MEMORY', 'GL_MAX_TEMP_BUFFER_SIZE', 'SPLIT_MEMORY', 'WASM_MEM_MAX', 'DEFAULT_PTHREAD_STACK_SIZE']:
           value = str(shared.expand_byte_size_suffixes(value))
 
         original_exported_response = False

--- a/src/settings.js
+++ b/src/settings.js
@@ -780,6 +780,14 @@ var USE_PTHREADS = 0; // If true, enables support for pthreads.
 
 var PTHREAD_POOL_SIZE = 0; // Specifies the number of web workers that are preallocated before runtime is initialized. If 0, workers are created on demand.
 
+var DEFAULT_PTHREAD_STACK_SIZE = 2*1024*1024; // If not explicitly specified, this is the stack size to use for newly created pthreads.
+                                              // According to http://man7.org/linux/man-pages/man3/pthread_create.3.html, default stack size on
+                                              // Linux/x86-32 for a new thread is 2 megabytes, so follow the same convention. Use
+                                              // pthread_attr_setstacksize() at thread creation time to explicitly specify the stack size, in which case
+                                              // this value is ignored. Note that the asm.js/wasm function call control flow stack is separate from this
+                                              // stack, and this stack only contains certain function local variables, such as those that have their
+                                              // addresses taken, or ones that are too large to fit as local vars in asm.js/wasm code.
+
 // Specifies the value returned by the function emscripten_num_logical_cores()
 // if navigator.hardwareConcurrency is not supported. Pass in a negative number
 // to show a popup dialog at startup so the user can configure this dynamically.

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -43,7 +43,7 @@ int main()
   void *stack_addr;
   pthread_attr_getstack(&attr, &stack_addr, &stack_size);
   printf("stack_size: %d, stack_addr: %p\n", (int)stack_size, stack_addr);
-  if (stack_size != 81920 || stack_addr == 0)
+  if (stack_size != 2*1024*1024 || stack_addr == 0)
     result = -100; // Report failure.
 
   pthread_join(thr, 0);


### PR DESCRIPTION
Fix handling of thread stack size creation, and add a setting -s DEFAULT_PTHREAD_STACK_SIZE to allow specifying the default stack size.