### PR TITLE
Fix -s parsing bug introduced by #6436

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -334,3 +334,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Valtteri Heikkilä <rnd@nic.fi>
 * Daniel McNab <daniel.mcnab6+emcc(at)gmail.com>
 * Tyler Limkemann <tslimkemann42 gmail.com>
+* Ben Smith <binji@google.com> (copyright owned by Google, Inc.)

--- a/emcc.py
+++ b/emcc.py
@@ -2796,6 +2796,7 @@ def parse_value(text):
   def parse_string_value(text):
     first = text[0]
     if first == "'" or first == '"':
+      text = text.rstrip()
       assert text[-1] == text[0] and len(text) > 1, 'unclosed opened quoted string. expected final character to be "%s" and length to be greater than 1 in "%s"' % (text[0],text)
       return text[1:-1]
     else:

--- a/emcc.py
+++ b/emcc.py
@@ -2832,6 +2832,7 @@ def parse_value(text):
     return result
 
   if text[0] == '[':
+    text = text.rstrip()
     assert text[-1] == ']', 'unclosed opened string list. expected final character to be "]" in "%s"' % (text)
     inner = text[1:-1]
     if inner.strip() == "":

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6939,15 +6939,15 @@ int main() {
     self.assertNotContained('AssertionError', err) # Do not mention that it is an assertion error
     self.assertContained('unclosed opened quoted string.', err)
 
-  def text_dash_s_unclosed_list(self):
+  def test_dash_s_unclosed_list(self):
     # Unclosed list
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, Value2"], stderr=PIPE, check=False).stderr
     self.assertNotContained('AssertionError', err) # Do not mention that it is an assertion error
     self.assertContained('unclosed opened string list. expected final character to be "]"', err)
 
-  def text_dash_s_valid_list(self):
+  def test_dash_s_valid_list(self):
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, \"Value2\"]"], stderr=PIPE, check=False).stderr
-    self.assertNotContained('a problem occured in evaluating the content after a "-s", specifically')
+    self.assertNotContained('a problem occured in evaluating the content after a "-s", specifically', err)
 
   def test_python_2_3(self): # check emcc/em++ can be called by any python
     # remove .py from EMCC(=emcc.py)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6917,6 +6917,11 @@ int main() {
     print(check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', '-std=c++03']))
     self.assertContained('hello, world!', run_js('a.out.js'))
 
+  def test_dash_s_response_file_string(self):
+    open('response_file', 'w').write('"MyModule"\n')
+    response_file = os.path.join(os.getcwd(), "response_file")
+    print(check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORT_NAME=@%s' % response_file]))
+
   def test_dash_s_response_file_list(self):
     open('response_file', 'w').write('["_main", "_malloc"]\n')
     response_file = os.path.join(os.getcwd(), "response_file")

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6917,6 +6917,11 @@ int main() {
     print(check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', '-std=c++03']))
     self.assertContained('hello, world!', run_js('a.out.js'))
 
+  def test_dash_s_response_file_list(self):
+    open('response_file', 'w').write('["_main", "_malloc"]\n')
+    response_file = os.path.join(os.getcwd(), "response_file")
+    print(check_execute([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@%s' % response_file, '-std=c++03']))
+
   def test_dash_s_unclosed_quote(self):
     # Unclosed quote
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY='MISSING_QUOTE"], stderr=PIPE, check=False).stderr


### PR DESCRIPTION
`-s` supports using response files with the `-s FOO=@filename` syntax,
where the contents of the file are used as the value for `FOO`. Text
files typically end with a newline, so checking the last character of
the value should strip whitespace first.