### PR TITLE
Add 'main' symbol to test_fs_dict

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7569,17 +7569,17 @@ extern "C" {
     self.do_run(open(os.path.join(self.get_dir(), 'main.cpp'), 'r').read(), 'able to run memprof')
 
   def test_fs_dict(self):
-      Settings.FORCE_FILESYSTEM = 1
-      open(self.in_dir('pre.js'), 'w').write('''
-        Module = {};
-        Module['preRun'] = function() {
-            Module.print(typeof FS.filesystems['MEMFS']);
-            Module.print(typeof FS.filesystems['IDBFS']);
-            Module.print(typeof FS.filesystems['NODEFS']);
-        };
-      ''')
-      self.emcc_args += ['--pre-js', 'pre.js']
-      self.do_run('', 'object\nobject\nobject')
+    Settings.FORCE_FILESYSTEM = 1
+    open(self.in_dir('pre.js'), 'w').write('''
+      Module = {};
+      Module['preRun'] = function() {
+          Module.print(typeof FS.filesystems['MEMFS']);
+          Module.print(typeof FS.filesystems['IDBFS']);
+          Module.print(typeof FS.filesystems['NODEFS']);
+      };
+    ''')
+    self.emcc_args += ['--pre-js', 'pre.js']
+    self.do_run('int main() { return 0; }', 'object\nobject\nobject')
 
   @sync
   @no_wasm_backend("wasm backend has no support for fastcomp's -emscripten-assertions flag")


### PR DESCRIPTION
Without this lld will fail since this test includes main
in EXPORTED_FUNCTIONS.  It seems that the existing linkers allow
for symbols in EXPORTED_FUNCTIONS to be missing (?).

Since this is the only test that seems to rely on this behavior
I'm tempted to say the failing at link in this case is actually the
correct behavior, and fix the test to include a `main`.