### PR TITLE
When assertions are on, show a warning when we try to grow memory above the practical limit

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1000,7 +1000,13 @@ function enlargeMemory() {
     if (TOTAL_MEMORY <= 536870912) {
       TOTAL_MEMORY = alignUp(2 * TOTAL_MEMORY, PAGE_MULTIPLE); // Simple heuristic: double until 1GB...
     } else {
-      TOTAL_MEMORY = Math.min(alignUp((3 * TOTAL_MEMORY + 2147483648) / 4, PAGE_MULTIPLE), LIMIT); // ..., but after that, add smaller increments towards 2GB, which we cannot reach
+      // ..., but after that, add smaller increments towards 2GB, which we cannot reach
+      TOTAL_MEMORY = Math.min(alignUp((3 * TOTAL_MEMORY + 2147483648) / 4, PAGE_MULTIPLE), LIMIT);
+#if ASSERTIONS
+      if (TOTAL_MEMORY === OLD_TOTAL_MEMORY) {
+        warnOnce('Cannot ask for more memory since we reached the practical limit in browsers (which is just below 2GB), so the request would have failed. Requesting only ' + TOTAL_MEMORY);
+      }
+#endif
     }
   }
 


### PR DESCRIPTION
The practical limit is 2GB and most (all?) browsers don't allow allocating more now, so emscripten doesn't ask for more, and instead increments memory in small chunks towards that limit (hoping it will be enough). This adds a warning when we reach the limit there, to make this less surprising to users.