### PR TITLE
Fix the new test_emmalloc on the newer LLVM+clang

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -724,6 +724,11 @@ base align: 0, 0, 0, 0'''])
     self.do_run(self.gen_struct_src.replace('{{gen_struct}}', '(S*)malloc(sizeof(S))').replace('{{del_struct}}', 'free'), '*51,62*')
 
   def test_emmalloc(self):
+    # in newer clang+llvm, the internal calls to malloc in emmalloc may be optimized under
+    # the assumption that they are external, so like in system_libs.py where we build
+    # malloc, we need to disable builtin here too
+    self.emcc_args += ['-fno-builtin']
+
     def test():
       self.do_run(open(path_from_root('system', 'lib', 'emmalloc.cpp')).read() + open(path_from_root('tests', 'core', 'test_emmalloc.cpp')).read(),
                   open(path_from_root('tests', 'core', 'test_emmalloc.txt')).read())


### PR DESCRIPTION
The test was added in #6249, and broke on the wasm backend which uses latest LLVM+clang.

We need `-fno-builtin`, just like when building emmalloc as a system lib which @aheejin fixed (and thanks to that work I knew what to do here ;)

