### PR TITLE
Overload val::array to accept a vector.

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -288,6 +288,14 @@ namespace emscripten {
             return val(internal::_emval_new_array());
         }
 
+        template<typename T>
+        static val array(const std::vector<T> vec) {
+            val new_array = array();
+            for(auto it = vec.begin(); it != vec.end(); it++)
+                new_array.call<void>("push", *it);
+            return new_array;
+        }
+
         static val object() {
             return val(internal::_emval_new_object());
         }

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -62,6 +62,32 @@ int main()
   ensure_js_not("a instanceof Boolean");
   ensure_js_not("a instanceof Number");
   
+  test("template<typename T> val array(const std::vector<T> vec)");
+  vector<val> vec1;
+  vec1.push_back(val(11));
+  vec1.push_back(val("a"));
+  vec1.push_back(val::array());
+  val::global().set("a", val::array(vec1));
+  ensure_js("a instanceof Array");
+  ensure_js_not("a instanceof Boolean");
+  ensure_js_not("a instanceof Number");
+  ensure_js("a[0] == 11");
+  ensure_js_not("a[0] == 12");
+  ensure_js("a[1] == 'a'");
+  ensure_js("a[2] instanceof Array");
+  vector<int> vec2;
+  vec2.push_back(0);
+  vec2.push_back(1);
+  vec2.push_back(3);
+  val::global().set("a", val::array(vec2));
+  ensure_js("a instanceof Array");
+  ensure_js_not("a instanceof Number");
+  ensure_js("a[0] == 0");
+  ensure_js_not("a[0] == 1");
+  ensure_js("a[1] == 1");
+  ensure_js("a[2] == 3");
+  ensure_js_not("a[2] == 2");
+  
   test("val object()");
   val::global().set("a", val::object());
   ensure_js("a instanceof Object");

--- a/tests/embind/test_val.out
+++ b/tests/embind/test_val.out
@@ -5,6 +5,22 @@ pass
 pass
 pass
 test:
+template<typename T> val array(const std::vector<T> vec)
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+test:
 val object()
 pass
 test:


### PR DESCRIPTION
A new js array will be created from the items in vector. The vector can be of any type 'val' can convert.

Demo:
```
#include <stdio.h>
#include <iostream>
#include <emscripten/bind.h>
#include <emscripten/val.h>

using namespace emscripten;
using namespace std;

int main()
{
  vector<val> vec;
  vec.push_back(val(11));
  vec.push_back(val("a"));
  vec.push_back(val::array());
  val array = val::array(vec);
  val::global().set("vec", array);

  vector<int> vec2;
  vec2.push_back(11);
  vec2.push_back(22);
  vec2.push_back(33);
  val array2 = val::array(vec2);
  val::global().set("vec2", array2);

  printf("done\n");
  return 0;
}
```
Observe `window.vec` and `window.vec2` in the browser console.