### PR TITLE
Multithreading 33/N: WebGL proxying preliminaries

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8250,7 +8250,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0, 0), # noqa; totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1489, ['invoke_v'],               ['waka'],                 226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+              1493, ['invoke_v'],               ['waka'],                 226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
     ]) # noqa
 
     print('test on a minimal pure computational thing')


### PR DESCRIPTION
WebGL fixes and cleanup. Add some missing signatures, aliases, handle copying of `__proxy` attributes, and don't trip up on makeContextCurrent/deleteContext(null).