### PR TITLE
Remove the source map run-dependency after the source map has been used.

### DIFF
--- a/src/emscripten-source-map.min.js
+++ b/src/emscripten-source-map.min.js
@@ -3,7 +3,6 @@ function define(e,t,n){if(typeof e!="string")throw new TypeError("Expected strin
 var emscripten_sourcemap_xmlHttp = undefined;
 function emscripten_sourceMapLoaded() {
   if (emscripten_sourcemap_xmlHttp.readyState === 4) {
-    removeRunDependency('sourcemap');
     if (emscripten_sourcemap_xmlHttp.status === 200 || emscripten_sourcemap_xmlHttp.status === 0) {
       emscripten_source_map = new window.sourceMap.SourceMapConsumer(emscripten_sourcemap_xmlHttp.responseText);
       console.log('Source map data loaded.');
@@ -11,6 +10,7 @@ function emscripten_sourceMapLoaded() {
       console.warn('Source map data loading failed with status code ' + emscripten_sourcemap_xmlHttp.status + '.');
     }
     emscripten_sourcemap_xmlHttp = undefined;
+    removeRunDependency('sourcemap');
   }
 }
 function emscripten_loadSourceMap() {

--- a/tools/colored_logger.py
+++ b/tools/colored_logger.py
@@ -11,34 +11,6 @@ def add_coloring_to_emit_windows(fn):
     return ctypes.windll.kernel32.GetStdHandle(self.STD_OUTPUT_HANDLE)
   out_handle = property(_out_handle)
 
-  def _get_color(self):
-    import ctypes
-    SHORT = ctypes.c_short
-    WORD = ctypes.c_ushort
-    class COORD(ctypes.Structure):
-      _fields_ = [
-        ("X", SHORT),
-        ("Y", SHORT)]
-    class SMALL_RECT(ctypes.Structure):
-      _fields_ = [
-        ("Left", SHORT),
-        ("Top", SHORT),
-        ("Right", SHORT),
-        ("Bottom", SHORT)]
-    class CONSOLE_SCREEN_BUFFER_INFO(ctypes.Structure):
-      _fields_ = [
-        ("dwSize", COORD),
-        ("dwCursorPosition", COORD),
-        ("wAttributes", WORD),
-        ("srWindow", SMALL_RECT),
-        ("dwMaximumWindowSize", COORD)]
-    # Constants from the Windows API
-    self.STD_OUTPUT_HANDLE = -11
-    hdl = ctypes.windll.kernel32.GetStdHandle(self.STD_OUTPUT_HANDLE)
-    csbi = CONSOLE_SCREEN_BUFFER_INFO()
-    ctypes.windll.kernel32.GetConsoleScreenBufferInfo(hdl, ctypes.byref(csbi))
-    return csbi.wAttributes
-
   def _set_color(self, code):
     import ctypes
     # Constants from the Windows API
@@ -46,7 +18,6 @@ def add_coloring_to_emit_windows(fn):
     hdl = ctypes.windll.kernel32.GetStdHandle(self.STD_OUTPUT_HANDLE)
     ctypes.windll.kernel32.SetConsoleTextAttribute(hdl, code)
 
-  setattr(logging.StreamHandler, '_get_color', _get_color)
   setattr(logging.StreamHandler, '_set_color', _set_color)
 
   def new(*args):
@@ -93,10 +64,9 @@ def add_coloring_to_emit_windows(fn):
         color = FOREGROUND_MAGENTA
     else:
         color =  FOREGROUND_WHITE
-    old_color = args[0]._get_color()
     args[0]._set_color(color)
     ret = fn(*args)
-    args[0]._set_color(old_color)
+    args[0]._set_color( FOREGROUND_WHITE )
     #print "after"
     return ret
   return new


### PR DESCRIPTION
Removing the source map run-dependency before the source map was used could lead to "Source map information is not available" errors.