### PR TITLE
Revert #6520 and fix it properly

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -602,26 +602,28 @@ fi
           try_delete(PORTS_DIR)
         else:
           self.do([PYTHON, compiler, '--clear-ports'])
+
+        # Make sure we get the binaryen port first, so we don't see notifications
+        # about it later
         assert not os.path.exists(PORTS_DIR)
+        Building.get_binaryen()
+        assert os.path.exists(PORTS_DIR)
 
         # Building a file that doesn't need ports should not trigger anything
-        # (avoid wasm to avoid the binaryen port)
-        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0'])
+        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp')])
         print('no', output)
         assert RETRIEVING_MESSAGE not in output, output
         assert BUILDING_MESSAGE not in output
-        assert not os.path.exists(PORTS_DIR)
 
         # Building a file that need a port does trigger stuff
-        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0', '-s', 'USE_SDL=2'])
+        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'USE_SDL=2'])
         print('yes', output)
         assert RETRIEVING_MESSAGE in output, output
         assert BUILDING_MESSAGE in output, output
-        assert os.path.exists(PORTS_DIR)
 
         def second_use():
           # Using it again avoids retrieve and build
-          output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0', '-s', 'USE_SDL=2'])
+          output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'USE_SDL=2'])
           assert RETRIEVING_MESSAGE not in output, output
           assert BUILDING_MESSAGE not in output, output
 
@@ -639,7 +641,7 @@ fi
         z.write(os.path.join('old-sub', 'a.txt'))
         z.write(os.path.join('old-sub', 'b.txt'))
         z.close()
-        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0', '-s', 'USE_SDL=2'])
+        output = self.do([compiler, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'USE_SDL=2'])
         assert RETRIEVING_MESSAGE in output, output
         assert BUILDING_MESSAGE in output, output
         assert os.path.exists(PORTS_DIR)

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -379,18 +379,13 @@ def inspect_code(headers, cpp_opts, structs, defines):
     if opt in safe_env:
       del safe_env[opt]
 
-  # Use binaryen, if necessary
-  binaryen = os.environ.get('EMCC_WASM_BACKEND_BINARYEN')
-  if binaryen:
-    cpp_opts += ['-s', 'BINARYEN=1']
-
   info = []
 
   try:
     try:
       # Compile the program.
       show('Compiling generated code...')
-      subprocess.check_call([shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1], '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-Oz', '--js-opts', '0', '--memory-init-file', '0', '-s', 'SINGLE_FILE=1', '-s', 'WASM=0'], env=safe_env) # -Oz optimizes enough to avoid warnings on code size/num locals
+      subprocess.check_call([shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1], '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-Oz', '--js-opts', '0', '--memory-init-file', '0', '-s', 'SINGLE_FILE=1'], env=safe_env) # -Oz optimizes enough to avoid warnings on code size/num locals
     except:
       sys.stderr.write('FAIL: Compilation failed!\n')
       sys.exit(1)


### PR DESCRIPTION
We may need to build with wasm in gen_struct info, for the wasm backend we have to, in fact. To fix that, just let gen_struct_info build normally - which is with wasm now, since it's the default - and fix the relevant sanity test to be aware that fetching the binaryen port can happen during gen_struct_info.

This also ends up making gen_struct_info simpler as it doesn't need to think about wasm or no wasm.