### PR TITLE
add a _embind_register_constant_float API

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2412,6 +2412,16 @@ var LibraryEmbind = {
         return [];
     });
   },
+
+  _embind_register_constant_float__deps: ['$readLatin1String', '$whenDependentTypesAreResolved'],
+  _embind_register_constant_float: function(name, type, value) {
+    name = readLatin1String(name);
+    whenDependentTypesAreResolved([], [type], function(type) {
+        type = type[0];
+        Module[name] = type['fromWireType'](value);
+        return [];
+    });
+  },
 };
 
 mergeInto(LibraryManager.library, LibraryEmbind);

--- a/tests/embind/test_float_constants.cpp
+++ b/tests/embind/test_float_constants.cpp
@@ -1,0 +1,25 @@
+#include <emscripten/bind.h>
+#include <emscripten/emscripten.h>
+#include <cstdio>
+
+#define PI 3.1416
+#define EULER 2.7182818
+const float pi = 3.1416;
+const double euler = 2.7182818;
+
+EMSCRIPTEN_BINDINGS(constants) {
+  emscripten::constant("PI", PI);
+  emscripten::constant("EULER", EULER);
+  emscripten::constant("pi", pi);
+  emscripten::constant("euler", euler);
+}
+
+int main()
+{
+    EM_ASM(
+        console.log("PI (as double) = " + Module['PI']);
+        console.log("EULER = " + Module['EULER']);
+        console.log("pi (as float) = " + Module['pi']);
+        console.log("euler = " + Module['euler']);
+    );
+}

--- a/tests/embind/test_float_constants.out
+++ b/tests/embind/test_float_constants.out
@@ -1,0 +1,4 @@
+PI (as double) = 3.1416
+EULER = 2.7182818
+pi (as float) = 3.1415998935699463
+euler = 2.7182818

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6741,6 +6741,11 @@ someweirdtext
     '''
     self.do_run(src, '418')
 
+  def test_embind_float_constants(self):
+    self.emcc_args += ['--bind']
+    self.do_run_from_file(path_from_root('tests', 'embind', 'test_float_constants.cpp'),
+                          path_from_root('tests', 'embind', 'test_float_constants.out'))
+
   @sync
   @no_wasm_backend()
   def test_webidl(self):


### PR DESCRIPTION
The _embind_register_constant API does not work for floating point
constants; we need something more sophisticated to handle `float` and
especially `double` (which is larger than a `uintptr_t` for current
Emscripten).

Fixes #5565.