### PR TITLE
Multithreading 22/N: asmfs_bootstrap_api

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1109,6 +1109,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         next_arg_index += 1
         options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
 
+      if shared.Settings.ASMFS:
+        options.js_libraries.append(shared.path_from_root('src', 'library_asmfs.js'))
+
       forced_stdlibs = []
       if shared.Settings.DEMANGLE_SUPPORT:
         shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']

--- a/src/library_asmfs.js
+++ b/src/library_asmfs.js
@@ -1,0 +1,45 @@
+var asmFS = {
+  $FS: {
+    populate: function(path, mode) {
+      var pathCString = allocate(intArrayFromString(path), 'i8', ALLOC_NORMAL);
+      mode = (mode !== undefined) ? mode : 511 /* 0777 */;
+      _emscripten_asmfs_populate(pathCString, mode);
+      _free(pathCString);
+    },
+
+    mkdir: function(path, mode) {
+      mode = (mode !== undefined) ? mode : 511 /* 0777 */;
+      var pathCString = allocate(intArrayFromString(path), 'i8', ALLOC_NORMAL);
+      _emscripten_asmfs_mkdir(pathCString, mode);
+      _free(pathCString);
+    },
+
+    mkdirTree: function(path, mode) {
+      var dirs = path.split('/');
+      var d = '';
+      for (var i = 0; i < dirs.length; ++i) {
+        if (!dirs[i]) continue;
+        d += '/' + dirs[i];
+        FS.mkdir(d, mode);
+      }
+    },
+
+    setRemoteUrl: function(path, remoteUrl) {
+      var pathCString = allocate(intArrayFromString(path), 'i8', ALLOC_NORMAL);
+      var remoteUrlCString = allocate(intArrayFromString(remoteUrl), 'i8', ALLOC_NORMAL);
+      _emscripten_asmfs_set_remote_url(pathCString, remoteUrlCString);
+      _free(pathCString);
+      _free(remoteUrlCString);
+    },
+
+    setFileData: function(path, data) {
+      var dataInHeap = _malloc(data.length);
+      HEAPU8.set(data, dataInHeap);
+      var pathCString = allocate(intArrayFromString(path), 'i8', ALLOC_NORMAL);
+      _emscripten_asmfs_set_file_data(pathCString, dataInHeap, data.length);
+      _free(pathCString);
+    }
+  }
+};
+
+mergeInto(LibraryManager.library, asmFS);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1972,6 +1972,7 @@ if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() { if (typeof SharedArrayBuff
 
 #if ASSERTIONS
 #if NO_FILESYSTEM
+#if !ASMFS
 var /* show errors on likely calls to FS when it was not included */ FS = {
   error: function() {
     abort('Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with  -s FORCE_FILESYSTEM=1');
@@ -1990,6 +1991,7 @@ var /* show errors on likely calls to FS when it was not included */ FS = {
 };
 Module['FS_createDataFile'] = FS.createDataFile;
 Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
+#endif
 #endif
 #endif
 

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -174,6 +174,38 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 // onerror() handler will be called in the calling thread before this function returns.
 EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
 
+#define emscripten_asmfs_open_t int
+
+// The following flags specify how opening files for reading works (from strictest behavior to most flexible)
+
+// When a file is opened for reading, the file data must already fully reside in memory. (most similar to MEMFS behavior)
+#define EMSCRIPTEN_ASMFS_OPEN_MEMORY    0
+
+// The file data does not need to be already in memory, but can reside in IndexedDB.
+#define EMSCRIPTEN_ASMFS_OPEN_INDEXEDDB 1
+
+// The file will be downloaded from remote server, as long as it has an index entry in local filesystem.
+#define EMSCRIPTEN_ASMFS_OPEN_REMOTE    2
+
+// A file entry does not need to exist on the local filesystem, but discovery will be attempted from remote server via an XHR first.
+#define EMSCRIPTEN_ASMFS_OPEN_REMOTE_DISCOVER 3
+
+// Specifies how calls to non-truncating open(), fopen(), std::ifstream etc. behave on the calling thread.
+void emscripten_asmfs_set_file_open_behavior(emscripten_asmfs_open_t behavior);
+
+// Returns the current file open behavior modein the calling thread.
+emscripten_asmfs_open_t emscripten_asmfs_get_file_open_behavior();
+
+void emscripten_asmfs_set_remote_url(const char *filename, const char *remoteUrl);
+
+void emscripten_asmfs_remote_url(const char *filename, char *outRemoteUrl, int maxBytesToWrite);
+
+void emscripten_asmfs_unload_data(const char *pathname);
+
+// Computes the total amount of bytes in memory utilized by the filesystem at the moment.
+// Note: This function can be slow since it walks through the whole filesystem.
+uint64_t emscripten_asmfs_compute_memory_usage();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Initial version of JavaScript ASMFS bootstrapping API and fopen() behavior.

In ASMFS mode, we want to get away with --preload-file and --embed-file, and currently ASMFS already does store files into IndexedDB so that later `fopen()` and `fread()` can access them. However there is a need to be able to prepopulate filesystems, either with "fat data" (download the files), or just "table of contents" (get knowledge about the files on the remote server, but don't download now) so that `readdir()` and similar are able to "enumerate" files on a remote web server.

I don't yet have a grand vision about how this API should end up looking like, posting the current form here for more comments. So far I've generally created a `preRun` task that populates the needed files. This seems to work well for simple cases, but needs more design before freezing the API for public use that one can depend on.