### PR TITLE
Add harfbuzz

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -326,3 +326,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kibeom Kim <kk1674@nyu.edu>
 * Marcel Klammer <m.klammer@tastenkunst.com>
 * Axel Forsman <axelsfor@gmail.com>
+* Ebrahim Byagowi <ebrahim@gnu.org>

--- a/embuilder.py
+++ b/embuilder.py
@@ -243,6 +243,8 @@ if operation == 'build':
       build_port('sdl2-net', 'libsdl2_net.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
     elif what == 'freetype':
       build_port('freetype', 'libfreetype.a', ['-s', 'USE_FREETYPE=1'])
+    elif what == 'harfbuzz':
+      build_port('harfbuzz', 'libharfbuzz.a', ['-s', 'USE_HARFBUZZ=1'])
     elif what == 'sdl2-ttf':
       build_port('sdl2-ttf', 'libsdl2_ttf.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_TTF=2', '-s', 'USE_FREETYPE=1'])
     elif what == 'binaryen':

--- a/src/settings.js
+++ b/src/settings.js
@@ -749,6 +749,7 @@ var USE_BULLET = 0; // 1 = use bullet from emscripten-ports
 var USE_VORBIS = 0; // 1 = use vorbis from emscripten-ports
 var USE_OGG = 0; // 1 = use ogg from emscripten-ports
 var USE_FREETYPE = 0; // 1 = use freetype from emscripten-ports
+var USE_HARFBUZZ = 0; // 1 = use harfbuzz from harfbuzz upstream
 var USE_COCOS2D = 0; // 3 = use cocos2d v3 from emscripten-ports
 
 var SDL2_IMAGE_FORMATS = []; // Formats to support in SDL2_image. Valid values: bmp, gif, lbm, pcx, png, pnm, tga, xcf, xpm, xv

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -726,6 +726,7 @@ fi
       ([PYTHON, 'embuilder.py', 'build', 'sdl2'], ['success'], True, [os.path.join('ports-builds', 'sdl2', 'libsdl2.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-image'], ['success'], True, [os.path.join('ports-builds', 'sdl2-image', 'libsdl2_image.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'freetype'], ['building and verifying freetype', 'success'], True, [os.path.join('ports-builds', 'freetype', 'libfreetype.a')]),
+      ([PYTHON, 'embuilder.py', 'build', 'harfbuzz'], ['building and verifying harfbuzz', 'success'], True, [os.path.join('ports-builds', 'harfbuzz', 'libharfbuzz.a')]),
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-ttf'], ['building and verifying sdl2-ttf', 'success'], True, [os.path.join('ports-builds', 'sdl2-ttf', 'libsdl2_ttf.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'sdl2-net'], ['building and verifying sdl2-net', 'success'], True, [os.path.join('ports-builds', 'sdl2-net', 'libsdl2_net.bc')]),
       ([PYTHON, 'embuilder.py', 'build', 'binaryen'], ['building and verifying binaryen', 'success'], True, []),

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -1,7 +1,7 @@
-from . import binaryen, bullet, cocos2d, freetype, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
+from . import binaryen, bullet, cocos2d, freetype, harfbuzz, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
-ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, sdl_ttf, sdl_net, binaryen, cocos2d]
+ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, harfbuzz, sdl_ttf, sdl_net, binaryen, cocos2d]
 
 ports_by_name = {}
 for port in ports:

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -1,0 +1,42 @@
+import os, logging
+
+TAG = '1.7.5'
+
+def get(ports, settings, shared):
+  if settings.USE_HARFBUZZ == 1:
+    ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
+      TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, is_tarbz2=True)
+    def create():
+      logging.info('building port: harfbuzz')
+      ports.clear_project_build('harfbuzz')
+
+      source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + TAG)
+      dest_path = os.path.join(ports.get_build_dir(), 'harfbuzz')
+
+      freetype_dir = os.path.join(ports.get_build_dir(), 'freetype')
+      freetype_lib = os.path.join(freetype_dir, 'libfreetype.a')
+      freetype_include = os.path.join(freetype_dir, 'include')
+      freetype_include_dirs = freetype_include + ';' + os.path.join(freetype_include, 'config')
+
+      shared.Building.configure(['cmake', '-H' + source_path, '-B' + dest_path,
+        '-DHB_HAVE_FREETYPE=ON', '-DFREETYPE_LIBRARY=' + freetype_lib,
+        '-DFREETYPE_INCLUDE_DIRS=' + freetype_include_dirs,
+        '-DCMAKE_BUILD_TYPE=Release'])
+      shared.Building.make(['make', '-C' + dest_path])
+      return os.path.join(dest_path, 'libharfbuzz.a')
+    return [shared.Cache.get('harfbuzz', create, what='port')]
+  else:
+    return []
+
+def process_dependencies(settings):
+  if settings.USE_HARFBUZZ == 1:
+    settings.USE_FREETYPE = 1
+
+def process_args(ports, args, settings, shared):
+  if settings.USE_HARFBUZZ == 1:
+    get(ports, settings, shared)
+    args += ['-Xclang', '-isystem' + os.path.join(ports.get_build_dir(), 'harfbuzz')]
+  return args
+
+def show():
+  return 'harfbuzz (USE_HARFBUZZ=1; MIT license)'


### PR DESCRIPTION
Honestly I can not run this right now but lets see where we can go from this :)

Maybe unlike other projects, as a maintainer on harfbuzz I like to offer in-tree support for emscripten instead hard forking harfbuzz on emscripten-ports, we have already a CI bot just to compile harfbuzz against emscripten, if we couldn't go this way however, I already am granted access to https://github.com/emscripten-ports/HarfBuzz and can use it for patches (or release files) can not put on upstream.

And hopefully to close #4754