### PR TITLE
Adds some functionality to 'val'.

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -132,6 +132,13 @@ var LibraryEmVal = {
     return __emval_register(v);
   },
 
+  _emval_new_spread__deps: ['_emval_register', '$requireHandle'],
+  _emval_new_spread: function(constructor, args) {
+    constructor = requireHandle(constructor);
+    args = requireHandle(args);
+    return __emval_register(new constructor(...args));
+  },
+
   $emval_newers: {}, // arity -> function
   $craftEmvalAllocator__deps: ['_emval_register', '$requireRegisteredType'],
   $craftEmvalAllocator: function(argCount) {
@@ -412,6 +419,21 @@ var LibraryEmVal = {
     handle = requireHandle(handle);
     return __emval_register(typeof handle);
   },
+
+  _emval_instanceof__deps: ['_emval_register', '$requireHandle'],
+  _emval_instanceof: function(object, constructor) {
+    object = requireHandle(object);
+    constructor = requireHandle(constructor);
+    return __emval_register(object instanceof constructor);
+  },
+
+  _emval_operator_cmp_e__deps: ['_emval_register', '$requireHandle'],
+  _emval_operator_cmp_e: function(object1, object2) {
+    object1 = requireHandle(object1);
+    object2 = requireHandle(object2);
+    return __emval_register(object1 == object2);
+  },
+
 };
 
 mergeInto(LibraryManager.library, LibraryEmVal);


### PR DESCRIPTION
### Adds 'instanceof' method to 'val'.
Something like this will now work.
```
#include <stdio.h>
#include <iostream>
#include <emscripten/bind.h>
#include <emscripten/val.h>

using namespace emscripten;

int main()
{
  val array_class = val::global("Array");
  val array = array_class.new_();
  val object_class = val::global("Object");
  val object = object_class.new_();
  
  printf("%d", array.instanceof(array_class).as<bool>()); // prints '1'
  printf("%d", object.instanceof(array_class).as<bool>()); // prints '0'
  return 0;
}
```
### Adds equality comparison operator to 'emscripten::val'.
Just adds `==` operator.
### Adds inequality comparison operator to 'emscripten::val'.
Just adds `!=` operator.
### Overloads val::new_ giving the option to supply a vector as arguments.
Can now pass vector or any type when building array.
Example:
```
#include <stdio.h>
#include <iostream>
#include <emscripten/bind.h>
#include <emscripten/val.h>

using namespace emscripten;
using namespace std;

int main()
{
  vector<int> vec;
  vec.push_back(11);
  vec.push_back(22);
  vec.push_back(33);
  val array = val::array(vec);
  val::global().set("tt", array);
  printf("done\n");
  return 0;
}
```
In the browser console, `window.tt`  should be `[11, 22, 33]`
And you can pass a vector to `new_` to call the constructor with a dynamic set of arguments at runtime.
Uses js spread so it will require _ES6_. It could probaly work with the existing implementation for `new_` to avoid this limitation but I could not figure out how it worked.