### PR TITLE
Fix preprocessor bug handling of truthy values; rework ENVIRONMENT setting options

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -9,6 +9,10 @@ Not all changes are documented here. In particular, new features, user-oriented 
 
 Current Trunk
 -------------
+ - Deprecate Module.ENVIRONMENT: Now that we have a compile-time option to set the environment, also having a runtime one on Module is complexity that we are better off without. When Module.ENVIRONMENT is used with ASSERTIONS it will show an error to direct users to the new option (-s ENVIRONMENT=web , or node, etc., at compile time).
+
+v1.38.6: 06/13/2018
+-------------------
 
 v1.38.5: 06/04/2018
 -------------------

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -40,6 +40,10 @@ var HAS_MAIN = ('_main' in IMPLEMENTED_FUNCTIONS) || MAIN_MODULE || SIDE_MODULE;
 var WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS =
   WASM_BACKEND && RESERVED_FUNCTION_POINTERS;
 
+// We need to check what the environment is if no environment is forced, but
+// also we need it when assertions are on, for verification.
+var NEED_ENVIRONMENT_SETS = !ENVIRONMENT || ASSERTIONS;
+
 // JSifier
 function JSify(data, functionsOnly) {
   var mainPass = !functionsOnly;

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -40,10 +40,6 @@ var HAS_MAIN = ('_main' in IMPLEMENTED_FUNCTIONS) || MAIN_MODULE || SIDE_MODULE;
 var WASM_BACKEND_WITH_RESERVED_FUNCTION_POINTERS =
   WASM_BACKEND && RESERVED_FUNCTION_POINTERS;
 
-// We need to check what the environment is if no environment is forced, but
-// also we need it when assertions are on, for verification.
-var NEED_ENVIRONMENT_SETS = !ENVIRONMENT || ASSERTIONS;
-
 // JSifier
 function JSify(data, functionsOnly) {
   var mainPass = !functionsOnly;

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -62,10 +62,16 @@ function preprocess(text, filenameHint) {
                 error('unsupported preprocessor op ' + op);
               }
             } else {
+              // Check if a value is truthy.
+              var short = ident[0] === '!' ? ident.substr(1) : ident;
+              var truthy = short in this;
+              if (truthy) {
+                truthy = !!this[short];
+              }
               if (ident[0] === '!') {
-                showStack.push(!(this[ident.substr(1)] > 0));
+                showStack.push(!truthy);
               } else {
-                showStack.push(ident in this && this[ident] > 0);
+                showStack.push(truthy);
               }
             }
           } else if (line[2] == 'n') { // include

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1173,7 +1173,7 @@ if (Module['buffer']) {
     assert(TOTAL_MEMORY % WASM_PAGE_SIZE === 0);
 #endif // ASSERTIONS
 #if ALLOW_MEMORY_GROWTH
-#if WASM_MEM_MAX
+#if WASM_MEM_MAX != -1
 #if ASSERTIONS
     assert({{{ WASM_MEM_MAX }}} % WASM_PAGE_SIZE == 0);
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -59,31 +59,11 @@ var ENVIRONMENT_IS_WEB = false;
 var ENVIRONMENT_IS_WORKER = false;
 var ENVIRONMENT_IS_NODE = false;
 var ENVIRONMENT_IS_SHELL = false;
-#endif // ENVIRONMENT
-
-#if NEED_ENVIRONMENT_SETS
 ENVIRONMENT_IS_WEB = typeof window === 'object';
 ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
 ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
 ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
-#endif
-
-#if ENVIRONMENT
-#if ASSERTIONS
-#if ENVIRONMENT == 'web'
-if (!ENVIRONMENT_IS_WEB) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
-#if ENVIRONMENT == 'worker'
-if (!ENVIRONMENT_IS_WORKER) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
-#if ENVIRONMENT == 'node'
-if (!ENVIRONMENT_IS_NODE) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
-#if ENVIRONMENT == 'shell'
-if (!ENVIRONMENT_IS_SHELL) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
-#endif
-#endif
+#endif // ENVIRONMENT
 
 #if ASSERTIONS
 if (Module['ENVIRONMENT']) {
@@ -105,6 +85,13 @@ var currentScriptUrl = (typeof document !== 'undefined' && document.currentScrip
 
 #if ENVIRONMENT_MAY_BE_NODE
 if (ENVIRONMENT_IS_NODE) {
+
+#if ENVIRONMENT
+#if ASSERTIONS
+  if (!(typeof process === 'object' && typeof require === 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+#endif
+#endif
+
   // Expose functionality in the same simple way that the shells work
   // Note that we pollute the global namespace here, otherwise we break in node
   var nodeFS;
@@ -171,6 +158,13 @@ if (ENVIRONMENT_IS_NODE) {
 #endif // ENVIRONMENT_MAY_BE_NODE
 #if ENVIRONMENT_MAY_BE_SHELL
 if (ENVIRONMENT_IS_SHELL) {
+
+#if ENVIRONMENT
+#if ASSERTIONS
+  if ((typeof process === 'object' && typeof require === 'function') || typeof window === 'object' || typeof importScripts === 'function') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+#endif
+#endif
+
   if (typeof read != 'undefined') {
     Module['read'] = function shell_read(f) {
 #if SUPPORT_BASE64_EMBEDDING
@@ -214,6 +208,13 @@ if (ENVIRONMENT_IS_SHELL) {
 #endif // ENVIRONMENT_MAY_BE_SHELL
 #if ENVIRONMENT_MAY_BE_WEB_OR_WORKER
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
+
+#if ENVIRONMENT
+#if ASSERTIONS
+  if (!(typeof window === 'object' || typeof importScripts === 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+#endif
+#endif
+
   Module['read'] = function shell_read(url) {
 #if SUPPORT_BASE64_EMBEDDING
     try {
@@ -282,9 +283,7 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #endif // ENVIRONMENT_MAY_BE_WEB_OR_WORKER
 {
 #if ASSERTIONS
-  throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#else // ASSERTIONS
-  throw new Error('not compiled for this environment');
+  throw new Error('environment detection error');
 #endif // ASSERTIONS
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7649,6 +7649,7 @@ extern "C" {
     self.do_run(open(path_from_root('tests', 'wrap_malloc.cpp')).read(), 'OK.')
 
   def test_environment(self):
+    Settings.ASSERTIONS = 1
     for engine in JS_ENGINES:
       for work in (1, 0):
         # set us to test in just this engine

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7335,7 +7335,7 @@ int main() {
     # with the wrong env we have very odd failures
     check_execute([PYTHON, EMCC, 'main.cpp', '-s', 'SINGLE_FILE=1'])
     src = open('a.out.js').read()
-    envs = ['WEB', 'WORKER', 'NODE', 'SHELL']
+    envs = ['web', 'worker', 'node', 'shell']
     for env in envs:
       for engine in JS_ENGINES:
         if engine == V8_ENGINE: continue # ban v8, weird failures
@@ -7349,20 +7349,8 @@ int main() {
         print('    ' + curr)
         open('test.js', 'w').write(curr + src)
         fail = False
-        try:
-          seen = run_js('test.js', engine=engine, stderr=PIPE)
-        except:
-          fail = True
-        if fail:
-          print('-- acceptable fail')
-          assert actual != env, 'ok to fail if in the wrong environment'
-        else:
-          for other in envs:
-            if env == other:
-              assert ('environment is %s? true' % other) in seen, seen
-            else:
-              assert ('environment is %s? false' % other) in seen, seen
-          print('-- verified proper env is shown')
+        seen = run_js('test.js', engine=engine, stderr=PIPE, full_output=True, assert_returncode=None)
+        self.assertContained('Module.ENVIRONMENT has been deprecated. To force the environment, use the ENVIRONMENT compile-time option (for example, -s ENVIRONMENT=web or -s ENVIRONMENT=node', seen)
 
   def test_warn_no_filesystem(self):
     WARNING = 'Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with  -s FORCE_FILESYSTEM=1'


### PR DESCRIPTION
See #6713 and #6717 for the background: the preprocessor didn't actually check for truthiness of JS values properly, and as a result, in particular the ENVIRONMENT setting option (where the user can say the code should run just on the web, or just in node, etc.) wasn't properly handled. To fix this, this PR

 * Fixes the truthiness handling: the processor will process a number, string, etc. as expected in JS as to whether it is true or not.
 * Fixes bugs in the code where we depended on the bad behavior, in particular, in the ENVIRONMENT code and one spot with `WASM_MEM_MAX`.
 * Reworking the ENVIRONMENT options, it was somewhat complicated because we have an older method to set the environment at runtime, by setting Module.ENVIRONMENT, and a recent compile-time setting, ENVIRONMENT. The compile-time setting is more powerful and allows removing more unnecessary code, so this PR removes the old option. I made it throw an error at runtime if the option is used, pointing to the new ENVIRONMENT option and how to use it, which tries to minimize any confusion.