### PR TITLE
Autodebugger: detect any declare/define of printf

### DIFF
--- a/tools/autodebugger.py
+++ b/tools/autodebugger.py
@@ -118,7 +118,7 @@ f = open(filename, 'r')
 data = f.read()
 f.close()
 
-if 'declare i32 @printf(' not in data and 'define internal i32 @printf(' not in data:
+if not re.search('(declare.*@printf\(|define.*@printf\()', data):
   POSTAMBLE += '''
 ; [#uses=1]
 declare i32 @printf(i8*, ...)


### PR DESCRIPTION
Wasm backend went from `define internal i32 @printf` to `define hidden i32 @printf`, this uses regex to support both in autodebugger.py.