### PR TITLE
Check joystick button state when the controller timestamp is zero.

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1252,7 +1252,9 @@ var LibrarySDL = {
         if (state === null) return;
         // Check only if the timestamp has differed.
         // NOTE: Timestamp is not available in Firefox.
-        if (typeof state.timestamp !== 'number' || state.timestamp !== prevState.timestamp) {
+        // NOTE: Timestamp is currently not properly set for the GearVR controller
+        // on Samsung Internet: it is always zero.
+        if (typeof state.timestamp !== 'number' || state.timestamp !== prevState.timestamp || state.timestamp == 0) {
           var i;
           for (i = 0; i < state.buttons.length; i++) {
             var buttonState = SDL.getJoystickButtonState(state.buttons[i]);


### PR DESCRIPTION
Hi! Currently, the GearVR controller (used on a Samsung Internet-based VR app) does not generate any joystick button events. This PR adds a small workaround to fix this. It seems the timestamp of the gamepad state is always set to 0, which prevents the button states from being checked. Here, I allow the check when the timestamp is equal to 0. This is not a breaking change since, if I understand correctly, the timestamp tests are only for optimization purpose here.