### PR TITLE
Adding booleans to ccall

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -30,7 +30,7 @@ Calling compiled C functions from JavaScript
 
 	The function executes a compiled C function from JavaScript and returns the result. C++ name mangling means that "normal" C++ functions cannot be called; the function must either be defined in a **.c** file or be a C++ function defined with ``extern "C"``.
 
-	``returnType`` and ``argTypes`` let you specify the types of parameters and the return value. The possible types are ``"number"``, ``"string"`` or ``"array"``, which correspond to the appropriate JavaScript types. Use ``"number"`` for any numeric type or C pointer, ``string`` for C ``char*`` that represent strings, and ``"array"`` for JavaScript arrays and typed arrays; for typed arrays, it must be a Uint8Array or Int8Array.
+	``returnType`` and ``argTypes`` let you specify the types of parameters and the return value. The possible types are ``"number"``, ``"string"``, ``"array"``, or ``"boolean"``, which correspond to the appropriate JavaScript types. Use ``"number"`` for any numeric type or C pointer, ``string`` for C ``char*`` that represent strings, ``"boolean"`` for a boolean type, ``"array"`` for JavaScript arrays and typed arrays; for typed arrays, it must be a Uint8Array or Int8Array.
 
 	.. code-block:: javascript
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -136,10 +136,17 @@ var JSfuncs = {
       stringToUTF8(str, ret, len);
     }
     return ret;
+  },
+  'boolToC': function (bool) {
+    return Boolean(bool);
   }
 };
 // For fast lookup of conversion functions
-var toC = {'string' : JSfuncs['stringToC'], 'array' : JSfuncs['arrayToC']};
+var toC = {
+  'string': JSfuncs['stringToC'],
+  'array': JSfuncs['arrayToC'],
+  'bool': JSfuncs['boolToC']
+};
 
 // C calling interface.
 function ccall (ident, returnType, argTypes, args, opts) {
@@ -170,6 +177,7 @@ function ccall (ident, returnType, argTypes, args, opts) {
 #endif
 #endif
   if (returnType === 'string') ret = Pointer_stringify(ret);
+  if (returnType === 'bool') ret = Boolean(ret);
   if (stack !== 0) {
 #if EMTERPRETIFY_ASYNC
     if (opts && opts.async) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -136,16 +136,12 @@ var JSfuncs = {
       stringToUTF8(str, ret, len);
     }
     return ret;
-  },
-  'boolToC': function (bool) {
-    return Boolean(bool);
   }
 };
+
 // For fast lookup of conversion functions
 var toC = {
-  'string': JSfuncs['stringToC'],
-  'array': JSfuncs['arrayToC'],
-  'bool': JSfuncs['boolToC']
+  'string': JSfuncs['stringToC'], 'array': JSfuncs['arrayToC']
 };
 
 // C calling interface.
@@ -177,7 +173,7 @@ function ccall (ident, returnType, argTypes, args, opts) {
 #endif
 #endif
   if (returnType === 'string') ret = Pointer_stringify(ret);
-  if (returnType === 'bool') ret = Boolean(ret);
+  if (returnType === 'boolean') ret = Boolean(ret);
   if (stack !== 0) {
 #if EMTERPRETIFY_ASYNC
     if (opts && opts.async) {

--- a/tests/core/test_ccall.cpp
+++ b/tests/core/test_ccall.cpp
@@ -1,14 +1,20 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <emscripten.h>
 
 extern "C" {
 int get_int() { return 5; }
 float get_float() { return 3.14; }
+bool get_bool() { return true; }
 const char *get_string() { return "hello world"; }
 void print_int(int x) { printf("%d\n", x); }
 void print_float(float x) { printf("%.2f\n", x); }
 void print_string(char *x) { printf("%s\n", x); }
+void print_bool(bool x) { 
+  if (x) printf("true\n"); 
+  else if (!x) printf("false\n");
+}
 int multi(int x, float y, int z, char *str) {
   if (x) puts(str);
   return (x + y) * z;

--- a/tests/core/test_ccall.out
+++ b/tests/core/test_ccall.out
@@ -1,10 +1,13 @@
 *
 number,5
 number,3.14
+boolean,true
 string,hello world
 12
 undefined
 14.56
+undefined
+true
 undefined
 cheez
 undefined

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6065,9 +6065,11 @@ def process(filename):
       var ret;
       ret = Module['ccall']('get_int', 'number'); Module.print([typeof ret, ret].join(','));
       ret = ccall('get_float', 'number'); Module.print([typeof ret, ret.toFixed(2)].join(','));
+      ret = ccall('get_bool', 'boolean'); Module.print([typeof ret, ret].join(','));
       ret = ccall('get_string', 'string'); Module.print([typeof ret, ret].join(','));
       ret = ccall('print_int', null, ['number'], [12]); Module.print(typeof ret);
       ret = ccall('print_float', null, ['number'], [14.56]); Module.print(typeof ret);
+      ret = ccall('print_bool', null, ['boolean'], [true]); Module.print(typeof ret);
       ret = ccall('print_string', null, ['string'], ["cheez"]); Module.print(typeof ret);
       ret = ccall('print_string', null, ['array'], [[97, 114, 114, 45, 97, 121, 0]]); Module.print(typeof ret); // JS array
       ret = ccall('print_string', null, ['array'], [new Uint8Array([97, 114, 114, 45, 97, 121, 0])]); Module.print(typeof ret); // typed array
@@ -6093,7 +6095,7 @@ def process(filename):
   open(filename, 'w').write(src)
 '''
 
-    Settings.EXPORTED_FUNCTIONS += ['_get_int', '_get_float', '_get_string', '_print_int', '_print_float', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc']
+    Settings.EXPORTED_FUNCTIONS += ['_get_int', '_get_float', '_get_bool', '_get_string', '_print_int', '_print_float', '_print_bool', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc']
     self.do_run_in_out_file_test('tests', 'core', 'test_ccall', post_build=post)
 
     if '-O2' in self.emcc_args or self.is_emterpreter():


### PR DESCRIPTION
This is a proposed fix for #4993.
Boolean types are now able to be used as arguments, and return types. 
```c
#include <stdbool.h>

bool test(int val, bool run) {
    if (val % 2 == 0 && run == true)
        return true;
    return false;
}
```
```js
var result = Module.ccall('test', // name of C function
        'bool', // return type
        ['number', 'bool'], // argument types
        [10, true]); // arguments
```
This is one of the samples I used, and the `typeof(result)` is `boolean`