### PR TITLE
Convert json metadata strings from unicode to utf8 str

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2188,7 +2188,7 @@ def load_metadata(metadata_raw):
     metadata[k] = v
 
   # Initializers call the global var version of the export, so they get the mangled name.
-  metadata['initializers'] = list(map(asmjs_mangle, metadata['initializers']))
+  metadata['initializers'] = [asmjs_mangle(str(i)) for i in metadata['initializers']]
 
   # functions marked llvm.used in the code are exports requested by the user
   shared.Building.user_requested_exports += metadata['exports']

--- a/emscripten.py
+++ b/emscripten.py
@@ -2184,11 +2184,19 @@ def load_metadata(metadata_raw):
     'invokeFuncs': [],
   }
 
-  for k, v in metadata_json.items():
-    metadata[k] = v
+  for key, value in metadata_json.items():
+    # json.loads returns `unicode` for strings but other code in this file
+    # generally works with utf8 encoded `str` objects, and they don't alwasy
+    # mix well.  e.g. s.replace(x, y) will blow up is `s` a uts8 str containing
+    # non-ascii and either x or y are unicode objects.
+    # TODO(sbc): Remove this encoding if we switch to unicode elsewhere
+    # (specifically the glue returned from compile_settings)
+    if type(value) == list:
+      value = [asstr(v) for v in value]
+    metadata[key] = value
 
   # Initializers call the global var version of the export, so they get the mangled name.
-  metadata['initializers'] = [asmjs_mangle(str(i)) for i in metadata['initializers']]
+  metadata['initializers'] = [asmjs_mangle(i) for i in metadata['initializers']]
 
   # functions marked llvm.used in the code are exports requested by the user
   shared.Building.user_requested_exports += metadata['exports']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5157,13 +5157,13 @@ int main(int argc, char** argv) {
   char buffer[11];
   buffer[10] = '\0';
   // call by a pointer, to force linking of memset, no llvm intrinsic here
-  volatile auto ptr = memset;
+  volatile auto ptr = &memset;
   (*ptr)(buffer, 'a', 10);
   depper(buffer);
   puts(buffer);
 }
 '''
-    self.emcc_args += ['--js-library', 'lib.js']
+    self.emcc_args += ['--js-library', 'lib.js',  '-std=c++11']
     self.do_run(src, 'dddddddddd')
     Settings.INCLUDE_FULL_LIBRARY = 1
     self.do_run(src, 'dddddddddd')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5157,7 +5157,7 @@ int main(int argc, char** argv) {
   char buffer[11];
   buffer[10] = '\0';
   // call by a pointer, to force linking of memset, no llvm intrinsic here
-  volatile auto ptr = &memset;
+  volatile auto ptr = memset;
   (*ptr)(buffer, 'a', 10);
   depper(buffer);
   puts(buffer);


### PR DESCRIPTION
These strings are being imported by the json library as unicode
and it was causing a very strange crashes with the lld path.