### PR TITLE
llvm custom passes draft

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -263,6 +263,8 @@ if operation == 'build':
       build_port('binaryen', None, ['-s', 'WASM=1'])
     elif what == 'cocos2d':
       build_port('cocos2d', None, ['-s', 'USE_COCOS2D=3', '-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1'])
+    elif what == 'llvm-config':
+      build_port('llvm-config', None, [])
     else:
       shared.logging.error('unfamiliar build target: ' + what)
       sys.exit(1)

--- a/src/settings.js
+++ b/src/settings.js
@@ -350,6 +350,12 @@ var NODEJS_CATCH_EXIT = 1; // By default we handle exit() in node, by catching t
                            // longer do that, and exceptions work normally, which can be useful for libraries
                            // or programs that don't need exit() to work.
 
+var EXTRA_LLVM_FINAL_OPT_ARGS = ""; // A comma-separated list of additional arguments that will be appended to
+                                    // 'opt' command. You can use it for example to  run custom optimization pass:
+                                    // -s EXTRA_LLVM_FINAL_OPT_ARGS="['-load', 'llvm_pass_print_function_names.so', '-print-function-names']"
+                                    // For -load command you can also use source (.cpp) instead of shared library (.so)
+                                    // see test_llvm_custom_pass_src in test_other.py
+
 // For more explanations of this option, please visit
 // https://github.com/kripken/emscripten/wiki/Asyncify
 var ASYNCIFY = 0; // Whether to enable asyncify transformation

--- a/tests/llvm_pass_print_function_names.cpp
+++ b/tests/llvm_pass_print_function_names.cpp
@@ -1,0 +1,23 @@
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+struct PrintFunctionNames : public FunctionPass {
+  static char ID;
+  PrintFunctionNames() : FunctionPass(ID) {}
+
+  bool runOnFunction(Function &F) override {
+    errs() << "PrintFunctionNames: ";
+    errs().write_escaped(F.getName()) << '\n';
+    return false;
+  }
+}; // end of struct Hello
+}  // end of anonymous namespace
+
+char PrintFunctionNames::ID = 0;
+static RegisterPass<PrintFunctionNames> X("print-function-names", "Print function names",
+                             false /* Only looks at CFG */,
+                             false /* Analysis Pass */);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6517,17 +6517,34 @@ Resolved: "/" => "/"
       custompass_src = path_from_root('tests', 'llvm_pass_print_function_names.cpp')
       source = path_from_root('tests', 'hello_libcxx.cpp')
 
-      print('== Running custom pass (1)')
+      print('\n== Running custom pass (1)')
       cmd = [PYTHON, EMCC, source, '--llvm-opts', '["-print-function-names"]', '-s', 'EXTRA_LLVM_FINAL_OPT_ARGS=["-load", "' + custompass_src + '"]']
-      print(cmd)
-      stderr = run_process(cmd, stderr=PIPE).stderr
+      res = run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
+      code   = res.returncode
+      stdout = res.stderr
+      stderr = res.stderr
+      if code != 0:
+        print('== ERROR executing\n', cmd, 'code', code)
+        print('== STDOUT\n', stdout)
+        print('== STDERR\n', stderr)
+        assert(False)
+
       self.assertContained('PrintFunctionNames: main', stderr)
       self.assertContained('hello, world!', run_js('a.out.js'))
 
       print('== Running custom pass (2)')
       cmd = [PYTHON, EMCC, source, '-s', 'EXTRA_LLVM_FINAL_OPT_ARGS=["-load", "' + custompass_src + '", "-print-function-names"]']
       print(cmd)
-      stderr = run_process(cmd, stderr=PIPE).stderr
+      res = run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
+      code = res.returncode
+      stdout = res.stderr
+      stderr = res.stderr
+      if code != 0:
+        print('== ERROR executing\n', cmd, 'code', code)
+        print('== STDOUT\n', stdout)
+        print('== STDERR\n', stderr)
+        assert(False)
+
       self.assertContained('PrintFunctionNames: main', stderr)
       self.assertContained('PrintFunctionNames: malloc', stderr) # link time, all functions
       self.assertContained('hello, world!', run_js('a.out.js'))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6512,6 +6512,26 @@ Resolved: "/" => "/"
     assert sizes[1] < sizes[0]
     assert sizes[3] < sizes[0]
 
