### PR TITLE
Fix some issues with static data in SIDE_MODULEs

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -433,9 +433,12 @@ function JSify(data, functionsOnly) {
           print('STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
         } else {
           print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}}), ' + MAX_GLOBAL_ALIGN + ' || 1);\n');
-          // Ideally, for efficiency, this would only zero memory after the static initialized
-          // data, but we don't know the size of that here.
-          print('for (let i = gb; i < gb + {{{ STATIC_BUMP }}}; ++i) HEAP8[i] = 0;\n');
+          // The static area consists of explicitly initialized data, followed by zero-initialized data.
+          // The latter may need zeroing out if the MAIN_MODULE has already used this memory area before
+          // dlopen'ing the SIDE_MODULE.  Since we don't know the size of the explicitly initialized data
+          // here, we just zero the whole thing, which is suboptimal, but should at least resolve bugs
+          // from uninitialized memory.
+          print('for (var i = gb; i < gb + {{{ STATIC_BUMP }}}; ++i) HEAP8[i] = 0;\n');
           print('// STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n'); // comment as metadata only
         }
         if (BINARYEN) {

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -432,7 +432,10 @@ function JSify(data, functionsOnly) {
           print('STATIC_BASE = GLOBAL_BASE;\n');
           print('STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
         } else {
-          print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}}, ' + MAX_GLOBAL_ALIGN + ' || 1));\n');
+          print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}}), ' + MAX_GLOBAL_ALIGN + ' || 1);\n');
+          // Ideally, for efficiency, this would only zero memory after the static initialized
+          // data, but we don't know the size of that here.
+          print('for (let i = gb; i < gb + {{{ STATIC_BUMP }}}; ++i) HEAP8[i] = 0;\n');
           print('// STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n'); // comment as metadata only
         }
         if (BINARYEN) {
@@ -618,4 +621,3 @@ function JSify(data, functionsOnly) {
   dprint('framework', 'Big picture: Finishing JSifier, main pass=' + mainPass);
   //B.stop('jsifier');
 }
-


### PR DESCRIPTION
This fixes #6310, though my hunches about the root cause turned out to be wrong.

There are two fixes here:

1) The static data in a module generally consists of content initialized with an array literal, followed by zeroinitialized content.  The latter was not getting zero-initialized when the static chunk is allocated.  Changing the `malloc` within `getMemory` to `calloc` seems to resolve this.

2) Static memory chunks in side modules were not getting aligned correctly.  This seems to be due to a parentheses placement bug.  This seems to manifest when there are short (empty) strings in the last 8 bytes at the end of the zero-initialized area.