### PR TITLE
Adds delete operator to val

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -440,6 +440,14 @@ var LibraryEmVal = {
     object = requireHandle(object);
     return item in object;
   },
+
+  _emval_delete__deps: ['$requireHandle'],
+  _emval_delete: function(object, property) {
+    object = requireHandle(object);
+    property = requireHandle(property);
+    return delete object[property];
+  },
+
 };
 
 mergeInto(LibraryManager.library, LibraryEmVal);

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -89,6 +89,7 @@ namespace emscripten {
             EM_VAL _emval_typeof(EM_VAL value);
             bool _emval_instanceof(EM_VAL object, EM_VAL constructor);
             bool _emval_in(EM_VAL item, EM_VAL object);
+            bool _emval_delete(EM_VAL object, EM_VAL property);
         }
 
         template<const char* address>
@@ -274,7 +275,6 @@ namespace emscripten {
     class val {
     public:
         // missing operators:
-        // * delete
         // * ! ~ - + ++ --
         // * * / %
         // * + -
@@ -497,6 +497,11 @@ namespace emscripten {
 
         bool in(const val& v) const {
             return internal::_emval_in(handle, v.handle);
+        }
+
+        template<typename T>
+        bool delete_(const T& property) const {
+            return internal::_emval_delete(handle, val(property).handle);
         }
 
     private:

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -475,6 +475,31 @@ int main()
   ensure(val("c").in(val::global("a")));
   ensure_not(val("d").in(val::global("a")));
   
+  test("template<typename T> bool delete_(const T& property)");
+  EM_ASM(
+    a = {};
+    a.b = undefined;
+    a[0] = null;
+    a[1] = 2;
+    a.c = 'c';
+  );
+  ensure_js("'b' in a");
+  ensure_js("0 in a");
+  ensure_js("1 in a");
+  ensure_js("'c' in a");
+  ensure(val::global("a").delete_("b") == true);
+  ensure_js_not("'b' in a");
+  ensure_js("0 in a");
+  ensure_js("1 in a");
+  ensure_js("'c' in a");
+  ensure(val::global("a").delete_(0) == true);
+  ensure(val::global("a").delete_(val(1)) == true);
+  ensure(val::global("a").delete_(val("c")) == true);
+  ensure_js_not("'b' in a");
+  ensure_js_not("0 in a");
+  ensure_js_not("1 in a");
+  ensure_js_not("'c' in a");
+  
   // this test should probably go elsewhere as it is not a member of val
   test("template<typename T> std::vector<T> vecFromJSArray(val v)");
   EM_ASM(

--- a/tests/embind/test_val.out
+++ b/tests/embind/test_val.out
@@ -199,6 +199,24 @@ bool in(const val& v)
 pass
 pass
 test:
+template<typename T> bool delete_(const T& property)
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+pass
+test:
 template<typename T> std::vector<T> vecFromJSArray(val v)
 pass
 pass


### PR DESCRIPTION
```js
// js
a = {};
a.b = 'test';
```
```cpp
// cpp
// to delete property you can now use:
val::global("a").delete_("b");
// or
val::global("a").delete_(val("b"));
```
You can also directly pass numbers and other js objects as keys.