### PR TITLE
fix: test_fs_errorstack was using incorrect signature

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4669,7 +4669,7 @@ def process(filename):
         std::cout << "hello world\n"; // should work with strict mode
         EM_ASM(
           try {
-            FS.write('/dummy.txt', 'homu');
+            FS.readFile('/dummy.txt');
           } catch (err) {
             err.stack = err.stack; // should be writable
             throw err;
@@ -4677,7 +4677,7 @@ def process(filename):
         );
         return 0;
       }
-    ''', 'at Object.write', js_engines=js_engines, post_build=post) # engines has different error stack format
+    ''', 'at Object.readFile', js_engines=js_engines, post_build=post) # engines has different error stack format
 
   @also_with_noderawfs
   def test_fs_llseek(self, js_engines=None):


### PR DESCRIPTION
Fixes #6262.

`FS.write` is an advanced internal function that receives a file descriptor and `Int8Array`, but this test passed strings. Here, NODERAWFS tried to get `ArrayBuffer` from the second argument by `Buffer.from` and failed with a non-filesystem error. The error object was general JavaScript `TypeError` on Node.js 8, whereas it was `NodeError` with `code` property on Node.js 9, which caused #6262.