### PR TITLE
Box2D doesn't need c++ exceptions or rtti, disabling them shrinks it by 15%

### DIFF
--- a/tests/box2d/Benchmark.cpp
+++ b/tests/box2d/Benchmark.cpp
@@ -19,14 +19,16 @@ typedef struct {
 } result_t;
 // ==============================
 
-
-
 #include <cstdio>
 #include <time.h>
 #include <math.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#endif
+
+#if NO_PRINTING
+#define printf(fmt, ...) (0)
 #endif
 
 #include "Box2D/Box2D.h"

--- a/tests/box2d/Makefile
+++ b/tests/box2d/Makefile
@@ -51,7 +51,7 @@ OBJECTS = \
 all: box2d.a
 
 %.o: %.cpp
-	$(CXX) $(CFLAGS) -I. $< -o $@ -O2 -c
+	$(CXX) $(CFLAGS) -I. $< -o $@ -O2 -c -fno-exceptions -fno-rtti
 
 box2d.a: $(OBJECTS)
 	$(AR) rvs $@ $(OBJECTS)


### PR DESCRIPTION
I was confused initially that just doing `-fno-rtti` was not enough to remove that overhead (since it is all libcxxabi code that is rtti related), but turns out I was just missing `-fno-exceptions`. With both flags, llvm can get rid of the libcxxabi overhead.