### PR TITLE
Don't check for 'arguments' in web/worker environments

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -254,10 +254,6 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
     xhr.send(null);
   };
 
-  if (typeof arguments != 'undefined') {
-    Module['arguments'] = arguments;
-  }
-
   Module['setWindowTitle'] = function(title) { document.title = title };
 }
 #if ASSERTIONS


### PR DESCRIPTION
It doesn't make sense to look for commandline arguments to there to pass to `main()`, and it makes us behave in surprising ways if we are inside a function that happens to have 'arguments' defined. Other script tags may also lead to confusing results here. I noticed this when debugging wasm-by-default testcases.

In theory, this is a breaking change, but this change should fix the problems mentioned above, and I'm not sure how this would have been used in a way that would break.

Note: `Module['arguments']` can of course still be set manually if commandline arguments are desired to be passed to `main()`.