### PR TITLE
MacOS python fix

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -12,6 +12,10 @@ Current Trunk
 
  - Breaking change: Simplify exception handling, disabling it by default. Previously it was disabled by default in -O1 and above and enabled in -O0, which could be confusing. You may notice this change if you need exceptions and only run in -O0 (since if you test in -O1 or above, you'd see you need to enable exceptions manually), in which case you will receive an error at runtime saying that exceptions are disabled by default and that you should build with -s DISABLE_EXCEPTION_CATCHING=0 to enable them.
 
+v1.37.37: 04/13/2018
+--------------------
+ - Regression: configure scripts on MacOS may be broken, see https://github.com/kripken/emscripten/issues/6456
+
 v1.37.36: 03/13/2018
 --------------------
 

--- a/em++
+++ b/em++
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emcc.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 # It also tells emcc.py that we want C++ and not C by default
-
-from tools import python_selector
 
 import os
 import sys
+from tools import python_selector
 
 sys.argv += ['--emscripten-cxx']
 
 emcc = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'emcc')
 if __name__ == '__main__':
-  python_selector.run(emcc, profile=True)
+  python_selector.run(emcc)

--- a/em++.py
+++ b/em++.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emcc.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 # It also tells emcc.py that we want C++ and not C by default
 
 import os

--- a/emar
+++ b/emar
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emar.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
 from tools import python_selector
 
-import sys
-
 if __name__ == '__main__':
-  python_selector.run(__file__, profile=True)
+  python_selector.run(__file__)

--- a/emcc
+++ b/emcc
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emcc.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
 from tools import python_selector
 
 import sys
 
 if __name__ == '__main__':
-  python_selector.run(__file__, profile=True)
+  python_selector.run(__file__)
 

--- a/emcmake
+++ b/emcmake
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emcmake.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
-
-import sys
 from tools import python_selector
 
 if __name__ == '__main__':

--- a/emconfigure
+++ b/emconfigure
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emconfigure.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
-
-import sys
 from tools import python_selector
 
 if __name__ == '__main__':

--- a/emmake
+++ b/emmake
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emmake.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
 from tools import python_selector
 
-import sys
-
-
 if __name__ == '__main__':
-  python_selector.run(__file__, profile=True)
+  python_selector.run(__file__)

--- a/emrun
+++ b/emrun
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-# This script should work in python 2 *or* 3. It loads emrun.py, which needs python 2.
+# This script should work in python 2 *or* 3. It loads the main code using
+# python_selector, which may pick a different version.
 
-import sys
 from tools import python_selector
 
 if __name__ == '__main__':

--- a/tools/python_selector.py
+++ b/tools/python_selector.py
@@ -31,7 +31,7 @@ def on_allowed_version():
 Runs filename+'.py' by opening Python 2 subprocess if required, or by importing.
 '''
 def run(filename, profile=False, main="run"):
-  if profile:
+  if os.environ.get('EM_PROFILE_TOOLCHAIN'):
     from tools.toolchain_profiler import ToolchainProfiler
     ToolchainProfiler.record_process_start()
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1410,15 +1410,21 @@ class Building(object):
         if env.get(dangerous) and env.get(dangerous) == non_native.get(dangerous):
           del env[dangerous] # better to delete it than leave it, as the non-native one is definitely wrong
       return env
-    # add python when necessary (on non-windows, we now support python 2 and 3 so
-    # it should be ok either way)
-    env['CC'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
-    env['CXX'] = quote(EMXX) if not WINDOWS else 'python %s' % quote(EMXX)
-    env['AR'] = quote(EMAR) if not WINDOWS else 'python %s' % quote(EMAR)
-    env['LD'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
+    # point CC etc. to the em* tools.
+    # on windows, we must specify python explicitly. on other platforms, we prefer
+    # not to, as some configure scripts expect e.g. CC to be a literal executable
+    # (but "python emcc.py" is not a file that exists).
+    # note that we point to emcc etc. here, without a suffix, instead of to
+    # emcc.py etc. The unsuffixed versions have the python_selector logic that can
+    # pick the right version as needed (which is not crucial right now as we support
+    # both 2 and 3, but eventually we may be 3-only).
+    env['CC'] = quote(unsuffixed(EMCC)) if not WINDOWS else 'python %s' % quote(EMCC)
+    env['CXX'] = quote(unsuffixed(EMXX)) if not WINDOWS else 'python %s' % quote(EMXX)
+    env['AR'] = quote(unsuffixed(EMAR)) if not WINDOWS else 'python %s' % quote(EMAR)
+    env['LD'] = quote(unsuffixed(EMCC)) if not WINDOWS else 'python %s' % quote(EMCC)
     env['NM'] = quote(LLVM_NM)
-    env['LDSHARED'] = quote(EMCC) if not WINDOWS else 'python %s' % quote(EMCC)
-    env['RANLIB'] = quote(EMRANLIB) if not WINDOWS else 'python %s' % quote(EMRANLIB)
+    env['LDSHARED'] = quote(unsuffixed(EMCC)) if not WINDOWS else 'python %s' % quote(EMCC)
+    env['RANLIB'] = quote(unsuffixed(EMRANLIB)) if not WINDOWS else 'python %s' % quote(EMRANLIB)
     env['EMMAKEN_COMPILER'] = quote(Building.COMPILER)
     env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
     env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(Building.COMPILER_TEST_OPTS)


### PR DESCRIPTION
Fixes #6456. Specifically, this fixes a regression in 1.37.37 from 9a5a9b6224b79eafb33517226bdb42c6acbd137f . The issue is that MacOS does not have `python2`, it has only `python` and `python2.7`.

The fix is to point configure scripts to `emcc`, not `emcc.py`, since `emcc` will pick the right python version. This does add some slight overhead, but when cleaning up those python scripts I removed some other minor overhead anyhow - should be fine.

Confirmed as fixing that breakage here: https://github.com/kripken/emscripten/commit/9a5a9b6224b79eafb33517226bdb42c6acbd137f#r28640368