### PR TITLE
Multithreading 28/N: Drop debug prints in ASMFS and Fetch API

### DIFF
--- a/system/lib/fetch/asmfs.cpp
+++ b/system/lib/fetch/asmfs.cpp
@@ -20,6 +20,9 @@
 #include <ctype.h>
 #include "syscall_arch.h"
 
+// Uncomment the following and clear the cache with emcc --clear-cache to rebuild this file to enable internal debugging.
+// #define ASMFS_DEBUG
+
 extern "C" {
 
 // http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
@@ -136,7 +139,9 @@ static void link_inode(inode *node, inode *parent)
 {
 	char parentName[PATH_MAX];
 	inode_abspath(parent, parentName, PATH_MAX);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('link_inode: node "' + Pointer_stringify($0) + '" to parent "' + Pointer_stringify($1) + '".'), node->name, parentName);
+#endif
 	// When linking a node, it can't be part of the filesystem tree (but it can have children of its own)
 	assert(!node->parent);
 	assert(!node->sibling);
@@ -168,7 +173,9 @@ static inode *find_predecessor_sibling(inode *node, inode *parent)
 
 static void unlink_inode(inode *node)
 {
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('unlink_inode: node ' + Pointer_stringify($0) + ' from its parent ' + Pointer_stringify($1) + '.'), node->name, node->parent->name);
+#endif
 	inode *parent = node->parent;
 	if (!parent) return;
 	node->parent = 0;
@@ -268,7 +275,9 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 	{
 		bool is_directory = false;
 		const char *child_path = path_cmp(path_to_file, node->name, &is_directory);
+#ifdef ASMFS_DEBUG
 		EM_ASM_INT( { err('path_cmp ' + Pointer_stringify($0) + ', ' + Pointer_stringify($1) + ', ' + Pointer_stringify($2) + ' .') }, path_to_file, node->name, child_path);
+#endif
 		if (child_path)
 		{
 			if (is_directory && node->type != INODE_DIR) return 0; // "A component used as a directory in pathname is not, in fact, a directory"
@@ -300,16 +309,20 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 			node = node->sibling;
 		}
 	}
-	EM_ASM(err('path_to_file ' + Pointer_stringify($0) + ' .'), path_to_file);
 	const char *basename_pos = basename_part(path_to_file);
+#ifdef ASMFS_DEBUG
+	EM_ASM(err('path_to_file ' + Pointer_stringify($0) + ' .'), path_to_file);
 	EM_ASM(err('basename_pos ' + Pointer_stringify($0) + ' .'), basename_pos);
+#endif
 	while(*path_to_file && path_to_file < basename_pos)
 	{
 		node = create_inode(INODE_DIR, mode);
 		path_to_file += strcpy_inodename(node->name, path_to_file) + 1;
 		link_inode(node, root);
+#ifdef ASMFS_DEBUG
 		EM_ASM(out('create_directory_hierarchy_for_file: created directory ' + Pointer_stringify($0) + ' under parent ' + Pointer_stringify($1) + '.'), 
 			node->name, node->parent->name);
+#endif
 		root = node;
 	}
 	return root;
@@ -331,7 +344,9 @@ static inode *find_parent_inode(inode *root, const char *path, int *out_errno)
 {
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('find_parent_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+#endif
 
 	assert(out_errno); // Passing in error is mandatory.
 
@@ -408,7 +423,9 @@ static inode *find_inode(inode *root, const char *path, int *out_errno)
 {
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('find_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+#endif
 
 	assert(out_errno); // Passing in error is mandatory.
 
@@ -548,10 +565,18 @@ void emscripten_dump_fs_root()
 	emscripten_dump_fs_tree(filesystem_root(), path);
 }
 
+#ifdef ASMFS_DEBUG
+
 #define RETURN_ERRNO(errno, error_reason) do { \
 		EM_ASM(err(Pointer_stringify($0) + '() returned errno ' + #errno + '(' + $1 + '): ' + error_reason + '!'), __FUNCTION__, errno); \
 		return -errno; \
 	} while(0)
+
+#else
+
+#define RETURN_ERRNO(errno, error_reason) do { return -errno; } while(0)
+
+#endif
 
 static char stdout_buffer[4096] = {};
 static int stdout_buffer_end = 0;
@@ -588,7 +613,9 @@ long __syscall3(int which, ...) // read
 	void *buf = va_arg(vl, void *);
 	size_t count = va_arg(vl, size_t);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('read(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
+#endif
 
 	iovec io = { buf, count };
 	return __syscall145(145/*readv*/, fd, &io, 1);
@@ -602,7 +629,9 @@ long __syscall4(int which, ...) // write
 	void *buf = va_arg(vl, void *);
 	size_t count = va_arg(vl, size_t);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('write(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
+#endif
 
 	iovec io = { buf, count };
 	return __syscall146(146/*writev*/, fd, &io, 1);
@@ -610,8 +639,10 @@ long __syscall4(int which, ...) // write
 
 static long open(const char *pathname, int flags, int mode)
 {
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ')'),
 		pathname, flags, mode);
+#endif
 
 	int accessMode = (flags & O_ACCMODE);
 
@@ -624,7 +655,9 @@ static long open(const char *pathname, int flags, int mode)
 //	if ((flags & O_EXCL) && !(flags & O_CREAT)) RETURN_ERRNO(EINVAL, "open() with O_EXCL flag needs to always be paired with O_CREAT");
 	// However existing earlier unit tests in Emscripten expect that O_EXCL is simply ignored when O_CREAT was not passed. So do that for now.
 	if ((flags & O_EXCL) && !(flags & O_CREAT)) {
+#ifdef ASMFS_DEBUG
 		EM_ASM(err('warning: open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ': flag O_EXCL should always be paired with O_CREAT. Ignoring O_EXCL)'), pathname, flags, mode);
+#endif
 		flags &= ~O_EXCL;
 	}
 
@@ -773,7 +806,9 @@ long __syscall5(int which, ...) // open
 
 static long close(int fd)
 {
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('close(fd=' + $0 + ')'), fd);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -806,7 +841,9 @@ long __syscall9(int which, ...) // link
 	const char *oldpath = va_arg(vl, const char *);
 	const char *newpath = va_arg(vl, const char *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('link(oldpath="' + Pointer_stringify($0) + '", newpath="' + Pointer_stringify($1) + '")'), oldpath, newpath);
+#endif
 
 	RETURN_ERRNO(ENOTSUP, "TODO: link() is a stub and not yet implemented in ASMFS");
 }
@@ -817,7 +854,9 @@ long __syscall10(int which, ...) // unlink
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('unlink(pathname="' + Pointer_stringify($0) + '")'), pathname);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -859,7 +898,9 @@ long __syscall12(int which, ...) // chdir
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('chdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -887,7 +928,9 @@ long __syscall14(int which, ...) // mknod
 	mode_t mode = va_arg(vl, mode_t);
 	int dev = va_arg(vl, int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('mknod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ', dev=' + $2 + ')'), pathname, mode, dev);
+#endif
 
 	RETURN_ERRNO(ENOTSUP, "TODO: mknod() is a stub and not yet implemented in ASMFS");
 }
@@ -899,7 +942,9 @@ long __syscall15(int which, ...) // chmod
 	const char *pathname = va_arg(vl, const char *);
 	int mode = va_arg(vl, int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('chmod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -928,7 +973,9 @@ long __syscall33(int which, ...) // access
 	const char *pathname = va_arg(vl, const char *);
 	int mode = va_arg(vl, int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('access(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -959,7 +1006,9 @@ long __syscall33(int which, ...) // access
 
 long __syscall36(int which, ...) // sync
 {
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('sync()'));
+#endif
 
 	// Spec mandates that "sync() is always successful".
 	return 0;
@@ -974,7 +1023,9 @@ long __syscall39(int which, ...) // mkdir
 	const char *pathname = va_arg(vl, const char *);
 	mode_t mode = va_arg(vl, mode_t);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('mkdir(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1014,7 +1065,9 @@ long __syscall40(int which, ...) // rmdir
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('rmdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1050,7 +1103,9 @@ long __syscall41(int which, ...) // dup
 	va_start(vl, which);
 	unsigned int fd = va_arg(vl, unsigned int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('dup(fd=' + $0 + ')'), fd);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1073,7 +1128,9 @@ long __syscall54(int which, ...) // ioctl/sysctl
 	int request = va_arg(vl, int);
 	char *argp = va_arg(vl, char *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('ioctl(fd=' + $0 + ', request=' + $1 + ', argp=0x' + $2 + ')'), fd, request, argp);
+#endif
 	RETURN_ERRNO(ENOTSUP, "TODO: ioctl() is a stub and not yet implemented in ASMFS");
 }
 
@@ -1114,8 +1171,10 @@ long __syscall140(int which, ...) // llseek
 	off_t *result = va_arg(vl, off_t *);
 	unsigned int whence = va_arg(vl, unsigned int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('llseek(fd=' + $0 + ', offset_high=' + $1 + ', offset_low=' + $2 + ', result=0x' + ($3).toString(16) + ', whence=' + $4 + ')'),
 		fd, offset_high, offset_low, result, whence);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1154,7 +1213,9 @@ long __syscall145(int which, ...) // readv
 	const iovec *iov = va_arg(vl, const iovec*);
 	int iovcnt = va_arg(vl, int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('readv(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1204,7 +1265,9 @@ long __syscall146(int which, ...) // writev
 	const iovec *iov = va_arg(vl, const iovec*);
 	int iovcnt = va_arg(vl, int);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('writev(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (fd != 1/*stdout*/ && fd != 2/*stderr*/) // TODO: Resolve the hardcoding of stdin,stdout & stderr
@@ -1276,7 +1339,9 @@ long __syscall183(int which, ...) // getcwd
 	char *buf = va_arg(vl, char *);
 	size_t size = va_arg(vl, size_t);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('getcwd(buf=0x' + $0 + ', size= ' + $1 + ')'), buf, size);
+#endif
 
 	if (!buf && size > 0) RETURN_ERRNO(EFAULT, "buf points to a bad address");
 	if (buf && size == 0) RETURN_ERRNO(EINVAL, "The size argument is zero and buf is not a null pointer");
@@ -1332,7 +1397,9 @@ long __syscall195(int which, ...) // SYS_stat64
 	const char *pathname = va_arg(vl, const char *);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('SYS_stat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1369,7 +1436,9 @@ long __syscall196(int which, ...) // SYS_lstat64
 	const char *pathname = va_arg(vl, const char *);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('SYS_lstat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+#endif
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1398,7 +1467,9 @@ long __syscall197(int which, ...) // SYS_fstat64
 	int fd = va_arg(vl, int);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('SYS_fstat64(fd="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), fd, buf);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1424,7 +1495,9 @@ long __syscall220(int which, ...) // getdents64 (get directory entries 64-bit)
 	va_end(vl);
 	unsigned int dirents_size = count / sizeof(dirent); // The number of dirent structures that can fit into the provided buffer.
 	dirent *de_end = de + dirents_size;
+#ifdef ASMFS_DEBUG
 	EM_ASM(err('getdents64(fd=' + $0 + ', de=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, de, count);
+#endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "Invalid file descriptor fd");

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -12,6 +12,9 @@
 #include <emscripten/emscripten.h>
 #include <math.h>
 
+// Uncomment the following and clear the cache with emcc --clear-cache to rebuild this file to enable internal debugging.
+// #define FETCH_DEBUG
+
 struct __emscripten_fetch_queue
 {
 	emscripten_fetch_t **queuedOperations;
@@ -44,8 +47,10 @@ void emscripten_proxy_fetch(emscripten_fetch_t *fetch)
 	__emscripten_fetch_queue *queue = _emscripten_get_fetch_queue();
 //	TODO handle case when queue->numQueuedItems >= queue->queueSize
 	queue->queuedOperations[queue->numQueuedItems++] = fetch;
+#ifdef FETCH_DEBUG
 	EM_ASM(console.log('Queued fetch to fetch-worker to process. There are now ' + $0 + ' operations in the queue.'),
 		queue->numQueuedItems);
+#endif
 	// TODO: mutex unlock
 }
 
@@ -67,8 +72,10 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 	const bool isMainBrowserThread = emscripten_is_main_browser_thread() != 0;
 	if (isMainBrowserThread && synchronous && (performXhr || readFromIndexedDB || writeToIndexedDB))
 	{
+#ifdef FETCH_DEBUG
 		EM_ASM(err('emscripten_fetch("' + Pointer_stringify($0) + '") failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.'), 
 			url);
+#endif
 		return 0;
 	}
 
@@ -162,23 +169,26 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeou
 	uint32_t proxyState = emscripten_atomic_load_u32(&fetch->__proxyState);
 	if (proxyState == 2) return EMSCRIPTEN_RESULT_SUCCESS; // already finished.
 	if (proxyState != 1) return EMSCRIPTEN_RESULT_INVALID_PARAM; // the fetch should be ongoing?
-// #ifdef FETCH_DEBUG
+#ifdef FETCH_DEBUG
 	EM_ASM(console.log('fetch: emscripten_fetch_wait..'));
-// #endif
+#endif
 	// TODO: timeoutMsecs is currently ignored. Return EMSCRIPTEN_RESULT_TIMED_OUT on timeout.
 	while(proxyState == 1/*sent to proxy worker*/)
 	{
 		emscripten_futex_wait(&fetch->__proxyState, proxyState, 100 /*TODO HACK:Sleep sometimes doesn't wake up?*/);//timeoutMsecs);
 		proxyState = emscripten_atomic_load_u32(&fetch->__proxyState);
 	}
-// #ifdef FETCH_DEBUG
+#ifdef FETCH_DEBUG
 	EM_ASM(console.log('fetch: emscripten_fetch_wait done..'));
-// #endif
+#endif
 
 	if (proxyState == 2) return EMSCRIPTEN_RESULT_SUCCESS;
 	else return EMSCRIPTEN_RESULT_FAILED;
 #else
+
+#ifdef FETCH_DEBUG
 	EM_ASM(console.error('fetch: emscripten_fetch_wait is not available when building without pthreads!'));
+#endif
 	return EMSCRIPTEN_RESULT_FAILED;
 #endif
 }


### PR DESCRIPTION
But keep them around for easier debugging. We don't currently have a machinery for doing debug and release versions of all libraries, so manage these manually for now.