### PR TITLE
Pass -no-pie to linker in nativize_llvm.py

### DIFF
--- a/tools/nativize_llvm.py
+++ b/tools/nativize_llvm.py
@@ -39,6 +39,6 @@ if not os.path.exists(filename + '.o'):
   sys.exit(1)
 
 print('o => runnable')
-check_call(['g++', path_from_root('system', 'lib', 'debugging.cpp'), filename + '.o', '-o', filename + '.run'] + ['-l' + lib for lib in libs])
+check_call(['g++', '-no-pie', path_from_root('system', 'lib', 'debugging.cpp'), filename + '.o', '-o', filename + '.run'] + ['-l' + lib for lib in libs])
 
 sys.exit(0)


### PR DESCRIPTION
The default (on my system anyway) seem to be -pie but the .bc.o file
contains relocations are not compatible with PIE.

TESTED=./tests/runner.py other.test_llvm_nativizer