### PR TITLE
Fix other.test_failing_alloc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   test-other:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=other skip:other.test_bad_triple skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_failing_alloc
+      - TEST_TARGET=other skip:other.test_bad_triple skip:other.test_native_link_error_message skip:other.test_emcc_v
       # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
       # CircleCI actively kills memory-over-consuming process
   test-browser:

--- a/src/settings.js
+++ b/src/settings.js
@@ -80,10 +80,10 @@ var ABORTING_MALLOC = 1; // If 1, then when malloc would fail we abort(). This i
                          // returning NULL (0) when it fails.
 var ALLOW_MEMORY_GROWTH = 0; // If false, we abort with an error if we try to allocate more memory than
                              // we can (TOTAL_MEMORY). If true, we will grow the memory arrays at
-                             // runtime, seamlessly and dynamically. This has a performance cost though,
+                             // runtime, seamlessly and dynamically. This has a performance cost in asm.js,
                              // both during the actual growth and in general (the latter is because in
                              // that case we must be careful about optimizations, in particular the
-                             // eliminator).
+                             // eliminator), but in wasm it is efficient and should be used whenever relevant.
                              // See https://code.google.com/p/v8/issues/detail?id=3907 regarding
                              // memory growth performance in chrome.
                              // Setting this option on will disable ABORTING_MALLOC, in other words,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5759,6 +5759,19 @@ int main() {
 #define CHUNK_SIZE (10*1024*1024)
 
 int main() {
+  EM_ASM({
+    // we want to allocate a lot until eventually we can't anymore. to simulate that, we limit how much
+    // can be allocated by Buffer, so that if we don't hit a limit before that, we don't keep going into
+    // swap space and other bad things.
+    var old = Module['reallocBuffer'];
+    Module['reallocBuffer'] = function(size) {
+      if (size > 500 * 1024 * 1024) {
+        return null;
+      }
+      return old(size);
+    };
+  });
+
   std::vector<void*> allocs;
   bool has = false;
   while (1) {


### PR DESCRIPTION
Enables the test on circle where it didn't pass until this. The issue is that the test allocates until we can't anymore, but depending on the OS and VM we may start swapping or hit other VM failures when we reach that dangerous point (if the VM gets to where the OS can no longer allocate, which seems to be the case sometimes). Instead, simulate a failure to allocate using the internal allocBuffer API, if we allocate over a large amount.