### PR TITLE
Fix test_source_map with EMCC_EXPERIMENTAL_USE_LLD=1

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1679,7 +1679,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         wasm_temp = temp_basename + '.wasm'
         shutil.move(wasm_temp, wasm_binary_target)
         open(wasm_text_target + '.mappedGlobals', 'w').write('{}') # no need for mapped globals for now, but perhaps some day
-        if options.debug_level >= 4 and not shared.Settings.EXPERIMENTAL_USE_LLD:
+        if options.debug_level >= 4:
           shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
 
       if shared.Settings.CYBERDWARF:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1735,9 +1735,9 @@ def emscript_wasm_backend(infile, settings, outfile, libraries, compiler_engine,
   #   * We may also run some Binaryen passes here.
 
   if shared.Settings.EXPERIMENTAL_USE_LLD:
-    wasm, metadata = build_wasm_lld(temp_files, infile, outfile, settings, DEBUG)
+    metadata = build_wasm_lld(temp_files, infile, outfile, settings, DEBUG)
   else:
-    wasm, metadata = build_wasm(temp_files, infile, outfile, settings, DEBUG)
+    metadata = build_wasm(temp_files, infile, outfile, settings, DEBUG)
 
   # optimize syscalls
 
@@ -1833,12 +1833,12 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
     s2wasm_args = create_s2wasm_args(temp_s, wasm)
     if settings['DEBUG_LEVEL'] >= 2 or settings['PROFILING_FUNCS']:
       s2wasm_args += ['-g']
-      if settings['DEBUG_LEVEL'] >= 4:
-        s2wasm_args += ['--source-map=' + wasm + '.map']
-        if not settings['SOURCE_MAP_BASE']:
-          logging.warn("Wasm source map won't be usable in a browser without --source-map-base")
-        else:
-          s2wasm_args += ['--source-map-url=' + settings['SOURCE_MAP_BASE'] + os.path.basename(settings['WASM_BINARY_FILE']) + '.map']
+    if settings['DEBUG_LEVEL'] >= 4:
+      s2wasm_args += ['--source-map=' + wasm + '.map']
+      if not settings['SOURCE_MAP_BASE']:
+        logging.warn("Wasm source map won't be usable in a browser without --source-map-base")
+      else:
+        s2wasm_args += ['--source-map-url=' + settings['SOURCE_MAP_BASE'] + os.path.basename(settings['WASM_BINARY_FILE']) + '.map']
     if DEBUG:
       logging.debug('emscript: binaryen s2wasm: ' + ' '.join(s2wasm_args))
       t = time.time()
@@ -1849,7 +1849,7 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
   if DEBUG:
     logging.debug('  emscript: binaryen s2wasm took %s seconds' % (time.time() - t))
     t = time.time()
-  return wasm, metadata
+  return metadata
 
 
 def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
@@ -1907,35 +1907,39 @@ def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
         cmd += ['--export', export[1:]] # Strip the leading underscore
     shared.check_call(cmd)
 
-    if settings['DEBUG_LEVEL'] >= 2 or settings['PROFILING_FUNCS']:
-      if settings['DEBUG_LEVEL'] >= 4:
-        sourcemap_cmd = [shared.PYTHON, path_from_root('tools', 'wasm-sourcemap.py'), 
-                         base_wasm,
-                         '--dwarfdump=' + shared.LLVM_DWARFDUMP,
-                         '-o',  base_wasm + '.map']
-        if not settings['SOURCE_MAP_BASE']:
-          logging.warn("Wasm source map won't be usable in a browser without --source-map-base")
-        else:
-          sourcemap_cmd += ['--source-map-url=' + settings['SOURCE_MAP_BASE'] + os.path.basename(settings['WASM_BINARY_FILE']) + '.map']
-        shared.check_call(sourcemap_cmd)
-
     if DEBUG:
       logging.debug('  emscript: lld took %s seconds' % (time.time() - t))
       t = time.time()
     debug_copy(base_wasm, 'base_wasm.wasm')
 
+    write_source_map = settings['DEBUG_LEVEL'] >= 4
+    if write_source_map:
+      base_source_map = base_wasm + '.map'
+      sourcemap_cmd = [shared.PYTHON, path_from_root('tools', 'wasm-sourcemap.py'), 
+                       base_wasm,
+                       '--dwarfdump=' + shared.LLVM_DWARFDUMP,
+                       '-o',  base_source_map]
+      if not settings['SOURCE_MAP_BASE']:
+        logging.warn("Wasm source map won't be usable in a browser without --source-map-base")
+      else:
+        sourcemap_cmd += ['--source-map-url=' + settings['SOURCE_MAP_BASE'] + os.path.basename(settings['WASM_BINARY_FILE']) + '.map']
+      shared.check_call(sourcemap_cmd)
+      debug_copy(base_source_map, 'base_wasm.map')
+
     cmd = [wasm_emscripten_finalize, base_wasm, '-o', wasm,
            '--global-base=%s' % shared.Settings.GLOBAL_BASE,
            ('--emscripten-reserved-function-pointers=%d' %
             shared.Settings.RESERVED_FUNCTION_POINTERS)]
-    if settings['DEBUG_LEVEL'] >= 2 or settings['PROFILING_FUNCS']:
-      cmd += ['-g', '--input-source-map=' + base_wasm + '.map']
-      cmd += ['--output-source-map=' + wasm + '.map']
+    if write_source_map:
+      cmd += ['-g', '--input-source-map=' + base_source_map]
+      cmd += ['--output-source-map=' + wasm + '.map' ]
     shared.check_call(cmd, stdout=open(metadata_file, 'w'))
+    if write_source_map:
+      debug_copy(wasm + '.map', 'post_finalize.map')
 
     metadata = create_metadata_wasm(open(metadata_file).read(), DEBUG)
 
-  return wasm, metadata
+  return metadata
 
 
 def read_metadata_wast(wast, DEBUG):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7038,14 +7038,13 @@ Module.printErr = Module['printErr'] = function(){};
         # the file attribute is optional, but if it is present it needs to refer
         # the output file.
         self.assertPathsIdentical(map_referent, data['file'])
-      if not self.is_wasm_backend():
+      if not self.is_wasm_backend() or Settings.EXPERIMENTAL_USE_LLD:
         assert len(data['sources']) == 1, data['sources']
         self.assertPathsIdentical(src_filename, data['sources'][0])
       else:
-        # Wasm backend currently adds every file linked as part of compiler-rt
+        # s2wasm currently adds every file linked as part of compiler-rt
         # to the 'sources' field.
-        # TODO(jgravelle): when LLD is the wasm-backend default, make sure it
-        # emits only the files we have lines for.
+        # TODO(sbc): Remove this once s2wasm goes away
         assert len(data['sources']) > 1, data['sources']
         normalized_srcs = [src.replace('\\', '/') for src in data['sources']]
         normalized_filename = src_filename.replace('\\', '/')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8378,7 +8378,7 @@ end
       except OSError:
         # Ignore missing python aliases.
         pass
-        
+
   def test_ioctl_window_size(self):
       self.do_other_test(os.path.join('other', 'ioctl', 'window_size'))
 
@@ -8413,8 +8413,8 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
     subprocess.check_call(wasm_map_cmd)
     output = open('a.out.wasm.map').read()
     # has "sources" entry with file (includes also `--prefix =wasm-src:///` replacement)
-    self.assertContained('wasm-src:///no_main.c', output)
+    self.assertIn('wasm-src:///no_main.c', output)
     # has "sourcesContent" entry with source code (included with `-s` option)
-    self.assertContained('int foo()', output)
+    self.assertIn('int foo()', output)
     # has some entries
-    self.assertIsNotNone(re.search(r'"mappings": "[A-Za-z0-9+/]', output))
+    self.assertRegexpMatches(output, r'"mappings":\s*"[A-Za-z0-9+/]')

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -203,10 +203,10 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources):
     last_line = line
     last_column = column
   return OrderedDict([('version', 3),
-      ('names', []),
-      ('sources', sources),
-      ('sourcesContent', sources_content),
-      ('mappings', ','.join(mappings))])
+                      ('names', []),
+                      ('sources', sources),
+                      ('sourcesContent', sources_content),
+                      ('mappings', ','.join(mappings))])
 
 
 def main():

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -5,10 +5,13 @@ it can collect original sources, change files prefixes, and strip debug
 sections from a wasm file.
 """
 
-from subprocess import Popen, PIPE
-import re
-import json
 import argparse
+from collections import OrderedDict
+import json
+import logging
+import os
+import re
+from subprocess import Popen, PIPE
 import sys
 
 
@@ -50,7 +53,7 @@ def read_var_uint(wasm, pos):
 
 
 def strip_debug_sections(wasm):
-  print('Strip debug sections')
+  logging.debug('Strip debug sections')
   pos = 8
   stripped = wasm[:pos]
 
@@ -80,14 +83,14 @@ def encode_uint_var(n):
 
 
 def append_source_mapping(wasm, url):
-  print('Append sourceMappingURL section')
+  logging.debug('Append sourceMappingURL section')
   section_name = "sourceMappingURL"
   section_content = encode_uint_var(len(section_name)) + section_name + encode_uint_var(len(url)) + url
   return wasm + encode_uint_var(0) + encode_uint_var(len(section_content)) + section_content
 
 
 def get_code_section_offset(wasm):
-  print('Read sections index')
+  logging.debug('Read sections index')
   pos = 8
 
   while pos < len(wasm):
@@ -102,15 +105,15 @@ def read_dwarf_entries(wasm, options):
   if options.dwarfdump_output:
     output = open(options.dwarfdump_output, 'r').read()
   elif options.dwarfdump:
-    print('Reading DWARF information from %s' % wasm)
+    logging.debug('Reading DWARF information from %s' % wasm)
     process = Popen([options.dwarfdump, "-debug-line", wasm], stdout=PIPE)
     output, err = process.communicate()
     exit_code = process.wait()
     if exit_code != 0:
-      print('Error during llvm-dwarfdump execution (%s)' % exit_code)
+      logging.error('Error during llvm-dwarfdump execution (%s)' % exit_code)
       sys.exit(1)
   else:
-    print('Please specify either --dwarfdump or --dwarfdump-output')
+    logging.error('Please specify either --dwarfdump or --dwarfdump-output')
     sys.exit(1)
 
   entries = []
@@ -199,7 +202,11 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources):
     last_source_id = source_id
     last_line = line
     last_column = column
-  return {'version': 3, 'names': [], 'sources': sources, 'sourcesContent': sources_content, 'mappings': ','.join(mappings)}
+  return OrderedDict([('version', 3),
+      ('names', []),
+      ('sources', sources),
+      ('sourcesContent', sources_content),
+      ('mappings', ','.join(mappings))])
 
 
 def main():
@@ -221,10 +228,10 @@ def main():
     else:
       prefixes.append({'prefix': p, 'replacement': None})
 
-  print('Saving to %s' % options.output)
+  logging.debug('Saving to %s' % options.output)
   map = build_sourcemap(entries, code_section_offset, prefixes, options.sources)
   with open(options.output, 'w') as outfile:
-    json.dump(map, outfile)
+    json.dump(map, outfile, separators=(',', ':'))
 
   if options.strip:
     wasm = strip_debug_sections(wasm)
@@ -233,12 +240,14 @@ def main():
     wasm = append_source_mapping(wasm, options.source_map_url)
 
   if options.w:
-    print('Saving wasm to %s' % options.w)
+    logging.debug('Saving wasm to %s' % options.w)
     with open(options.w, 'wb') as outfile:
       outfile.write(wasm)
 
-  print('Done.')
+  logging.debug('Done')
+  return 0
 
 
 if __name__ == '__main__':
+  logging.basicConfig(level=logging.DEBUG if os.environ.get('EMCC_DEBUG') else logging.INFO)
   sys.exit(main())


### PR DESCRIPTION
Have wasm-sourcemap.py emit json source map in a format
that the current binaryen parser can understand.

The current source map parsing in binaryen is very
brittle and cannot tolerate whitespace or changes in the
order of keys.