### PR TITLE
Improve "other" test suite on travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN cd /root/ \
 
 ARG TEST_TARGET
 RUN export EMSCRIPTEN_BROWSER=0 \
- && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit skip:other.test_single_file skip:other.test_vorbis skip:other.test_eval_ctors
 
 # skip:other.test_emcc_v to prevent tool version differences from breaking CI

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7617,34 +7617,33 @@ int main() {
             (['-Os'], False, True),
             (['-Oz'], False, True), # ctor evaller turned off since only-wasm
           ]:
-          for option in ['BINARYEN', 'WASM']: # the two should be identical
-            try_delete('a.out.js')
-            try_delete('a.out.wast')
-            cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c'), '-s', option + '=1', '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
-            print(args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd))
-            err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
-            assert expect_js_opts == ('applying js optimization passes:' in err), err
-            assert expect_only_wasm == ('-emscripten-only-wasm' in err and '--wasm-only' in err), err # check both flag to fastcomp and to asm2wasm
-            wast = open('a.out.wast').read()
-            # i64s
-            i64s = wast.count('(i64.')
-            print('    seen i64s:', i64s)
-            assert expect_only_wasm == (i64s > 30), 'i64 opts can be emitted in only-wasm mode, but not normally' # note we emit a few i64s even without wasm-only, when we replace udivmoddi (around 15 such)
-            selects = wast.count('(select')
-            print('    seen selects:', selects)
-            if '-Os' in args or '-Oz' in args:
-              assert selects > 50, 'when optimizing for size we should create selects'
-            else:
-              assert selects < 10, 'when not optimizing for size we should not create selects'
-            # asm2wasm opt line
-            asm2wasm_line = [line for line in err.split('\n') if 'asm2wasm' in line]
-            asm2wasm_line = '' if not asm2wasm_line else asm2wasm_line[0]
-            if '-O0' in args or '-O' not in str(args):
-              assert '-O' not in asm2wasm_line, 'no opts should be passed to asm2wasm: ' + asm2wasm_line
-            else:
-              opts_str = args[0]
-              assert opts_str.startswith('-O')
-              assert opts_str in asm2wasm_line, 'expected opts: ' + asm2wasm_line
+          try_delete('a.out.js')
+          try_delete('a.out.wast')
+          cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c'), '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
+          print(args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd))
+          err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
+          assert expect_js_opts == ('applying js optimization passes:' in err), err
+          assert expect_only_wasm == ('-emscripten-only-wasm' in err and '--wasm-only' in err), err # check both flag to fastcomp and to asm2wasm
+          wast = open('a.out.wast').read()
+          # i64s
+          i64s = wast.count('(i64.')
+          print('    seen i64s:', i64s)
+          assert expect_only_wasm == (i64s > 30), 'i64 opts can be emitted in only-wasm mode, but not normally' # note we emit a few i64s even without wasm-only, when we replace udivmoddi (around 15 such)
+          selects = wast.count('(select')
+          print('    seen selects:', selects)
+          if '-Os' in args or '-Oz' in args:
+            assert selects > 50, 'when optimizing for size we should create selects'
+          else:
+            assert selects < 10, 'when not optimizing for size we should not create selects'
+          # asm2wasm opt line
+          asm2wasm_line = [line for line in err.split('\n') if 'asm2wasm' in line]
+          asm2wasm_line = '' if not asm2wasm_line else asm2wasm_line[0]
+          if '-O0' in args or '-O' not in str(args):
+            assert '-O' not in asm2wasm_line, 'no opts should be passed to asm2wasm: ' + asm2wasm_line
+          else:
+            opts_str = args[0]
+            assert opts_str.startswith('-O')
+            assert opts_str in asm2wasm_line, 'expected opts: ' + asm2wasm_line
       finally:
         del os.environ['EMCC_DEBUG']
 


### PR DESCRIPTION
This helps with #6448, the frequent timeouts of `other` on travis as it is close to the 50min limit. This skips some of the longest and least-necessary tests there, and also speeds up a long but important test (`binaryen_opts`) by removing work that became unnecessary after wasm-by-default.

Result is `other` took 35min, which will hopefully be far enough from 50 to reduce random fails significantly.