### PR TITLE
Temp files fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
       environment:
         LANG: C.UTF-8
         EMSCRIPTEN_ALLOW_NEWER_PYTHON: 1
+        EM_TESTRUNNER_DETECT_TEMPFILE_LEAKS: 1
   working_directory: ~/
 
 test-defaults: &test-defaults

--- a/emcc.py
+++ b/emcc.py
@@ -271,7 +271,7 @@ class JSOptimizer(object):
     final = shared.Building.js_optimizer(final, passes, self.debug_level >= 4,
                                          self.extra_info, just_split=just_split,
                                          just_concat=just_concat,
-                                         output_filename=self.in_temp('jsopted.js'))
+                                         output_filename=self.in_temp(os.path.basename(final) + '.jsopted.js'))
     self.js_transform_tempfiles.append(final)
     if DEBUG: save_intermediate(title, suffix='js' if 'emitJSON' not in passes else 'json')
 

--- a/emcc.py
+++ b/emcc.py
@@ -1867,8 +1867,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         separate_asm_js(final, asm_target)
         generated_text_files_with_native_eols += [asm_target]
 
-      binaryen_method_sanity_check()
       if shared.Settings.BINARYEN:
+        binaryen_method_sanity_check()
         do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                     wasm_text_target, misc_temp_files, optimizer)
 
@@ -2173,7 +2173,7 @@ def parse_args(newargs):
 
 def emterpretify(js_target, optimizer, options):
   global final
-  optimizer.flush()
+  optimizer.flush('pre-emterpretify')
   logging.debug('emterpretifying')
   import json
   try:
@@ -2217,7 +2217,7 @@ def emterpretify(js_target, optimizer, options):
   if not shared.Settings.BINARYEN:
     optimizer.do_minify()
   optimizer.queue += ['last']
-  optimizer.flush()
+  optimizer.flush('finalizing-emterpreted-code')
 
   # finalize the original as well, if we will be swapping it in (TODO: add specific option for this)
   if shared.Settings.SWAPPABLE_ASM_MODULE:
@@ -2228,7 +2228,7 @@ def emterpretify(js_target, optimizer, options):
     if not shared.Settings.BINARYEN:
       optimizer.do_minify()
     optimizer.queue += ['last']
-    optimizer.flush()
+    optimizer.flush('finalizing-original-code')
     safe_copy(final, original)
     final = real
 

--- a/emcc.py
+++ b/emcc.py
@@ -1844,6 +1844,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # no need to add this to js_transform_tempfiles, because closure and
         # debug_level > 0 are never simultaneously true
         final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
+        misc_temp_files.note(final)
         if DEBUG: save_intermediate('closure')
 
     log_time('js opts')

--- a/emcc.py
+++ b/emcc.py
@@ -1140,6 +1140,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # When only targeting wasm, the .asm.js file is not executable, so is treated as an intermediate build file that can be cleaned up.
         if shared.Building.is_wasm_only():
           asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
+          misc_temp_files.note(asm_target)
 
       if shared.Settings.TOTAL_MEMORY < 16*1024*1024:
         exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))

--- a/emcc.py
+++ b/emcc.py
@@ -562,6 +562,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   else:
     final_suffix = ''
 
+  # Temporary file handling: we ensure that TEMP_DIR exists, which is the general
+  # location for all temp files from us on this system. We then create a temp dir
+  # under that, and store our main files there. As we process the main js file,
+  # we update the variable `final`, giving it an extra suffix each time, and
+  # relying on the entire dir going away for cleanup. For other miscellaneous
+  # temporary files (like in the js optimizer) we need to note() them so they
+  # get removed.
+
   temp_root = shared.TEMP_DIR
   if not os.path.exists(temp_root):
     os.makedirs(temp_root)

--- a/emcc.py
+++ b/emcc.py
@@ -2442,6 +2442,7 @@ def modularize():
   logging.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
   src = open(final).read()
   final = final + '.modular.js'
+  shared.configuration.get_temp_files().note(final)
   f = open(final, 'w')
   # Included code may refer to Module (e.g. from file packager), so alias it
   # Export the function as Node module, otherwise it is lost when loaded in Node.js or similar environments

--- a/emcc.py
+++ b/emcc.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 import os, sys, shutil, tempfile, subprocess, shlex, time, re, logging
 from subprocess import PIPE
 from tools import shared, jsrun, system_libs
-from tools.shared import execute, suffix, unsuffixed, unsuffixed_basename, WINDOWS, safe_move, run_process, asbytes
+from tools.shared import execute, suffix, unsuffixed, unsuffixed_basename, WINDOWS, safe_copy, safe_move, run_process, asbytes
 from tools.response_file import substitute_response_files
 import tools.line_endings
 
@@ -1841,11 +1841,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # no need to add this to js_transform_tempfiles, because closure and
         # debug_level > 0 are never simultaneously true
         final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
