### PR TITLE
fix_mem_init_file_with_wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1222,9 +1222,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           shared.Settings.BINARYEN_PASSES += 'safe-heap'
         # we will include the mem init data in the wasm, when we don't need the
         # mem init file to be loadable by itself
-        shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                           'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
-                                           not shared.Settings.USE_PTHREADS
+        if shared.Settings.MEM_INIT_IN_WASM == -1:
+          shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
+                                             'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
+                                             not shared.Settings.USE_PTHREADS
 
       # wasm outputs are only possible with a side wasm
       if target.endswith(WASM_ENDINGS):
@@ -1720,7 +1721,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if DEBUG:
             # Copy into temp dir as well, so can be run there too
             shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-          if not shared.Settings.BINARYEN or 'asmjs' in shared.Settings.BINARYEN_METHOD or 'interpret-asm2wasm' in shared.Settings.BINARYEN_METHOD:
+          if not shared.Settings.BINARYEN or 'asmjs' in shared.Settings.BINARYEN_METHOD or 'interpret-asm2wasm' in shared.Settings.BINARYEN_METHOD or (shared.Settings.BINARYEN and not shared.Settings.MEM_INIT_IN_WASM):
             return 'memoryInitializer = "%s";' % shared.JS.get_subresource_location(memfile, embed_memfile(options))
           else:
             return ''

--- a/src/settings.js
+++ b/src/settings.js
@@ -881,7 +881,10 @@ var WASM_BINARY_FILE = ''; // name of the file containing wasm binary, if releva
 var ASMJS_CODE_FILE = ''; // name of the file containing asm.js, if relevant
 var SOURCE_MAP_BASE = ''; // Base URL the source mapfile, if relevant
 
-var MEM_INIT_IN_WASM = 0; // for internal use only
+var MEM_INIT_IN_WASM = -1; // Choose whether to embed the global data section inside the .wasm file.
+                           // -1: Choose automatically depending on other build settings such as threading, and if dual-deploying asm.js and wasm (default),
+                           //  0: Explicitly choose to generate a .mem file,
+                           //  1: Explicitly choose to embed global data section in the .wasm file
 
 var SUPPORT_BASE64_EMBEDDING = 0; // If set to 1, src/base64Utils.js will be included in the bundle.
                                   // This is set internally when needed (SINGLE_FILE)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3468,6 +3468,16 @@ window.close = function() {
   def test_pthread_clock_drift(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_clock_drift.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  # Tests that when using a .mem memory initializer file with .wasm, that it will get applied before main() is run
+  def test_mem_init_file_with_wasm(self):
+    for args in [
+      ['-s', 'USE_PTHREADS=1'],
+      ['--memory-init-file', '1', '-s', 'MEM_INIT_IN_WASM=0'],
+#      ['--memory-init-file', '1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'] # XXX TODO Enable when PR #6189 lands
+    ]:
+      print(str(args))
+      self.btest(path_from_root('tests', 'test_mem_init_file_with_wasm.c'), expected='1', args=args + ['-s', 'WASM=1'])
+
   # test atomicrmw i64
   def test_atomicrmw_i64(self):
     Popen([PYTHON, EMCC, path_from_root('tests', 'atomicrmw_i64.ll'), '-s', 'USE_PTHREADS=1', '-s', 'IN_TEST_HARNESS=1', '-o', 'test.html']).communicate()

--- a/tests/test_mem_init_file_with_wasm.c
+++ b/tests/test_mem_init_file_with_wasm.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <emscripten.h>
+
+int global_data = 123;
+int main() {
+	int success = (global_data == 123) && MAIN_THREAD_EM_ASM_INT(return memoryInitializer.indexOf('.mem')) != -1;
+	if (success) puts("success"); // This depends on global FILE* stdout being initialized to non-null, otherwise will crash in musl __overflow() function.
+	else puts("fail");
+#ifdef REPORT_RESULT
+	REPORT_RESULT(success);
+#endif
+}


### PR DESCRIPTION
Fix regression where memory initializer file would not be applied when building to wasm with multithreading enabled.

It looks like at some point `incoming` has regressed to no longer apply global data initializer when building with `-s USE_PTHREADS=1` and `-s WASM=1` together.

The current code always embeds memory initializer into .wasm (`MEM_INIT_IN_WASM` was hardcoded to always take True value). The PR also adds support for one to explicitly build with `-s MEM_INIT_IN_WASM=0` to disable embedding initializer into .wasm and instead opt to keep using .mem file. This is useful for debugging purposes when e.g. cross-referencing against multithreading enabled vs disabled.