### PR TITLE
fix_simd_right_shift

### DIFF
--- a/tests/core/test_simd_shift_right.c
+++ b/tests/core/test_simd_shift_right.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+typedef int int32x4 __attribute__((__vector_size__(16), __may_alias__));
+typedef unsigned int uint32x4 __attribute__((__vector_size__(16), __may_alias__));
+
+int main() {
+
+  uint32x4 v = { 0, 0x80000000u, 0x7fffffff, 0xffffffffu};
+  v = v >> 2;
+  printf("%x %x %x %x\n", v[0], v[1], v[2], v[3]);
+
+  int32x4 w = { 0, 0x80000000u, 0x7fffffff, 0xffffffffu};
+  w = w >> 2;
+  printf("%x %x %x %x\n", w[0], w[1], w[2], w[3]);
+}

--- a/tests/core/test_simd_shift_right.out
+++ b/tests/core/test_simd_shift_right.out
@@ -1,0 +1,2 @@
+0 20000000 1fffffff 3fffffff
+0 e0000000 1fffffff ffffffff

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5688,6 +5688,10 @@ return malloc(size);
   def test_simd_sitofp(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_simd_sitofp')
 
+  @SIMD
+  def test_simd_shift_right(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_simd_shift_right')
+
   def test_gcc_unmangler(self):
     Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('third_party')]
 


### PR DESCRIPTION
Add test for shifting signed and unsigned LLVM vector types right.