### PR TITLE
library_sdl.js: Support AUDIO_F32 sample format in SDL_OpenAudio

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1166,7 +1166,7 @@ var LibrarySDL = {
     webAudioAvailable: function() { return !!SDL.audioContext; },
 
     fillWebAudioBufferFromHeap: function(heapPtr, sizeSamplesPerChannel, dstAudioBuffer) {
-      // The input audio data is interleaved across the channels, i.e. [L, R, L, R, L, R, ...] and is either 8-bit or 16-bit as
+      // The input audio data is interleaved across the channels, i.e. [L, R, L, R, L, R, ...] and is either 8-bit, 16-bit or float as
       // supported by the SDL API. The output audio wave data for Web Audio API must be in planar buffers of [-1,1]-normalized Float32 data,
       // so perform a buffer conversion for the data.
       var numChannels = SDL.audio.channels;
@@ -1183,6 +1183,10 @@ var LibrarySDL = {
           for(var j = 0; j < sizeSamplesPerChannel; ++j) {
             var v = ({{{ makeGetValue('heapPtr', 'j*numChannels + c', 'i8', 0, 0) }}});
             channelData[j] = ((v >= 0) ? v-128 : v+128) /128;
+          }
+        } else if (SDL.audio.format == 0x8120 /*AUDIO_F32*/) {
+          for(var j = 0; j < sizeSamplesPerChannel; ++j) {
+            channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float', 0, 0) }}});
           }
         }
       }
@@ -2397,6 +2401,8 @@ var LibrarySDL = {
         SDL.audio.silence = 128; // Audio ranges in [0, 255], so silence is half-way in between.
       } else if (SDL.audio.format == 0x8010 /*AUDIO_S16LSB*/) {
         SDL.audio.silence = 0; // Signed data in range [-32768, 32767], silence is 0.
+      } else if (SDL.audio.format == 0x8120 /*AUDIO_F32*/) {
+        SDL.audio.silence = 0.0; // Float data in range [-1.0, 1.0], silence is 0.0
       } else {
         throw 'Invalid SDL audio format ' + SDL.audio.format + '!';
       }
@@ -2431,7 +2437,15 @@ var LibrarySDL = {
       }
 
       var totalSamples = SDL.audio.samples*SDL.audio.channels;
-      SDL.audio.bytesPerSample = (SDL.audio.format == 0x0008 /*AUDIO_U8*/ || SDL.audio.format == 0x8008 /*AUDIO_S8*/) ? 1 : 2;
+      if (SDL.audio.format == 0x0008 /*AUDIO_U8*/) {
+        SDL.audio.bytesPerSample = 1;
+      }
+      else if (SDL.audio.format == 0x8120 /*AUDIO_F32*/) {
+        SDL.audio.bytesPerSample = 4;
+      }
+      else {
+        SDL.audio.bytesPerSample = 2;
+      }
       SDL.audio.bufferSize = totalSamples*SDL.audio.bytesPerSample;
       SDL.audio.bufferDurationSecs = SDL.audio.bufferSize / SDL.audio.bytesPerSample / SDL.audio.channels / SDL.audio.freq; // Duration of a single queued buffer in seconds.
       SDL.audio.bufferingDelay = 50 / 1000; // Audio samples are played with a constant delay of this many seconds to account for browser and jitter.

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1188,6 +1188,8 @@ var LibrarySDL = {
           for(var j = 0; j < sizeSamplesPerChannel; ++j) {
             channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float', 0, 0) }}});
           }
+        } else {
+          throw 'Invalid SDL audio format ' + SDL.audio.format + '!';
         }
       }
     },
@@ -2439,12 +2441,12 @@ var LibrarySDL = {
       var totalSamples = SDL.audio.samples*SDL.audio.channels;
       if (SDL.audio.format == 0x0008 /*AUDIO_U8*/) {
         SDL.audio.bytesPerSample = 1;
-      }
-      else if (SDL.audio.format == 0x8120 /*AUDIO_F32*/) {
-        SDL.audio.bytesPerSample = 4;
-      }
-      else {
+      } else if (SDL.audio.format == 0x8010 /*AUDIO_S16LSB*/) {
         SDL.audio.bytesPerSample = 2;
+      } else if (SDL.audio.format == 0x8120 /*AUDIO_F32*/) {
+        SDL.audio.bytesPerSample = 4;
+      } else {
+        throw 'Invalid SDL audio format ' + SDL.audio.format + '!';
       }
       SDL.audio.bufferSize = totalSamples*SDL.audio.bytesPerSample;
       SDL.audio.bufferDurationSecs = SDL.audio.bufferSize / SDL.audio.bytesPerSample / SDL.audio.channels / SDL.audio.freq; // Duration of a single queued buffer in seconds.


### PR DESCRIPTION
***I think this PR is complete and ready for review/merge now***

This PR adds the minimal required changes to add support for float samples to the SDL_OpenAudio wrapper (currently only 8-bit and 16-bit integer samples are supported).

If the application works with floating point samples, this removes a conversion step from float to int16_t and back to float (this is for instance the case with the SoLoud "SDL static" backend).

So far I have only tested this with SoLoud in the following demos:

- MOD playback: http://floooh.github.io/oryol-samples/wasm/SoloudMOD.html
- TED/SID player: http://floooh.github.io/oryol-samples/wasm/SoloudTedSid.html
- KC85 emulator (start games by clicking on the cassette tapes lying around): http://floooh.github.io/oryol-samples/wasm/KC85-3.html
- the actual emulator (best to boot into the Amstrad CPC6128: press TAB, top left menu, System..., then Quickload menu, and start any of the games, or the "DTC (Demo)": http://floooh.github.io/virtualkc/

As far as I can tell it sounds pretty much the same as before. The audio glitches that happen in the emulator from time to time also happen with the original code (this happens when the audio playback gets out of sync with the emulation, I haven't found a waterproof solution so far... and doubt that this is even possible).

What still needs to be done:
- ~~~run the emscripten tests~~~ (appears to work)
- ~~~probably need to add new tests (...do I?)~~~ (I extended the test interactive.test_sdl_audio_beeps)
- test if other projects expecting the old behaviour still work (for instance try to build Bananebread)
- any other things I should check?

I should probably also mention that this only affects SDL_OpenAudio, I haven't looked any of the SDL_Mixer stuff (I'm not using this anywhere in my code, so I don't need it and wouldn't know how to test it).
