### PR TITLE
Make emterpreter-async bad state checking more focused

### DIFF
--- a/tests/emterpreter_async_bad_2.cpp
+++ b/tests/emterpreter_async_bad_2.cpp
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <assert.h>
+
+extern "C" {
+
+void EMSCRIPTEN_KEEPALIVE finish(int result) {
+  EM_ASM({
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", "http://localhost:8888/report_result?1");
+    xhr.onload = xhr.onerror = function() {
+      window.close();
+    };
+    xhr.send();
+  });
+}
+
+void __attribute__((noinline)) emterped() {
+  // sleep, but non-emterpreted middle() in the way
+  emscripten_sleep(1);
+}
+
+void __attribute__((noinline)) middle() {
+  emterped();
+  // this is not an emterpreted function. when we pause emterped(), we can't pause here,
+  // so we end up calling the next line
+  finish(1);
+}
+
+int main() {
+  EM_ASM({
+    window.onerror = function(err) {
+      var str = err.toString();
+      assert(str.indexOf('This error happened during an emterpreter-async save or load of the stack') > 0, 'expect good error message');
+      assert(str.indexOf('-12') > 0, '-12 error from emterpreter-async');
+      // manually REPORT_RESULT; we can't call back into native code at this point, assertions would trigger
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", "http://localhost:8888/report_result?2");
+      xhr.onload = xhr.onerror = function() {
+        window.close();
+      };
+      xhr.send();
+    };
+  });
+
+  printf("call middle..\n");
+  middle();
+  printf("called middle\n");
+}
+
+}
+

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3020,6 +3020,15 @@ window.close = function() {
       print(opts)
       self.btest('emterpreter_async_bad.cpp', '1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-O' + str(opts), '-s', 'EMTERPRETIFY_BLACKLIST=["_middle"]', '-s', 'ASSERTIONS=1'])
 
+  def test_emterpreter_async_bad_2(self):
+    for opts in [0, 1, 2, 3]:
+      for assertions in [0, 1]:
+        # without assertions, we end up continuing to run more non-emterpreted code in this testcase, returning 1
+        # with assertions, we hit the emterpreter-async assertion on that, and report a  clear error
+        expected = '2' if assertions else '1'
+        print(opts, assertions, expected)
+        self.btest('emterpreter_async_bad_2.cpp', expected, args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-O' + str(opts), '-s', 'EMTERPRETIFY_BLACKLIST=["_middle"]', '-s', 'ASSERTIONS=%s' % assertions])
+
   def test_emterpreter_async_mainloop(self):
     for opts in [0, 1, 2, 3]:
       print(opts)

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7384,8 +7384,8 @@ function emterpretify(ast) {
           // A bad state is when saving or restoring the stack. Note that it is ok to run code
           // during a sleep, for coroutines or yield funcs, etc. - we don't check those.
           return ['binary', '|',
-            ['binary', '==', ['name', 'asyncState'], ['num', 1]],
-            ['binary', '==', ['name', 'asyncState'], ['num', 2]],
+            ['binary', '==', makeAsmCoercion(['name', 'asyncState'], ASM_INT), ['num', 1]],
+            ['binary', '==', makeAsmCoercion(['name', 'asyncState'], ASM_INT), ['num', 2]],
           ];
         }
         var stack = [];

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -6093,8 +6093,8 @@ function emterpretify(ast) {
   }
 
   // functions which are ok to run while async, even if not emterpreted
-  var OK_TO_CALL_WHILE_ASYNC = set('stackSave', 'stackRestore', 'stackAlloc', 'setThrew', '_memset', '_memcpy', '_memmove', '_strlen', '_strncpy', '_strcpy', '_strcat', 'SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_FT_MASK');
-  function okToCallWhileAsync(name) {
+  var OK_TO_CALL_WHILE_ASYNC = set('SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_FT_MASK');
+  function okToCallWhileAsyncSaveOrRestore(name) {
     // dynCall *can* be on the stack, they are just bridges; what matters is where they go
     if (/^dynCall_/.test(name)) return true;
     if (name in OK_TO_CALL_WHILE_ASYNC) return true;
@@ -7376,7 +7376,7 @@ function emterpretify(ast) {
 
     if (ignore) {
       // we are not emterpreting this function
-      if (ASYNC && ASSERTIONS && !okToCallWhileAsync(func[1])) {
+      if (ASYNC && ASSERTIONS && !okToCallWhileAsyncSaveOrRestore(func[1])) {
         // we need to be careful to never enter non-emterpreted code while doing an async save/restore,
         // which is what happens if non-emterpreted code is on the stack while we attempt to save.
         // add asserts right after each call


### PR DESCRIPTION
Check for entering non-emterpreted code when saving or restoring the stack only - before, we also checked during an async operation, but it is valid to run code at that time, like a coroutine, or an SDL key event handler, etc. - it is the responsibility of the program to check stuff like that.

When saving and restoring the stack, any non-emterpreted code is a problem because we can't pause/resume it, so we keep throwing an error then.