### PR TITLE
Overloads val::new_ to accept a vector of arguments.

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -132,6 +132,13 @@ var LibraryEmVal = {
     return __emval_register(v);
   },
 
+  _emval_new_spread__deps: ['_emval_register', '$requireHandle'],
+  _emval_new_spread: function(constructor, args) {
+    constructor = requireHandle(constructor);
+    args = requireHandle(args);
+    return __emval_register(new constructor(...args));
+  },
+
   $emval_newers: {}, // arity -> function
   $craftEmvalAllocator__deps: ['_emval_register', '$requireRegisteredType'],
   $craftEmvalAllocator: function(argCount) {

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -52,6 +52,7 @@ namespace emscripten {
                 unsigned argCount,
                 const TYPEID argTypes[],
                 EM_VAR_ARGS argv);
+            EM_VAL _emval_new_spread(EM_VAL constructor, EM_VAL args);
 
             EM_VAL _emval_get_global(const char* name);
             EM_VAL _emval_get_module_property(const char* name);
@@ -429,6 +430,12 @@ namespace emscripten {
 
         bool operator<= (const val& v) const {
             return (*this < v) || (*this == v);
+        }
+
+        template<typename T>
+        val new_(const std::vector<T> args) const {
+            val arr = array(args);
+            return val(_emval_new_spread(handle, arr.handle));
         }
 
         template<typename... Args>


### PR DESCRIPTION
Does anyone have any opinions on `val::new_` also accepting a vector of arguments? This will allow you to pass a dynamic set of arguments at run time.
I implemented it using the ES6 spread operator which will obviously limit some of the older browsers that can't support this addition. I would have based it on the current implementation of `new_` but I could not figure out how to work with it.

If anyone with an understanding of how `internalCall` works in `val.h` can assist me that would be awesome.

I also tried to overload `val:operator()` and `val::call` in the same way but could not get them working and don't have any use case for them myself. See my branch `val_vector_issues` as a starting point if anyone has any interest in getting it to work.