### PR TITLE
WIP: Add preload plugin to compile wasm side modules async

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -555,7 +555,7 @@ Functions
 
 	Load file from url in *synchronously*. For the asynchronous version, see the :c:func:`emscripten_async_wget`.
 
-	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we synchronously do the work to make the browser decode the image or audio etc.).
+	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we synchronously do the work to make the browser decode the image or audio etc.).  See :ref:`preloading-plugins` for more information on preloading files.
  
 	This function is blocking; it won't return until all operations are finished. You can then open and read the file if it succeeded.
 
@@ -569,7 +569,8 @@ Functions
 		 
 	Loads a file from a URL asynchronously. 
 
-	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we asynchronously do the work to make the browser decode the image or audio etc.).
+	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we asynchronously do the work to make the browser decode the image or audio etc.).  See :ref:`preloading-plugins` for more information on preloading files.
+
 
 	When the file is ready the ``onload`` callback will be called. If any error occurs ``onerror`` will be called. The callbacks are called with the file as their argument.
 	
@@ -615,7 +616,8 @@ Functions
 	
 	This is an **experimental** "more feature-complete" version of :c:func:`emscripten_async_wget`. 
 	
-	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we asynchronously do the work to make the browser decode the image, audio, etc.).
+	In addition to fetching the URL from the network, preload plugins are executed so that the data is usable in ``IMG_Load`` and so forth (we asynchronously do the work to make the browser decode the image, audio, etc.). See :ref:`preloading-plugins` for more information on preloading files.
+
 
 	When the file is ready the ``onload`` callback will be called with the object pointers given in ``arg`` and ``file``. During the download the ``onprogress`` callback is called.
 	
@@ -695,7 +697,8 @@ Functions
 
 .. c:function:: void emscripten_run_preload_plugins_data(char* data, int size, const char *suffix, void *arg, em_run_preload_plugins_data_onload_func onload, em_arg_callback_func onerror)
 		 
-	Runs preload plugins on a buffer of data asynchronously. This is a "data" version of :c:func:`emscripten_run_preload_plugins`, which receives raw data as input instead of a filename (this can prevent the need to write data to a file first). 
+	Runs preload plugins on a buffer of data asynchronously. This is a "data" version of :c:func:`emscripten_run_preload_plugins`, which receives raw data as input instead of a filename (this can prevent the need to write data to a file first). See :ref:`preloading-plugins` for more information on preload plugins.
+
 	
 	When file is loaded then the ``onload`` callback will be called. If any error occurs ``onerror`` will be called.
 	
@@ -797,7 +800,8 @@ Emscripten Asynchronous IndexedDB API
 
 .. c:function:: int emscripten_run_preload_plugins(const char* file, em_str_callback_func onload, em_str_callback_func onerror)
 		 
-	Runs preload plugins on a file asynchronously. It works on file data already present and performs any required asynchronous operations available as preload plugins, such as decoding images for use in ``IMG_Load``, or decoding audio for use in ``Mix_LoadWAV``. 
+	Runs preload plugins on a file asynchronously. It works on file data already present and performs any required asynchronous operations available as preload plugins, such as decoding images for use in ``IMG_Load``, or decoding audio for use in ``Mix_LoadWAV``. See :ref:`preloading-plugins` for more information on preloading plugins.
+
 	
 	Once the operations are complete, the ``onload`` callback will be called. If any error occurs ``onerror`` will be called. The callbacks are called with the file as their argument.
 
@@ -1300,5 +1304,3 @@ Functions
 .. c:function:: void emscripten_yield(void)
 
     This function should only be called in a coroutine created by `emscripten_coroutine_create`, when it called, the coroutine is paused and the caller will continue.
-    
-

--- a/site/source/docs/compiling/Building-Projects.rst
+++ b/site/source/docs/compiling/Building-Projects.rst
@@ -177,7 +177,7 @@ Emscripten Ports is a collection of useful libraries, ported to Emscripten. They
 
 You should see some notifications about SDL2 being used, and built if it wasn't previously. You can then view ``sdl2.html`` in your browser.
 
