### PR TITLE
Fix EM_JS test in C for for lld but avoiding prototypeless functions

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1895,7 +1895,7 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
       '--initial-memory=%s' % shared.Settings.TOTAL_MEMORY,
       temp_o, libc_rt_lib, compiler_rt_lib,
       '-o', base_wasm,
-      '--entry=main',
+      '--no-entry',
       '--allow-undefined',
       '--import-memory',
       '--export', '__wasm_call_ctors']
@@ -2022,10 +2022,13 @@ def create_em_js(forwarded_json, metadata):
   em_js_funcs = []
   separator = '<::>'
   for name, raw in metadata.get('emJsFuncs', {}).items():
-    parts = raw.split(separator)
-    assert len(parts) >= 2
-    args, body = parts[0], separator.join(parts[1:])
-    args = args[1:-1].split(',')
+    assert separator in raw
+    args, body = raw.split(separator, 1)
+    args = args[1:-1]
+    if args == 'void':
+      args = []
+    else:
+      args = args.split(',')
     arg_names = [arg.split()[-1] for arg in args if arg]
     func = 'function {}({}){}'.format(name, ','.join(arg_names), body)
     em_js_funcs.append(func)
@@ -2124,11 +2127,11 @@ var establishStackSpace = Module['establishStackSpace'];
   module.append(jscall_funcs)
   return module
 
-def create_backend_args_wasm(infile, temp_s, settings):
+def create_backend_args_wasm(infile, outfile, settings):
   backend_compiler = os.path.join(shared.LLVM_ROOT, 'llc')
   args = [backend_compiler, infile, '-mtriple={}'.format(shared.WASM_TARGET),
                   '-asm-verbose=false',
-                  '-o', temp_s]
+                  '-o', outfile]
   if settings['EXPERIMENTAL_USE_LLD']:
     args += ['-filetype=obj']
   else:

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -1,12 +1,12 @@
 #include <emscripten.h>
 #include <stdio.h>
 
-EM_JS(void, noarg, (), { Module['print']("no args works"); });
-EM_JS(int, noarg_int, (), {
+EM_JS(void, noarg, (void), { Module['print']("no args works"); });
+EM_JS(int, noarg_int, (void), {
   Module['print']("no args returning int");
   return 12;
 });
-EM_JS(double, noarg_double, (), {
+EM_JS(double, noarg_double, (void), {
   Module['print']("no args returning double");
   return 12.25;
 });
@@ -36,11 +36,11 @@ EM_JS(double, add_outer, (double x, double y, double z), {
   Module['print']("  " + x + " + " + z);
   return x + z;
 });
-EM_JS(int, user_separator, (), {
+EM_JS(int, user_separator, (void), {
   Module['print']("  can use <::> separator in user code");
   return 15;
 });
-EM_JS(int, user_comma, (), {
+EM_JS(int, user_comma, (void), {
   var x, y;
   x = {};
   y = 3;
@@ -49,7 +49,7 @@ EM_JS(int, user_comma, (), {
   return x[y][1];
 });
 
-EM_JS(const char*, return_str, (), {
+EM_JS(const char*, return_str, (void), {
   var jsString = 'hello from js';
   var lengthBytes = jsString.length+1;
   var stringOnWasmHeap = _malloc(lengthBytes);


### PR DESCRIPTION
Also, correctly handle prototypeless functions in EM_JS metadata
parsing;