### PR TITLE
Set default values for the canonical temp dir in the core test runner

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -155,7 +155,12 @@ use_all_engines = os.environ.get('EM_ALL_ENGINES') # generally js engines are eq
 
 class RunnerCore(unittest.TestCase):
   emcc_args = None
+
+  # default temporary directory settings. set_temp_dir may be called later to
+  # override these
   temp_dir = TEMP_DIR
+  canonical_temp_dir = get_canonical_temp_dir(TEMP_DIR)
+
   save_dir = os.environ.get('EM_SAVE_DIR')
   save_JS = 0
   stderr_redirect = STDOUT # This avoids cluttering the test runner output, which is stderr too, with compiler warnings etc.


### PR DESCRIPTION
This un-breaks running an individual test that uses the canonical temp dir (as opposed to running it in the parallel test runner, which calls set_temp_dir manually). For example, `./tests/runner.py other.test_binaryen_opts`.

It's odd we didn't notice this was broken, and it appears to have been broken for quite some time. I guess it's not often we run just one individual test manually for debugging purposes that is also one of the rare tests using the canonical temp dir.