-.. note:: *SDL_image* has also been added to ports, use it with ``-s USE_SDL_IMAGE=2``. To see a list of all available ports, run ``emcc --show-ports``. For SDL2_image to be useful, you generally need to specify the image formats you are planning on using with e.g. ``-s SDL2_IMAGE_FORMATS='["bmp","png","xpm"]'`` (note: jpg support is not available yet as of Jun 22 2018 - libjpg needs to be added to emscripten-ports). This will also ensure that ``IMG_Init`` works properly when you specify those formats. Alternatively, you can use ``emcc --use-preload-plugins`` (and ``--preload-file`` your images, so the browser codecs decode them), a code path in the SDL2_image port will load through :c:func:`emscripten_get_preloaded_image_data`, but then your calls to ``IMG_Init`` with those image formats will fail (as while the images will work through preloading, IMG_Init reports no support for those formats, as it doesn't have support compiled in - in other words, IMG_Init does not report support for formats that only work through preloading).```
+.. note:: *SDL_image* has also been added to ports, use it with ``-s USE_SDL_IMAGE=2``. To see a list of all available ports, run ``emcc --show-ports``. For SDL2_image to be useful, you generally need to specify the image formats you are planning on using with e.g. ``-s SDL2_IMAGE_FORMATS='["bmp","png","xpm"]'`` (note: jpg support is not available yet as of Jun 22 2018 - libjpg needs to be added to emscripten-ports). This will also ensure that ``IMG_Init`` works properly when you specify those formats. Alternatively, you can use ``emcc --use-preload-plugins`` and ``--preload-file`` your images, so the browser codecs decode them (see :ref:`preloading-files`). A code path in the SDL2_image port will load through :c:func:`emscripten_get_preloaded_image_data`, but then your calls to ``IMG_Init`` with those image formats will fail (as while the images will work through preloading, IMG_Init reports no support for those formats, as it doesn't have support compiled in - in other words, IMG_Init does not report support for formats that only work through preloading).```
 
 .. note:: *SDL_net* has also been added to ports, use it with ``-s USE_SDL_NET=2``. To see a list of all available ports, run ``emcc --show-ports``.
 
@@ -309,6 +309,3 @@ Troubleshooting
 	.. note:: You can use ``llvm-nm`` to see which symbols are defined in each bitcode file.
 	
 	One solution is to use the :ref:`building-projects-dynamic-linking-workaround` approach described above. This ensures that libraries are linked only once, in the final build stage. 
-
-
-

--- a/site/source/docs/porting/files/packaging_files.rst
+++ b/site/source/docs/porting/files/packaging_files.rst
@@ -10,15 +10,8 @@ There are two alternatives for how files are packaged: *preloading* and *embeddi
 	
 *Emcc* uses the *file packager* to package the files and generate the :ref:`File System API <Filesystem-API>` calls that create and load the file system at run time. While *Emcc* is the recommended tool for packaging, there are cases where it can make sense to run the *file packager* manually.
 
-With ``--use-preload-plugins``, files can be automatically decoded
-using the browser's codecs, based on their extension (this can also be
-done manually by calling :c:func:`emscripten_run_preload_plugins` on
-each file).  The files remain stored in their original form in the
-file system, but their decoded form can be used by ``IMG_Load`` (SDL1
-and SDL2 port, which rely on
-:c:func:`emscripten_get_preloaded_image_data`) or ``Mix_LoadWAV``
-(SDL1 only).
-
+With ``--use-preload-plugins``, files can be automatically decoded based on
+their extension. See :ref:`preload-files` for more information.
 
 Packaging using emcc
 ====================
@@ -121,8 +114,35 @@ An alternative approach is to look at :js:func:`FS.readFiles` in your compiled J
 
 .. note:: You can also modify the :js:func:`FS.readFiles` object or remove it entirely. This can be useful, say, in order to see which files are read between two points in time in your app.
 
+.. _preloading-files:
+
+Preloading files
+================
+
+With ``--use-preload-plugins``, files can be automatically decoded based on
+their extension. This can also be done manually by calling
+:c:func:`emscripten_run_preload_plugins` on each file. The files remain stored
+in their original form in the file system, but their decoded form can be used
+directly.
+
+The following formats are supported:
+
+- **Images** (``.jpg``, ``.jpeg``, ``.png``, ``.bmp``): The files are decoded
+  using the browser's image decoder, and can then be used by ``IMG_Load`` (SDL1
+  and SDL2 port, which rely on :c:func:`emscripten_get_preloaded_image_data`).
+  (Set ``Module.noImageDecoding`` to ``true`` to disable).
+
+- **Audio** (``.ogg``, ``.wav``, ``.mp3``): The files are decoded using the
+  browser's audio decoder, and can then by used with ``Mix_LoadWAV`` (SDL1
+  only).  (Set ``Module.noAudioDecoding`` to ``true`` to disable).
+
+- **Dynamic libraries** (``.so``): The files are precompiled and instantiated
+  using ``WebAssembly.instantiate``. This is useful for browsers, such as
+  Chrome, that require compiling large WebAssembly modules asynchronously, if
+  you then want to load the module synchronously using ``dlopen`` later. (Set
+  ``Module.noWasmDecoding`` to ``true`` to disable).
+
 Test code
 =========
 
 The `test suite <https://github.com/kripken/emscripten/blob/master/tests/>`_ contains many file packaging examples, and is a good place to search for working code. 
-

