### PR TITLE
Fix wasm side module importing of global.Math; fixes #6365

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -139,8 +139,8 @@ function loadWebAssemblyModule(binary) {
     global: {
       'NaN': NaN,
       'Infinity': Infinity,
-      'Math': Math
     },
+    'global.Math': Math,
     env: env
   };
 #if ASSERTIONS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3586,11 +3586,13 @@ Module = {
       Initter initter;
     ''', expected=['extern is 456.\n'])
 
-  def test_dylink_mallocs(self):
+  def test_dylink_stdlib(self):
     self.dylink_test(header=r'''
+      #include <math.h>
       #include <stdlib.h>
       #include <string.h>
       char *side(const char *data);
+      double pow_two(double x);
     ''', main=r'''
       #include <stdio.h>
       #include "header.h"
@@ -3600,6 +3602,7 @@ Module = {
         strcpy(ret, temp);
         temp[1] = 'x';
         puts(ret);
+        printf("pow_two: %d.\n", int(pow_two(5.9)));
         return 0;
       }
     ''', side=r'''
@@ -3609,7 +3612,10 @@ Module = {
         strcpy(ret, data);
         return ret;
       }
-    ''', expected=['hello through side\n'])
+      double pow_two(double x) {
+        return pow(2, x);
+      }
+    ''', expected=['hello through side\n\npow_two: 59.'])
 
   def test_dylink_jslib(self):
     Settings.BINARYEN_TRAP_MODE = 'clamp' # avoid using asm2wasm imports, which don't work in side modules yet (should they?)


### PR DESCRIPTION
Wasm imports have 2 levels, not 3, so we must import JS Math.* stuff from "global.Math" and not try to import Math from "global".