### PR TITLE
EM_JS implementation

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2006,11 +2006,11 @@ function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
 
 def create_em_js_wasm(forwarded_json, metadata):
   em_js_funcs = []
+  separator = '<::>'
   for name, raw in metadata['emJsFuncs'].iteritems():
-    parts = raw.split('<::>')
-    # TODO(jgravelle): support seeing the separator string in user code
-    assert len(parts) == 2
-    args, body = parts
+    parts = raw.split(separator)
+    assert len(parts) >= 2
+    args, body = parts[0], separator.join(parts[1:])
     args = args[1:-1].split(',')
     arg_names = [arg.split()[-1] for arg in args if arg]
     func = 'function {}({}){}'.format(name, ','.join(arg_names), body)

--- a/emscripten.py
+++ b/emscripten.py
@@ -2010,7 +2010,7 @@ function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
 def create_em_js(forwarded_json, metadata):
   em_js_funcs = []
   separator = '<::>'
-  for name, raw in metadata.get('emJsFuncs', {}).iteritems():
+  for name, raw in metadata.get('emJsFuncs', {}).items():
     parts = raw.split(separator)
     assert len(parts) >= 2
     args, body = parts[0], separator.join(parts[1:])

--- a/emscripten.py
+++ b/emscripten.py
@@ -698,8 +698,11 @@ function _emscripten_asm_const_%s(%s) {
   asm_consts_text = '\nvar ASM_CONSTS = [' + ',\n '.join(asm_consts) + '];\n'
   asm_funcs_text = '\n'.join(asm_const_funcs) + '\n'
 
+  em_js_funcs = create_em_js(forwarded_json, metadata)
+  em_js_text = '\n'.join(em_js_funcs) + '\n'
+
   body_marker = '// === Body ==='
-  return pre.replace(body_marker, body_marker + '\n' + asm_consts_text + asstr(asm_funcs_text))
+  return pre.replace(body_marker, body_marker + '\n' + asm_consts_text + asstr(asm_funcs_text) + em_js_text)
 
 # Test if the parentheses at body[openIdx] and body[closeIdx] are a match to each other.
 def parentheses_match(body, openIdx, closeIdx):
@@ -1772,7 +1775,7 @@ def emscript_wasm_backend(infile, settings, outfile, libraries=None, compiler_en
   exported_implemented_functions = create_exported_implemented_functions_wasm(pre, forwarded_json, metadata, settings)
 
   asm_consts, asm_const_funcs = create_asm_consts_wasm(forwarded_json, metadata)
-  em_js_funcs = create_em_js_wasm(forwarded_json, metadata)
+  em_js_funcs = create_em_js(forwarded_json, metadata)
   pre = pre.replace(
     '// === Body ===',
     ('// === Body ===\n\nvar ASM_CONSTS = [' +
@@ -2004,10 +2007,10 @@ function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
   return asm_consts, asm_const_funcs
 
 
-def create_em_js_wasm(forwarded_json, metadata):
+def create_em_js(forwarded_json, metadata):
   em_js_funcs = []
   separator = '<::>'
-  for name, raw in metadata['emJsFuncs'].iteritems():
+  for name, raw in metadata.get('emJsFuncs', {}).iteritems():
     parts = raw.split(separator)
     assert len(parts) >= 2
     args, body = parts[0], separator.join(parts[1:])

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -1,0 +1,21 @@
+#ifndef __em_js_h__
+#define __em_js_h__
+
+#ifdef __cplusplus
+#define _EM_JS_CPP_BEGIN extern "C" {
+#define _EM_JS_CPP_END   }
+#else // __cplusplus
+#define _EM_JS_CPP_BEGIN
+#define _EM_JS_CPP_END
+#endif // __cplusplus
+
+#define EM_JS(ret, name, params, code)           \
+  ret name params;                               \
+  _EM_JS_CPP_BEGIN                               \
+  __attribute__((used))                          \
+  const char* __em_js__##name() {                \
+    return #ret " " #name " " #params " " #code; \
+  }                                              \
+  _EM_JS_CPP_END
+
+#endif // __em_js_h__

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -9,13 +9,13 @@
 #define _EM_JS_CPP_END
 #endif // __cplusplus
 
-#define EM_JS(ret, name, params, ...)                   \
-  ret name params;                                      \
-  _EM_JS_CPP_BEGIN                                      \
-  __attribute__((used, visibility("default")))          \
-  const char* __em_js__##name() {                       \
-    return #ret " " #name " " #params " " #__VA_ARGS__; \
-  }                                                     \
+#define EM_JS(ret, name, params, ...)          \
+  _EM_JS_CPP_BEGIN                             \
+  ret name params;                             \
+  __attribute__((used, visibility("default"))) \
+  const char* __em_js__##name() {              \
+    return #params "<::>" #__VA_ARGS__;        \
+  }                                            \
   _EM_JS_CPP_END
 
 #endif // __em_js_h__

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -9,13 +9,13 @@
 #define _EM_JS_CPP_END
 #endif // __cplusplus
 
-#define EM_JS(ret, name, params, code)           \
-  ret name params;                               \
-  _EM_JS_CPP_BEGIN                               \
-  __attribute__((used))                          \
-  const char* __em_js__##name() {                \
-    return #ret " " #name " " #params " " #code; \
-  }                                              \
+#define EM_JS(ret, name, params, ...)                   \
+  ret name params;                                      \
+  _EM_JS_CPP_BEGIN                                      \
+  __attribute__((used, visibility("default")))          \
+  const char* __em_js__##name() {                       \
+    return #ret " " #name " " #params " " #__VA_ARGS__; \
+  }                                                     \
   _EM_JS_CPP_END
 
 #endif // __em_js_h__

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -15,6 +15,7 @@
  */
 
 #include "em_asm.h"
