### PR TITLE
Fix #6331 - handle js cleanup properly when dfe has been run

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1879,6 +1879,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and options.opt_level >= 2:
           optimizer.flush()
           shared.Building.eliminate_duplicate_funcs(final)
+          if DEBUG: save_intermediate('dfe', 'js')
 
       if shared.Settings.EVAL_CTORS and options.memory_init_file and options.debug_level < 4 and not shared.Settings.WASM:
         optimizer.flush()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,6 +90,15 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
   def is_windows(self):
     return WINDOWS
 
+  # whether the test mode supports duplicate function elimination in js
+  def supports_js_dfe(self):
+    if self.is_wasm(): return False # wasm does this when optimizing anyhow
+    supported_opt_levels = ['-O2', '-O3', '-Oz', '-Os']
+    for opt_level in supported_opt_levels:
+      if opt_level in self.emcc_args:
+        return True
+    return False
+
   # Use closure in some tests for some additional coverage
   def maybe_closure(self):
     if '-O2' in self.emcc_args or '-Os' in self.emcc_args:
@@ -5851,19 +5860,13 @@ def process(filename):
 
     test()
 
-    if not self.is_wasm(): # wasm does this all the time
-      # Run with duplicate function elimination turned on
-      dfe_supported_opt_levels = ['-O2', '-O3', '-Oz', '-Os']
-
-      for opt_level in dfe_supported_opt_levels:
-        if opt_level in self.emcc_args:
-          print("Testing poppler with ELIMINATE_DUPLICATE_FUNCTIONS set to 1", file=sys.stderr)
-          num_original_funcs = self.count_funcs('src.cpp.o.js')
-          Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
-          test()
-          # Make sure that DFE ends up eliminating more than 200 functions (if we can view source)
-          assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
-          break
+    if self.supports_js_dfe():
+      print("Testing poppler with ELIMINATE_DUPLICATE_FUNCTIONS set to 1", file=sys.stderr)
+      num_original_funcs = self.count_funcs('src.cpp.o.js')
+      Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
+      test()
+      # Make sure that DFE ends up eliminating more than 200 functions (if we can view source)
+      assert (num_original_funcs - self.count_funcs('src.cpp.o.js')) > 200
 
   @sync
   def test_openjpeg(self):
@@ -7644,6 +7647,13 @@ extern "C" {
             raise
         js = open('src.cpp.o.js').read()
         assert ('require(' in js) == (Settings.ENVIRONMENT == 'node'), 'we should have require() calls only if node js specified'
+
+  def test_dfe(self):
+    if not self.supports_js_dfe(): return self.skip('dfe-only')
+    Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 1
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+    self.emcc_args += ['-g2'] # test for issue #6331
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
 # Generate tests for everything
 def make_run(fullname, name=-1, compiler=-1, embetter=0, quantum_size=0,

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -505,7 +505,6 @@ EMSCRIPTEN_FUNCS();
       after = 'wakaUnknownAfter'
       start = coutput.find(after)
       end = coutput.find(')', start)
-      open('/tmp/emscripten_temp/pre2b.js', 'w').write(pre_2)
       # If the closure comment to suppress useless code is present, we need to look one
       # brace past it, as the first is in there. Otherwise, the first brace is the
       # start of the function body (what we want).

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -505,9 +505,18 @@ EMSCRIPTEN_FUNCS();
       after = 'wakaUnknownAfter'
       start = coutput.find(after)
       end = coutput.find(')', start)
-      # First brace is from Closure Compiler comment, thus we need a second one
-      pre_2_second_brace = pre_2.find('{', pre_2.find('{')+1)
-      pre = coutput[:start] + '(/** @suppress {uselessCode} */ function(global,env,buffer) {\n' + pre_2[pre_2_second_brace+1:]
+      open('/tmp/emscripten_temp/pre2b.js', 'w').write(pre_2)
+      # If the closure comment to suppress useless code is present, we need to look one
+      # brace past it, as the first is in there. Otherwise, the first brace is the
+      # start of the function body (what we want).
+      USELESS_CODE_COMMENT = '/** @suppress {uselessCode} */ '
+      USELESS_CODE_COMMENT_BODY = 'uselessCode'
+      brace = pre_2.find('{') + 1
+      has_useless_code_comment = False
+      if pre_2[brace:brace + len(USELESS_CODE_COMMENT_BODY)] == USELESS_CODE_COMMENT_BODY:
+        brace = pre_2.find('{', brace) + 1
+        has_useless_code_comment = True
+      pre = coutput[:start] + '(' + (USELESS_CODE_COMMENT if has_useless_code_comment else '') + 'function(global,env,buffer) {\n' + pre_2[brace:]
       post = post_1 + end_asm + coutput[end+1:]
 
   with ToolchainProfiler.profile_block('write_pre'):


### PR DESCRIPTION
DFE removes comments, including the closure comment, and we assumed it was always there, which broke DUPLICATE_FUNCTION_ELIMINATION in asm.js when doing something like `-g2` (which runs the cleanup that cares about that, as opposed to without `-g2`, the main code path, which was all we tested before).