### PR TITLE
Fix use of asm2wasm imports in side modules

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2016,32 +2016,7 @@ function integrateWasmJS() {
   var info = {
     'global': null,
     'env': null,
-    'asm2wasm': { // special asm2wasm imports
-      "f64-rem": function(x, y) {
-        return x % y;
-      },
-      "debugger": function() {
-        debugger;
-      }
-#if NEED_ALL_ASM2WASM_IMPORTS
-      ,
-      "f64-to-int": function(x) {
-        return x | 0;
-      },
-      "i32s-div": function(x, y) {
-        return ((x | 0) / (y | 0)) | 0;
-      },
-      "i32u-div": function(x, y) {
-        return ((x >>> 0) / (y >>> 0)) >>> 0;
-      },
-      "i32s-rem": function(x, y) {
-        return ((x | 0) % (y | 0)) | 0;
-      },
-      "i32u-rem": function(x, y) {
-        return ((x >>> 0) % (y >>> 0)) >>> 0;
-      }
-#endif // NEED_ALL_ASM2WASM_IMPORTS
-    },
+    'asm2wasm': asm2wasmImports,
     'parent': Module // Module inside wasm-js.cpp refers to wasm-js.cpp; this allows access to the outside program.
   };
 

--- a/src/support.js
+++ b/src/support.js
@@ -84,34 +84,34 @@ function loadDynamicLibrary(lib) {
   loadedDynamicLibraries.push(libModule);
 }
 
-#if WASM
 var asm2wasmImports = { // special asm2wasm imports
-    "f64-rem": function(x, y) {
-        return x % y;
-    },
-    "debugger": function() {
-        debugger;
-    }
+  "f64-rem": function(x, y) {
+    return x % y;
+  },
+  "debugger": function() {
+    debugger;
+  }
 #if NEED_ALL_ASM2WASM_IMPORTS
-    ,
-    "f64-to-int": function(x) {
-        return x | 0;
-    },
-    "i32s-div": function(x, y) {
-        return ((x | 0) / (y | 0)) | 0;
-    },
-    "i32u-div": function(x, y) {
-        return ((x >>> 0) / (y >>> 0)) >>> 0;
-    },
-    "i32s-rem": function(x, y) {
-        return ((x | 0) % (y | 0)) | 0;
-    },
-    "i32u-rem": function(x, y) {
-        return ((x >>> 0) % (y >>> 0)) >>> 0;
-    }
+  ,
+  "f64-to-int": function(x) {
+    return x | 0;
+  },
+  "i32s-div": function(x, y) {
+    return ((x | 0) / (y | 0)) | 0;
+  },
+  "i32u-div": function(x, y) {
+    return ((x >>> 0) / (y >>> 0)) >>> 0;
+  },
+  "i32s-rem": function(x, y) {
+    return ((x | 0) % (y | 0)) | 0;
+  },
+  "i32u-rem": function(x, y) {
+    return ((x >>> 0) % (y >>> 0)) >>> 0;
+  }
 #endif // NEED_ALL_ASM2WASM_IMPORTS
 };
 
+#if WASM
 // Loads a side module from binary data
 function loadWebAssemblyModule(binary) {
   var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);

--- a/src/support.js
+++ b/src/support.js
@@ -44,6 +44,33 @@ function warnOnce(text) {
   }
 }
 
+var asm2wasmImports = { // special asm2wasm imports
+    "f64-rem": function(x, y) {
+        return x % y;
+    },
+    "debugger": function() {
+        debugger;
+    }
+#if NEED_ALL_ASM2WASM_IMPORTS
+    ,
+    "f64-to-int": function(x) {
+        return x | 0;
+    },
+    "i32s-div": function(x, y) {
+        return ((x | 0) / (y | 0)) | 0;
+    },
+    "i32u-div": function(x, y) {
+        return ((x >>> 0) / (y >>> 0)) >>> 0;
+    },
+    "i32s-rem": function(x, y) {
+        return ((x | 0) % (y | 0)) | 0;
+    },
+    "i32u-rem": function(x, y) {
+        return ((x >>> 0) % (y >>> 0)) >>> 0;
+    }
+#endif // NEED_ALL_ASM2WASM_IMPORTS
+};
+
 #if RELOCATABLE
 var loadedDynamicLibraries = [];
 
