### PR TITLE
Fix ASYNCIFY on programs that don't actually use it

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -647,7 +647,7 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
       funcs += ['emterpret']
       if settings['EMTERPRETIFY_ASYNC']:
         funcs += ['setAsyncState', 'emtStackSave', 'emtStackRestore', 'getEmtStackMax', 'setEmtStackMax']
-    if settings['ASYNCIFY']:
+    if settings['ASYNCIFY'] and need_asyncify(funcs):
       funcs += ['setAsync']
 
   return sorted(set(funcs))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7505,6 +7505,12 @@ extern "C" {
   def test_coroutine_asyncify(self):
     self.do_test_coroutine({'ASYNCIFY': 1})
 
+  @no_wasm_backend('ASYNCIFY is not supported in the LLVM wasm backend')
+  def test_asyncify_unused(self):
+    # test a program not using asyncify, but the pref is set
+    Settings.ASYNCIFY = 1
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+
   @no_wasm_backend('EMTERPRETIFY causes JSOptimizer to run, which is '
                    'unsupported with Wasm backend')
   def test_coroutine_emterpretify_async(self):


### PR DESCRIPTION
We can't create the export in that case as there is no such function to export, which would break asm.js and wasm validation.