### PR TITLE
Add -text git attribute to tools/crunch-worker.js

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# This file has a 76,000 charactar line which we don't to show up in the
+# output of `git grep`
+tools/crunch-worker.js -diff


### PR DESCRIPTION
Without this running `git grep` will often pick up
something in the 76,000 character line in this file.