### PR TITLE
Show a clear error when LEGACY_VM_SUPPORT and WASM are both enabled

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1012,7 +1012,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if shared.Settings.LEGACY_VM_SUPPORT:
         # legacy vms don't have wasm
-        shared.Settings.WASM = 0
+        assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
 
       if shared.Settings.SPLIT_MEMORY:
         if shared.Settings.WASM:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3199,15 +3199,20 @@ int main() {
 
   def test_LEGACY_VM_SUPPORT(self):
     # when modern features are lacking, we can polyfill them or at least warn
+    with open('pre.js', 'w') as f: f.write('Math.imul = undefined;')
     def test(expected, opts=[]):
-      self.clear()
-      with open('pre.js', 'w') as f: f.write('Math.imul = undefined;')
-      subprocess.check_call([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--pre-js', 'pre.js'] + opts)
-      self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS, assert_returncode=None))
+      print(opts)
+      result = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--pre-js', 'pre.js'] + opts, stderr=PIPE, check=False)
+      if result.returncode == 0:
+        self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS, assert_returncode=None))
+      else:
+        self.assertContained(expected, result.stderr)
+    # when legacy is needed, we show an error indicating so
     test('this is a legacy browser, build with LEGACY_VM_SUPPORT')
-    assert os.path.exists('a.out.wasm'), 'emit wasm by default'
-    test('hello, world!', ['-s', 'LEGACY_VM_SUPPORT=1'])
-    assert not os.path.exists('a.out.wasm'), 'LEGACY_VM_SUPPORT disables wasm'
+    # wasm is on by default, and does not mix with legacy, so we show an error
+    test('LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0', ['-s', 'LEGACY_VM_SUPPORT=1'])
+    # legacy + disabling wasm works
+    test('hello, world!', ['-s', 'LEGACY_VM_SUPPORT=1', '-s', 'WASM=0'])
 
   def test_on_abort(self):
     expected_output = 'Module.onAbort was called'


### PR DESCRIPTION
Instead of the legacy flag silently turning off wasm, which could be confusing, show a clear error.

See #5837