--- a/src/library.js
+++ b/src/library.js
@@ -998,7 +998,7 @@ LibraryManager.library = {
   llvm_va_copy: function(ppdest, ppsrc) {
     // copy the list start
     {{{ makeCopyValues('ppdest', 'ppsrc', Runtime.QUANTUM_SIZE, 'null', null, 1) }}};
-    
+
     // copy the list's current offset (will be advanced with each call to va_arg)
     {{{ makeCopyValues('(ppdest+'+Runtime.QUANTUM_SIZE+')', '(ppsrc+'+Runtime.QUANTUM_SIZE+')', Runtime.QUANTUM_SIZE, 'null', null, 1) }}};
   },
@@ -1741,39 +1741,44 @@ LibraryManager.library = {
       return handle;
     }
 
+    var lib_module;
     if (filename === '__self__') {
       var handle = -1;
-      var lib_module = Module;
+      lib_module = Module;
     } else {
-      var target = FS.findObject(filename);
-      if (!target || target.isFolder || target.isDevice) {
-        DLFCN.errorMsg = 'Could not find dynamic lib: ' + filename;
-        return 0;
-      }
-      FS.forceLoadFile(target);
+      if (Module['preloadedWasm'] !== undefined &&
+          Module['preloadedWasm'][filename] !== undefined) {
+        lib_module = Module['preloadedWasm'][filename];
+      } else {
+        var target = FS.findObject(filename);
+        if (!target || target.isFolder || target.isDevice) {
+          DLFCN.errorMsg = 'Could not find dynamic lib: ' + filename;
+          return 0;
+        }
+        FS.forceLoadFile(target);
 
-      var lib_module;
-      try {
+        try {
 #if WASM
-        // the shared library is a shared wasm library (see tools/shared.py WebAssembly.make_shared_library)
-        var lib_data = FS.readFile(filename, { encoding: 'binary' });
-        if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
-        //err('libfile ' + filename + ' size: ' + lib_data.length);
-        lib_module = loadWebAssemblyModule(lib_data);
+          // the shared library is a shared wasm library (see tools/shared.py WebAssembly.make_shared_library)
+          var lib_data = FS.readFile(filename, { encoding: 'binary' });
+          if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
+          //err('libfile ' + filename + ' size: ' + lib_data.length);
+          lib_module = loadWebAssemblyModule(lib_data);
 #else
-        // the shared library is a JS file, which we eval
-        var lib_data = FS.readFile(filename, { encoding: 'utf8' });
-        lib_module = eval(lib_data)(
-          alignFunctionTables(),
-          Module
-        );
+          // the shared library is a JS file, which we eval
+          var lib_data = FS.readFile(filename, { encoding: 'utf8' });
+          lib_module = eval(lib_data)(
+            alignFunctionTables(),
+            Module
+          );
 #endif
-      } catch (e) {
+        } catch (e) {
 #if ASSERTIONS
-        err('Error in loading dynamic library: ' + e);
+          err('Error in loading dynamic library: ' + e);
 #endif
-        DLFCN.errorMsg = 'Could not evaluate dynamic lib: ' + filename + '\n' + e;
-        return 0;
+          DLFCN.errorMsg = 'Could not evaluate dynamic lib: ' + filename + '\n' + e;
+          return 0;
+        }
       }
 
       // Not all browsers support Object.keys().
@@ -2210,7 +2215,7 @@ LibraryManager.library = {
           newDate.setFullYear(newDate.getFullYear()+1);
         }
       } else {
-        // we stay in current month 
+        // we stay in current month
         newDate.setDate(newDate.getDate()+days);
         return newDate;
       }
@@ -2322,7 +2327,7 @@ LibraryManager.library = {
           } else {
             return thisDate.getFullYear();
           }
-        } else { 
+        } else {
           return thisDate.getFullYear()-1;
         }
     };
