### PR TITLE
Disable wasm in gen_struct_info.py

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -390,7 +390,7 @@ def inspect_code(headers, cpp_opts, structs, defines):
     try:
       # Compile the program.
       show('Compiling generated code...')
-      subprocess.check_call([shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1], '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-Oz', '--js-opts', '0', '--memory-init-file', '0', '-s', 'SINGLE_FILE=1'], env=safe_env) # -Oz optimizes enough to avoid warnings on code size/num locals
+      subprocess.check_call([shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1], '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-Oz', '--js-opts', '0', '--memory-init-file', '0', '-s', 'SINGLE_FILE=1', '-s', 'WASM=0'], env=safe_env) # -Oz optimizes enough to avoid warnings on code size/num locals
     except:
       sys.stderr.write('FAIL: Compilation failed!\n')
       sys.exit(1)


### PR DESCRIPTION
When boostrapping `struct_info.compiled.json`, there is no need for wasm (we are just compiling small programs to detect C constants from headers). And in fact it builds the binaryen port just for that, which confuses `sanity.test_emcc_ports`.