### PR TITLE
PERF: Memoize lookups from SIDE_MODULE into MAIN_MODULE

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1396,7 +1396,8 @@ Module['NAMED_GLOBALS'] = NAMED_GLOBALS;
       named_globals += '''
 for (var named in NAMED_GLOBALS) {
   (function(named) {
-    Module['g$_' + named] = function() { return Module['_' + named] };
+    var func = Module['_' + named];
+    Module['g$_' + named] = function() { return func };
   })(named);
 }
 '''


### PR DESCRIPTION
In running Numpy benchmarks in WebAssembly, I noticed that particularly for the benchmarks that are much slower than native, a large fraction of the time was spent looking up symbols in the main module from the side module (at least I think that's what this code does):

```
for (var named in NAMED_GLOBALS) {
  (function(named) {
    Module['g$_' + named] = function() { return Module['_' + named] // <- 50% of runtime };
  })(named);
}
```
By memoizing the lookup, that significantly speeds things up.

(x scale is slowdown factor of WebAssembly vs. native.  Grey is before this change, blue is after).

![benchmark_improvement](https://user-images.githubusercontent.com/38294/38583861-65896908-3ce2-11e8-8592-c95122903e34.png)
