### PR TITLE
Add timespec_get to JS implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -338,5 +338,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sylvain Beucler <beuc@beuc.net>
 * Patrik Weiskircher <patrik@weiskircher.name>
 * Tobias Widlund <widlundtobias(at)gmail.com>
+* Rob Fors <mail@robfors.com>
 * Mike Frysinger <vapier@chromium.org> (copyright owned by Google, Inc.)
 * Sébasiten Crozet <developer@crozet.re>

--- a/src/library.js
+++ b/src/library.js
@@ -2786,7 +2786,7 @@ LibraryManager.library = {
       ___setErrNo(ERRNO_CODES.EINVAL);
       return 0;
     }
-    var ret = clock_gettime({{{ cDefine('CLOCK_REALTIME') }}}, ts);
+    var ret = _clock_gettime({{{ cDefine('CLOCK_REALTIME') }}}, ts);
     return ret < 0 ? 0 : base;
   },
 

--- a/src/library.js
+++ b/src/library.js
@@ -2777,6 +2777,19 @@ LibraryManager.library = {
     return 0;
   },
 
+  timespec_get__deps: ['clock_gettime', '$ERRNO_CODES', '__setErrNo'],
+  timespec_get: function(ts, base) {
+    //int timespec_get(struct timespec *ts, int base);
+    if (base !== {{{ cDefine('TIME_UTC') }}})
+    {
+      // There is no other implemented value than TIME_UTC; all other values are considered erroneous.
+      ___setErrNo(ERRNO_CODES.EINVAL);
+      return 0;
+    }
+    var ret = clock_gettime({{{ cDefine('CLOCK_REALTIME') }}}, ts);
+    return ret < 0 ? 0 : base;
+  },
+
   // ==========================================================================
   // sys/time.h
   // ==========================================================================

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -208,6 +208,7 @@
         "file": "libc/time.h", 
         "defines": [
             ["li", "CLOCKS_PER_SEC"],
+            "TIME_UTC",
             "CLOCK_REALTIME",
             "CLOCK_MONOTONIC"
         ],

--- a/tests/time/output.txt
+++ b/tests/time/output.txt
@@ -41,3 +41,10 @@ winter month again: 11
 ctime matched: 1
 clock(start): 1
 clock(end): 1
+timespec_get test 0: 1
+timespec_get test 1: 1
+timespec_get test 2: 1
+timespec_get test 3: 1
+timespec_get test 4: 1
+timespec_get test 5: 1
+timespec_get test 6: 1

--- a/tests/time/src.cpp
+++ b/tests/time/src.cpp
@@ -153,5 +153,25 @@ int main() {
   clock_t diff = time(NULL) - start_t;
   printf("clock(end): %d\n", diff >= 2 && diff < 30);
 
+  // Verify timespec_get() will only accept a base of TIME_UTC
+  //timespec ts; *already defined*
+  printf("timespec_get test 0: %d\n", timespec_get(&ts, TIME_UTC) == TIME_UTC);
+  printf("timespec_get test 1: %d\n", timespec_get(&ts, (TIME_UTC + 1)) == 0);
+
+  // Verify the resultant timespec values set by timespec_get() are valid
+  //timespec ts; *already defined*
+  timespec_get(&ts, TIME_UTC);
+  printf("timespec_get test 2: %d\n", ts.tv_sec >= 0);
+  printf("timespec_get test 3: %d\n", ts.tv_sec != 0); // 0 is valid but not practical as the current time
+  printf("timespec_get test 4: %d\n", ts.tv_nsec >= 0);
+  printf("timespec_get test 5: %d\n", ts.tv_nsec <= 999999999);
+
+  // Verify timespec_get() gets similar time value as clock_gettime
+  timespec ts_timespec_get;
+  timespec_get(&ts_timespec_get, TIME_UTC);
+  timespec ts_clock_gettime;
+  clock_gettime(CLOCK_REALTIME, &ts_clock_gettime);
+  printf("timespec_get test 6: %d\n", abs(ts_timespec_get.tv_sec - ts_clock_gettime.tv_sec) <= 2);
+
   return 0;
 }


### PR DESCRIPTION
See #6555 for more info.

This PR is not fully ready yet.
When I compile I get:
```
Internal compiler error in src/compiler.js!
Please raise a bug report at https://github.com/kripken/emscripten/issues/ with a log of the build and the input files used to run.
Exception message: "XXX missing C define TIME_UTC!" | undefined
```
I don't know where I should define `TIME_UTC` in the emscripten code base.
I see `TIME_UTC` and `CLOCK_REALTIME` are defined in `time.h`. `CLOCK_REALTIME` works but not `TIME_UTC`.