### PR TITLE
Wasm backend requires BINARYEN_ROOT to be set in emscripten config

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1838,7 +1838,6 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
       t = time.time()
       shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
 
-    assert shared.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
     basename = shared.unsuffixed(outfile.name)
     wasm = basename + '.wasm'
     metadata_file = basename + '.metadata'
@@ -1866,7 +1865,6 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
 
 
 def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
-  assert shared.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen tools on the backend output'
   wasm_emscripten_finalize = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-emscripten-finalize')
   wasm_as = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-as')
   wasm_dis = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-dis')

--- a/emscripten.py
+++ b/emscripten.py
@@ -1838,7 +1838,7 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
       t = time.time()
       shutil.copyfile(temp_s, os.path.join(shared.CANONICAL_TEMP_DIR, 'emcc-llvm-backend-output.s'))
 
-    assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
+    assert shared.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen s2wasm on the backend output'
     basename = shared.unsuffixed(outfile.name)
     wasm = basename + '.wasm'
     metadata_file = basename + '.metadata'
@@ -1866,10 +1866,10 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
 
 
 def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
-  assert shared.Settings.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen tools on the backend output'
-  wasm_emscripten_finalize = os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-emscripten-finalize')
-  wasm_as = os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-as')
-  wasm_dis = os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 'wasm-dis')
+  assert shared.BINARYEN_ROOT, 'need BINARYEN_ROOT config set so we can use Binaryen tools on the backend output'
+  wasm_emscripten_finalize = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-emscripten-finalize')
+  wasm_as = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-as')
+  wasm_dis = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-dis')
 
   def debug_copy(src, dst):
     if DEBUG:
@@ -2155,7 +2155,7 @@ def create_s2wasm_args(temp_s, wasm):
   compiler_rt_lib = shared.Cache.get('wasm_compiler_rt.a', wasm_rt_fail('wasm_compiler_rt.a'), 'a')
   libc_rt_lib = shared.Cache.get('wasm_libc_rt.a', wasm_rt_fail('wasm_libc_rt.a'), 'a')
 
-  s2wasm_path = os.path.join(shared.Settings.BINARYEN_ROOT, 'bin', 's2wasm')
+  s2wasm_path = os.path.join(shared.BINARYEN_ROOT, 'bin', 's2wasm')
 
   args = [s2wasm_path, temp_s, '-o', wasm, '--emscripten-glue', '--emit-binary']
   args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1212,6 +1212,15 @@ class SettingsManager(object):
 
 Settings = SettingsManager()
 
+if Settings.WASM_BACKEND:
+  try:
+    BINARYEN_ROOT
+  except:
+    logging.fatal('emcc: BINARYEN_ROOT must be set in the .emscripten config'
+                  ' when using the LLVM wasm backend')
+    sys.exit(1)
+  assert BINARYEN_ROOT, 'BINARYEN_ROOT path is empty'
+
 # llvm-ar appears to just use basenames inside archives. as a result, files with the same basename
 # will trample each other when we extract them. to help warn of such situations, we warn if there
 # are duplicate entries in the archive


### PR DESCRIPTION
See discussion in #6520 and #6522 

This uses `shared.BINARYEN_ROOT` instead of `shared.Settings.BINARYEN_ROOT`, which means `BINARYEN_ROOT` must be set in the emscripten config file instead of pulled in via port.