### PR TITLE
Fix test runner error reporting, which regressed in #6701

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1094,7 +1094,7 @@ def main(args):
   args = skip_requested_tests(args, modules)
   args = args_for_random_tests(args, modules)
   suites, unmatched_tests = load_test_suites(args, modules)
-  run_tests(suites, unmatched_tests)
+  return run_tests(suites, unmatched_tests)
 
 def print_help_if_args_empty(args):
   if len(args) == 2 and args[1] in ['--help', '-h']:
@@ -1324,11 +1324,11 @@ def suite_for_module(module, tests):
 
 def run_tests(suites, unmatched_test_names):
   resultMessages = []
-  numFailures = 0
+  num_failures = 0
 
   if len(unmatched_test_names) > 0:
     print('WARNING: could not find the following tests: ' + ' '.join(unmatched_test_names))
-    numFailures += len(unmatched_test_names)
+    num_failures += len(unmatched_test_names)
     resultMessages.append('Could not find %s tests' % (len(unmatched_test_names),))
 
   print('Test suites:')
@@ -1341,7 +1341,7 @@ def run_tests(suites, unmatched_test_names):
     msg = '%s: %s run, %s errors, %s failures, %s skipped' % (mod_name,
         res.testsRun, len(res.errors), len(res.failures), len(res.skipped)
     )
-    numFailures += len(res.errors) + len(res.failures)
+    num_failures += len(res.errors) + len(res.failures)
     resultMessages.append(msg)
 
   if len(resultMessages) > 1:
@@ -1352,7 +1352,7 @@ def run_tests(suites, unmatched_test_names):
       print('    ' + msg)
 
   # Return the number of failures as the process exit code for automating success/failure reporting.
-  return min(numFailures, 255)
+  return min(num_failures, 255)
 
 
 if __name__ == '__main__':

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1001,9 +1001,10 @@ class BrowserCore(RunnerCore):
     filepath = path_from_root('tests', filename) if not filename_is_src else ('main.c' if force_c else 'main.cpp')
     temp_filepath = os.path.join(self.get_dir(), os.path.basename(filepath))
     original_args = args[:]
-    if os.environ.get('EMCC_TEST_WASM_PTHREADS', '0') != '1':
-      # Browsers currently have wasm threads off by default, so don't test them unless explicitly enabled.
-      args = args + ['-s', 'WASM=0']
+    if 'USE_PTHREADS=1' in args or 'USE_PTHREADS=2' in args:
+      if os.environ.get('EMCC_TEST_WASM_PTHREADS', '0') != '1':
+        # Browsers currently have wasm threads off by default, so don't test them unless explicitly enabled.
+        args = args + ['-s', 'WASM=0']
     if not 'WASM=0' in args:
       # Filter out separate-asm, which is implied by wasm
       args = [a for a in args if a != '--separate-asm']

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3542,13 +3542,15 @@ window.close = function() {
     for opts in [['-O0'], ['-O1'], ['-O2'], ['-O2', '--closure', '1']]:
       print(opts)
       open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
-      Popen([PYTHON, EMCC, 'src.cpp', '-o', 'test.html', '-s', 'WASM=0'] + opts).communicate()
+      run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.html', '-s', 'WASM=0'] + opts)
       self.run_browser('test.html', None, '/report_result?0')
 
+      print('run one');
       open('one.html', 'w').write('<script src="test.js"></script>')
       self.run_browser('one.html', None, '/report_result?0')
 
-      Popen([PYTHON, path_from_root('tools', 'separate_asm.py'), 'test.js', 'asm.js', 'rest.js']).communicate()
+      print('run two');
+      run_process([PYTHON, path_from_root('tools', 'separate_asm.py'), 'test.js', 'asm.js', 'rest.js'])
       open('two.html', 'w').write('''
         <script>
           var Module = {};
@@ -3558,11 +3560,14 @@ window.close = function() {
       ''')
       self.run_browser('two.html', None, '/report_result?0')
 
+      print('run hello world');
       self.clear()
       assert not os.path.exists('tests.asm.js')
       self.btest('browser_test_hello_world.c', expected='0', args=opts + ['-s', 'WASM=0', '--separate-asm'])
       assert os.path.exists('test.asm.js')
       os.unlink('test.asm.js')
+
+      print('see a fail');
       self.run_browser('test.html', None, '[no http server activity]', timeout=5) # fail without the asm
 
   def test_emterpretify_file(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7999,7 +7999,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0), # totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1533, ['invoke_i'],               ['waka'],                 496958, 163, 2560),
+              1534, ['invoke_i'],               ['waka'],                 496958, 163, 2560),
     ])
 
     print('test on a minimal pure computational thing')

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -26,9 +26,7 @@ else:
   import re
   m = re.search('\((\w+)\.ENVIRONMENT\)', everything)
   if not m:
-    m = re.search('(\w+)\.arguments = \[\];', everything)
-  if not m:
-    m = re.search('(\w+)\.arguments=\[\];', everything)
+    m = re.search('(\w+)\.arguments\s*=\s*\[\];', everything)
   assert m, 'cannot figure out the closured name of Module statically'
   closured_name = m.group(1)
   everything = everything.replace(module, closured_name + '["asm"]')

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -25,6 +25,10 @@ else:
   # seek a pattern like (e.ENVIRONMENT), which is in the shell.js if-cascade for the ENVIRONMENT override
   import re
   m = re.search('\((\w+)\.ENVIRONMENT\)', everything)
+  if not m:
+    m = re.search('(\w+)\.arguments = \[\];', everything)
+  if not m:
+    m = re.search('(\w+)\.arguments=\[\];', everything)
   assert m, 'cannot figure out the closured name of Module statically'
   closured_name = m.group(1)
   everything = everything.replace(module, closured_name + '["asm"]')


### PR DESCRIPTION
We forgot to return the error code, so errors were shown on the console but CI didn't notice them and things looked green.

I guess we need a test that checks that errors are noticed by CI, but how would we test it? ;) A question for the philosophers perhaps.

Also this PR fixes a minor regression that occurred meanwhile, in the metadce test.