### PR TITLE
Pass --no-entry to lld

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1895,7 +1895,7 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
       '--initial-memory=%s' % shared.Settings.TOTAL_MEMORY,
       temp_o, libc_rt_lib, compiler_rt_lib,
       '-o', base_wasm,
-      '--entry=main',
+      '--no-entry',
       '--allow-undefined',
       '--import-memory',
       '--export', '__wasm_call_ctors']


### PR DESCRIPTION
main is always explicitly exports via --export flags so we don't
want it additionally required as that entry point.  This is especially
try to programs that don't have a main at all which will fail to link
today.