### PR TITLE
Detect racing in creating temp directories. Fixes #6515 on Windows.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -580,7 +580,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   temp_root = shared.TEMP_DIR
   if not os.path.exists(temp_root):
-    os.makedirs(temp_root)
+    try:
+      os.makedirs(temp_root)
+    except Exception as e:
+      if os.path.exists(temp_root):
+        pass # If running multiple emcc instances simultaneously, they may race to create the temp directory if it did not initially exist. In that case, we can proceed.
+      else:
+        raise
+
   temp_dir = tempfile.mkdtemp(dir=temp_root)
 
   def in_temp(name):


### PR DESCRIPTION
I was not able to find Python to expose a single unified error code that would work across platforms, so other OSes will need their own detection for "path already exists" code; possibly `if e.errno == errno.EEXIST` but I'm not currently on Linux or macOS to verify.