### PR TITLE
Implement `-dumpversion` compiler argument

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -327,3 +327,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Marcel Klammer <m.klammer@tastenkunst.com>
 * Axel Forsman <axelsfor@gmail.com>
 * Ebrahim Byagowi <ebrahim@gnu.org>
+* Thorsten Möller <thorsten.moeller@sbi.ch>

--- a/emcc.py
+++ b/emcc.py
@@ -380,7 +380,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     print(shared.get_llvm_target())
     exit(0)
   
-  elif '-dumpversion' in sys.argv: # gcc's doc states "Print the compiler version [...] and don’t do anything else."
+  elif '-dumpversion' in sys.argv: # gcc's doc states "Print the compiler version [...] and don't do anything else."
     print(shared.EMSCRIPTEN_VERSION)
     exit(0)
 

--- a/emcc.py
+++ b/emcc.py
@@ -379,6 +379,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   elif '-dumpmachine' in sys.argv:
     print(shared.get_llvm_target())
     exit(0)
+  
+  elif '-dumpversion' in sys.argv: # gcc's doc states "Print the compiler version [...] and don’t do anything else."
+    print(shared.EMSCRIPTEN_VERSION)
+    exit(0)
 
   elif '--cflags' in sys.argv:
     # fake running the command, to see the full args we pass to clang

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -101,6 +101,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # -dumpmachine
       output = run_process([PYTHON, compiler, '-dumpmachine'], stdout=PIPE, stderr=PIPE)
       self.assertContained(get_llvm_target(), output.stdout)
+      
+      # -dumpversion
+      output = run_process([PYTHON, compiler, '-dumpversion'], stdout=PIPE, stderr=PIPE)
+      self.assertEqual(EMSCRIPTEN_VERSION, output.stdout, 'results should be identical')
 
       # emcc src.cpp ==> writes a.out.js
       self.clear()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -104,7 +104,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       
       # -dumpversion
       output = run_process([PYTHON, compiler, '-dumpversion'], stdout=PIPE, stderr=PIPE)
-      self.assertEqual(EMSCRIPTEN_VERSION, output.stdout, 'results should be identical')
+      self.assertEqual(EMSCRIPTEN_VERSION + os.linesep, output.stdout, 'results should be identical')
 
       # emcc src.cpp ==> writes a.out.js
       self.clear()


### PR DESCRIPTION
#6258 

Implement `-dumpversion` compiler argument.

As the changes that come with this pull request are rather simple, they haven't been tested, to be honest. Cross-check please.