### PR TITLE
Add -fno-builtin to dlmalloc / math library build

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -132,7 +132,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
               break
           if not cancel:
             libc_files.append(os.path.join(musl_srcdir, dirpath, f))
-    args = ['-Os']
+    args = ['-Os', '-fno-builtin']
     if shared.Settings.USE_PTHREADS:
       args += ['-s', 'USE_PTHREADS=1']
       assert '-mt' in libname
@@ -340,7 +340,9 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
         '-mthread-model', 'single',
         output_flag,
         shared.path_from_root('system', 'lib', src),
-        '-O2', '-o', o] + musl_internal_includes() + shared.EMSDK_OPTS)
+        '-O2', '-fno-builtin', '-o', o] +
+        musl_internal_includes() +
+        shared.EMSDK_OPTS)
       o_s.append(o)
     run_commands(commands)
     lib = in_temp(libname)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -196,7 +196,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'atan2.c', 'atan2f.c', 'atan2l.c', 'exp.c', 'expf.c', 'expl.c',
                  'log.c', 'logf.c', 'logl.c', 'pow.c', 'powf.c', 'powl.c'])
 
-    return build_libc(libname, files, ['-O2'])
+    return build_libc(libname, files, ['-O2', '-fno-builtin'])
 
   # libcxx
   def create_libcxx(libname):
@@ -307,7 +307,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   def create_dlmalloc(out_name):
     o = in_temp(out_name)
-    cflags = ['-O2']
+    cflags = ['-O2', '-fno-builtin']
     if shared.Settings.USE_PTHREADS:
       cflags += ['-s', 'USE_PTHREADS=1']
     if shared.Settings.EMSCRIPTEN_TRACING:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -200,10 +200,6 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'atan2.c', 'atan2f.c', 'atan2l.c', 'exp.c', 'expf.c', 'expl.c',
                  'log.c', 'logf.c', 'logl.c', 'pow.c', 'powf.c', 'powl.c'])
 
-    # Without -fno-builtin, LLVM can optimize away or convert calls to library
-    # functions to something else based on assumptions that they behave exactly
-    # like the standard library. This can cause unexpected bugs when we use our
-    # custom standard library. The same for other libc/libm builds.
     return build_libc(libname, files, ['-O2', '-fno-builtin'])
 
   # libcxx
@@ -315,10 +311,6 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   def create_dlmalloc(out_name):
     o = in_temp(out_name)
-    # Without -fno-builtin, LLVM can optimize away or convert calls to library
-    # functions to something else based on assumptions that they behave exactly
-    # like the standard library. This can cause unexpected bugs when we use our
-    # custom standard library. The same for other libc/libm builds.
     cflags = ['-O2', '-fno-builtin']
     if shared.Settings.USE_PTHREADS:
       cflags += ['-s', 'USE_PTHREADS=1']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -132,6 +132,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
               break
           if not cancel:
             libc_files.append(os.path.join(musl_srcdir, dirpath, f))
+    # Without -fno-builtin, LLVM can optimize away or convert calls to library
+    # functions to something else based on assumptions that they behave exactly
+    # like the standard library. This can cause unexpected bugs when we use our
+    # custom standard library. The same for other libc/libm builds.
     args = ['-Os', '-fno-builtin']
     if shared.Settings.USE_PTHREADS:
       args += ['-s', 'USE_PTHREADS=1']
@@ -196,6 +200,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'atan2.c', 'atan2f.c', 'atan2l.c', 'exp.c', 'expf.c', 'expl.c',
                  'log.c', 'logf.c', 'logl.c', 'pow.c', 'powf.c', 'powl.c'])
 
+    # Without -fno-builtin, LLVM can optimize away or convert calls to library
+    # functions to something else based on assumptions that they behave exactly
+    # like the standard library. This can cause unexpected bugs when we use our
+    # custom standard library. The same for other libc/libm builds.
     return build_libc(libname, files, ['-O2', '-fno-builtin'])
 
   # libcxx
@@ -307,6 +315,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   def create_dlmalloc(out_name):
     o = in_temp(out_name)
+    # Without -fno-builtin, LLVM can optimize away or convert calls to library
+    # functions to something else based on assumptions that they behave exactly
+    # like the standard library. This can cause unexpected bugs when we use our
+    # custom standard library. The same for other libc/libm builds.
     cflags = ['-O2', '-fno-builtin']
     if shared.Settings.USE_PTHREADS:
       cflags += ['-s', 'USE_PTHREADS=1']


### PR DESCRIPTION
They should be built with `-fno-builtin` because otherwise LLVM can optimize their callsites in various ways assuming they are functions from the standard library.

This fixes [the test_regex failure in the current wasm waterfall](https://logs.chromium.org/v/?s=chromium%2Fbb%2Fclient.wasm.llvm%2Flinux%2F29568%2F%2B%2Frecipes%2Fsteps%2FExecute_emscripten_testsuite__emwasm_%2F0%2Fstdout).

Here I added the flag to dlmalloc and math library. Should we add `-fno-builtin` in other library builds as well?