### PR TITLE
Remove timing-sensitive part of browser.test_emscripten_main_loop_and_blocker

### DIFF
--- a/tests/emscripten_main_loop_and_blocker.cpp
+++ b/tests/emscripten_main_loop_and_blocker.cpp
@@ -26,15 +26,6 @@ void looper() {
   double timeSincePrevious = curTime - prevTime;
   prevTime = curTime;
   printf("frame: %d. dt: %g. absolute: %g\n", frame, timeSincePrevious, curTime);
-  if (frame > 1 && timeSincePrevious <= 14.5) // should be 16, but browser jitter
-  {
-    printf("Abort: main loop tick was called too quickly (%f ms > 16) after the previous frame!\n", timeSincePrevious);
-#ifdef REPORT_RESULT
-    REPORT_RESULT(1);
-#endif
-    emscripten_cancel_main_loop();
-    exit(0);
-  }
 
   if (frame == 20) {
     emscripten_cancel_main_loop();


### PR DESCRIPTION
There is just no good way to test that an event wasn't just a little too fast or too slow in web browsers.