@@ -2351,16 +2356,16 @@ LibraryManager.library = {
         return leadingSomething(date.tm_mday, 2, ' ');
       },
       '%g': function(date) {
-        // %g, %G, and %V give values according to the ISO 8601:2000 standard week-based year. 
-        // In this system, weeks begin on a Monday and week 1 of the year is the week that includes 
-        // January 4th, which is also the week that includes the first Thursday of the year, and 
-        // is also the first week that contains at least four days in the year. 
-        // If the first Monday of January is the 2nd, 3rd, or 4th, the preceding days are part of 
-        // the last week of the preceding year; thus, for Saturday 2nd January 1999, 
-        // %G is replaced by 1998 and %V is replaced by 53. If December 29th, 30th, 
-        // or 31st is a Monday, it and any following days are part of week 1 of the following year. 
+        // %g, %G, and %V give values according to the ISO 8601:2000 standard week-based year.
+        // In this system, weeks begin on a Monday and week 1 of the year is the week that includes
+        // January 4th, which is also the week that includes the first Thursday of the year, and
+        // is also the first week that contains at least four days in the year.
+        // If the first Monday of January is the 2nd, 3rd, or 4th, the preceding days are part of
+        // the last week of the preceding year; thus, for Saturday 2nd January 1999,
+        // %G is replaced by 1998 and %V is replaced by 53. If December 29th, 30th,
+        // or 31st is a Monday, it and any following days are part of week 1 of the following year.
         // Thus, for Tuesday 30th December 1997, %G is replaced by 1998 and %V is replaced by 01.
-        
+
         return getWeekBasedYear(date).toString().substring(2);
       },
       '%G': function(date) {
@@ -2406,13 +2411,13 @@ LibraryManager.library = {
         return day.getDay() || 7;
       },
       '%U': function(date) {
-        // Replaced by the week number of the year as a decimal number [00,53]. 
-        // The first Sunday of January is the first day of week 1; 
+        // Replaced by the week number of the year as a decimal number [00,53].
+        // The first Sunday of January is the first day of week 1;
         // days in the new year before this are in week 0. [ tm_year, tm_wday, tm_yday]
         var janFirst = new Date(date.tm_year+1900, 0, 1);
         var firstSunday = janFirst.getDay() === 0 ? janFirst : __addDays(janFirst, 7-janFirst.getDay());
         var endDate = new Date(date.tm_year+1900, date.tm_mon, date.tm_mday);
-        
+
         // is target date after the first Sunday?
         if (compareByDay(firstSunday, endDate) < 0) {
           // calculate difference in days between first Sunday and endDate
@@ -2425,10 +2430,10 @@ LibraryManager.library = {
         return compareByDay(firstSunday, janFirst) === 0 ? '01': '00';
       },
       '%V': function(date) {
-        // Replaced by the week number of the year (Monday as the first day of the week) 
-        // as a decimal number [01,53]. If the week containing 1 January has four 
-        // or more days in the new year, then it is considered week 1. 
-        // Otherwise, it is the last week of the previous year, and the next week is week 1. 
+        // Replaced by the week number of the year (Monday as the first day of the week)
+        // as a decimal number [01,53]. If the week containing 1 January has four
+        // or more days in the new year, then it is considered week 1.
+        // Otherwise, it is the last week of the previous year, and the next week is week 1.
         // Both January 4th and the first Thursday of January are always in week 1. [ tm_year, tm_wday, tm_yday]
         var janFourthThisYear = new Date(date.tm_year+1900, 0, 4);
         var janFourthNextYear = new Date(date.tm_year+1901, 0, 4);
@@ -2441,7 +2446,7 @@ LibraryManager.library = {
         if (compareByDay(endDate, firstWeekStartThisYear) < 0) {
           // if given date is before this years first week, then it belongs to the 53rd week of last year
           return '53';
-        } 
+        }
 
         if (compareByDay(firstWeekStartNextYear, endDate) <= 0) {
           // if given date is after next years first week, then it belongs to the 01th week of next year
@@ -2464,8 +2469,8 @@ LibraryManager.library = {
         return day.getDay();
       },
       '%W': function(date) {
-        // Replaced by the week number of the year as a decimal number [00,53]. 
-        // The first Monday of January is the first day of week 1; 
+        // Replaced by the week number of the year as a decimal number [00,53].
+        // The first Monday of January is the first day of week 1;
         // days in the new year before this are in week 0. [ tm_year, tm_wday, tm_yday]
         var janFirst = new Date(date.tm_year, 0, 1);
         var firstMonday = janFirst.getDay() === 1 ? janFirst : __addDays(janFirst, janFirst.getDay() === 0 ? 1 : 7-janFirst.getDay()+1);
@@ -2514,7 +2519,7 @@ LibraryManager.library = {
     var bytes = intArrayFromString(pattern, false);
     if (bytes.length > maxsize) {
       return 0;
-    } 
+    }
 
     writeArrayToMemory(bytes, s);
     return bytes.length-1;
@@ -2555,7 +2560,7 @@ LibraryManager.library = {
     for (var matcher in EQUIVALENT_MATCHERS) {
       pattern = pattern.replace(matcher, EQUIVALENT_MATCHERS[matcher]);
     }
-    
+
     // TODO: take care of locale
 
     var DATE_PATTERNS = {
@@ -2585,7 +2590,7 @@ LibraryManager.library = {
     var DAY_NUMBERS_MON_FIRST = {MON: 0, TUE: 1, WED: 2, THU: 3, FRI: 4, SAT: 5, SUN: 6};
 
     for (var datePattern in DATE_PATTERNS) {
-      pattern = pattern.replace(datePattern, '('+datePattern+DATE_PATTERNS[datePattern]+')');    
+      pattern = pattern.replace(datePattern, '('+datePattern+DATE_PATTERNS[datePattern]+')');
     }
 
     // take care of capturing groups
@@ -2673,7 +2678,7 @@ LibraryManager.library = {
       } else if ((value=getMatch('b'))) {
         // parse from month name
         date.month = MONTH_NUMBERS[value.substring(0,3).toUpperCase()] || 0;
-        // TODO: derive month from day in year+year, week number+day of week+year 
+        // TODO: derive month from day in year+year, week number+day of week+year
       }
 
       // day
@@ -2695,12 +2700,12 @@ LibraryManager.library = {
         var weekDay = value.substring(0,3).toUpperCase();
         if ((value=getMatch('U'))) {
           // ... and week number (Sunday being first day of week)
-          // Week number of the year (Sunday as the first day of the week) as a decimal number [00,53]. 
+          // Week number of the year (Sunday as the first day of the week) as a decimal number [00,53].
           // All days in a new year preceding the first Sunday are considered to be in week 0.
           var weekDayNumber = DAY_NUMBERS_SUN_FIRST[weekDay];
           var weekNumber = parseInt(value);
 
-          // January 1st 
+          // January 1st
           var janFirst = new Date(date.year, 0, 1);
           var endDate;
           if (janFirst.getDay() === 0) {
@@ -2714,12 +2719,12 @@ LibraryManager.library = {
           date.month = endDate.getMonth();
         } else if ((value=getMatch('W'))) {
           // ... and week number (Monday being first day of week)
-          // Week number of the year (Monday as the first day of the week) as a decimal number [00,53]. 
+          // Week number of the year (Monday as the first day of the week) as a decimal number [00,53].
           // All days in a new year preceding the first Monday are considered to be in week 0.
           var weekDayNumber = DAY_NUMBERS_MON_FIRST[weekDay];
           var weekNumber = parseInt(value);
 
-          // January 1st 
+          // January 1st
           var janFirst = new Date(date.year, 0, 1);
           var endDate;
           if (janFirst.getDay()===1) {
@@ -2741,10 +2746,10 @@ LibraryManager.library = {
       tm_hour int hours since midnight  0-23
       tm_mday int day of the month  1-31
       tm_mon  int months since January  0-11
-      tm_year int years since 1900  
+      tm_year int years since 1900
       tm_wday int days since Sunday 0-6
       tm_yday int days since January 1  0-365
-      tm_isdst  int Daylight Saving Time flag 
+      tm_isdst  int Daylight Saving Time flag
       */
 
       var fullDate = new Date(date.year, date.month, date.day, date.hour, date.min, date.sec, 0);
@@ -2761,7 +2766,7 @@ LibraryManager.library = {
       // we need to convert the matched sequence into an integer array to take care of UTF-8 characters > 0x7F
       // TODO: not sure that intArrayFromString handles all unicode characters correctly
       return buf+intArrayFromString(matches[0]).length-1;
-    } 
+    }
 
     return 0;
   },
@@ -2852,7 +2857,7 @@ LibraryManager.library = {
   // ==========================================================================
   // sys/timeb.h
   // ==========================================================================
-  
+
   ftime: function(p) {
     var millis = Date.now();
     {{{ makeSetValue('p', C_STRUCTS.timeb.time, '(millis/1000)|0', 'i32') }}};
@@ -3882,7 +3887,7 @@ LibraryManager.library = {
 
     if (val in GAI_ERRNO_MESSAGES) {
       if (GAI_ERRNO_MESSAGES[val].length > buflen - 1) {
-        msg = 'Message too long'; // EMSGSIZE message. This should never occur given the GAI_ERRNO_MESSAGES above. 
+        msg = 'Message too long'; // EMSGSIZE message. This should never occur given the GAI_ERRNO_MESSAGES above.
       } else {
         msg = GAI_ERRNO_MESSAGES[val];
       }
@@ -3956,7 +3961,7 @@ LibraryManager.library = {
     // struct protoent *getprotoent(void);
     // reads the  next  entry  from  the  protocols 'database' or return NULL if 'eof'
     if (_setprotoent.index === Protocols.list.length) {
-      return 0; 
+      return 0;
     } else {
       var result = Protocols.list[_setprotoent.index++];
       return result;
@@ -4138,14 +4143,14 @@ LibraryManager.library = {
       while (stack_args[1].indexOf('_emscripten_') >= 0)
         stack_args = __emscripten_traverse_stack(stack_args[0]);
     }
-    
+
     // Process all lines:
     var lines = callstack.split('\n');
     callstack = '';
     var newFirefoxRe = new RegExp('\\s*(.*?)@(.*?):([0-9]+):([0-9]+)'); // New FF30 with column info: extract components of form '       Object._main@http://server.com:4324:12'
     var firefoxRe = new RegExp('\\s*(.*?)@(.*):(.*)(:(.*))?'); // Old FF without column info: extract components of form '       Object._main@http://server.com:4324'
     var chromeRe = new RegExp('\\s*at (.*?) \\\((.*):(.*):(.*)\\\)'); // Extract components of form '    at Object._main (http://server.com/file.html:4324:12)'
-    
+
     for (var l in lines) {
       var line = lines[l];
 
@@ -4199,7 +4204,7 @@ LibraryManager.library = {
         }
         callstack += (haveSourceMap ? ('     = '+jsSymbolName) : ('    at '+cSymbolName)) + ' (' + file + ':' + lineno + ':' + column + ')\n';
       }
-      
+
       // If we are still keeping track with the callstack by traversing via 'arguments.callee', print the function parameters as well.
       if (flags & 128 /*EM_LOG_FUNC_PARAMS*/ && stack_args[0]) {
         if (stack_args[1] == jsSymbolName && stack_args[2].length > 0) {
@@ -4789,4 +4794,3 @@ function autoAddDeps(object, name) {
     }
   }
 }
-

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -237,9 +237,9 @@ var LibraryBrowser = {
         // loadWebAssemblyModule can not load modules out-of-order, so rather
         // than just running the promises in parallel, this makes a chain of
         // promises to run in series.
-        this.asyncWasmLoadPromise = this.asyncWasmLoadPromise.then(
+        this['asyncWasmLoadPromise'] = this['asyncWasmLoadPromise'].then(
           function() {
-            return Module.loadWebAssemblyModule(byteArray, true)
+            return loadWebAssemblyModule(byteArray, true);
           }).then(
             function(module) {
               Module.preloadedWasm[name] = module;

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -242,7 +242,7 @@ var LibraryBrowser = {
             return loadWebAssemblyModule(byteArray, true);
           }).then(
             function(module) {
-              Module.preloadedWasm[name] = module;
+              Module['preloadedWasm'][name] = module;
               onload();
             },
             function(err) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -227,7 +227,8 @@ var LibraryBrowser = {
 
 #if WASM && MAIN_MODULE
       var wasmPlugin = {};
-      wasmPlugin['asyncWasmLoadPromise'] = new Promise((resolve, reject) => resolve());
+      wasmPlugin['asyncWasmLoadPromise'] = new Promise(
+        function(resolve, reject) { return resolve(); });
       wasmPlugin['canHandle'] = function(name) {
         return !Module.noWasmDecoding && (name.endsWith('.so') || name.endsWith('.wasm'));
       };

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -225,7 +225,7 @@ var LibraryBrowser = {
       };
       Module['preloadPlugins'].push(audioPlugin);
 
-#if WASM && MAIN_MODULE
+#if (WASM != 0) && (MAIN_MODULE != 0)
       var wasmPlugin = {};
       wasmPlugin['asyncWasmLoadPromise'] = new Promise(
         function(resolve, reject) { return resolve(); });

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -225,7 +225,7 @@ var LibraryBrowser = {
       };
       Module['preloadPlugins'].push(audioPlugin);
 
-#if WASM
+#if WASM && MAIN_MODULE
       var wasmPlugin = {};
       wasmPlugin['asyncWasmLoadPromise'] = new Promise((resolve, reject) => resolve());
       wasmPlugin['canHandle'] = function(name) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -225,7 +225,8 @@ var LibraryBrowser = {
       };
       Module['preloadPlugins'].push(audioPlugin);
 
-#if (WASM != 0) && (MAIN_MODULE != 0)
+#if WASM
+#if MAIN_MODULE
       var wasmPlugin = {};
       wasmPlugin['asyncWasmLoadPromise'] = new Promise(
         function(resolve, reject) { return resolve(); });
@@ -250,7 +251,8 @@ var LibraryBrowser = {
             });
       };
       Module['preloadPlugins'].push(wasmPlugin);
-#endif
+#endif // MAIN_MODULE
+#endif // WASM
 
       // Canvas event setup
 
@@ -264,7 +266,7 @@ var LibraryBrowser = {
       if (canvas) {
         // forced aspect ratio can be enabled by defining 'forcedAspectRatio' on Module
         // Module['forcedAspectRatio'] = 4 / 3;
-        
+
         canvas.requestPointerLock = canvas['requestPointerLock'] ||
                                     canvas['mozRequestPointerLock'] ||
                                     canvas['webkitRequestPointerLock'] ||
@@ -517,7 +519,7 @@ var LibraryBrowser = {
         'mp3': 'audio/mpeg'
       }[name.substr(name.lastIndexOf('.')+1)];
     },
-    
+
     getUserMedia: function(func) {
       if(!window.getUserMedia) {
         window.getUserMedia = navigator['getUserMedia'] ||
@@ -551,13 +553,13 @@ var LibraryBrowser = {
     getMouseWheelDelta: function(event) {
       var delta = 0;
       switch (event.type) {
-        case 'DOMMouseScroll': 
+        case 'DOMMouseScroll':
           delta = event.detail;
           break;
-        case 'mousewheel': 
+        case 'mousewheel':
           delta = event.wheelDelta;
           break;
-        case 'wheel': 
+        case 'wheel':
           delta = event['deltaY'];
           break;
         default:
@@ -585,7 +587,7 @@ var LibraryBrowser = {
           Browser.mouseMovementX = Browser.getMovementX(event);
           Browser.mouseMovementY = Browser.getMovementY(event);
         }
-        
+
         // check if SDL is available
         if (typeof SDL != "undefined") {
           Browser.mouseX = SDL.mouseX + Browser.mouseMovementX;
@@ -595,7 +597,7 @@ var LibraryBrowser = {
           // FIXME: ideally this should be clamped against the canvas size and zero
           Browser.mouseX += Browser.mouseMovementX;
           Browser.mouseY += Browser.mouseMovementY;
-        }        
+        }
       } else {
         // Otherwise, calculate the movement based on the changes
         // in the coordinates.
@@ -627,7 +629,7 @@ var LibraryBrowser = {
           adjustedY = adjustedY * (ch / rect.height);
 
           var coords = { x: adjustedX, y: adjustedY };
-          
+
           if (event.type === 'touchstart') {
             Browser.lastTouches[touch.identifier] = coords;
             Browser.touches[touch.identifier] = coords;
@@ -636,7 +638,7 @@ var LibraryBrowser = {
             if (!last) last = coords;
             Browser.lastTouches[touch.identifier] = last;
             Browser.touches[touch.identifier] = coords;
-          } 
+          }
           return;
         }
 
@@ -1154,10 +1156,10 @@ var LibraryBrowser = {
         }
         console.log('main loop blocker "' + blocker.name + '" took ' + (Date.now() - start) + ' ms'); //, left: ' + Browser.mainLoop.remainingBlockers);
         Browser.mainLoop.updateStatus();
-        
+
         // catches pause/resume main loop from blocker execution
         if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) return;
-        
+
         setTimeout(Browser.mainLoop.runner, 0);
         return;
       }
@@ -1327,7 +1329,7 @@ var LibraryBrowser = {
   emscripten_set_canvas_size: function(width, height) {
     Browser.setCanvasSize(width, height);
   },
-  
+
   emscripten_get_canvas_size__proxy: 'sync',
   emscripten_get_canvas_size__sig: 'viii',
   emscripten_get_canvas_size: function(width, height, isFullscreen) {
@@ -1515,4 +1517,3 @@ function slowLog(label, text) {
 }
 
 */
-

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -231,7 +231,7 @@ var LibraryBrowser = {
       wasmPlugin['asyncWasmLoadPromise'] = new Promise(
         function(resolve, reject) { return resolve(); });
       wasmPlugin['canHandle'] = function(name) {
-        return !Module.noWasmDecoding && (name.endsWith('.so') || name.endsWith('.wasm'));
+        return !Module.noWasmDecoding && name.endsWith('.so');
       };
       wasmPlugin['handle'] = function(byteArray, name, onload, onerror) {
         // loadWebAssemblyModule can not load modules out-of-order, so rather

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1839,7 +1839,7 @@ function removeRunDependency(id) {
 
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
-#if WASM && MAIN_MODULE
+#if (WASM != 0) && (MAIN_MODULE != 0)
 Module["preloadedWasm"] = {}; // maps url to wasm instance exports
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1839,6 +1839,7 @@ function removeRunDependency(id) {
 
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
+Module["preloadedWasm"] = {}; // maps url to wasm instance exports
 
 #if PGO
 var PGOMonitor = {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1839,7 +1839,9 @@ function removeRunDependency(id) {
 
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
+#if WASM && MAIN_MODULE
 Module["preloadedWasm"] = {}; // maps url to wasm instance exports
+#endif
 
 #if PGO
 var PGOMonitor = {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1839,9 +1839,11 @@ function removeRunDependency(id) {
 
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
-#if (WASM != 0) && (MAIN_MODULE != 0)
+#if WASM
+#if MAIN_MODULE
 Module["preloadedWasm"] = {}; // maps url to wasm instance exports
-#endif
+#endif // MAIN_MODULE
+#endif // WASM
 
 #if PGO
 var PGOMonitor = {

--- a/src/support.js
+++ b/src/support.js
@@ -120,7 +120,7 @@ function loadDynamicLibrary(lib) {
 
 #if WASM
 // Loads a side module from binary data
-function loadWebAssemblyModule(binary) {
+function loadWebAssemblyModule(binary, load_async) {
   var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
   assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm
   // we should see the dylink section right after the magic number and wasm version
@@ -201,59 +201,71 @@ function loadWebAssemblyModule(binary) {
     oldTable.push(table.get(i));
   }
 #endif
-  // create a module from the instance
-  var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), info);
+
+  function postInstantiation(instance) {
+    var exports = {};
 #if ASSERTIONS
-  // the table should be unchanged
-  assert(table === originalTable);
-  assert(table === Module['wasmTable']);
-  if (instance.exports['table']) {
-    assert(table === instance.exports['table']);
-  }
-  // the old part of the table should be unchanged
-  for (var i = 0; i < oldTableSize; i++) {
-    assert(table.get(i) === oldTable[i], 'old table entries must remain the same');
-  }
-  // verify that the new table region was filled in
-  for (var i = 0; i < tableSize; i++) {
-    assert(table.get(oldTableSize + i) !== undefined, 'table entry was not filled in');
-  }
-#endif
-  var exports = {};
-  for (var e in instance.exports) {
-    var value = instance.exports[e];
-    if (typeof value === 'object') {
-      // a breaking change in the wasm spec, globals are now objects
-      // https://github.com/WebAssembly/mutable-global/issues/1
-      value = value.value;
+    // the table should be unchanged
+    assert(table === originalTable);
+    assert(table === Module['wasmTable']);
+    if (instance.exports['table']) {
+      assert(table === instance.exports['table']);
     }
-    if (typeof value === 'number') {
-      // relocate it - modules export the absolute value, they can't relocate before they export
-#if EMULATED_FUNCTION_POINTERS
-      // it may be a function pointer
-      if (e.substr(0, 3) == 'fp$' && typeof instance.exports[e.substr(3)] === 'function') {
-        value = value + env['tableBase'];
-      } else {
+    // the old part of the table should be unchanged
+    for (var i = 0; i < oldTableSize; i++) {
+      assert(table.get(i) === oldTable[i], 'old table entries must remain the same');
+    }
+    // verify that the new table region was filled in
+    for (var i = 0; i < tableSize; i++) {
+      assert(table.get(oldTableSize + i) !== undefined, 'table entry was not filled in');
+    }
 #endif
-        value = value + env['memoryBase'];
-#if EMULATED_FUNCTION_POINTERS
+    for (var e in instance.exports) {
+      var value = instance.exports[e];
+      if (typeof value === 'object') {
+        // a breaking change in the wasm spec, globals are now objects
+        // https://github.com/WebAssembly/mutable-global/issues/1
+        value = value.value;
       }
+      if (typeof value === 'number') {
+        // relocate it - modules export the absolute value, they can't relocate before they export
+#if EMULATED_FUNCTION_POINTERS
+        // it may be a function pointer
+        if (e.substr(0, 3) == 'fp$' && typeof instance.exports[e.substr(3)] === 'function') {
+          value = value + env['tableBase'];
+        } else {
 #endif
+          value = value + env['memoryBase'];
+#if EMULATED_FUNCTION_POINTERS
+        }
+#endif
+      }
+      exports[e] = value;
     }
-    exports[e] = value;
-  }
-  // initialize the module
-  var init = exports['__post_instantiate'];
-  if (init) {
-    if (runtimeInitialized) {
-      init();
-    } else {
-      // we aren't ready to run compiled code yet
-      __ATINIT__.push(init);
+    // initialize the module
+    var init = exports['__post_instantiate'];
+    if (init) {
+      if (runtimeInitialized) {
+        init();
+      } else {
+        // we aren't ready to run compiled code yet
+        __ATINIT__.push(init);
+      }
     }
+    return exports;
   }
-  return exports;
+
+  if (load_async) {
+    return WebAssembly.instantiate(binary, info).then(function(result) {
+      return postInstantiation(result.instance);
+    });
+  } else {
+    var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), info);
+    return postInstantiation(instance);
+  }
 }
+Module['loadWebAssemblyModule'] = loadWebAssemblyModule;
+
 #endif // WASM
 #endif // RELOCATABLE
 

--- a/src/support.js
+++ b/src/support.js
@@ -120,7 +120,7 @@ function loadDynamicLibrary(lib) {
 
 #if WASM
 // Loads a side module from binary data
-function loadWebAssemblyModule(binary, load_async) {
+function loadWebAssemblyModule(binary, loadAsync) {
   var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
   assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm
   // we should see the dylink section right after the magic number and wasm version
@@ -255,7 +255,7 @@ function loadWebAssemblyModule(binary, load_async) {
     return exports;
   }
 
-  if (load_async) {
+  if (loadAsync) {
     return WebAssembly.instantiate(binary, info).then(function(result) {
       return postInstantiation(result.instance);
     });


### PR DESCRIPTION
This is a possible solution to #6633 related to dlopen'ing SIDE_MODULES using async wasm compilation (required by Chromium).

This adds a new preload handler for `.so` and `.wasm` files to compile them using the async API (`WebAssembly.instantiate`) at data-loading time.  The actual dynamic linking happens synchronously when calling `dlopen` later.  The downside here is that you may end up compiling wasm that never actually gets dlopen'ed, but I think that's probably a domain-specific problem and will be up to the user to resolve, ultimately.

The only change required on the user end is to add `--use-preload-plugins` when file packaging.

Of note is that `loadWebAssemblyModule` most be called one at a time, since it sets up an environment in global variables that is later used when the wasm is compiled asynchronously.  So this uses a chain of promises to do the compilation, rather than just `Promise.all`.

This will need tests, obviously, but I thought I'd get feedback on the general approach first.