### PR TITLE
ctor-eval fix for wasm: handle infinite loops

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -470,6 +470,14 @@ class RunnerCore(unittest.TestCase):
 
     return num_funcs
 
+  def count_wasm_contents(self, wasm_binary, what):
+    out = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-opt'), wasm_binary, '--metrics'], stdout=PIPE).stdout
+    # output is something like
+    # [?]        : 125
+    line = [line for line in out.split('\n') if '[' + what + ']' in line][0].strip()
+    ret = line.split(':')[1].strip()
+    return int(ret)
+
   def run_generated_code(self, engine, filename, args=[], check_timeout=True, output_nicerizer=None, assert_returncode=0):
     stdout = os.path.join(self.get_dir(), 'stdout') # use files, as PIPE can get too full and hang us
     stderr = os.path.join(self.get_dir(), 'stderr')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7015,106 +7015,117 @@ int main() {
     self.assertContained('LLVM ERROR: EM_ASM should not receive i64s as inputs, they are not valid in JS', err)
 
   def test_eval_ctors(self):
-    print('non-terminating ctor')
-    src = r'''
-      struct C {
-        C() {
-          volatile int y = 0;
-          while (y == 0) {}
-        }
-      };
-      C always;
-      int main() {}
-    '''
-    open('src.cpp', 'w').write(src)
-    check_execute([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs'])
-    print('check no ctors is ok')
-    check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Oz'])
-    self.assertContained('hello, world!', run_js('a.out.js'))
-    # on by default in -Oz, but user-overridable
-    def get_size(args):
-      print('get_size', args)
-      check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')] + args)
-      self.assertContained('hello, world!', run_js('a.out.js'))
-      return (os.stat('a.out.js').st_size, os.stat('a.out.js.mem').st_size)
-    def check_size(left, right):
-      if left[0] == right[0] and left[1] == right[1]: return 0
-      if left[0] < right[0] and left[1] > right[1]: return -1 # smaller js, bigger mem
-      if left[0] > right[0] and left[1] < right[1]: return 1
-      assert 0, [left, right]
-    o2_size = get_size(['-O2'])
-    assert check_size(get_size(['-O2']), o2_size) == 0, 'deterministic'
-    assert check_size(get_size(['-O2', '-s', 'EVAL_CTORS=1']), o2_size) < 0, 'eval_ctors works if user asks for it'
-    oz_size = get_size(['-Oz'])
-    assert check_size(get_size(['-Oz']), oz_size) == 0, 'deterministic'
-    assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=1']), oz_size) == 0, 'eval_ctors is on by default in oz'
-    assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=0']), oz_size) == 1, 'eval_ctors can be turned off'
-
-    linkable_size =   get_size(['-Oz', '-s', 'EVAL_CTORS=1', '-s', 'LINKABLE=1'])
-    assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=0', '-s', 'LINKABLE=1']), linkable_size) == 1, 'noticeable difference in linkable too'
-
-    # ensure order of execution remains correct, even with a bad ctor
-    def test(p1, p2, p3, last, expected):
+    for wasm in (1, 0):
+      print('wasm', wasm)
+      print('non-terminating ctor')
       src = r'''
-        #include <stdio.h>
-        #include <stdlib.h>
-        volatile int total = 0;
         struct C {
-          C(int x) {
-            volatile int y = x;
-            y++;
-            y--;
-            if (y == 0xf) {
-              printf("you can't eval me ahead of time\n"); // bad ctor
-            }
-            total <<= 4;
-            total += int(y);
+          C() {
+            volatile int y = 0;
+            while (y == 0) {}
           }
         };
-        C __attribute__((init_priority(%d))) c1(0x5);
-        C __attribute__((init_priority(%d))) c2(0x8);
-        C __attribute__((init_priority(%d))) c3(%d);
-        int main() {
-          printf("total is 0x%%x.\n", total);
-        }
-      ''' % (p1, p2, p3, last)
+        C always;
+        int main() {}
+      '''
       open('src.cpp', 'w').write(src)
-      check_execute([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs'])
-      self.assertContained('total is %s.' % hex(expected), run_js('a.out.js'))
-      shutil.copyfile('a.out.js', 'x' + hex(expected) + '.js')
-      return open('a.out.js').read().count('function _')
-    print('no bad ctor')
-    first  = test(1000, 2000, 3000, 0xe, 0x58e)
-    second = test(3000, 1000, 2000, 0xe, 0x8e5)
-    third  = test(2000, 3000, 1000, 0xe, 0xe58)
-    print(first, second, third)
-    assert first == second and second == third
-    print('with bad ctor')
-    first  = test(1000, 2000, 3000, 0xf, 0x58f) # 2 will succeed
-    second = test(3000, 1000, 2000, 0xf, 0x8f5) # 1 will succedd
-    third  = test(2000, 3000, 1000, 0xf, 0xf58) # 0 will succeed
-    print(first, second, third)
-    assert first < second and second < third
+      check_execute([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
+      print('check no ctors is ok')
+      check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Oz', '-s', 'WASM=%d' % wasm])
+      self.assertContained('hello, world!', run_js('a.out.js'))
+      # on by default in -Oz, but user-overridable
+      def get_size(args):
+        print('get_size', args)
+        check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=%d' % wasm] + args)
+        self.assertContained('hello, world!', run_js('a.out.js'))
+        if not wasm:
+          return (os.stat('a.out.js').st_size, os.stat('a.out.js.mem').st_size)
+        else:
+          return (os.stat('a.out.js').st_size, 0) # can't measure just the mem out of the wasm
+      def check_size(left, right):
+        # can't measure just the mem out of the wasm, so ignore [1] for wasm
+        if left[0] == right[0] and (wasm or left[1] == right[1]): return 0
+        if left[0] < right[0] and (wasm or left[1] > right[1]): return -1 # smaller js, bigger mem
+        if left[0] > right[0] and (wasm or left[1] < right[1]): return 1
+        assert 0, [left, right]
+      o2_size = get_size(['-O2'])
+      assert check_size(get_size(['-O2']), o2_size) == 0, 'deterministic'
+      assert check_size(get_size(['-O2', '-s', 'EVAL_CTORS=1']), o2_size) < 0, 'eval_ctors works if user asks for it'
+      oz_size = get_size(['-Oz'])
+      assert check_size(get_size(['-Oz']), oz_size) == 0, 'deterministic'
+      assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=1']), oz_size) == 0, 'eval_ctors is on by default in oz'
+      assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=0']), oz_size) == 1, 'eval_ctors can be turned off'
 
-    print('helpful output')
-    if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
-    try:
-      os.environ['EMCC_DEBUG'] = '1'
-      open('src.cpp', 'w').write(r'''
-#include <stdio.h>
-struct C {
-  C() { printf("constructing!\n"); } // don't remove this!
-};
-C c;
-int main() {}
-      ''')
-      with clean_write_access_to_canonical_temp_dir(self.canonical_temp_dir):
-        err = run_process([PYTHON, EMCC, 'src.cpp', '-Oz'], stderr=PIPE).stderr
-      self.assertContained('___syscall54', err) # the failing call should be mentioned
-      self.assertContained('ctorEval.js', err) # with a stack trace
-      self.assertContained('ctor_evaller: not successful', err) # with logging
-    finally:
-      del os.environ['EMCC_DEBUG']
+      linkable_size =   get_size(['-Oz', '-s', 'EVAL_CTORS=1', '-s', 'LINKABLE=1'])
+      assert check_size(get_size(['-Oz', '-s', 'EVAL_CTORS=0', '-s', 'LINKABLE=1']), linkable_size) == 1, 'noticeable difference in linkable too'
+
+      # ensure order of execution remains correct, even with a bad ctor
+      def test(p1, p2, p3, last, expected):
+        src = r'''
+          #include <stdio.h>
+          #include <stdlib.h>
+          volatile int total = 0;
+          struct C {
+            C(int x) {
+              volatile int y = x;
+              y++;
+              y--;
+              if (y == 0xf) {
+                printf("you can't eval me ahead of time\n"); // bad ctor
+              }
+              total <<= 4;
+              total += int(y);
+            }
+          };
+          C __attribute__((init_priority(%d))) c1(0x5);
+          C __attribute__((init_priority(%d))) c2(0x8);
+          C __attribute__((init_priority(%d))) c3(%d);
+          int main() {
+            printf("total is 0x%%x.\n", total);
+          }
+        ''' % (p1, p2, p3, last)
+        open('src.cpp', 'w').write(src)
+        check_execute([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
+        self.assertContained('total is %s.' % hex(expected), run_js('a.out.js'))
+        shutil.copyfile('a.out.js', 'x' + hex(expected) + '.js')
+        if not wasm:
+          return open('a.out.js').read().count('function _')
+        else:
+          shutil.copyfile('a.out.wasm', 'x' + hex(expected) + '.wasm')
+          return self.count_wasm_contents('a.out.wasm', 'total')
+      print('no bad ctor')
+      first  = test(1000, 2000, 3000, 0xe, 0x58e)
+      second = test(3000, 1000, 2000, 0xe, 0x8e5)
+      third  = test(2000, 3000, 1000, 0xe, 0xe58)
+      print(first, second, third)
+      assert first == second and second == third
+      print('with bad ctor')
+      first  = test(1000, 2000, 3000, 0xf, 0x58f) # 2 will succeed
+      second = test(3000, 1000, 2000, 0xf, 0x8f5) # 1 will succedd
+      third  = test(2000, 3000, 1000, 0xf, 0xf58) # 0 will succeed
+      print(first, second, third)
+      assert first < second and second < third, [first, second, third]
+
+      print('helpful output')
+      if os.environ.get('EMCC_DEBUG'): return self.skip('cannot run in debug mode')
+      try:
+        os.environ['EMCC_DEBUG'] = '1'
+        open('src.cpp', 'w').write(r'''
+  #include <stdio.h>
+  struct C {
+    C() { printf("constructing!\n"); } // don't remove this!
+  };
+  C c;
+  int main() {}
+        ''')
+        with clean_write_access_to_canonical_temp_dir(self.canonical_temp_dir):
+          err = run_process([PYTHON, EMCC, 'src.cpp', '-Oz', '-s', 'WASM=%d' % wasm], stderr=PIPE).stderr
+        self.assertContained('___syscall54', err) # the failing call should be mentioned
+        if not wasm: # js will show a stack trace
+          self.assertContained('ctorEval.js', err) # with a stack trace
+        self.assertContained('ctor_evaller: not successful', err) # with logging
+      finally:
+        del os.environ['EMCC_DEBUG']
 
   def test_override_environment(self):
     open('main.cpp', 'w').write(r'''

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -289,7 +289,13 @@ def eval_ctors_wasm(js, wasm_file, num):
   if debug_info:
     cmd += ['-g']
   shared.logging.debug('wasm ctor cmd: ' + str(cmd))
-  err = shared.run_process(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+  try:
+    err = shared.jsrun.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
+  except Exception as e:
+    if 'Timed out' not in str(e): raise e
+    shared.logging.debug('ctors timed out\n')
+    return 0, js
   num_successful = err.count('success on')
   shared.logging.debug(err)
   if len(ctors) == num_successful:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1177,7 +1177,7 @@ class SettingsManager(object):
         self.attrs['ASSERTIONS'] = 0
         self.attrs['DISABLE_EXCEPTION_CATCHING'] = 1
         self.attrs['ALIASING_FUNCTION_POINTERS'] = 1
-      if shrink_level >= 2 and not self.attrs['BINARYEN']:
+      if shrink_level >= 2:
         self.attrs['EVAL_CTORS'] = 1
 
     def __getattr__(self, attr):


### PR DESCRIPTION
Also run testing in both asm.js and wasm for that feature, as the code supporting it is separate.