+  def test_llvm_custom_pass_src(self):
+    with temp_directory() as temp_dir:
+      custompass_src = path_from_root('tests', 'llvm_pass_print_function_names.cpp')
+      source = path_from_root('tests', 'hello_libcxx.cpp')
+
+      print('== Running custom pass (1)')
+      cmd = [PYTHON, EMCC, source, '--llvm-opts', '["-print-function-names"]', '-s', 'EXTRA_LLVM_FINAL_OPT_ARGS=["-load", "' + custompass_src + '"]']
+      print(cmd)
+      stderr = run_process(cmd, stderr=PIPE).stderr
+      self.assertContained('PrintFunctionNames: main', stderr)
+      self.assertContained('hello, world!', run_js('a.out.js'))
+
+      print('== Running custom pass (2)')
+      cmd = [PYTHON, EMCC, source, '-s', 'EXTRA_LLVM_FINAL_OPT_ARGS=["-load", "' + custompass_src + '", "-print-function-names"]']
+      print(cmd)
+      stderr = run_process(cmd, stderr=PIPE).stderr
+      self.assertContained('PrintFunctionNames: main', stderr)
+      self.assertContained('PrintFunctionNames: malloc', stderr) # link time, all functions
+      self.assertContained('hello, world!', run_js('a.out.js'))
+
   def test_dlmalloc_modes(self):
     open('src.cpp', 'w').write(r'''
       #include <stdlib.h>

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -1,7 +1,7 @@
-from . import binaryen, bullet, cocos2d, freetype, harfbuzz, libpng, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
+from . import binaryen, bullet, cocos2d, freetype, harfbuzz, libpng, llvmconfig, ogg, sdl, sdl_image, sdl_ttf, sdl_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
-ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, harfbuzz, sdl_ttf, sdl_net, binaryen, cocos2d]
+ports = [zlib, libpng, sdl, sdl_image, ogg, vorbis, bullet, freetype, harfbuzz, sdl_ttf, sdl_net, binaryen, cocos2d, llvmconfig]
 
 ports_by_name = {}
 for port in ports:

--- a/tools/ports/llvmconfig.py
+++ b/tools/ports/llvmconfig.py
@@ -1,0 +1,89 @@
+import os
+import logging
+from subprocess import PIPE
+
+TAG = 'incoming'
+PORT_NAME = 'llvm-config'
+PORT_KEY = 'emscripten-fastcomp-' + TAG
+
+def getroot(ports):
+    return os.path.join(ports.get_dir(), PORT_NAME, PORT_KEY)
+
+def get(ports, settings, shared):
+    ports.fetch_project(PORT_NAME, 'https://github.com/kripken/emscripten-fastcomp/archive/' + TAG + '.zip', PORT_KEY)
+
+    def create():
+        logging.info('building: %s' % PORT_KEY)
+
+        root = getroot(ports)
+        buildroot = os.path.join(root, 'build')
+
+        if not(os.path.exists(buildroot)):
+            os.mkdir(buildroot)
+
+        ports.build_native(buildroot, '..', target='llvm-config')
+        ports.build_native(buildroot, '..', target='intrinsics_gen')
+
+        # the "output" of this port build is a tag file, saying which port we have
+        tag_file = os.path.join(root, 'tag.txt')
+        open(tag_file, 'w').write(TAG)
+        return tag_file
+
+    return [shared.Cache.get(PORT_KEY, create, what='port', extension='.txt')]
+
+
+def process_dependencies(settings):
+    pass
+
+
+def process_args(ports, args, settings, shared):
+    scope = [True, []]
+
+    def lib_suffix(name):
+        return name + '.dll' if shared.WINDOWS else name + '.so'
+
+    def compile_shared(src):
+        compile_flags = scope[1]
+
+        temp_dir = shared.get_emscripten_temp_dir()
+        so = os.path.join(temp_dir, lib_suffix(os.path.basename(src)))
+
+        logging.info("Building %s -> %s", src, so)
+
+        if len(compile_flags) == 0:
+            binroot = os.path.join(getroot(ports), 'build', 'bin')
+            llvmconfig = os.path.join(binroot, shared.exe_suffix('llvm-config'))
+            cmd = [llvmconfig, '--cxxflags']
+            flags = shared.run_process(cmd, check=True, stdout=PIPE).stdout
+            compile_flags += flags.split()
+            compile_flags += ['-D_GLIBCXX_USE_CXX11_ABI=0']  # https://stackoverflow.com/questions/37366291/undefined-symbol-for-self-built-llvm-opt)
+            scope[1] = compile_flags
+
+        cmd = [shared.CLANG_CPP]
+        cmd += compile_flags
+        cmd += ['-shared', src, '-o', so]
+        shared.check_execute(cmd)
+        return so
+
+    def getport():
+        if scope[0]:
+            get(ports, settings, shared)
+            scope[0] = False
+
+    idx = 0
+    while idx < len(settings.EXTRA_LLVM_FINAL_OPT_ARGS):
+        if settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx].strip() == '-load':
+            idx += 1
+            loadfile = settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx]
+
+            if loadfile.endswith('.cpp'):
+                getport()
+                so = compile_shared(loadfile)
+                settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx] = so
+        idx += 1
+
+    return args
+
+
+def show():
+    return PORT_NAME

--- a/tools/ports/llvmconfig.py
+++ b/tools/ports/llvmconfig.py
@@ -77,7 +77,8 @@ def process_args(ports, args, settings, shared):
             compile_flags += ['-D_GLIBCXX_USE_CXX11_ABI=0']  # https://stackoverflow.com/questions/37366291/undefined-symbol-for-self-built-llvm-opt)
 
             # clang includes
-            compile_flags += ['-I' + os.path.join(getroot(ports), 'include')]
+            # compile_flags += ['-I' + os.path.join(getroot(ports), 'include')]
+            compile_flags += ['-I' + os.path.join(ports.get_dir(), FASTCOMP_CLANG_PORT, FASTCOMP_CLANG_KEY, 'lib', 'Headers')]
             scope[1] = compile_flags
 
         cmd = [shared.CLANG_CPP]

--- a/tools/ports/llvmconfig.py
+++ b/tools/ports/llvmconfig.py
@@ -48,21 +48,52 @@ def process_args(ports, args, settings, shared):
         temp_dir = shared.get_emscripten_temp_dir()
         so = os.path.join(temp_dir, lib_suffix(os.path.basename(src)))
 
-        logging.info("Building %s -> %s", src, so)
+        print("@@@DEBUG")
+        print("Building %s -> %s" % (src, so))
+
+        logging.info("Building %s -> %s" % (src, so))
 
         if len(compile_flags) == 0:
             binroot = os.path.join(getroot(ports), 'build', 'bin')
+
+            # llvm-config flags
             llvmconfig = os.path.join(binroot, shared.exe_suffix('llvm-config'))
             cmd = [llvmconfig, '--cxxflags']
             flags = shared.run_process(cmd, check=True, stdout=PIPE).stdout
             compile_flags += flags.split()
             compile_flags += ['-D_GLIBCXX_USE_CXX11_ABI=0']  # https://stackoverflow.com/questions/37366291/undefined-symbol-for-self-built-llvm-opt)
+
+            # clang includes
+            # http://clang-developers.42468.n3.nabble.com/How-to-determine-clang-s-system-include-dirs-to-set-in-ASTVisitor-td4029080.html
+            foo = os.path.join(shared.get_emscripten_temp_dir(), 'foo.cpp')
+            with open(foo, 'w') as f:
+                pass
+
+            out = shared.run_process([shared.CLANG_CPP, '-###', '-c', foo], stderr=PIPE).stderr
+            print("========\/")
+            print(out)
+            print("===")
+
+            idx = 0
+            tokens = out.split()
+            for next in tokens:
+                idx += 1
+                if '-resource-dir' in next:
+                    break
+
+            assert(idx < len(tokens))
+            compile_flags += ['-I' + os.path.join(tokens[idx].replace("'", "").replace('"', ''), 'include')]
             scope[1] = compile_flags
 
         cmd = [shared.CLANG_CPP]
         cmd += compile_flags
         cmd += ['-shared', src, '-o', so]
-        shared.check_execute(cmd)
+
+        print("Run", cmd)
+        out = shared.run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
+        print("== STDOUT:\n%s\n== STDERR:\n%s\n" % (out.stdout, out.stderr))
+        assert(out.returncode == 0)
+
         return so
 
     def getport():

--- a/tools/ports/llvmconfig.py
+++ b/tools/ports/llvmconfig.py
@@ -17,7 +17,28 @@ FASTCOMP_CLANG_KEY = FASTCOMP_CLANG_PORT + '-' + TAG
 def getroot(ports):
     return os.path.join(ports.get_dir(), PORT_NAME)
 
+def should_build_llvm_config(settings):
+    return len(find_cpp_passes(settings)) > 0
+
+def find_cpp_passes(settings):
+    cpp_passes = []
+
+    if not hasattr(settings, 'EXTRA_LLVM_FINAL_OPT_ARGS'):
+        return cpp_passes
+
+    for idx, val in enumerate(settings.EXTRA_LLVM_FINAL_OPT_ARGS):
+        if val.strip() == '-load':
+            fileindex = idx + 1
+            loadfile = settings.EXTRA_LLVM_FINAL_OPT_ARGS[fileindex]
+            if loadfile.endswith('.cpp'):
+                cpp_passes += [fileindex]
+
+    return cpp_passes
+
 def get(ports, settings, shared):
+    if not should_build_llvm_config(settings):
+        return []
+
     ports.fetch_project(FASTCOMP_PORT, 'https://github.com/kripken/emscripten-fastcomp/archive/' + TAG + '.zip', FASTCOMP_KEY)
     ports.fetch_project(FASTCOMP_CLANG_PORT, 'https://github.com/kripken/emscripten-fastcomp-clang/archive/' + TAG + '.zip', FASTCOMP_CLANG_KEY)
 
@@ -34,8 +55,8 @@ def get(ports, settings, shared):
         ports.build_native(buildroot, os.path.join(ports.get_dir(), FASTCOMP_PORT, FASTCOMP_KEY), target='llvm-config')
         ports.build_native(buildroot, os.path.join(ports.get_dir(), FASTCOMP_PORT, FASTCOMP_KEY), target='intrinsics_gen')
 
-        copyfile(os.path.join(ports.get_dir(), FASTCOMP_CLANG_PORT, FASTCOMP_CLANG_KEY, 'lib', 'Headers', 'stdarg.h'),
-                 os.path.join(includeroot, 'stdarg.h'))
+        # copyfile(os.path.join(ports.get_dir(), FASTCOMP_CLANG_PORT, FASTCOMP_CLANG_KEY, 'lib', 'Headers', 'stdarg.h'),
+        #          os.path.join(includeroot, 'stdarg.h'))
 
         # the "output" of this port build is a tag file, saying which port we have
         tag_file = os.path.join(root, 'tag.txt')
@@ -45,69 +66,61 @@ def get(ports, settings, shared):
     return [shared.Cache.get(PORT_KEY, create, what='port', extension='.txt')]
 
 
+def compile_pass(src, compile_flags, shared):
+    def lib_suffix(name):
+        return name + '.dll' if shared.WINDOWS else name + '.so'
+
+    temp_dir = shared.get_emscripten_temp_dir()
+    so = os.path.join(temp_dir, lib_suffix(os.path.basename(src)))
+
+    logging.info("@@@DEBUG")
+    logging.info("Building %s -> %s" % (src, so))
+
+    logging.info("Building %s -> %s" % (src, so))
+
+    cmd = [shared.CLANG_CPP]
+    cmd += compile_flags
+    cmd += ['-shared', src, '-o', so]
+
+    logging.info("Run %s" % cmd)
+    out = shared.run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
+    logging.info("== STDOUT:\n%s\n== STDERR:\n%s\n" % (out.stdout, out.stderr))
+    assert(out.returncode == 0)
+
+    return so
+
+def compile_flags(ports, shared):
+    compile_flags = []
+    binroot = os.path.join(getroot(ports), 'build', 'bin')
+
+    # llvm-config flags
+    llvmconfig = os.path.join(binroot, shared.exe_suffix('llvm-config'))
+    cmd = [llvmconfig, '--cxxflags']
+    flags = shared.run_process(cmd, check=True, stdout=PIPE).stdout
+    compile_flags += flags.split()
+    compile_flags += ['-D_GLIBCXX_USE_CXX11_ABI=0']  # https://stackoverflow.com/questions/37366291/undefined-symbol-for-self-built-llvm-opt
+    compile_flags += ['-fno-rtti'] # https://stackoverflow.com/questions/42998440/undefined-symbol-for-llvm-plugin
+
+    # clang includes
+    # compile_flags += ['-I' + os.path.join(getroot(ports), 'include')]
+    compile_flags += ['-I' + os.path.join(ports.get_dir(), FASTCOMP_CLANG_PORT, FASTCOMP_CLANG_KEY, 'lib', 'Headers')]
+
+    return compile_flags
+
 def process_dependencies(settings):
     pass
 
 
 def process_args(ports, args, settings, shared):
-    scope = [True, []]
+    flags = []
+    cpp_passes = find_cpp_passes(settings)
 
-    def lib_suffix(name):
-        return name + '.dll' if shared.WINDOWS else name + '.so'
+    if len(cpp_passes) > 0:
+        get(ports, settings, shared)
+        flags = compile_flags(ports, shared)
 
-    def compile_shared(src):
-        compile_flags = scope[1]
-
-        temp_dir = shared.get_emscripten_temp_dir()
-        so = os.path.join(temp_dir, lib_suffix(os.path.basename(src)))
-
-        print("@@@DEBUG")
-        print("Building %s -> %s" % (src, so))
-
-        logging.info("Building %s -> %s" % (src, so))
-
-        if len(compile_flags) == 0:
-            binroot = os.path.join(getroot(ports), 'build', 'bin')
-
-            # llvm-config flags
-            llvmconfig = os.path.join(binroot, shared.exe_suffix('llvm-config'))
-            cmd = [llvmconfig, '--cxxflags']
-            flags = shared.run_process(cmd, check=True, stdout=PIPE).stdout
-            compile_flags += flags.split()
-            compile_flags += ['-D_GLIBCXX_USE_CXX11_ABI=0']  # https://stackoverflow.com/questions/37366291/undefined-symbol-for-self-built-llvm-opt)
-
-            # clang includes
-            # compile_flags += ['-I' + os.path.join(getroot(ports), 'include')]
-            compile_flags += ['-I' + os.path.join(ports.get_dir(), FASTCOMP_CLANG_PORT, FASTCOMP_CLANG_KEY, 'lib', 'Headers')]
-            scope[1] = compile_flags
-
-        cmd = [shared.CLANG_CPP]
-        cmd += compile_flags
-        cmd += ['-shared', src, '-o', so]
-
-        print("Run", cmd)
-        out = shared.run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
-        print("== STDOUT:\n%s\n== STDERR:\n%s\n" % (out.stdout, out.stderr))
-        assert(out.returncode == 0)
-
-        return so
-
-    def getport():
-        if scope[0]:
-            get(ports, settings, shared)
-            scope[0] = False
-
-    idx = 0
-    while idx < len(settings.EXTRA_LLVM_FINAL_OPT_ARGS):
-        if settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx].strip() == '-load':
-            idx += 1
-            loadfile = settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx]
-
-            if loadfile.endswith('.cpp'):
-                getport()
-                so = compile_shared(loadfile)
-                settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx] = so
-        idx += 1
+    for idx in cpp_passes:
+        settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx] = compile_pass(settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx], flags, shared)
 
     return args
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1854,7 +1854,7 @@ class Building(object):
       return link_args
 
   # LLVM optimizations
-  # @param opt A list of LLVM optimization parameters
+  # @param opts A list of LLVM optimization parameters
   @staticmethod
   def llvm_opt(filename, opts, out=None):
     inputs = filename
@@ -1876,10 +1876,21 @@ class Building(object):
     else:
       opts += ['-bb-vectorize-vector-bits=128']
 
-    logging.debug('emcc: LLVM opts: ' + ' '.join(opts) + '  [num inputs: ' + str(len(inputs)) + ']')
+    load_args = []
+    extra_args = []
+    idx = 0
+    while idx < len(Settings.EXTRA_LLVM_FINAL_OPT_ARGS):
+      if Settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx].strip() == '-load':
+        idx += 1
+        load_args += ['-load', Settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx]]
+      else:
+        extra_args += [Settings.EXTRA_LLVM_FINAL_OPT_ARGS[idx]]
+      idx += 1
+
+    logging.debug('emcc: LLVM opts: ' ' '.join(load_args) + ' ' + ' '.join(opts) + ' ' + ' '.join(extra_args) + ' [num inputs: ' + str(len(inputs)) + ']')
     target = out or (filename + '.opt.bc')
     try:
-      run_process([LLVM_OPT] + inputs + opts + ['-o', target], stdout=PIPE)
+      run_process([LLVM_OPT] + load_args + inputs + opts + extra_args +  ['-o', target], stdout=PIPE)
       assert os.path.exists(target), 'llvm optimizer emitted no output.'
     except subprocess.CalledProcessError as e:
       logging.error('Failed to run llvm optimizations: ' + e.output)


### PR DESCRIPTION
Hi. Related to https://github.com/kripken/emscripten/issues/6379. I've tried to improve build system to allow using of custom llvm passes. Not very sure about correctness, feel free to give proposal. 

`LLVM_LTO_PASSES` needed just because we need way to run passes on link step.On other side we can reuse --llvm-lto, but we need fix it because now it's accept only number and not passes name. Another disadvantage of llvm-lto it is run only when optimizations are enabled.