### PR TITLE
Emterpreter-async-assertions float fix

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -210,7 +210,7 @@ Module['callMain'] = function callMain(args) {
 #if EMTERPRETIFY_ASYNC
     // if we are saving the stack, then do not call exit, we are not
     // really exiting now, just unwinding the JS stack
-    if (EmterpreterAsync.state !== 1) {
+    if (typeof EmterpreterAsync === 'object' && EmterpreterAsync.state !== 1) {
 #endif // EMTERPRETIFY_ASYNC
     // if we're not running an evented main loop, it's time to exit
       exit(ret, /* implicit = */ true);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5362,22 +5362,25 @@ function _main() {
       ('double', '18.51'),
     ]:
       print(t, out)
-      open('src.cpp', 'w').write(r'''
+      open('src.c', 'w').write(r'''
         #include <stdio.h>
         #include <emscripten.h>
 
         #define TYPE %s
 
-        TYPE func(TYPE input) {
+        TYPE marfoosh(TYPE input) {
           return input * 1.5;
         }
 
+        TYPE fleefl(TYPE input) {
+          return marfoosh(input);
+        }
+
         int main(void) {
-          emscripten_sleep(1); // just make sure we are in emterpreter-async mode
-          printf("result: %%.2f\n", (double)func((TYPE)12.34));
+          printf("result: %%.2f\n", (double)fleefl((TYPE)12.34));
         }
       ''' % t)
-      run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_main"]'])
+      run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_fleefl"]', '-s', 'PRECISE_F32=1'])
       self.assertContained('result: ' + out, run_js('a.out.js'))
 
   def test_link_with_a_static(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5353,6 +5353,33 @@ function _main() {
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'emterpreter_advise_synclist.c'), '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_ADVISE=1', '-s', 'EMTERPRETIFY_SYNCLIST=["_j","_k"]'], stdout=PIPE).stdout
     self.assertContained('-s EMTERPRETIFY_WHITELIST=\'["_a", "_b", "_e", "_f", "_main"]\'', out)
 
+  def test_emterpreter_async_assertions(self):
+    # emterpretify-async mode with assertions adds checks on each call out of the emterpreter;
+    # make sure we handle all possible types there
+    for t, out in [
+      ('int',    '18.00'),
+      ('float',  '18.51'),
+      ('double', '18.51'),
+    ]:
+      print(t, out)
+      open('src.cpp', 'w').write(r'''
+        #include <stdio.h>
+        #include <emscripten.h>
+
+        #define TYPE %s
+
+        TYPE func(TYPE input) {
+          return input * 1.5;
+        }
+
+        int main(void) {
+          emscripten_sleep(1); // just make sure we are in emterpreter-async mode
+          printf("result: %%.2f\n", (double)func((TYPE)12.34));
+        }
+      ''' % t)
+      run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_main"]'])
+      self.assertContained('result: ' + out, run_js('a.out.js'))
+
   def test_link_with_a_static(self):
     for args in [[], ['-O2']]:
       print(args)

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1931,6 +1931,7 @@ function detectType(node, asmInfo, inVarDef) {
       if (!parseHeap(node[1][1])) return ASM_NONE;
       return parseHeapTemp.float ? ASM_DOUBLE : ASM_INT; // XXX ASM_FLOAT?
     }
+    case 'stat': return ASM_NONE;
   }
   assert(0 , 'horrible ' + JSON.stringify(node));
 }
@@ -7380,18 +7381,15 @@ function emterpretify(ast) {
           var callType = ASM_NONE;
           var parent = stack[stack.length-1];
           if (parent) {
+            callType = detectType(parent, asmData);
             var temp = null;
-            if (parent[0] === 'binary' && parent[1] === '|' && parent[3][0] === 'num' && parent[3][1] === 0 &&
-                parent[2] === node) {
-              // int-coerced call
-              callType = ASM_INT;
-              temp = 'tempInt';
-            } else if (parent[0] === 'unary-prefix' && parent[1] === '+' && parent[2] === node) {
-              // double-coerced call
-              callType = ASM_DOUBLE;
-              temp = 'tempDouble';
+            switch (callType) {
+              case ASM_INT:    temp = 'tempInt'; break;
+              case ASM_DOUBLE: temp = 'tempDouble'; break;
+              case ASM_FLOAT:  temp = 'tempFloat'; break;
+              case ASM_NONE:   break;
+              default: throw 'unhandled parent type in emterpter-async-assertions: ' + callType;
             }
-            // XXX fails on other coercions of odd types, like float32, simd, etc!
             if (temp) {
               // assign to temp, assert, return proper value:     temp = call() , (asyncState ? abort() : temp)
               trample(node, ['seq',


### PR DESCRIPTION
Fixes float calls in emterpreter-async plus assertions mode. See #6425