### PR TITLE
Fix dynamic library alignment, and add test for #6355

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -432,7 +432,7 @@ function JSify(data, functionsOnly) {
           print('STATIC_BASE = GLOBAL_BASE;\n');
           print('STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
         } else {
-          print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}}), ' + MAX_GLOBAL_ALIGN + ' || 1);\n');
+          print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}} + ' + MAX_GLOBAL_ALIGN + '), ' + MAX_GLOBAL_ALIGN + ' || 1);\n');
           // The static area consists of explicitly initialized data, followed by zero-initialized data.
           // The latter may need zeroing out if the MAIN_MODULE has already used this memory area before
           // dlopen'ing the SIDE_MODULE.  Since we don't know the size of the explicitly initialized data

--- a/src/shell_sharedlib.js
+++ b/src/shell_sharedlib.js
@@ -14,7 +14,7 @@
   assert(STACKTOP % 8 == 0);
   var STACK_MAX = STACKTOP + TOTAL_STACK;
   Module.cleanups.push(function() {
-    parentModule['_free'](STACKTOP); // XXX ensure exported
+    parentModule['_free'](STACKTOP); // XXX ensure exported, and that it was actually malloc'ed and not static memory FIXME
     parentModule['_free'](gb);
   });
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2775,6 +2775,7 @@ def process(filename):
                 post_build=self.dlfcn_post_build)
 
   @no_wasm # wasm shared libraries are just .wasm files, and there is no way to describe alignment there yet
+           # see https://github.com/WebAssembly/tool-conventions/pull/51
   def test_dlfcn_alignment_and_zeroing(self):
     if not self.can_dlfcn(): return
 


### PR DESCRIPTION
As a followup for #6355, this adds a test for both alignment and zero-initialization of dynamic libraries.

Turns out the alignment part was not quite right yet, fixed here.

The new test would fail before all the relevant 3 fixes (2 from that PR, 1 from here).

This doesn't work in wasm yet as dynamic libraries can't request an alignment. Opened https://github.com/WebAssembly/tool-conventions/pull/51