### PR TITLE
Fix sanity.test_vanilla test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
           ./emsdk activate latest
           popd
           echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> .emscripten
-          echo BINARYEN_ROOT="''" >> .emscripten
           EMCC_CORES=4 python3 emscripten/embuilder.py build ALL
           python3 emscripten/tests/runner.py test_hello_world
           mkdir tmp-firefox-profile/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           ./emsdk activate latest
           popd
           echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> .emscripten
+          echo BINARYEN_ROOT="''" >> .emscripten
           EMCC_CORES=4 python3 emscripten/embuilder.py build ALL
           python3 emscripten/tests/runner.py test_hello_world
           mkdir tmp-firefox-profile/

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -889,7 +889,10 @@ fi
 
     def make_fake(report):
       f = open(CONFIG_FILE, 'a')
-      f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"\n')
+      f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"\n') 
+      # $BINARYEN_ROOT needs to exist in the config, even though this test
+      # doesn't actually use it.
+      f.write('BINARYEN_ROOT= "%s"\n' % path_from_root('tests', 'fake', 'bin'))
       f.close()
 
       f = open(path_from_root('tests', 'fake', 'bin', 'llc'), 'w')

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -890,7 +890,7 @@ fi
     def make_fake(report):
       f = open(CONFIG_FILE, 'a')
       f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"\n') 
-      # $BINARYEN_ROOT needs to exist in the config, even though this test
+      # BINARYEN_ROOT needs to exist in the config, even though this test
       # doesn't actually use it.
       f.write('BINARYEN_ROOT= "%s"\n' % path_from_root('tests', 'fake', 'bin'))
       f.close()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -889,7 +889,7 @@ fi
 
     def make_fake(report):
       f = open(CONFIG_FILE, 'a')
-      f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"\n') 
+      f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"\n')
       # BINARYEN_ROOT needs to exist in the config, even though this test
       # doesn't actually use it.
       f.write('BINARYEN_ROOT= "%s"\n' % path_from_root('tests', 'fake', 'bin'))


### PR DESCRIPTION
Its no longer enough to set BINARYEN_ROOT to an empty string
since #6523.