### PR TITLE
Assume no side effects in JS optimizer on Math.something

### DIFF
--- a/tests/optimizer/JSDCE-output.js
+++ b/tests/optimizer/JSDCE-output.js
@@ -48,6 +48,7 @@ function ___cxa_find_matching_catch_after() {
  if (!___cxa_find_matching_catch_after.buffer) ___cxa_find_matching_catch_after.buffer = {};
 }
 ___cxa_find_matching_catch_after();
+var dotOther = Side.effect;
 
 
 

--- a/tests/optimizer/JSDCE.js
+++ b/tests/optimizer/JSDCE.js
@@ -87,4 +87,7 @@ function ___cxa_find_matching_catch_after() {
  if (!___cxa_find_matching_catch_after.buffer) ___cxa_find_matching_catch_after.buffer = {};
 }
 ___cxa_find_matching_catch_after();
+// dot stuff
+var dotMath = Math.something;
+var dotOther = Side.effect;
 

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1426,6 +1426,15 @@ function hasSideEffects(node) { // this is 99% incomplete!
       }
       return false;
     }
+    case 'dot': {
+      // In theory any property access in JS can have side effects, but not in
+      // objects we assume are static.
+      if (node[1][0] === 'name') {
+        var name = node[1][1];
+        if (name === 'Math') return false;
+      }
+      return true;
+    }
     default: return true;
   }
 }


### PR DESCRIPTION
This lets us get rid of globals like `var floor = Math.floor;`

This saves 500 bytes (2.5%) of our `-Os` JS size.