### PR TITLE
Do not emit bad name in getProcAddress error.

### DIFF
--- a/system/lib/gl.c
+++ b/system/lib/gl.c
@@ -1729,7 +1729,6 @@ void* emscripten_GetProcAddress(const char *name_) {
   else if (!strcmp(name, "glCopyTexSubImage2D")) return emscripten_glCopyTexSubImage2D;
   else if (!strcmp(name, "glDrawBuffers")) return emscripten_glDrawBuffers;
 
-  EM_ASM(Module.printErr('bad name in getProcAddress: ' + [Pointer_stringify($0), Pointer_stringify($1)]), name_, name);
   return 0;
 }
 


### PR DESCRIPTION
We're using an OpenGL graphics library called Ion for cross-platform support.  They do support Emscripten and work nicely in the browser, however, they eagerly look up a bunch of function names and such for feature detection.  Names not supported by Emscripten show up as log output even in our prod builds in opt mode with logging disabled.

I'd like to no longer emit these messages.

I tried making it conditional on GL_ASSERTIONS but couldn't find a way for the C++ preprocessor to not eat the macro definition used in the code generation step in the JS files.  In other words, I couldn't get "#if GL_ASSERTIONS" to show up in the JS output of EM_ASM.  The simplest thing is to just drop the print entirely.  The other idea I had was to move the entire function to JS, where I could use the #if GL_ASSERTIONS check, but that seems unnecessary.  Missing functions will be obvious when someone checks the return value or tries to use the function.