### PR TITLE
Move tzname from JS library code into C

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -50,6 +50,9 @@
   "socket": ["htonl", "htons", "ntohs"],
   "sleep": ["usleep"],
   "recv": ["htons"],
-  "send": ["htons"]
+  "send": ["htons"],
+  "localtime": ["_get_tzname"],
+  "localtime_r": ["_get_tzname"],
+  "tzset": ["_get_tzname"],
 }
 

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -53,6 +53,6 @@
   "send": ["htons"],
   "localtime": ["_get_tzname"],
   "localtime_r": ["_get_tzname"],
-  "tzset": ["_get_tzname"],
+  "tzset": ["_get_tzname"]
 }
 

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -51,8 +51,12 @@
   "sleep": ["usleep"],
   "recv": ["htons"],
   "send": ["htons"],
+  "ctime": ["_get_tzname"],
+  "ctime_r": ["_get_tzname"],
   "localtime": ["_get_tzname"],
   "localtime_r": ["_get_tzname"],
+  "mktime": ["_get_tzname"],
+  "timegm": ["_get_tzname"],
   "tzset": ["_get_tzname"]
 }
 

--- a/src/library.js
+++ b/src/library.js
@@ -2068,7 +2068,7 @@ LibraryManager.library = {
     var dst = (summerOffset != winterOffset && date.getTimezoneOffset() == Math.min(winterOffset, summerOffset))|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_isdst, 'dst', 'i32') }}};
 
-    var zonePtr = {{{ makeGetValue(makeGlobalUse('_tzname'), 'dst ? ' + Runtime.QUANTUM_SIZE + ' : 0', 'i32') }}};
+    var zonePtr = {{{ makeGetValue('__get_tzname()', 'dst ? ' + Runtime.QUANTUM_SIZE + ' : 0', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_zone, 'zonePtr', 'i32') }}};
 
     return tmPtr;
@@ -2129,15 +2129,13 @@ LibraryManager.library = {
   // TODO: Initialize these to defaults on startup from system settings.
   // Note: glibc has one fewer underscore for all of these. Also used in other related functions (timegm)
 #if USE_PTHREADS
-  tzname: '; if (ENVIRONMENT_IS_PTHREAD) _tzname = PthreadWorkerInit._tzname; else PthreadWorkerInit._tzname = _tzname = allocate({{{ 2*Runtime.QUANTUM_SIZE }}}, "i32*", ALLOC_STATIC)',
   daylight: '; if (ENVIRONMENT_IS_PTHREAD) _daylight = PthreadWorkerInit._daylight; else PthreadWorkerInit._daylight = _daylight = allocate(1, "i32*", ALLOC_STATIC)',
   timezone: '; if (ENVIRONMENT_IS_PTHREAD) _timezone = PthreadWorkerInit._timezone; else PthreadWorkerInit._timezone = _timezone = allocate(1, "i32*", ALLOC_STATIC)',
 #else
-  tzname: '{{{ makeStaticAlloc(2*Runtime.QUANTUM_SIZE) }}}',
   daylight: '{{{ makeStaticAlloc(1) }}}',
   timezone: '{{{ makeStaticAlloc(1) }}}',
 #endif
-  tzset__deps: ['tzname', 'daylight', 'timezone'],
+  tzset__deps: ['daylight', 'timezone'],
   tzset__proxy: 'sync',
   tzset__sig: 'v',
   tzset: function() {
@@ -2166,11 +2164,11 @@ LibraryManager.library = {
     var summerNamePtr = allocate(intArrayFromString(summerName), 'i8', ALLOC_NORMAL);
     if (summer.getTimezoneOffset() < winter.getTimezoneOffset()) {
       // Northern hemisphere
-      {{{ makeSetValue(makeGlobalUse('_tzname'), '0', 'winterNamePtr', 'i32') }}};
-      {{{ makeSetValue(makeGlobalUse('_tzname'), Runtime.QUANTUM_SIZE, 'summerNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', '0', 'winterNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', Runtime.QUANTUM_SIZE, 'summerNamePtr', 'i32') }}};
     } else {
-      {{{ makeSetValue(makeGlobalUse('_tzname'), '0', 'summerNamePtr', 'i32') }}};
-      {{{ makeSetValue(makeGlobalUse('_tzname'), Runtime.QUANTUM_SIZE, 'winterNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', '0', 'summerNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', Runtime.QUANTUM_SIZE, 'winterNamePtr', 'i32') }}};
     }
   },
 

--- a/system/lib/libc.symbols
+++ b/system/lib/libc.symbols
@@ -80,6 +80,7 @@
 -------- d gb18030
 -------- d __get_locale.loc_head
 -------- d __get_locale.lock
+-------- T _get_tzname
 -------- d getmntent.linebuf
 -------- d getmntent.mnt
 -------- d getservbyname.buf

--- a/system/lib/libc/extras.c
+++ b/system/lib/libc/extras.c
@@ -1,0 +1,9 @@
+
+// Extra libc helper functions
+
+char *tzname[2];
+
+void* _get_tzname() {
+  return (void*)tzname;
+}
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2874,7 +2874,7 @@ def process(filename):
           raise Exception('Could not find symbol table!')
       table = table[table.find('{'):table.find('}')+1]
       # ensure there aren't too many globals; we don't want unnamed_addr
-      assert table.count(',') <= 27, table.count(',')
+      assert table.count(',') <= 28, table.count(',')
 
     test_path = path_from_root('tests', 'core', 'test_dlfcn_self')
     src, output = (test_path + s for s in ('.c', '.out'))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7976,7 +7976,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0), # totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1542, ['invoke_i'],               ['waka'],                 496958, 168, 2558),
+              1542, ['invoke_i'],               ['waka'],                 496958, 168, 2560),
     ])
 
     print('test on a minimal pure computational thing')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -132,6 +132,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
               break
           if not cancel:
             libc_files.append(os.path.join(musl_srcdir, dirpath, f))
+    # Add in extra non-musl things
+    libc_files.append(shared.path_from_root('system', 'lib', 'libc', 'extras.c'))
     # Without -fno-builtin, LLVM can optimize away or convert calls to library
     # functions to something else based on assumptions that they behave exactly
     # like the standard library. This can cause unexpected bugs when we use our


### PR DESCRIPTION
The main goal here is to work around current lld limitations, namely that we can't import a global location from JS there. See https://github.com/WebAssembly/tool-conventions/issues/48

This is a first step to a better solution, which would be to import the global location from compiled code, instead of importing a function we call to get that location.

There are some downsides to this PR,

 * It doesn't fix the lld issue, just works around it. As discussed in that issue, even if we remove all such usages from the emscripten system libraries, emscripten users may have their own. But that is likely very rare.
 * It adds overhead, now we call into compiled code to get the address. I doubt for these methods it matters, though, and as mentioned above we should eventually replace the function call with a global address once JS can import such things from wasm.
 * This uses the `deps_info.json` mechanism which is not the prettiest - it tells the linker that if we see a symbol, we need to link in more C code as JS code will need it to be there (otherwise, we'd get to the JS linking at the end and only then figure it out). But not a big deal either, I'd say. And we can hopefully improve that in time (autogenerate it and/or replace it).

cc @sbc100 