### PR TITLE
Use alignment in wasm shared modules

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -112,12 +112,29 @@ function loadWebAssemblyModule(binary) {
   assert(binary[next] === 'n'.charCodeAt(0)); next++;
   assert(binary[next] === 'k'.charCodeAt(0)); next++;
   var memorySize = getLEB();
+  var memoryAlign = getLEB();
   var tableSize = getLEB();
+  var tableAlign = getLEB();
+  // alignments are powers of 2
+  memoryAlign = Math.pow(2, memoryAlign);
+  tableAlign = Math.pow(2, tableAlign);
+  // finalize alignments and verify them
+  memoryAlign = Math.max(memoryAlign, STACK_ALIGN); // we at least need stack alignment
+  assert(tableAlign === 1);
+  // prepare memory
+  var memoryStart = alignMemory(getMemory(memorySize + memoryAlign), memoryAlign); // TODO: add to cleanups
+  // The static area consists of explicitly initialized data, followed by zero-initialized data.
+  // The latter may need zeroing out if the MAIN_MODULE has already used this memory area before
+  // dlopen'ing the SIDE_MODULE.  Since we don't know the size of the explicitly initialized data
+  // here, we just zero the whole thing, which is suboptimal, but should at least resolve bugs
+  // from uninitialized memory.
+  for (var i = memoryStart; i < memoryStart + memorySize; ++i) HEAP8[i] = 0;
+  // prepare env imports
   var env = Module['asmLibraryArg'];
   // TODO: use only memoryBase and tableBase, need to update asm.js backend
   var table = Module['wasmTable'];
   var oldTableSize = table.length;
-  env['memoryBase'] = env['gb'] = alignMemory(getMemory(memorySize + STACK_ALIGN), STACK_ALIGN); // TODO: add to cleanups
+  env['memoryBase'] = env['gb'] = memoryStart;
   env['tableBase'] = env['fb'] = oldTableSize;
   var originalTable = table;
   table.grow(tableSize);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2774,8 +2774,6 @@ def process(filename):
     self.do_run(src, '100\n200\n13\n42\n',
                 post_build=self.dlfcn_post_build)
 
-  @no_wasm # wasm shared libraries are just .wasm files, and there is no way to describe alignment there yet
-           # see https://github.com/WebAssembly/tool-conventions/pull/51
   def test_dlfcn_alignment_and_zeroing(self):
     if not self.can_dlfcn(): return
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2643,7 +2643,6 @@ class WebAssembly(object):
     import math
     # a wasm shared library has a special "dylink" section, see tools-conventions repo
     js = open(js_file).read()
-    open('/tmp/emscripten_temp/lib.js', 'w').write(js)
     m = re.search("var STATIC_BUMP = (\d+);", js)
     mem_size = int(m.group(1))
     m = re.search("Module\['wasmTableSize'\] = (\d+);", js)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2640,13 +2640,19 @@ class WebAssembly(object):
 
   @staticmethod
   def make_shared_library(js_file, wasm_file):
+    import math
     # a wasm shared library has a special "dylink" section, see tools-conventions repo
     js = open(js_file).read()
+    open('/tmp/emscripten_temp/lib.js', 'w').write(js)
     m = re.search("var STATIC_BUMP = (\d+);", js)
     mem_size = int(m.group(1))
     m = re.search("Module\['wasmTableSize'\] = (\d+);", js)
     table_size = int(m.group(1))
-    logging.debug('creating wasm dynamic library with mem size %d, table size %d' % (mem_size, table_size))
+    m = re.search('gb = alignMemory\(getMemory\(\d+ \+ (\d+)\), (\d+) \|\| 1\);', js)
+    assert m.group(1) == m.group(2), 'js must contain a clear alignment for the wasm shared library'
+    mem_align = int(m.group(1))
+    mem_align = int(math.log(mem_align, 2))
+    logging.debug('creating wasm dynamic library with mem size %d, table size %d, align %d' % (mem_size, table_size, mem_align))
     wso = js_file + '.wso'
     # write the binary
     wasm = open(wasm_file, 'rb').read()
@@ -2656,7 +2662,8 @@ class WebAssembly(object):
     f.write(b'\0') # user section is code 0
     # need to find the size of this section
     name = b"\06dylink" # section name, including prefixed size
-    contents = WebAssembly.lebify(mem_size) + WebAssembly.lebify(table_size)
+    contents = WebAssembly.lebify(mem_size) + WebAssembly.lebify(mem_align) + \
+               WebAssembly.lebify(table_size) + WebAssembly.lebify(0)
     size = len(name) + len(contents)
     f.write(WebAssembly.lebify(size))
     f.write(name)


### PR DESCRIPTION
Implements https://github.com/WebAssembly/tool-conventions/pull/51

Fixes wasm on `test_dlfcn_alignment_and_zeroing`, which tests alignment of memory of shared modules.
