### PR TITLE
Add ES6 exports

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -613,6 +613,8 @@ var MODULARIZE_INSTANCE = 0; // Similar to MODULARIZE, but while that mode expor
                              // Note that the promise-like API MODULARIZE provides isn't
                              // available here (since you arean't creating the instance
                              // yourself).
+var EXPORT_ES6 = 0; // Export using an ES6 Module export rather than a UMD export.
+                    // MODULARIZE must be enabled for ES6 exports.
 
 var BENCHMARK = 0; // If 1, will just time how long main() takes to execute, and not
                    // print out anything at all whatsoever. This is useful for benchmarking.


### PR DESCRIPTION
Fixes #6284 

The code change is very simple. But I'm not sure about tests.

What version of Node is bundled in emsdk?
Can I just make a simple test that checks importing the built module works, or does it need more rigorous testing?

Node requires ES6 modules to have the extension `.mjs`. Should this mode automatically export files as `a.out.mjs` instead of `.js`? And it should support `-o out.mjs`. Maybe that could even automatically turn on EXPORT_ES6 if we wanted to be clever!