@@ -83,33 +110,6 @@ function loadDynamicLibrary(lib) {
   }
   loadedDynamicLibraries.push(libModule);
 }
-
-var asm2wasmImports = { // special asm2wasm imports
-  "f64-rem": function(x, y) {
-    return x % y;
-  },
-  "debugger": function() {
-    debugger;
-  }
-#if NEED_ALL_ASM2WASM_IMPORTS
-  ,
-  "f64-to-int": function(x) {
-    return x | 0;
-  },
-  "i32s-div": function(x, y) {
-    return ((x | 0) / (y | 0)) | 0;
-  },
-  "i32u-div": function(x, y) {
-    return ((x >>> 0) / (y >>> 0)) >>> 0;
-  },
-  "i32s-rem": function(x, y) {
-    return ((x | 0) % (y | 0)) | 0;
-  },
-  "i32u-rem": function(x, y) {
-    return ((x >>> 0) % (y >>> 0)) >>> 0;
-  }
-#endif // NEED_ALL_ASM2WASM_IMPORTS
-};
 
 #if WASM
 // Loads a side module from binary data

--- a/src/support.js
+++ b/src/support.js
@@ -158,7 +158,33 @@ function loadWebAssemblyModule(binary) {
       'Infinity': Infinity,
     },
     'global.Math': Math,
-    env: env
+    env: env,
+    'asm2wasm': { // special asm2wasm imports
+      "f64-rem": function(x, y) {
+        return x % y;
+      },
+      "debugger": function() {
+        debugger;
+      }
+#if NEED_ALL_ASM2WASM_IMPORTS
+      ,
+      "f64-to-int": function(x) {
+        return x | 0;
+      },
+      "i32s-div": function(x, y) {
+        return ((x | 0) / (y | 0)) | 0;
+      },
+      "i32u-div": function(x, y) {
+        return ((x >>> 0) / (y >>> 0)) >>> 0;
+      },
+      "i32s-rem": function(x, y) {
+        return ((x | 0) % (y | 0)) | 0;
+      },
+      "i32u-rem": function(x, y) {
+        return ((x >>> 0) % (y >>> 0)) >>> 0;
+      }
+#endif // NEED_ALL_ASM2WASM_IMPORTS
+    },
   };
 #if ASSERTIONS
   var oldTable = [];
@@ -504,4 +530,3 @@ var GLOBAL_BASE = {{{ GLOBAL_BASE }}};
 #if RELOCATABLE
 GLOBAL_BASE = alignMemory(GLOBAL_BASE, {{{ MAX_GLOBAL_ALIGN || 1 }}});
 #endif
-

--- a/src/support.js
+++ b/src/support.js
@@ -85,6 +85,33 @@ function loadDynamicLibrary(lib) {
 }
 
 #if WASM
