### PR TITLE
vr: Add missing void for parameters of emscripten_vr_deinit

### DIFF
--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -121,7 +121,7 @@ typedef struct VRFrameData {
 
 extern int emscripten_vr_ready(void);
 extern int emscripten_vr_init(em_vr_arg_callback_func callback, void* userData);
-extern int emscripten_vr_deinit();
+extern int emscripten_vr_deinit(void);
 
 extern int emscripten_vr_version_major(void);
 extern int emscripten_vr_version_minor(void);


### PR DESCRIPTION
Hi @juj !

As you requested in #5640 , here's the minor fix for the deinit parameters to comply to the C standard.

Cheers, Jonathan