### PR TITLE
fix error message about malformed js library

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -173,8 +173,9 @@ var LibraryManager = {
     for (var i = 0; i < libraries.length; i++) {
       var filename = libraries[i];
       var src = read(filename);
+      var processed = undefined;
       try {
-        var processed = processMacros(preprocess(src, filename));
+        processed = processMacros(preprocess(src, filename));
         eval(processed);
       } catch(e) {
         var details = [e, e.lineNumber ? 'line number: ' + e.lineNumber : '', (e.stack || "").toString().replace('Object.<anonymous>', filename)];


### PR DESCRIPTION
Without this fix, preprocessed source of the previous js library is printed.