### PR TITLE
 Remove memory grow log for wasm build

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1023,7 +1023,7 @@ function enlargeMemory() {
   updateGlobalBufferViews();
 
 #if ASSERTIONS
-  Module.printErr('enlarged memory arrays from ' + OLD_TOTAL_MEMORY + ' to ' + TOTAL_MEMORY + ', took ' + (Date.now() - start) + ' ms (has ArrayBuffer.transfer? ' + (!!ArrayBuffer.transfer) + ')');
+  Module.print('enlarged memory arrays from ' + OLD_TOTAL_MEMORY + ' to ' + TOTAL_MEMORY + ', took ' + (Date.now() - start) + ' ms (has ArrayBuffer.transfer? ' + (!!ArrayBuffer.transfer) + ')');
 #endif
 
 #if ASSERTIONS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1023,10 +1023,6 @@ function enlargeMemory() {
   updateGlobalBufferViews();
 
 #if ASSERTIONS
-  Module.print('enlarged memory arrays from ' + OLD_TOTAL_MEMORY + ' to ' + TOTAL_MEMORY + ', took ' + (Date.now() - start) + ' ms (has ArrayBuffer.transfer? ' + (!!ArrayBuffer.transfer) + ')');
-#endif
-
-#if ASSERTIONS
   if (!Module["usingWasm"]) {
     Module.printErr('Warning: Enlarging memory arrays, this is not fast! ' + [OLD_TOTAL_MEMORY, TOTAL_MEMORY]);
   }


### PR DESCRIPTION
Growing memory is fast on wasm so we don't need to log.