### PR TITLE
emcc: Improve handling of subprocess exit codes

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -500,7 +500,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not os.path.exists(target):
         return ret # note that emcc -c will cause target to have the wrong value here;
                    # but then, we don't care about bitcode outputs anyhow, below, so
-                   # skipping to exit(ret) is fine
+                   # skipping returning early is fine
       if target.endswith('.js'):
         shutil.copyfile(target, unsuffixed(target))
         target = unsuffixed(target)
@@ -2795,10 +2795,4 @@ def validate_arg_level(level_string, max_level, err_msg, clamp=False):
 
 
 if __name__ == '__main__':
-  try:
-    sys.exit(run())
-  except subprocess.CalledProcessError as e:
-    # Handle subprocess failure cleanly unles DEBUG is set
-    if DEBUG:
-      raise
-    sys.exit(e.returncode)
+  sys.exit(run())

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -4,7 +4,7 @@ sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tools import response_file
 
-EM_PROFILE_TOOLCHAIN = int(os.getenv('EM_PROFILE_TOOLCHAIN')) if os.getenv('EM_PROFILE_TOOLCHAIN') != None else 0
+EM_PROFILE_TOOLCHAIN = int(os.getenv('EM_PROFILE_TOOLCHAIN', '0'))
 
 if EM_PROFILE_TOOLCHAIN:
   original_sys_exit = sys.exit
@@ -61,7 +61,7 @@ if EM_PROFILE_TOOLCHAIN:
       ToolchainProfiler.record_subprocess_finish(self.pid, self.returncode)
       return output
 
-  exit = sys.exit = profiled_sys_exit
+  sys.exit = profiled_sys_exit
   subprocess.call = profiled_call
   subprocess.check_call = profiled_check_call
   subprocess.check_output = profiled_check_output
@@ -194,8 +194,6 @@ if EM_PROFILE_TOOLCHAIN:
       return ToolchainProfiler.imaginary_pid_
 
 else:
-  exit = sys.exit
-
   class ToolchainProfiler(object):
     @staticmethod
     def record_process_start():


### PR DESCRIPTION
Use `return` rather than `sys.exit` to return from run() so that the process exits
in a single place.  Make for more re-usable and testable code.

Also, remove unused toolchain_profiler.exit global.  This was always
set to sys.exit.