+#include "em_js.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -1,0 +1,57 @@
+#include <emscripten.h>
+#include <stdio.h>
+
+EM_JS(void, noarg, (), { Module['print']("no args works"); });
+EM_JS(int, noarg_int, (), {
+  Module['print']("no args returning int");
+  return 12;
+});
+EM_JS(double, noarg_double, (), {
+  Module['print']("no args returning double");
+  return 12.25;
+});
+EM_JS(void, intarg, (int x), { Module['print']("  takes ints: " + x);});
+EM_JS(void, doublearg, (double d), { Module['print']("  takes doubles: " + d);});
+EM_JS(double, stringarg, (char* str), {
+  Module['print']("  takes strings: " + Pointer_stringify(str));
+  return 7.75;
+});
+EM_JS(int, multi_intarg, (int x, int y), {
+  Module['print']("  takes multiple ints: " + x + ", " + y);
+  return 6;
+});
+EM_JS(double, multi_mixedarg, (int x, const char* str, double d), {
+  Module['print']("  mixed arg types: " + x + ", " + Pointer_stringify(str) + ", " + d);
+  return 8.125;
+});
+EM_JS(int, unused_args, (int unused), {
+  Module['print']("  ignores unused args");
+  return 5.5;
+});
+EM_JS(double, skip_args, (int x, int y), {
+  Module['print']("  skips unused args: " + y);
+  return 6;
+});
+EM_JS(double, add_outer, (double x, double y, double z), {
+  Module['print']("  " + x + " + " + z);
+  return x + z;
+});
+
+int main() {
+  printf("BEGIN\n");
+  noarg();
+  printf("    noarg_int returned: %d\n", noarg_int());
+  printf("    noarg_double returned: %f\n", noarg_double());
+
+  intarg(5);
+  doublearg(5.0675);
+  printf("    stringarg returned: %f\n", stringarg("string arg"));
+  printf("    multi_intarg returned: %d\n", multi_intarg(5, 7));
+  printf("    multi_mixedarg returned: %f\n", multi_mixedarg(3, "hello", 4.75));
+  printf("    unused_args returned: %d\n", unused_args(0));
+  printf("    skip_args returned: %f\n", skip_args(5, 7));
+  printf("    add_outer returned: %f\n", add_outer(5.5, 7.0, 14.375));
+
+  printf("END\n");
+  return 0;
+}

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -36,6 +36,10 @@ EM_JS(double, add_outer, (double x, double y, double z), {
   Module['print']("  " + x + " + " + z);
   return x + z;
 });
+EM_JS(int, user_separator, (), {
+  Module['print']("  can use <::> separator in user code");
+  return 15;
+});
 
 int main() {
   printf("BEGIN\n");
@@ -51,6 +55,7 @@ int main() {
   printf("    unused_args returned: %d\n", unused_args(0));
   printf("    skip_args returned: %f\n", skip_args(5, 7));
   printf("    add_outer returned: %f\n", add_outer(5.5, 7.0, 14.375));
+  printf("    user_separator returned: %d\n", user_separator());
 
   printf("END\n");
   return 0;

--- a/tests/core/test_em_js.out
+++ b/tests/core/test_em_js.out
@@ -18,4 +18,6 @@ no args returning double
     skip_args returned: 6.000000
   5.5 + 14.375
     add_outer returned: 19.875000
+  can use <::> separator in user code
+    user_separator returned: 15
 END

--- a/tests/core/test_em_js.out
+++ b/tests/core/test_em_js.out
@@ -1,0 +1,21 @@
+BEGIN
+no args works
+no args returning int
+    noarg_int returned: 12
+no args returning double
+    noarg_double returned: 12.250000
+  takes ints: 5
+  takes doubles: 5.0675
+  takes strings: string arg
+    stringarg returned: 7.750000
+  takes multiple ints: 5, 7
+    multi_intarg returned: 6
+  mixed arg types: 3, hello, 4.75
+    multi_mixedarg returned: 8.125000
+  ignores unused args
+    unused_args returned: 5
+  skips unused args: 7
+    skip_args returned: 6.000000
+  5.5 + 14.375
+    add_outer returned: 19.875000
+END

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1709,6 +1709,10 @@ int main(int argc, char **argv) {
     Building.COMPILER_TEST_OPTS += ['-std=c++11']
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_parameter_pack')
 
+  def test_em_js(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_js')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_js', force_c=True)
+
   def test_runtime_stacksave(self):
     src = open(path_from_root('tests', 'core', 'test_runtime_stacksave.c')).read()
     self.do_run(src, 'success')


### PR DESCRIPTION
Implements EM_JS (https://github.com/kripken/emscripten/issues/6147).
Only supports wasm backend at the moment, will need to plumb this through for asm2wasm before we can merge. I am not entirely sure how to do that. Ideally it would use the same binaryen tooling, because why not. However that's not where asm2wasm emits its metadata. We could put the metadata in a custom section on the wasm binary and read it in python, which would maybe be better for the wasm backend as well. Or we could emit metadata as a separate file.
However again, I pretty much completely forgot about asm.js without wasm, so maybe this needs logic in fastcomp anyway.

So unless I hear otherwise, I'm assuming we want support for this in asm.js, and that we should have that before landing this. Still, here's my proof-of-concept.