-        print(temp_dir, final)
         if DEBUG: save_intermediate('closure')
 
     log_time('js opts')
-    # exit block 'js opts'
 
     with ToolchainProfiler.profile_block('final emitting'):
       if shared.Settings.EMTERPRETIFY:
@@ -1858,14 +1856,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Bundle symbol data in with the cyberdwarf file
       if shared.Settings.CYBERDWARF:
-          execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
+        execute([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target+'.symbols'])
 
       if options.debug_level >= 4 and not shared.Settings.BINARYEN:
         emit_js_source_maps(target, optimizer.js_transform_tempfiles)
 
       # track files that will need native eols
       generated_text_files_with_native_eols = []
-
       if (options.separate_asm or shared.Settings.BINARYEN) and not shared.Settings.WASM_BACKEND:
         separate_asm_js(final, asm_target)
         generated_text_files_with_native_eols += [asm_target]
@@ -2232,7 +2229,7 @@ def emterpretify(js_target, optimizer, options):
       optimizer.do_minify()
     optimizer.queue += ['last']
     optimizer.flush()
-    safe_move(final, original)
+    safe_copy(final, original)
     final = real
 
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -232,7 +232,12 @@ class RunnerCore(unittest.TestCase):
           for dirname in dirnames: temp_files_after_run.append(os.path.normpath(os.path.join(root, dirname)))
           for filename in filenames: temp_files_after_run.append(os.path.normpath(os.path.join(root, filename)))
 
-        left_over_files = list(set(temp_files_after_run) - set(self.temp_files_before_run))
+        # Our leak detection will pick up *any* new temp files in the temp dir. They may not be due to
+        # us, but e.g. the browser when running browser tests. Until we figure out a proper solution,
+        # ignore some temp file names that we see on our CI infrastructure.
+        ignorable_files = ['/tmp/tmpaddon']
+
+        left_over_files = list(set(temp_files_after_run) - set(self.temp_files_before_run) - set(ignorable_files))
         if len(left_over_files) > 0:
           print('ERROR: After running test, there are ' + str(len(left_over_files)) + ' new temporary files/directories left behind:', file=sys.stderr)
           for f in left_over_files:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5843,42 +5843,6 @@ def process(filename):
 
     do_test()
 
-    # some test coverage for EMCC_DEBUG 1 and 2
-    assert 'asm2g' in test_modes
-    if self.run_name == 'asm2g':
-      shutil.copyfile('src.c.o.js', 'release.js')
-      try:
-        os.environ['EMCC_DEBUG'] = '1'
-        print('2')
-        do_test()
-        shutil.copyfile('src.c.o.js', 'debug1.js')
-        os.environ['EMCC_DEBUG'] = '2'
-        print('3')
-        do_test()
-        shutil.copyfile('src.c.o.js', 'debug2.js')
-      finally:
-        del os.environ['EMCC_DEBUG']
-      for debug in [1,2]:
-        def clean(text):
-          text = text.replace('\n\n', '\n').replace('\n\n', '\n').replace('\n\n', '\n').replace('\n\n', '\n').replace('\n\n', '\n').replace('{\n}', '{}')
-          return '\n'.join(sorted(text.split('\n')))
-        sizes = len(open('release.js').read()), len(open('debug%d.js' % debug).read())
-        print(debug, 'sizes', sizes, file=sys.stderr)
-        assert abs(sizes[0] - sizes[1]) < 0.001*sizes[0], sizes # we can't check on identical output, compilation is not 100% deterministic (order of switch elements, etc.), but size should be ~identical
-        print('debug check %d passed too' % debug, file=sys.stderr)
-
-      try:
-        os.environ['EMCC_FORCE_STDLIBS'] = '1'
-        print('EMCC_FORCE_STDLIBS')
-        do_test()
-      finally:
-        del os.environ['EMCC_FORCE_STDLIBS']
-      print('EMCC_FORCE_STDLIBS ok', file=sys.stderr)
-
-      try_delete(CANONICAL_TEMP_DIR)
-    else:
-      print('not doing debug check', file=sys.stderr)
-
     if Settings.ALLOW_MEMORY_GROWTH == 1: # extra testing
       print('no memory growth', file=sys.stderr)
       Settings.ALLOW_MEMORY_GROWTH = 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6934,22 +6934,6 @@ Module.printErr = Module['printErr'] = function(){};
 
     build_and_check()
 
