### PR TITLE
Simplify exception catching support: disable by default in -O0 too

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -191,9 +191,9 @@ if operation == 'build':
     elif what == 'wasm-libc':
       build(C_WITH_STDLIB, ['wasm-libc.bc'], ['-s', 'WASM=1'])
     elif what == 'libcxx':
-      build(CXX_WITH_STDLIB, ['libcxx.a'])
+      build(CXX_WITH_STDLIB, ['libcxx.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     elif what == 'libcxx_noexcept':
-      build(CXX_WITH_STDLIB, ['libcxx_noexcept.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=1'])
+      build(CXX_WITH_STDLIB, ['libcxx_noexcept.a'])
     elif what == 'libcxxabi':
       build('''
         struct X { int x; virtual void a() {} };

--- a/src/settings.js
+++ b/src/settings.js
@@ -324,18 +324,18 @@ var LZ4 = 0; // Enable this to support lz4-compressed file packages. They are st
              //     preloadPlugin stuff, etc.
              //   * LZ4 files are read-only.
 
-var DISABLE_EXCEPTION_CATCHING = 0; // Disables generating code to actually catch exceptions. If the code you
-                                    // are compiling does not actually rely on catching exceptions (but the
-                                    // compiler generates code for it, maybe because of stdlibc++ stuff),
-                                    // then this can make it much faster. If an exception actually happens,
-                                    // it will not be caught and the program will halt (so this will not
-                                    // introduce silent failures, which is good).
+var DISABLE_EXCEPTION_CATCHING = 1; // Disables generating code to actually catch exceptions. This disabling is on
+                                    // by default as the overhead of exceptions is quite high in size and speed
+                                    // currently (in the future, wasm should improve that). When exceptions are
+                                    // disabled, if an exception actually happens then it will not be caught
+                                    // and the program will halt (so this will not introduce silent failures).
+                                    // There are 3 specific modes here:
                                     // DISABLE_EXCEPTION_CATCHING = 0 - generate code to actually catch exceptions
                                     // DISABLE_EXCEPTION_CATCHING = 1 - disable exception catching at all
                                     // DISABLE_EXCEPTION_CATCHING = 2 - disable exception catching, but enables
-                                    // catching in whitelist
+                                    //                                  catching in whitelist
                                     // XXX note that this removes *catching* of exceptions, which is the main
-                                    //     issue for speed, but for code size you need to build with
+                                    //     issue for speed, but you should build source files with
                                     //     -fno-exceptions to really get rid of all exceptions code overhead,
                                     //     as it may contain thrown exceptions that are never caught (e.g.
                                     //     just using std::vector can have that). -fno-rtti may help as well.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4396,7 +4396,7 @@ int main()
     try:
       os.environ['EMCC_FORCE_STDLIBS'] = 'libc,libcxxabi,libcxx'
       os.environ['EMCC_ONLY_FORCED_STDLIBS'] = '1'
-      Popen([PYTHON, EMXX, 'src.cpp']).communicate()
+      Popen([PYTHON, EMXX, 'src.cpp', '-s', 'DISABLE_EXCEPTION_CATCHING=0']).communicate()
       self.assertContained('Caught exception: std::exception', run_js('a.out.js', stderr=PIPE))
     finally:
       del os.environ['EMCC_FORCE_STDLIBS']
@@ -4833,7 +4833,7 @@ main(const int argc, const char * const * const argv)
   }
 }
     ''')
-    Popen([PYTHON, EMCC, 'src.cpp', '-s', 'NO_EXIT_RUNTIME=0']).communicate()
+    Popen([PYTHON, EMCC, 'src.cpp', '-s', 'NO_EXIT_RUNTIME=0', '-s', 'DISABLE_EXCEPTION_CATCHING=0']).communicate()
     self.assertContained('Constructed locale "C"\nThis locale is the global locale.\nThis locale is the C locale.', run_js('a.out.js', args=['C']))
     self.assertContained('''Can't construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka''', run_js('a.out.js', args=['waka'], assert_returncode=1))
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1175,7 +1175,6 @@ class SettingsManager(object):
       if opt_level >= 1:
         self.attrs['ASM_JS'] = 1
         self.attrs['ASSERTIONS'] = 0
-        self.attrs['DISABLE_EXCEPTION_CATCHING'] = 1
         self.attrs['ALIASING_FUNCTION_POINTERS'] = 1
       if shrink_level >= 2 and not self.attrs['BINARYEN']:
         self.attrs['EVAL_CTORS'] = 1


### PR DESCRIPTION
This PR proposes we disable exception catching (DISABLE_EXCEPTION_CATCHING) in -O0 as well, not just in -O1 and above as we used to. This simplifies things: exception catching is just off by default.

This is a breaking change for -O0 builds, which used to have exception catching enabled but no longer would, the flag would need to be turned on for them. This may surprise existing users but is probably better for new users. For existing users, they will get an error suggesting they enable that option if an exception is thrown at runtime, so it should be easy to find out how to fix things.

Thoughts?

