### PR TITLE
Fix how empty function pointer cast tables are handled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -328,3 +328,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Axel Forsman <axelsfor@gmail.com>
 * Ebrahim Byagowi <ebrahim@gnu.org>
 * Thorsten Möller <thorsten.moeller@sbi.ch>
+* Michael Droettboom <mdroettboom@mozilla.com>

--- a/emscripten.py
+++ b/emscripten.py
@@ -168,7 +168,10 @@ def fixup_metadata_tables(metadata, settings):
     for k, v in metadata['tables'].items():
       curr = v.count(',')+1
       if curr < max_size:
-        metadata['tables'][k] = v.replace(']', (',0'*(max_size - curr)) + ']')
+        if v.count('[]') == 1:
+          metadata['tables'][k] = v.replace(']', (','.join(['0'] * (max_size - curr)) + ']'))
+        else:
+          metadata['tables'][k] = v.replace(']', (',0'*(max_size - curr)) + ']')
 
   if settings['SIDE_MODULE']:
     for k in metadata['tables'].keys():


### PR DESCRIPTION
This fixes what I think is a fairly straightforward bug when `EMULATE_FUNCTION_POINTER_CASTS` is turned on.

When compiling Python as [here](http://github.com/iodide-project/pyodide), some of the tables end up having 0 length.  In that case, they look like `[]` and when `fixup_metadata_tables` tries to make all the tables the same length, it sets these empty ones to `[,0,0]` rather than `[0,0]` as it should.  This triggers the assertion:

```
          assert i not in function_pointer_targets
```

later on in `make_function_tables_defs`, since many of the tables have the same empty string in the first entry in the table.

This patch seems to get me to a working state, but I don't know if having empty tables in the first place is the sign of some deeper issue.