### PR TITLE
Remove the source map run-dependency after the source map has been used.

### DIFF
--- a/src/emscripten-source-map.min.js
+++ b/src/emscripten-source-map.min.js
@@ -3,7 +3,6 @@ function define(e,t,n){if(typeof e!="string")throw new TypeError("Expected strin
 var emscripten_sourcemap_xmlHttp = undefined;
 function emscripten_sourceMapLoaded() {
   if (emscripten_sourcemap_xmlHttp.readyState === 4) {
-    removeRunDependency('sourcemap');
     if (emscripten_sourcemap_xmlHttp.status === 200 || emscripten_sourcemap_xmlHttp.status === 0) {
       emscripten_source_map = new window.sourceMap.SourceMapConsumer(emscripten_sourcemap_xmlHttp.responseText);
       console.log('Source map data loaded.');
@@ -11,6 +10,7 @@ function emscripten_sourceMapLoaded() {
       console.warn('Source map data loading failed with status code ' + emscripten_sourcemap_xmlHttp.status + '.');
     }
     emscripten_sourcemap_xmlHttp = undefined;
+    removeRunDependency('sourcemap');
   }
 }
 function emscripten_loadSourceMap() {


### PR DESCRIPTION
Removing the source map run-dependency before the source map was used could lead to "Source map information is not available" errors.