### PR TITLE
[proposal] New build system option "EXECUTE_PROCESS"

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -350,6 +350,15 @@ var NODEJS_CATCH_EXIT = 1; // By default we handle exit() in node, by catching t
                            // longer do that, and exceptions work normally, which can be useful for libraries
                            // or programs that don't need exit() to work.
 
+var EXECUTE_PROCESS = [];  // Allows you to run process after one of specific build step:
+                           // -s EXECUTE_PROCESS="['COMMAND', '<BUILD_STEP_NAME>', '<cmd1>', '<args1>', ..., '<argsN>', 'COMMAND', ...]"
+                           // Known build steps:
+                           // * AFTER_LLVM_OPT - process will be called after llvm optimization step.
+                           //                    for this step you can use <TARGET> placeholder:
+                           //                    -s EXECUTE_PROCESS="['COMMAND', 'AFTER_LLVM_OPT', 'wc', '-l', '<TARGET>']"
+                           //                    <TARGET> would points to result of opt command
+
+
 // For more explanations of this option, please visit
 // https://github.com/kripken/emscripten/wiki/Asyncify
 var ASYNCIFY = 0; // Whether to enable asyncify transformation

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6512,6 +6512,17 @@ Resolved: "/" => "/"
     assert sizes[1] < sizes[0]
     assert sizes[3] < sizes[0]
 
+  def test_execute_process_after_llvm_opt(self):
+    with temp_directory() as temp_dir:
+      target = os.path.join(temp_dir, 'a.out.bc')
+      source = path_from_root('tests', 'hello_libcxx.cpp')
+      cmd = [PYTHON, EMCC, source, '-s', 'EXECUTE_PROCESS=["COMMAND", "AFTER_LLVM_OPT", "ls", "-l", "<TARGET>", \
+                                                           "COMMAND", "AFTER_LLVM_OPT", "cp", "<TARGET>", "%s"]' % target]
+      res = run_process(cmd, stdout=PIPE)
+      filesize = os.path.getsize(target)
+      self.assertContained('a.out.bc', res.stdout)
+      self.assertContained(str(filesize), res.stdout)
+
   def test_dlmalloc_modes(self):
     open('src.cpp', 'w').write(r'''
       #include <stdlib.h>

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1212,6 +1212,26 @@ class SettingsManager(object):
 
 Settings = SettingsManager()
 
+def execute_step_process(step, placeholders):
+  commands = Settings.EXECUTE_PROCESS
+  roots = [idx for idx, val in enumerate(commands) if val == 'COMMAND']
+  roots += [len(commands)]
+
+  for idx, root in enumerate(roots):
+    if root + 1 < len(commands) and commands[root + 1] == step:
+      begin = root + 2
+      end = roots[idx + 1]
+      cmd = []
+
+      for next in commands[begin:end]:
+        if next in placeholders:
+          cmd.append(placeholders[next])
+        else:
+          cmd.append(next)
+
+      logging.info('Execute process on step (%s): %s\n' % (step, ' '.join(cmd)))
+      run_process(cmd, check=True)
+
 # llvm-ar appears to just use basenames inside archives. as a result, files with the same basename
 # will trample each other when we extract them. to help warn of such situations, we warn if there
 # are duplicate entries in the archive
@@ -1854,7 +1874,7 @@ class Building(object):
       return link_args
 
   # LLVM optimizations
-  # @param opt A list of LLVM optimization parameters
+  # @param opts A list of LLVM optimization parameters
   @staticmethod
   def llvm_opt(filename, opts, out=None):
     inputs = filename
@@ -1881,6 +1901,7 @@ class Building(object):
     try:
       run_process([LLVM_OPT] + inputs + opts + ['-o', target], stdout=PIPE)
       assert os.path.exists(target), 'llvm optimizer emitted no output.'
+      execute_step_process('AFTER_LLVM_OPT', { '<TARGET>': target })
     except subprocess.CalledProcessError as e:
       logging.error('Failed to run llvm optimizations: ' + e.output)
       for i in inputs:


### PR DESCRIPTION
New build system option "EXECUTE_PROCESS" that allows to execute custom commands after specific build steps. 

I want use this option to run custom llvm passes over emitted bc. This is replacement for previous PR #6421. I think this way is much flexible, because we not limited only with llvm passes and much much easier to test.

In future new steps can be added. For example after producing js I usually run SFE optimizer, it can be added as new AFTER_JS step.