### PR TITLE
Allow both python 2 and 3, now that both are stable and tested

### DIFF
--- a/tests/emmake/make.py
+++ b/tests/emmake/make.py
@@ -1,0 +1,34 @@
+import os
+
+def which(program):
+  def is_exe(fpath):
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+  fpath, fname = os.path.split(program)
+  if fpath:
+    if is_exe(program):
+      return program
+  else:
+    for path in os.getenv("PATH", "").split(os.pathsep):
+      exe_file = os.path.join(path, program)
+      if is_exe(exe_file):
+        return exe_file
+  raise Exception('that is very bad')
+
+def test(what):
+  print(what)
+  print(which(os.getenv(what, '')))
+
+def check_ar():
+  print("Testing...")
+  test("CC")
+  test("CXX")
+  test("AR")
+  test("LD")
+  test("NM")
+  test("LDSHARED")
+  test("RANLIB")
+  print("Done.")
+
+check_ar()
+

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -74,10 +74,9 @@ class other(RunnerCore):
 
       output = run_process(py + [path_from_root('emcc'), '--version'], stdout=PIPE, stderr=PIPE, env=env).stderr
       expected_call = 'Running on Python %s which is not officially supported yet' % major
-      if major > 2:
-        assert expected_call in output
-      else:
-        assert expected_call not in output
+      # we currently support python 2 and 3 officially
+      assert expected_call not in output
+      assert output == '', output
 
   def test_emcc(self):
     for compiler in [EMCC, EMXX]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5622,6 +5622,13 @@ print(os.environ.get('NM'))
 ''')
     check('emconfigure', [PYTHON, 'test.py'], expect=tools.shared.LLVM_NM)
 
+  def test_emmake_python(self):
+    # simulates a configure/make script that looks for things like CC, AR, etc., and which we should
+    # not confuse by setting those vars to something containing `python X` as the script checks for
+    # the existence of an executable.
+    result = run_process([PYTHON, path_from_root('emmake.py'), PYTHON, path_from_root('tests', 'emmake', 'make.py')], stdout=PIPE, stderr=PIPE)
+    print(result.stdout, result.stderr)
+
   def test_sdl2_config(self):
     for args, expected in [
       [['--version'], '2.0.0'],

--- a/tools/python_selector.py
+++ b/tools/python_selector.py
@@ -22,15 +22,10 @@ def run_by_subprocess(filename):
   return subprocess.run(py2 + [os.path.realpath(filename) + '.py'] + sys.argv[1:]).returncode
 
 def on_allowed_version():
-  major = sys.version_info.major
-  if major == 2:
-    return True
-  if os.environ.get('EMSCRIPTEN_ALLOW_NEWER_PYTHON'):
-    import logging
-    from tools import colored_logger
-    logging.warning('Running on Python %s which is not officially supported yet', major)
-    return True
-  return False
+  # we now allow python 2 or 3. eventually, we will only allow 3, and can change
+  # this. when we do that, also note that in shared.get_building_env() we'll need
+  # to specify the proper python to be executed, and need to do that carefully.
+  return True
 
 '''
 Runs filename+'.py' by opening Python 2 subprocess if required, or by importing.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1406,12 +1406,14 @@ class Building(object):
         if env.get(dangerous) and env.get(dangerous) == non_native.get(dangerous):
           del env[dangerous] # better to delete it than leave it, as the non-native one is definitely wrong
       return env
-    env['CC'] = 'python %s' % quote(EMCC)
-    env['CXX'] = 'python %s' % quote(EMXX)
-    env['AR'] = 'python %s' % quote(EMAR)
-    env['LD'] = 'python %s' % quote(EMCC)
+    # add python when necessary (on non-windows, we now support python 2 and 3 so
+    # it should be ok either way)
+    env['CC'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
+    env['CXX'] = quote(EMXX) if not WINDOWS else 'python %s' % quote(EMXX)
+    env['AR'] = quote(EMAR) if not WINDOWS else 'python %s' % quote(EMAR)
+    env['LD'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
     env['NM'] = quote(LLVM_NM)
-    env['LDSHARED'] = 'python %s' % quote(EMCC)
+    env['LDSHARED'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
     env['RANLIB'] = quote(EMRANLIB) if not WINDOWS else 'python %s' % quote(EMRANLIB)
     env['EMMAKEN_COMPILER'] = quote(Building.COMPILER)
     env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')


### PR DESCRIPTION
And after doing that, it is easy to fix #6378 by reverting the change (for supporting only 2) that broke it.