### PR TITLE
Fix CI bustage due to pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,10 @@ jobs:
   test-other:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=other skip:other.test_bad_triple skip:other.test_native_link_error_message skip:other.test_emcc_v
+      - TEST_TARGET=other skip:other.test_bad_triple skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit
       # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
       # CircleCI actively kills memory-over-consuming process
+      # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI
   test-browser:
     <<: *test-defaults
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,7 @@ test-defaults: &test-defaults
 
     - run: |
         apt-get update
-        apt-get install -y python3 python3-pip cmake build-essential openjdk-9-jre-headless $TEST_DEPENDENCY
-        pip3 install --upgrade pip
-        pip3 install lit
+        apt-get install -y python3 cmake build-essential openjdk-9-jre-headless $TEST_DEPENDENCY
         EMCC_CORES=4 python3 emscripten/tests/runner.py $TEST_TARGET
 
 version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ COPY . /root/emscripten/
 
 RUN cd /root/ \
  && apt-get update \
- && apt-get install -y python python-pip cmake build-essential openjdk-9-jre-headless \
- && pip install --upgrade pip \
- && pip install lit \
+ && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
  && wget https://github.com/juj/emsdk/archive/master.tar.gz \
  && tar -xf master.tar.gz \
  && pushd emsdk-master \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN cd /root/ \
 
 ARG TEST_TARGET
 RUN export EMSCRIPTEN_BROWSER=0 \
- && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit
 
 # skip:other.test_emcc_v to prevent tool version differences from breaking CI


### PR DESCRIPTION
Somehow, `pip` started to fail on both travis and circle today,
```
Collecting pip
  Downloading https://files.pythonhosted.org/packages/62/a1/0d452b6901b0157a0134fd27ba89bf95a857fbda64ba52e1ca2cf61d8412/pip-10.0.0-py2.py3-none-any.whl (1.3MB)
    100% |████████████████████████████████| 1.3MB 1.2MB/s 
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
Successfully installed pip-10.0.0
Traceback (most recent call last):
  File "/usr/bin/pip3", line 9, in <module>
    from pip import main
ImportError: cannot import name 'main'
```
([example log](https://circleci.com/gh/kripken/emscripten/15118?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)).

Anyone know what's going on there?

Unless we can figure that out, this PR fixes the bustage as follows: It seems we only use `pip` to get `lit`, and we need that for just one test, `other.test_llvm_lit`. It's a low-priority test as it's only needed for asm.js backend changes. This PR disables the test and removes `pip`.