### PR TITLE
Add rest of Intel includes to immintrin.h.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -324,3 +324,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nathan Froyd <froydnj@gmail.com> (copyright owned by Mozilla Foundation)
 * Daniel Wirtz <dcode@dcode.io>
 * Kibeom Kim <kk1674@nyu.edu>
+* Axel Forsman <axelsfor@gmail.com>

--- a/system/include/SSE/immintrin.h
+++ b/system/include/SSE/immintrin.h
@@ -1,8 +1,28 @@
 #ifndef __emscripten_immintrin_h__
 #define __emscripten_immintrin_h__
 
-// Include all the *mmintrin.h headers that Emscripten has.
+// Include all Intel specific intrinsics.
+
+#if __SSE__
 #include <xmmintrin.h>
+#else
+#warning immintrin.h included without SIMD.js support enabled.
+#endif
+
+#if __SSE2__
 #include <emmintrin.h>
+#endif
+
+#if __SSE3__
+#include <pmmintrin.h>
+#endif
+
+#if __SSSE3__
+#include <tmmintrin.h>
+#endif
+
+#if __SSE4_1__
+#include <smmintrin.h>
+#endif
 
 #endif


### PR DESCRIPTION
immintrin.h is supposed to include all headers for Intel extension intrinsics.
See the [immintrin.h](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/immintrin.h) in GCC for an example.
However, when new intrinsics headers were added
their respective include directives weren't added to immintrin.h.

The suggested changes are copied verbatim from x86intrin.h.