### PR TITLE
Handle subprocess failures cleanly

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2914,6 +2914,6 @@ def validate_arg_level(level_string, max_level, err_msg, clamp=False):
 if __name__ == '__main__':
   try:
     sys.exit(run())
-  except shared.EmError as e:
+  except shared.FatalError as e:
     logging.error(str(e))
     sys.exit(1)

--- a/emcc.py
+++ b/emcc.py
@@ -2912,4 +2912,8 @@ def validate_arg_level(level_string, max_level, err_msg, clamp=False):
 
 
 if __name__ == '__main__':
-  sys.exit(run())
+  try:
+    sys.exit(run())
+  except shared.EmError as e:
+    logging.error(str(e))
+    sys.exit(1)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -12,9 +12,11 @@ import logging, platform, multiprocessing
 from .tempfiles import try_delete
 
 
-class EmError(Exception):
-  """Emscripten error class.  These are usually fatal and handled at the entry
-  point of each script."""
+class FatalError(Exception):
+  """Error representing an unrecoverable error such as the failure of
+  a subprocess.
+
+  These are usually handled at the entry point of each script."""
   pass
 
 
@@ -154,14 +156,14 @@ def check_execute(cmd, *args, **kw):
     subprocess.check_output(cmd, *args, **kw)
     logging.debug("Successfuly executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError as e:
-    raise EmError("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
+    raise FatalError("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
 
 def check_call(cmd, *args, **kw):
   try:
     subprocess.check_call(cmd, *args, **kw)
     logging.debug("Successfully executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError as e:
-    raise EmError("'%s' failed" % " ".join(cmd))
+    raise FatalError("'%s' failed" % " ".join(cmd))
 
 
 # Emscripten configuration is done through the --em-config command line option or

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -11,6 +11,13 @@ import logging, platform, multiprocessing
 # Temp file utilities
 from .tempfiles import try_delete
 
+
+class EmError(Exception):
+  """Emscripten error class.  These are usually fatal and handled at the entry
+  point of each script."""
+  pass
+
+
 # On Windows python suffers from a particularly nasty bug if python is spawning new processes while python itself is spawned from some other non-console process.
 # Use a custom replacement for Popen on Windows to avoid the "WindowsError: [Error 6] The handle is invalid" errors when emcc is driven through cmake or mingw32-make.
 # See http://bugs.python.org/issue3905
@@ -147,16 +154,14 @@ def check_execute(cmd, *args, **kw):
     subprocess.check_output(cmd, *args, **kw)
     logging.debug("Successfuly executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError as e:
-    logging.error("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
-    raise
+    raise EmError("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
 
 def check_call(cmd, *args, **kw):
   try:
     subprocess.check_call(cmd, *args, **kw)
     logging.debug("Successfully executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError as e:
-    logging.error("'%s' failed" % " ".join(cmd))
-    raise
+    raise EmError("'%s' failed" % " ".join(cmd))
 
 
 # Emscripten configuration is done through the --em-config command line option or


### PR DESCRIPTION
We don't want to be showing backtraces to users there a subprocess
fails.