### PR TITLE
Update binaryen to version_44

### DIFF
--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_42'
+TAG = 'version_44'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
This brings a determinism fix for `binaryen*.test_iostream_and_determinism`. With that fix I don't see any failures after running the test repeatedly overnight.