### PR TITLE
Move assertions behind flags

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1482,6 +1482,7 @@ function getTotalMemory() {
   return TOTAL_MEMORY;
 }
 
+#if ASSERTIONS
 // Endianness check (note: assumes compiler arch was little-endian)
 #if SAFE_SPLIT_MEMORY == 0
 #if USE_PTHREADS
@@ -1495,7 +1496,8 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
 HEAP16[1] = 0x6373;
 if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
-#endif
+#endif // SAFE_SPLIT_MEMORY == 0
+#endif // ASSERTIONS
 
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1482,9 +1482,9 @@ function getTotalMemory() {
   return TOTAL_MEMORY;
 }
 
-#if ASSERTIONS
 // Endianness check (note: assumes compiler arch was little-endian)
 #if SAFE_SPLIT_MEMORY == 0
+#if STACK_OVERFLOW_CHECK
 #if USE_PTHREADS
 if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
@@ -1493,11 +1493,13 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 } else {
   if (HEAP32[0] !== 0x63736d65) throw 'Runtime error: The application has corrupted its heap memory area (address zero)!';
 }
-#endif
+#endif // USE_PTHREADS
+#endif // STACK_OVERFLOW_CHECK
+#if ASSERTIONS
 HEAP16[1] = 0x6373;
 if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
-#endif // SAFE_SPLIT_MEMORY == 0
 #endif // ASSERTIONS
+#endif // SAFE_SPLIT_MEMORY == 0
 
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {


### PR DESCRIPTION
Put the stack overflow/corruption check behind the `STACK_OVERFLOW_CHECK`, and the endianness check behind `ASSERTIONS`. We don't need to emit that code by default in all builds.