### PR TITLE
Always generate debug symbols for emscripten-wasm-finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1900,8 +1900,12 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
       '--import-memory',
       '--export', '__wasm_call_ctors']
 
-    if settings['DEBUG_LEVEL'] < 2 and not settings['PROFILING_FUNCS']:
-      cmd.append('--strip-debug')
+    # emscripten-wasm-finalize currently depends on the presence of debug
+    # symbols for renaming of the __invoke symbols
+    # TODO(sbc): Re-enable once emscripten-wasm-finalize is fixed or we
+    # no longer need to rename these symbols.
+    #if settings['DEBUG_LEVEL'] < 2 and not settings['PROFILING_FUNCS']:
+    #  cmd.append('--strip-debug')
 
     for export in shared.expand_response(settings['EXPORTED_FUNCTIONS']):
       cmd += ['--export', export[1:]] # Strip the leading underscore

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -810,12 +810,14 @@ base align: 0, 0, 0, 0'''])
     self.do_run_in_out_file_test('tests', 'core', 'test_assert')
 
   def test_libcextra(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_libcextra')
+    self.do_run_in_out_file_test('tests', 'core', 'test_libcextra')
 
   def test_regex(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_regex')
+    self.do_run_in_out_file_test('tests', 'core', 'test_regex')
 
   def test_longjmp(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_longjmp')
+    self.emcc_args.append('-g3')
     self.do_run_in_out_file_test('tests', 'core', 'test_longjmp')
 
   def test_longjmp2(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -810,14 +810,12 @@ base align: 0, 0, 0, 0'''])
     self.do_run_in_out_file_test('tests', 'core', 'test_assert')
 
   def test_libcextra(self):
-    self.do_run_in_out_file_test('tests', 'core', 'test_libcextra')
+      self.do_run_in_out_file_test('tests', 'core', 'test_libcextra')
 
   def test_regex(self):
-    self.do_run_in_out_file_test('tests', 'core', 'test_regex')
+      self.do_run_in_out_file_test('tests', 'core', 'test_regex')
 
   def test_longjmp(self):
-    self.do_run_in_out_file_test('tests', 'core', 'test_longjmp')
-    self.emcc_args.append('-g3')
     self.do_run_in_out_file_test('tests', 'core', 'test_longjmp')
 
   def test_longjmp2(self):


### PR DESCRIPTION
Sadly, the current code in emscripten-wasm-finalize depends on
debug names being present.