### PR TITLE
Update binaryen to version_47

### DIFF
--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_46'
+TAG = 'version_47'
 
 def needed(settings, shared, ports):
   if not settings.BINARYEN: return False


### PR DESCRIPTION
Brings in some recent optimizer improvements. For example lua is now 1.5% smaller.