### PR TITLE
Set initial stack pointer using stackRestore

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2107,16 +2107,15 @@ var asm = Module['asm'](%s, %s, buffer);
      'Module' + access_quote('asmLibraryArg'),
      receiving)]
 
-  # wasm backend stack goes down, and is stored in the first global var location
+  # wasm backend stack goes down
   module.append('''
 STACKTOP = STACK_BASE + TOTAL_STACK;
 STACK_MAX = STACK_BASE;
-HEAP32[%d >> 2] = STACKTOP;
 var stackAlloc = Module['_stackAlloc'];
 var stackSave = Module['_stackSave'];
 var stackRestore = Module['_stackRestore'];
 var establishStackSpace = Module['establishStackSpace'];
-''' % shared.Settings.GLOBAL_BASE)
+''')
 
   # some runtime functionality may not have been generated in
   # the wasm; provide a JS shim for it

--- a/emscripten.py
+++ b/emscripten.py
@@ -2107,10 +2107,7 @@ var asm = Module['asm'](%s, %s, buffer);
      'Module' + access_quote('asmLibraryArg'),
      receiving)]
 
-  # wasm backend stack goes down
   module.append('''
-STACKTOP = STACK_BASE + TOTAL_STACK;
-STACK_MAX = STACK_BASE;
 var stackAlloc = Module['_stackAlloc'];
 var stackSave = Module['_stackSave'];
 var stackRestore = Module['_stackRestore'];

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2180,9 +2180,12 @@ function integrateWasmJS() {
       Module['asm'] = exports;
       Module["usingWasm"] = true;
 #if WASM_BACKEND
-      //exports.stackRestore(STACKTOP);
+      // wasm backend stack goes down
+      STACKTOP = STACK_BASE + TOTAL_STACK;
+      STACK_MAX = STACK_BASE;
+      // can't call stackRestore() here since this function can be called
+      // synchronously before stackRestore() is declared.
       Module["asm"]["stackRestore"](STACKTOP);
-      //stackRestore(STACKTOP);
 #endif
 #if USE_PTHREADS
       // Keep a reference to the compiled module so we can post it to the workers.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2187,6 +2187,7 @@ function integrateWasmJS() {
 #else
       removeRunDependency('wasm-instantiate');
 #endif
+      stackRestore(STACKTOP);
     }
 #if USE_PTHREADS
     if (!ENVIRONMENT_IS_PTHREAD) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2180,7 +2180,9 @@ function integrateWasmJS() {
       Module['asm'] = exports;
       Module["usingWasm"] = true;
 #if WASM_BACKEND
-      Module["_stackRestore"](STACKTOP);
+      //exports.stackRestore(STACKTOP);
+      Module["asm"]["stackRestore"](STACKTOP);
+      //stackRestore(STACKTOP);
 #endif
 #if USE_PTHREADS
       // Keep a reference to the compiled module so we can post it to the workers.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2179,6 +2179,9 @@ function integrateWasmJS() {
       if (exports.memory) mergeMemory(exports.memory);
       Module['asm'] = exports;
       Module["usingWasm"] = true;
+#if WASM_BACKEND
+      Module["_stackRestore"](STACKTOP);
+#endif
 #if USE_PTHREADS
       // Keep a reference to the compiled module so we can post it to the workers.
       Module['wasmModule'] = module;
@@ -2187,7 +2190,6 @@ function integrateWasmJS() {
 #else
       removeRunDependency('wasm-instantiate');
 #endif
-      stackRestore(STACKTOP);
     }
 #if USE_PTHREADS
     if (!ENVIRONMENT_IS_PTHREAD) {


### PR DESCRIPTION
Don't assume its stored in linear memory.  When using
wasm32-unknown-unkown-wasm we use a wasm global to model
the stack pointer.

This code should work for both s2wasm and lld use cases.