-    assert 'asm2g' in test_modes
-    if self.run_name == 'asm2g':
-      # EMCC_DEBUG=2 causes lots of intermediate files to be written, and so
-      # serves as a stress test for source maps because it needs to correlate
-      # line numbers across all those files.
-      old_emcc_debug = os.environ.get('EMCC_DEBUG', None)
-      os.environ.pop('EMCC_DEBUG', None)
-      try:
-        os.environ['EMCC_DEBUG'] = '2'
-        build_and_check()
-      finally:
-        if old_emcc_debug is not None:
-          os.environ['EMCC_DEBUG'] = old_emcc_debug
-        else:
-          os.environ.pop('EMCC_DEBUG', None)
-
   def test_modularize_closure_pre(self):
     emcc_args = self.emcc_args[:]
     for instance in [0, 1]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7523,7 +7523,7 @@ int main() {
         self.assertNotContained(warning, err)
 
   def test_binaryen_invalid_method(self):
-    proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', "BINARYEN_METHOD='invalid'"])
+    proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='invalid'"])
     proc.communicate()
     assert proc.returncode != 0
 

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -49,7 +49,7 @@ def run_on_chunk(command):
     output = proc.stdout
     assert proc.returncode == 0, 'Error in optimizer (return code ' + str(proc.returncode) + '): ' + output
     assert len(output) > 0 and not output.startswith('Assertion failed'), 'Error in optimizer: ' + output
-    filename = temp_files.get(os.path.basename(filename) + '.jo' + file_suffix).name
+    filename = temp_files.get(os.path.basename(filename) + '.dfjo' + file_suffix).name
 
     f = open(filename, 'w')
     f.write(output)

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -262,6 +262,10 @@ def run_on_js(filename, gen_hash_info=False):
   else:
     filenames = []
 
+  # we create temp files in the child threads, clean them up here when we are done
+  for filename in filenames:
+    temp_files.note(filename)
+
   json_files = []
 
   # We're going to be coalescing the files back at the end

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2089,6 +2089,7 @@ class Building(object):
       filename = temp
     if not return_output:
       next = original_filename + '.jso.js'
+      configuration.get_temp_files().note(next)
       subprocess.check_call(NODE_JS + [js_optimizer.JS_OPTIMIZER, filename] + passes, stdout=open(next, 'w'))
       return next
     else:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2211,19 +2211,16 @@ class Building(object):
   # and wasm optimizations; here we do the very final optimizations on them
   @staticmethod
   def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespace, use_closure_compiler, debug_info, emit_symbol_map):
-    temp_files = configuration.get_temp_files()
     # start with JSDCE, to clean up obvious JS garbage. When optimizing for size,
     # use AJSDCE (aggressive JS DCE, performs multiple iterations)
     passes = ['noPrintMetadata', 'JSDCE' if not expensive_optimizations else 'AJSDCE']
     if minify_whitespace:
       passes.append('minifyWhitespace')
     logging.debug('running cleanup on shell code: ' + ' '.join(passes))
-    temp_files.note(js_file)
     js_file = Building.js_optimizer_no_asmjs(js_file, passes)
     # if we are optimizing for size, shrink the combined wasm+JS
     # TODO: support this when a symbol map is used
     if expensive_optimizations and not emit_symbol_map:
-      temp_files.note(js_file)
       js_file = Building.metadce(js_file, wasm_file, minify_whitespace=minify_whitespace, debug_info=debug_info)
       # now that we removed unneeded communication between js and wasm, we can clean up
       # the js some more.
@@ -2231,12 +2228,10 @@ class Building(object):
       if minify_whitespace:
         passes.append('minifyWhitespace')
       logging.debug('running post-meta-DCE cleanup on shell code: ' + ' '.join(passes))
-      temp_files.note(js_file)
       js_file = Building.js_optimizer_no_asmjs(js_file, passes)
     # finally, optionally use closure compiler to finish cleaning up the JS
     if use_closure_compiler:
       logging.debug('running closure on shell code')
-      temp_files.note(js_file)
       js_file = Building.closure_compiler(js_file, pretty=not minify_whitespace)
     return js_file
 
@@ -2283,7 +2278,6 @@ class Building(object):
     if minify_whitespace:
       passes.append('minifyWhitespace')
     extra_info = { 'unused': unused }
-    temp_files.note(js_file)
     return Building.js_optimizer_no_asmjs(js_file, passes, extra_info=json.dumps(extra_info))
 
   # the exports the user requested


### PR DESCRIPTION
The [buildbot page](http://ec2-54-213-252-128.us-west-2.compute.amazonaws.com:8112/#/) enables checking for leaking of temp files, and has had many errors. This PR will hopefully clean that up and prevent future issues. It does the following:

 * Enable leak tests on circleCI here on github, so we notice these problems better.
 * Document the temp file approach in emcc.py, which is to create a temp dir during startup and keep the main JS file there as we progressively process it. Other side temp files must be `note()`ed so that they are cleaned up.
 * Apply that logic more consistently.
 * Fix a bunch of temp file leaks in various places.
 * Remove some excessive  `EMCC_DEBUG=2` tests, which is a mode that saves extra temp files for each js optimization pass. This matters less and less with wasm (I can't remember the last time I used it, and I doubt anyone else does) and it's slow anyhow.