+var asm2wasmImports = { // special asm2wasm imports
+    "f64-rem": function(x, y) {
+        return x % y;
+    },
+    "debugger": function() {
+        debugger;
+    }
+#if NEED_ALL_ASM2WASM_IMPORTS
+    ,
+    "f64-to-int": function(x) {
+        return x | 0;
+    },
+    "i32s-div": function(x, y) {
+        return ((x | 0) / (y | 0)) | 0;
+    },
+    "i32u-div": function(x, y) {
+        return ((x >>> 0) / (y >>> 0)) >>> 0;
+    },
+    "i32s-rem": function(x, y) {
+        return ((x | 0) % (y | 0)) | 0;
+    },
+    "i32u-rem": function(x, y) {
+        return ((x >>> 0) % (y >>> 0)) >>> 0;
+    }
+#endif // NEED_ALL_ASM2WASM_IMPORTS
+};
+
 // Loads a side module from binary data
 function loadWebAssemblyModule(binary) {
   var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
@@ -159,32 +186,7 @@ function loadWebAssemblyModule(binary) {
     },
     'global.Math': Math,
     env: env,
-    'asm2wasm': { // special asm2wasm imports
-      "f64-rem": function(x, y) {
-        return x % y;
-      },
-      "debugger": function() {
-        debugger;
-      }
-#if NEED_ALL_ASM2WASM_IMPORTS
-      ,
-      "f64-to-int": function(x) {
-        return x | 0;
-      },
-      "i32s-div": function(x, y) {
-        return ((x | 0) / (y | 0)) | 0;
-      },
-      "i32u-div": function(x, y) {
-        return ((x >>> 0) / (y >>> 0)) >>> 0;
-      },
-      "i32s-rem": function(x, y) {
-        return ((x | 0) % (y | 0)) | 0;
-      },
-      "i32u-rem": function(x, y) {
-        return ((x >>> 0) % (y >>> 0)) >>> 0;
-      }
-#endif // NEED_ALL_ASM2WASM_IMPORTS
-    },
+    'asm2wasm': asm2wasmImports
   };
 #if ASSERTIONS
   var oldTable = [];

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6135,12 +6135,13 @@ hello3 ()
 ''')
     open('hello4.c', 'w').write(r'''
 #include <stdio.h>
+#include <math.h>
 
-void
-hello4 ()
+double
+hello4 (double x)
 {
   printf ("Hello4\n");
-  return;
+  return fmod(x, 2.0);
 }
 
 ''')
@@ -6160,6 +6161,7 @@ main()
 {
   void *h;
   void (*f) ();
+  double (*f2) (double);
 
   h = dlopen ("libhello1.wasm", RTLD_NOW);
   f = dlsym (h, "hello1");
@@ -6174,9 +6176,13 @@ main()
   f();
   dlclose (h);
   h = dlopen ("/usr/local/lib/libhello4.wasm", RTLD_NOW);
-  f = dlsym (h, "hello4");
-  f();
+  f2 = dlsym (h, "hello4");
+  double result = f2(5.5);
   dlclose (h);
+
+  if (result != 1.5) {
+    printf("Floating-point remainder failed\n");
+  }
   return 0;
 }
 
@@ -6197,6 +6203,7 @@ main()
     self.assertContained('Hello2', out)
     self.assertContained('Hello3', out)
     self.assertContained('Hello4', out)
+    self.assertNotContained('Floating-point remainder failed', out)
 
   def test_dlopen_rtld_global(self):
     # TODO: wasm support. this test checks RTLD_GLOBAL where a module is loaded

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6180,8 +6180,8 @@ main()
   double result = f2(5.5);
   dlclose (h);
 
-  if (result != 1.5) {
-    printf("Floating-point remainder failed\n");
+  if (result == 1.5) {
+    printf("Ok\n");
   }
   return 0;
 }
@@ -6203,7 +6203,7 @@ main()
     self.assertContained('Hello2', out)
     self.assertContained('Hello3', out)
     self.assertContained('Hello4', out)
-    self.assertNotContained('Floating-point remainder failed', out)
+    self.assertContained('Ok', out)
 
   def test_dlopen_rtld_global(self):
     # TODO: wasm support. this test checks RTLD_GLOBAL where a module is loaded


### PR DESCRIPTION
This is something that seems to have broken sometime between 1.37.39 and now.
If a SIDE_MODULE needs one of the helper functions in `asm2wasm`, in this case floating-point remainder, it can't find it at dynamic linking time and fails with:

```
TypeError: import object field 'asm2wasm' is not an Object
```
This solves that by just copying-and-pasting what the MAIN_MODULE gets.  I'm sure there's a better way to avoid this duplication, but I couldn't see it.  Any thoughts?  Happy to fix this to make it right.