### PR TITLE
Use EMCONFIGURE_JS=2 by default, thanks to NODERAWFS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -417,7 +417,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # 0 - use native compilation for configure checks
     # 1 - use js when we think it will work
     # 2 - always use js for configure checks
-    use_js = int(os.environ.get('EMCONFIGURE_JS') or 1)
+    use_js = int(os.environ.get('EMCONFIGURE_JS') or 2)
 
     if debug_configure:
       tempout = '/tmp/emscripten_temp/out'
@@ -474,6 +474,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if use_js:
       cmd += ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1'] # configure tests should fail when an undefined symbol exists
       cmd += ['-s', 'NO_EXIT_RUNTIME=0'] # configure tests want a more shell-like style, where we emit return codes on exit()
+      cmd += ['-s', 'NODERAWFS=1'] # use node.js raw filesystem access, to behave just like a native executable
 
     logging.debug('just configuring: ' + ' '.join(cmd))
     if debug_configure: open(tempout, 'a').write('emcc, just configuring: ' + ' '.join(cmd) + '\n\n')


### PR DESCRIPTION
This makes configure/cmake configuration checks build to JS and use NODERAWFS so that they look like normal native executables, including file I/O. This is much better than the other two modes, to either build to native executables but use the emscripten headers to try to make checks work (mode 0) or build to JS except when using things like file I/O (mode 1).

I'm actually surprised all the tests pass, I was expecting to have more to do here...