### PR TITLE
fix: check top _wrapNodeError instead of anything lower

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4677,7 +4677,7 @@ def process(filename):
         );
         return 0;
       }
-    ''', 'at Object.write', js_engines=js_engines, post_build=post) # engines has different error stack format
+    ''', 'at Object._wrapNodeError', js_engines=js_engines, post_build=post) # engines has different error stack format
 
   @also_with_noderawfs
   def test_fs_llseek(self, js_engines=None):


### PR DESCRIPTION
Fixes #6262.

This test at first checked `new ErrnoError` but then changed to check `Object.write`. Both can be called by `_wrapNodeError` depending on the existence of `e.code`. It seems Node.js 8 somehow lacks it, and Node.js 9.5+ returns it.

Checking `_wrapNodeError` ensures the stack is successfully assigned in any case.