### PR TITLE
De-Module[]-arize print and printErr

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -11,6 +11,7 @@ Current Trunk
 -------------
  - Correctness fix for stack handling in invoke_*()s. This may add noticeable overhead to programs using C++ exceptions and (less likely) setjmp/longjmp - please report any issues. See #6666 #6702
  - Deprecate Module.ENVIRONMENT: Now that we have a compile-time option to set the environment, also having a runtime one on Module is complexity that we are better off without. When Module.ENVIRONMENT is used with ASSERTIONS it will show an error to direct users to the new option (-s ENVIRONMENT=web , or node, etc., at compile time).
+ - Breaking change: Do not export print/printErr by default. Similar to other similar changes (like getValue/setValue). We now use out() and err() functions in JS to print to stdout/stderr respectively. See #6756.
 
 v1.38.6: 06/13/2018
 -------------------

--- a/emscripten.py
+++ b/emscripten.py
@@ -953,11 +953,11 @@ def create_mftCall_funcs(function_table_data, settings):
 
 def get_function_pointer_error(sig, function_table_sigs, settings):
   if settings['ASSERTIONS'] <= 1:
-    extra = ' Module["printErr"]("Build with ASSERTIONS=2 for more info.");'
+    extra = ' err("Build with ASSERTIONS=2 for more info.");'
     pointer = ' '
   else:
     pointer = ' \'" + x + "\' '
-    extra = ' Module["printErr"]("This pointer might make sense in another type signature: '
+    extra = ' err("This pointer might make sense in another type signature: '
     # sort signatures, attempting to show most likely related ones first
     sigs = list(function_table_sigs)
     sigs.sort(key=signature_sort_key(sig))
@@ -965,7 +965,7 @@ def get_function_pointer_error(sig, function_table_sigs, settings):
       if other != sig:
         extra += other + ': " + debug_table_' + other + '[x] + "  '
     extra += '"); '
-  return 'Module["printErr"]("Invalid function pointer' + pointer + 'called with signature \'' + sig + '\'. ' + \
+  return 'err("Invalid function pointer' + pointer + 'called with signature \'' + sig + '\'. ' + \
          'Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? ' + \
          'Or calling a function with an incorrect type, which will fail? ' + \
          '(it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)' + \

--- a/emscripten.py
+++ b/emscripten.py
@@ -1215,7 +1215,7 @@ function ftCall_%s(%s) {
           table_access = 'parentModule["' + table_access + '"]' # side module tables were merged into the parent, we need to access the global one
         table_read = table_access + '[x]'
       prelude = '''
-  if (x < 0 || x >= %s.length) { Module.printErr("Function table mask error (out of range)"); %s ; abort(x) }''' % (table_access, get_function_pointer_error(sig, function_table_sigs, settings))
+  if (x < 0 || x >= %s.length) { err("Function table mask error (out of range)"); %s ; abort(x) }''' % (table_access, get_function_pointer_error(sig, function_table_sigs, settings))
       asm_setup += '''
 function ftCall_%s(%s) {%s
   return %s(%s);

--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -39,11 +39,12 @@ When generating HTML, Emscripten creates a ``Module`` object with default method
 
 		Module['print'] = function(text) { alert('stdout: ' + text) };
 
+Note that once the Module object is received by the main JavaScript file, it will look for `Module['print']` and so forth at that time, and use them accordingly. Changing their values later may not be noticed.
 
 Affecting execution
 ===================
 
-The following ``Module`` attributes affect code execution. 
+The following ``Module`` attributes affect code execution. Set them to customize behavior.
 
 
 .. js:attribute:: Module.arguments
@@ -62,7 +63,7 @@ The following ``Module`` attributes affect code execution.
 
 .. js:attribute:: Module.logReadFiles
 
-	If set, :js:attr:`Module.printErr` will log when any file is read.
+	If set, stderr will log when any file is read.
 
 
 .. js:attribute:: Module.onAbort

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -254,7 +254,7 @@ following JavaScript:
 
 .. note:: The function ``alert`` is present in browsers, but not in *node*
    or other JavaScript shells. A more generic alternative is to call
-   :js:func:`Module.print`.
+   `console.log`.
 
 
 A faster way to call JavaScript from C is to write "inline JavaScript",
@@ -307,7 +307,7 @@ You can also send values from C into JavaScript inside :c:macro:`EM_ASM_`
 .. code-block:: cpp
 
       EM_ASM_({
-        Module.print('I received: ' + $0);
+        console.log('I received: ' + $0);
       }, 100);
 
 This will show ``I received: 100``. 
@@ -318,7 +318,7 @@ and then ``101``.
 .. code-block:: cpp
 
       int x = EM_ASM_INT({
-        Module.print('I received: ' + $0);
+        console.log('I received: ' + $0);
         return $0 + 1;
       }, 100);
       printf("%d\n", x);

--- a/site/source/docs/porting/files/packaging_files.rst
+++ b/site/source/docs/porting/files/packaging_files.rst
@@ -115,7 +115,7 @@ Monitoring file usage
 
 .. important:: Only package the files your app actually needs, in order to reduce download size and improve startup speed. 
 
-There is an option to log which files are actually used at runtime. To use it, define the :js:attr:`Module.logReadFiles` object. The :js:attr:`Module.printErr` function will be called on each file that is read (this function must also be defined, and should log to a convenient place).
+There is an option to log which files are actually used at runtime. To use it, define the :js:attr:`Module.logReadFiles` object. Each file that is read will be logged to stderr.
 
 An alternative approach is to look at :js:func:`FS.readFiles` in your compiled JavaScript. This is an object with keys for all the files that were read from. You may find it easier to use than logging as it records files rather than potentially multiple file accesses. 
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -257,6 +257,8 @@ Options that are modified or new in *emcc* are listed below:
 ``--pre-js <file>``
 	Specify a file whose contents are added before the emitted code and optimized together with it. Note that this might not literally be the very first thing in the JS output, for example if ``MODULARIZE`` is used (see ``src/settings.js``). If you want that, you can just prepend to the output from emscripten; the benefit of ``--pre-js`` is that it optimizes the code with the rest of the emscripten output, which allows better dead code elimination and minification, and it should only be used for that purpose. In particular, ``--pre-js`` code should not alter the main output from emscripten in ways that could confuse the optimizer, such as using ``--pre-js`` + ``--post-js`` to put all the output in an inner function scope (see ``MODULARIZE`` for that).
 
+	`--pre-js` (but not `--post-js`) is also useful for specifying things on the ``Module`` object, as it appears before the JS looks at ``Module`` (for example, you can define ``Module['print']`` there).
+
 .. _emcc-post-js:
 	
 ``--post-js <file>``

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -117,10 +117,10 @@ var Fetch = {
       else if (Module['pthreadMainPrefixURL']) fetchJs = Module['pthreadMainPrefixURL'] + fetchJs;
       Fetch.worker = new Worker(fetchJs);
       Fetch.worker.onmessage = function(e) {
-        Module['print']('fetch-worker sent a message: ' + e.filename + ':' + e.lineno + ': ' + e.message);
+        out('fetch-worker sent a message: ' + e.filename + ':' + e.lineno + ': ' + e.message);
       };
       Fetch.worker.onerror = function(e) {
-        Module['printErr']('fetch-worker sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+        err('fetch-worker sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
       };
     }
 #else

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -33,12 +33,12 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
     // If the address contains localhost, or we are running the page from port 6931, we can assume we're running the test runner and should post stdout logs.
     if (document.URL.search("localhost") != -1 || document.URL.search(":6931/") != -1) {
       var emrun_http_sequence_number = 1;
-      var prevPrint = Module['print'];
-      var prevErr = Module['printErr'];
+      var prevPrint = out;
+      var prevErr = err;
       function emrun_exit() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; };
       Module['addOnExit'](emrun_exit);
-      Module['print'] = function emrun_print(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevPrint(text); }
-      Module['printErr'] = function emrun_printErr(text) { post('^err^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevErr(text); }
+      out = function emrun_print(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevPrint(text); }
+      err = function emrun_printErr(text) { post('^err^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevErr(text); }
 
       // Notify emrun web server that this browser has successfully launched the page.
       post('^pageload^');

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -49,7 +49,7 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
   // To use from C code, call e.g. EM_ASM({emrun_file_dump("file.dat", HEAPU8.subarray($0, $0 + $1));}, my_data_pointer, my_data_pointer_byte_length);
   function emrun_file_dump(filename, data) {
     var http = new XMLHttpRequest();
-    Module['print']('Dumping out file "' + filename + '" with ' + data.length + ' bytes of data.');
+    out('Dumping out file "' + filename + '" with ' + data.length + ' bytes of data.');
     http.open("POST", "stdio.html?file=" + filename, true);
     http.send(data); // XXX  this does not work in workers, for some odd reason (issue #2681)
   }

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -122,8 +122,8 @@ function JSify(data, functionsOnly) {
     // name the function; overwrite if it's already named
     snippet = snippet.replace(/function(?:\s+([^(]+))?\s*\(/, 'function ' + finalName + '(');
     if (LIBRARY_DEBUG && !LibraryManager.library[ident + '__asm']) {
-      snippet = snippet.replace('{', '{ var ret = (function() { if (runtimeDebug) Module.printErr("[library call:' + finalName + ': " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]"); ');
-      snippet = snippet.substr(0, snippet.length-1) + '}).apply(this, arguments); if (runtimeDebug && typeof ret !== "undefined") Module.printErr("  [     return:" + prettyPrint(ret)); return ret; \n}';
+      snippet = snippet.replace('{', '{ var ret = (function() { if (runtimeDebug) err("[library call:' + finalName + ': " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]"); ');
+      snippet = snippet.substr(0, snippet.length-1) + '}).apply(this, arguments); if (runtimeDebug && typeof ret !== "undefined") err("  [     return:" + prettyPrint(ret)); return ret; \n}';
     }
     return snippet;
   }
@@ -247,7 +247,7 @@ function JSify(data, functionsOnly) {
         }
         if (!(MAIN_MODULE || SIDE_MODULE)) {
           // emit a stub that will fail at runtime
-          LibraryManager.library[shortident] = new Function("Module['printErr']('missing function: " + shortident + "'); abort(-1);");
+          LibraryManager.library[shortident] = new Function("err('missing function: " + shortident + "'); abort(-1);");
         } else {
           var target = (MAIN_MODULE ? '' : 'parent') + "Module['_" + shortident + "']";
           var assertion = '';
@@ -389,7 +389,7 @@ function JSify(data, functionsOnly) {
         if (LibraryManager.library[shortident + '__asm']) {
           warn('cannot kill asm library function ' + item.ident);
         } else {
-          LibraryManager.library[shortident] = new Function("Module['printErr']('dead function: " + shortident + "'); abort(-1);");
+          LibraryManager.library[shortident] = new Function("err('dead function: " + shortident + "'); abort(-1);");
           delete LibraryManager.library[shortident + '__inline'];
           delete LibraryManager.library[shortident + '__deps'];
         }

--- a/src/library.js
+++ b/src/library.js
@@ -1114,19 +1114,19 @@ LibraryManager.library = {
         var info = EXCEPTIONS.infos[ptr];
         if (info.adjusted === adjusted) {
 #if EXCEPTION_DEBUG
-          Module.printErr('de-adjusted exception ptr ' + adjusted + ' to ' + ptr);
+          err('de-adjusted exception ptr ' + adjusted + ' to ' + ptr);
 #endif
           return ptr;
         }
       }
 #if EXCEPTION_DEBUG
-      Module.printErr('no de-adjustment for unknown exception ptr ' + adjusted);
+      err('no de-adjustment for unknown exception ptr ' + adjusted);
 #endif
       return adjusted;
     },
     addRef: function(ptr) {
 #if EXCEPTION_DEBUG
-      Module.printErr('addref ' + ptr);
+      err('addref ' + ptr);
 #endif
       if (!ptr) return;
       var info = EXCEPTIONS.infos[ptr];
@@ -1134,7 +1134,7 @@ LibraryManager.library = {
     },
     decRef: function(ptr) {
 #if EXCEPTION_DEBUG
-      Module.printErr('decref ' + ptr);
+      err('decref ' + ptr);
 #endif
       if (!ptr) return;
       var info = EXCEPTIONS.infos[ptr];
@@ -1155,7 +1155,7 @@ LibraryManager.library = {
         delete EXCEPTIONS.infos[ptr];
         ___cxa_free_exception(ptr);
 #if EXCEPTION_DEBUG
-        Module.printErr('decref freeing exception ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
+        err('decref freeing exception ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
 #endif
       }
     },
@@ -1177,7 +1177,7 @@ LibraryManager.library = {
       return _free(ptr);
     } catch(e) { // XXX FIXME
 #if ASSERTIONS
-      Module.printErr('exception during cxa_free_exception: ' + e);
+      err('exception during cxa_free_exception: ' + e);
 #endif
     }
   },
@@ -1195,7 +1195,7 @@ LibraryManager.library = {
   __cxa_throw__deps: ['_ZSt18uncaught_exceptionv', '__cxa_find_matching_catch', '$EXCEPTIONS'],
   __cxa_throw: function(ptr, type, destructor) {
 #if EXCEPTION_DEBUG
-    Module.printErr('Compiled code throwing an exception, ' + [ptr,type,destructor]);
+    err('Compiled code throwing an exception, ' + [ptr,type,destructor]);
 #endif
     EXCEPTIONS.infos[ptr] = {
       ptr: ptr,
@@ -1227,7 +1227,7 @@ LibraryManager.library = {
       EXCEPTIONS.infos[ptr].rethrown = true;
     }
 #if EXCEPTION_DEBUG
-    Module.printErr('Compiled code RE-throwing an exception, popped ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
+    err('Compiled code RE-throwing an exception, popped ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
 #endif
     EXCEPTIONS.last = ptr;
     {{{ makeThrow('ptr') }}}
@@ -1258,7 +1258,7 @@ LibraryManager.library = {
     if (info) info.rethrown = false;
     EXCEPTIONS.caught.push(ptr);
 #if EXCEPTION_DEBUG
-		Module.printErr('cxa_begin_catch ' + [ptr, 'stack', EXCEPTIONS.caught]);
+		err('cxa_begin_catch ' + [ptr, 'stack', EXCEPTIONS.caught]);
 #endif
     EXCEPTIONS.addRef(EXCEPTIONS.deAdjust(ptr));
     return ptr;
@@ -1274,7 +1274,7 @@ LibraryManager.library = {
     // Call destructor if one is registered then clear it.
     var ptr = EXCEPTIONS.caught.pop();
 #if EXCEPTION_DEBUG
-    Module.printErr('cxa_end_catch popped ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
+    err('cxa_end_catch popped ' + [ptr, EXCEPTIONS.last, 'stack', EXCEPTIONS.caught]);
 #endif
     if (ptr) {
       EXCEPTIONS.decRef(EXCEPTIONS.deAdjust(ptr));
@@ -1283,7 +1283,7 @@ LibraryManager.library = {
   },
   __cxa_get_exception_ptr: function(ptr) {
 #if EXCEPTION_DEBUG
-    Module.printErr('cxa_get_exception_ptr ' + ptr);
+    err('cxa_get_exception_ptr ' + ptr);
 #endif
     // TODO: use info.adjusted?
     return ptr;
@@ -1297,7 +1297,7 @@ LibraryManager.library = {
   },
 
   __cxa_call_unexpected: function(exception) {
-    Module.printErr('Unexpected exception thrown, this is not properly supported - aborting');
+    err('Unexpected exception thrown, this is not properly supported - aborting');
     ABORT = true;
     throw exception;
   },
@@ -1354,7 +1354,7 @@ LibraryManager.library = {
     // can_catch receives a **, add indirection
     if (!___cxa_find_matching_catch.buffer) ___cxa_find_matching_catch.buffer = _malloc(4);
 #if EXCEPTION_DEBUG
-    Module.print("can_catch on " + [thrown]);
+    out("can_catch on " + [thrown]);
 #endif
     {{{ makeSetValue('___cxa_find_matching_catch.buffer', '0', 'thrown', '*') }}};
     thrown = ___cxa_find_matching_catch.buffer;
@@ -1367,7 +1367,7 @@ LibraryManager.library = {
         thrown = {{{ makeGetValue('thrown', '0', '*') }}}; // undo indirection
         info.adjusted = thrown;
 #if EXCEPTION_DEBUG
-        Module.print("  can_catch found " + [thrown, typeArray[i]]);
+        out("  can_catch found " + [thrown, typeArray[i]]);
 #endif
         {{{ makeStructuralReturn(['thrown', 'typeArray[i]']) }}};
       }
@@ -1382,7 +1382,7 @@ LibraryManager.library = {
   __resumeException__deps: ['$EXCEPTIONS', function() { Functions.libraryFunctions['___resumeException'] = 1 }], // will be called directly from compiled code
   __resumeException: function(ptr) {
 #if EXCEPTION_DEBUG
-    Module.print("Resuming exception " + [ptr, EXCEPTIONS.last]);
+    out("Resuming exception " + [ptr, EXCEPTIONS.last]);
 #endif
     if (!EXCEPTIONS.last) { EXCEPTIONS.last = ptr; }
     {{{ makeThrow('ptr') }}}
@@ -1758,7 +1758,7 @@ LibraryManager.library = {
         // the shared library is a shared wasm library (see tools/shared.py WebAssembly.make_shared_library)
         var lib_data = FS.readFile(filename, { encoding: 'binary' });
         if (!(lib_data instanceof Uint8Array)) lib_data = new Uint8Array(lib_data);
-        //Module.printErr('libfile ' + filename + ' size: ' + lib_data.length);
+        //err('libfile ' + filename + ' size: ' + lib_data.length);
         lib_module = loadWebAssemblyModule(lib_data);
 #else
         // the shared library is a JS file, which we eval
@@ -1770,7 +1770,7 @@ LibraryManager.library = {
 #endif
       } catch (e) {
 #if ASSERTIONS
-        Module.printErr('Error in loading dynamic library: ' + e);
+        err('Error in loading dynamic library: ' + e);
 #endif
         DLFCN.errorMsg = 'Could not evaluate dynamic lib: ' + filename + '\n' + e;
         return 0;
@@ -2596,7 +2596,7 @@ LibraryManager.library = {
     }
 
     var matches = new RegExp('^'+pattern, "i").exec(Pointer_stringify(buf))
-    // Module['print'](Pointer_stringify(buf)+ ' is matched by '+((new RegExp('^'+pattern)).source)+' into: '+JSON.stringify(matches));
+    // out(Pointer_stringify(buf)+ ' is matched by '+((new RegExp('^'+pattern)).source)+' into: '+JSON.stringify(matches));
 
     function initDate() {
       function fixup(value, min, max) {
@@ -3250,7 +3250,7 @@ LibraryManager.library = {
   __setErrNo: function(value) {
     if (Module['___errno_location']) {{{ makeSetValue("Module['___errno_location']()", 0, 'value', 'i32') }}};
 #if ASSERTIONS
-    else Module.printErr('failed to set errno from JS');
+    else err('failed to set errno from JS');
 #endif
     return value;
   },
@@ -4244,9 +4244,9 @@ LibraryManager.library = {
         console.log(str);
       }
     } else if (flags & 6 /*EM_LOG_ERROR|EM_LOG_WARN*/) {
-      Module.printErr(str);
+      err(str);
     } else {
-      Module.print(str);
+      out(str);
     }
   },
 
@@ -4395,33 +4395,33 @@ LibraryManager.library = {
 
   _Unwind_RaiseException__deps: ['__cxa_throw'],
   _Unwind_RaiseException: function(ex) {
-    Module.printErr('Warning: _Unwind_RaiseException is not correctly implemented');
+    err('Warning: _Unwind_RaiseException is not correctly implemented');
     return ___cxa_throw(ex, 0, 0);
   },
 
   _Unwind_DeleteException: function(ex) {
-    Module.printErr('TODO: Unwind_DeleteException');
+    err('TODO: Unwind_DeleteException');
   },
 
   // autodebugging
 
   emscripten_autodebug_i64: function(line, valuel, valueh) {
-    Module.print('AD:' + [line, valuel, valueh]);
+    out('AD:' + [line, valuel, valueh]);
   },
   emscripten_autodebug_i32: function(line, value) {
-    Module.print('AD:' + [line, value]);
+    out('AD:' + [line, value]);
   },
   emscripten_autodebug_i16: function(line, value) {
-    Module.print('AD:' + [line, value]);
+    out('AD:' + [line, value]);
   },
   emscripten_autodebug_i8: function(line, value) {
-    Module.print('AD:' + [line, value]);
+    out('AD:' + [line, value]);
   },
   emscripten_autodebug_float: function(line, value) {
-    Module.print('AD:' + [line, value]);
+    out('AD:' + [line, value]);
   },
   emscripten_autodebug_double: function(line, value) {
-    Module.print('AD:' + [line, value]);
+    out('AD:' + [line, value]);
   },
 
   // misc definitions to avoid unnecessary unresolved symbols from fastcomp

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -3,7 +3,7 @@
 // Utilities for browser environments
 var LibraryBrowser = {
   $Browser__deps: ['emscripten_set_main_loop', 'emscripten_set_main_loop_timing'],
-  $Browser__postset: 'Module["requestFullScreen"] = function Module_requestFullScreen(lockPointer, resizeCanvas, vrDevice) { Module.printErr("Module.requestFullScreen is deprecated. Please call Module.requestFullscreen instead."); Module["requestFullScreen"] = Module["requestFullscreen"]; Browser.requestFullScreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
+  $Browser__postset: 'Module["requestFullScreen"] = function Module_requestFullScreen(lockPointer, resizeCanvas, vrDevice) { err("Module.requestFullScreen is deprecated. Please call Module.requestFullscreen instead."); Module["requestFullScreen"] = Module["requestFullscreen"]; Browser.requestFullScreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
                      'Module["requestFullscreen"] = function Module_requestFullscreen(lockPointer, resizeCanvas, vrDevice) { Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice) };\n' + // exports
                      'Module["requestAnimationFrame"] = function Module_requestAnimationFrame(func) { Browser.requestAnimationFrame(func) };\n' +
                      'Module["setCanvasSize"] = function Module_setCanvasSize(width, height, noUpdates) { Browser.setCanvasSize(width, height, noUpdates) };\n' +
@@ -68,7 +68,7 @@ var LibraryBrowser = {
           if (e instanceof ExitStatus) {
             return;
           } else {
-            if (e && typeof e === 'object' && e.stack) Module.printErr('exception thrown: ' + [e, e.stack]);
+            if (e && typeof e === 'object' && e.stack) err('exception thrown: ' + [e, e.stack]);
             throw e;
           }
         }
@@ -383,7 +383,7 @@ var LibraryBrowser = {
     },
 
     requestFullScreen: function(lockPointer, resizeCanvas, vrDevice) {
-        Module.printErr('Browser.requestFullScreen() is deprecated. Please call Browser.requestFullscreen instead.');
+        err('Browser.requestFullScreen() is deprecated. Please call Browser.requestFullscreen instead.');
         Browser.requestFullScreen = function(lockPointer, resizeCanvas, vrDevice) {
           return Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice);
         }
@@ -1163,7 +1163,7 @@ var LibraryBrowser = {
 #endif
 
       if (Browser.mainLoop.method === 'timeout' && Module.ctx) {
-        Module.printErr('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
+        err('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
         Browser.mainLoop.method = ''; // just warn once per call to set main loop
       }
 
@@ -1482,7 +1482,7 @@ function slowLog(label, text) {
   if (!slowLog.labels[label]) slowLog.labels[label] = 0;
   var now = Date.now();
   if (now - slowLog.labels[label] > 1000) {
-    Module.print(label + ': ' + text);
+    out(label + ': ' + text);
     slowLog.labels[label] = now;
   }
 }

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -283,7 +283,7 @@ var LibraryEGL = {
     }
     if (glesContextVersion != 2) {
 #if GL_ASSERTIONS
-      Module.printErr('When initializing GLES2/WebGL1 via EGL, one must pass EGL_CONTEXT_CLIENT_VERSION = 2 to GL context attributes! GLES version ' + glesContextVersion + ' is not supported!');
+      err('When initializing GLES2/WebGL1 via EGL, one must pass EGL_CONTEXT_CLIENT_VERSION = 2 to GL context attributes! GLES version ' + glesContextVersion + ' is not supported!');
 #endif
       EGL.setErrorCode(0x3005 /* EGL_BAD_CONFIG */);
       return 0; /* EGL_NO_CONTEXT */

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -442,7 +442,7 @@ mergeInto(LibraryManager.library, {
     var result = __formatString(format, varargs);
     var string = intArrayToString(result);
     if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    Module.print(string);
+    out(string);
     return result.length;
   },
   puts: function(s) {
@@ -450,7 +450,7 @@ mergeInto(LibraryManager.library, {
     var result = Pointer_stringify(s);
     var string = result.substr(0);
     if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    Module.print(string);
+    out(string);
     return result.length;
   },
 });

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1057,7 +1057,7 @@ mergeInto(LibraryManager.library, {
         if (!FS.readFiles) FS.readFiles = {};
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
-          Module['printErr']('read file: ' + path);
+          err('read file: ' + path);
         }
       }
       try {
@@ -1374,7 +1374,7 @@ mergeInto(LibraryManager.library, {
     ensureErrnoError: function() {
       if (FS.ErrnoError) return;
       FS.ErrnoError = function ErrnoError(errno, node) {
-        //Module.printErr(stackTrace()); // useful for debugging
+        //err(stackTrace()); // useful for debugging
         this.node = node;
         this.setErrno = function(errno) {
           this.errno = errno;

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -295,7 +295,7 @@ var LibraryGL = {
           var extension = GLctx.getExtension("OES_standard_derivatives");
 #if GL_DEBUG
           if (!extension) {
-            Module.printErr("Shader attempts to use the standard derivatives extension which is not available.");
+            err("Shader attempts to use the standard derivatives extension which is not available.");
           }
 #endif
         }
@@ -530,7 +530,7 @@ var LibraryGL = {
         }
         if (!ctx) throw ':(';
       } catch (e) {
-        Module.print('Could not create canvas: ' + [errorInfo, e, JSON.stringify(webGLContextAttributes)]);
+        out('Could not create canvas: ' + [errorInfo, e, JSON.stringify(webGLContextAttributes)]);
         return 0;
       }
 
@@ -790,7 +790,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glGetString: Unknown parameter ' + name_ + '!');
+        err('GL_INVALID_ENUM in glGetString: Unknown parameter ' + name_ + '!');
 #endif
         return 0;
     }
@@ -805,7 +805,7 @@ var LibraryGL = {
     // better to report an error instead of doing anything random.
     if (!p) {
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGet' + type + 'v(name=' + name_ + ': Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGet' + type + 'v(name=' + name_ + ': Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -819,7 +819,7 @@ var LibraryGL = {
         if (type !== 'Integer' && type !== 'Integer64') {
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-          Module.printErr('GL_INVALID_ENUM in glGet' + type + 'v(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
+          err('GL_INVALID_ENUM in glGet' + type + 'v(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
 #endif
         }
         return; // Do not write anything to the out pointer, since no binary formats are supported.
@@ -867,7 +867,7 @@ var LibraryGL = {
         case "string":
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-          Module.printErr('GL_INVALID_ENUM in glGet' + type + 'v(' + name_ + ') on a name which returns a string!');
+          err('GL_INVALID_ENUM in glGet' + type + 'v(' + name_ + ') on a name which returns a string!');
 #endif
           return;
         case "object":
@@ -893,7 +893,7 @@ var LibraryGL = {
               default: {
                 GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-                Module.printErr('GL_INVALID_ENUM in glGet' + type + 'v(' + name_ + ') and it returns null!');
+                err('GL_INVALID_ENUM in glGet' + type + 'v(' + name_ + ') and it returns null!');
 #endif
                 return;
               }
@@ -927,7 +927,7 @@ var LibraryGL = {
           } else {
             GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-            Module.printErr('GL_INVALID_ENUM in glGet' + type + 'v: Unknown object returned from WebGL getParameter(' + name_ + ')!');
+            err('GL_INVALID_ENUM in glGet' + type + 'v: Unknown object returned from WebGL getParameter(' + name_ + ')!');
 #endif
             return;
           }
@@ -935,7 +935,7 @@ var LibraryGL = {
         default:
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-          Module.printErr('GL_INVALID_ENUM in glGetIntegerv: Native code calling glGet' + type + 'v(' + name_ + ') and it returns ' + result + ' of type ' + typeof(result) + '!');
+          err('GL_INVALID_ENUM in glGetIntegerv: Native code calling glGet' + type + 'v(' + name_ + ') and it returns ' + result + ' of type ' + typeof(result) + '!');
 #endif
           return;
       }
@@ -961,7 +961,7 @@ var LibraryGL = {
       if (index < 0 || index >= stringiCache.length) {
         GL.recordError(0x0501/*GL_INVALID_VALUE*/);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_VALUE in glGetStringi: index out of range (' + index + ')!');
+        err('GL_INVALID_VALUE in glGetStringi: index out of range (' + index + ')!');
 #endif
         return 0;
       }
@@ -980,7 +980,7 @@ var LibraryGL = {
         if (index < 0 || index >= stringiCache.length) {
           GL.recordError(0x0501/*GL_INVALID_VALUE*/);
 #if GL_ASSERTIONS
-          Module.printErr('GL_INVALID_VALUE in glGetStringi: index out of range (' + index + ') in a call to GL_EXTENSIONS!');
+          err('GL_INVALID_VALUE in glGetStringi: index out of range (' + index + ') in a call to GL_EXTENSIONS!');
 #endif
           return 0;
         }
@@ -988,7 +988,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glGetStringi: Unknown parameter ' + name + '!');
+        err('GL_INVALID_ENUM in glGetStringi: Unknown parameter ' + name + '!');
 #endif
         return 0;
     }
@@ -1025,7 +1025,7 @@ var LibraryGL = {
     if (bufSize < 0) {
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetInternalformativ: bufSize=' + bufSize + ' < 0');
+      err('GL_INVALID_VALUE in glGetInternalformativ: bufSize=' + bufSize + ' < 0');
 #endif
       return;
     }
@@ -1034,7 +1034,7 @@ var LibraryGL = {
       // probably target != GL_RENDERBUFFER or bad internalformat
       GL.recordError(0x0500 /* GL_INVALID_ENUM */);
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_ENUM in glGetInternalformativ');
+      err('GL_INVALID_ENUM in glGetInternalformativ');
 #endif
       return;
     }
@@ -1055,7 +1055,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500 /* GL_INVALID_ENUM */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM due to unknown pname in glGetInternalformativ: ' + pname);
+        err('GL_INVALID_ENUM due to unknown pname in glGetInternalformativ: ' + pname);
 #endif
     }
   },
@@ -1068,7 +1068,7 @@ var LibraryGL = {
       if (!texture) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */); // GLES + EGL specs don't specify what should happen here, so best to issue an error and create IDs with 0.
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenTextures: GLctx.createTexture returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenTextures: GLctx.createTexture returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('textures', 'i++*4', 0, 'i32') }}};
         return;
@@ -1184,7 +1184,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM due to unknown format in glTex[Sub]Image/glReadPixels, format: ' + format);
+        err('GL_INVALID_ENUM due to unknown format in glTex[Sub]Image/glReadPixels, format: ' + format);
 #endif
         return null;
     }
@@ -1227,7 +1227,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type + ', format: ' + format);
+        err('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type + ', format: ' + format);
 #endif
         return null;
     }
@@ -1283,7 +1283,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type);
+        err('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type);
 #endif
         return null;
     }
@@ -1447,7 +1447,7 @@ var LibraryGL = {
     if (!pixelData) {
       GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_ENUM in glReadPixels: Unrecognized combination of type=' + type + ' and format=' + format + '!');
+      err('GL_INVALID_ENUM in glReadPixels: Unrecognized combination of type=' + type + ' and format=' + format + '!');
 #endif
       return;
     }
@@ -1468,7 +1468,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetTexParameterfv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetTexParameterfv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1482,7 +1482,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetTexParameteriv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetTexParameteriv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1516,7 +1516,7 @@ var LibraryGL = {
       if (!buffer) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenBuffers: GLctx.createBuffer returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenBuffers: GLctx.createBuffer returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('buffers', 'i++*4', 0, 'i32') }}};
         return;
@@ -1553,7 +1553,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
       // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetBufferParameteriv(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetBufferParameteriv(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1568,7 +1568,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
       // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetBufferParameteri64v(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetBufferParameteri64v(target=' + target + ', value=' + value + ', data=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1627,7 +1627,7 @@ var LibraryGL = {
       if (!query) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenQueriesEXT: GLctx.disjointTimerQueryExt.createQueryEXT returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenQueriesEXT: GLctx.disjointTimerQueryExt.createQueryEXT returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('ids', 'i++*4', 0, 'i32') }}};
         return;
@@ -1684,7 +1684,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetQueryivEXT(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetQueryivEXT(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1698,7 +1698,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetQueryObject(u)ivEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetQueryObject(u)ivEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1724,7 +1724,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetQueryObject(u)i64vEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetQueryObject(u)i64vEXT(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -1783,13 +1783,13 @@ var LibraryGL = {
   glMapBufferRange__deps: ['$emscriptenWebGLGetBufferBinding', '$emscriptenWebGLValidateMapBufferTarget'],
   glMapBufferRange: function(target, offset, length, access) {
     if (access != 0x1A && access != 0xA) {
-      Module.printErr("glMapBufferRange is only supported when access is MAP_WRITE|INVALIDATE_BUFFER");
+      err("glMapBufferRange is only supported when access is MAP_WRITE|INVALIDATE_BUFFER");
       return 0;
     }
 
     if (!emscriptenWebGLValidateMapBufferTarget(target)) {
       GL.recordError(0x0500/*GL_INVALID_ENUM*/);
-      Module.printErr('GL_INVALID_ENUM in glMapBufferRange');
+      err('GL_INVALID_ENUM in glMapBufferRange');
       return 0;
     }
 
@@ -1817,7 +1817,7 @@ var LibraryGL = {
       {{{ makeSetValue('params', '0', 'ptr', 'i32') }}};
     } else {
       GL.recordError(0x0500/*GL_INVALID_ENUM*/);
-      Module.printErr('GL_INVALID_ENUM in glGetBufferPointerv');
+      err('GL_INVALID_ENUM in glGetBufferPointerv');
     }
   },
 
@@ -1826,7 +1826,7 @@ var LibraryGL = {
   glFlushMappedBufferRange: function(target, offset, length) {
     if (!emscriptenWebGLValidateMapBufferTarget(target)) {
       GL.recordError(0x0500/*GL_INVALID_ENUM*/);
-      Module.printErr('GL_INVALID_ENUM in glFlushMappedBufferRange');
+      err('GL_INVALID_ENUM in glFlushMappedBufferRange');
       return;
     }
 
@@ -1859,7 +1859,7 @@ var LibraryGL = {
   glUnmapBuffer: function(target) {
     if (!emscriptenWebGLValidateMapBufferTarget(target)) {
       GL.recordError(0x0500/*GL_INVALID_ENUM*/);
-      Module.printErr('GL_INVALID_ENUM in glUnmapBuffer');
+      err('GL_INVALID_ENUM in glUnmapBuffer');
       return 0;
     }
 
@@ -1942,7 +1942,7 @@ var LibraryGL = {
       if (!query) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenQueries: GLctx.createQuery returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenQueries: GLctx.createQuery returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('ids', 'i++*4', 0, 'i32') }}};
         return;
@@ -1986,7 +1986,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetQueryiv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetQueryiv(target=' + target +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2000,7 +2000,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetQueryObjectuiv(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetQueryObjectuiv(id=' + id +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2027,7 +2027,7 @@ var LibraryGL = {
       if (!sampler) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenSamplers: GLctx.createSampler returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenSamplers: GLctx.createSampler returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('samplers', 'i++*4', 0, 'i32') }}};
         return;
@@ -2106,7 +2106,7 @@ var LibraryGL = {
       // GLES3 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetSamplerParameterfv(sampler=' + sampler +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetSamplerParameterfv(sampler=' + sampler +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2121,7 +2121,7 @@ var LibraryGL = {
       // GLES3 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetSamplerParameteriv(sampler=' + sampler +', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetSamplerParameteriv(sampler=' + sampler +', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2138,7 +2138,7 @@ var LibraryGL = {
       if (!transformFeedback) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenTransformFeedbacks: GLctx.createTransformFeedback returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenTransformFeedbacks: GLctx.createTransformFeedback returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('ids', 'i++*4', 0, 'i32') }}};
         return;
@@ -2220,7 +2220,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if data is a null pointer. Since calling this function does not make sense
       // if data == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetInteger(64)i_v(target=' + target + ', index=' + index + ', data=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetInteger(64)i_v(target=' + target + ', index=' + index + ', data=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2244,7 +2244,7 @@ var LibraryGL = {
             default: {
               GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-              Module.printErr('GL_INVALID_ENUM in glGetInteger(64)i_v(' + target + ') and it returns null!');
+              err('GL_INVALID_ENUM in glGetInteger(64)i_v(' + target + ') and it returns null!');
 #endif
               return;
             }
@@ -2254,7 +2254,7 @@ var LibraryGL = {
         } else {
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-          Module.printErr('GL_INVALID_ENUM in glGetInteger(64)i_v: Unknown object returned from WebGL getIndexedParameter(' + target + ')!');
+          err('GL_INVALID_ENUM in glGetInteger(64)i_v: Unknown object returned from WebGL getIndexedParameter(' + target + ')!');
 #endif
           return;
         }
@@ -2262,7 +2262,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glGetInteger(64)i_v: Native code calling glGetInteger(64)i_v(' + target + ') and it returns ' + result + ' of type ' + typeof(result) + '!');
+        err('GL_INVALID_ENUM in glGetInteger(64)i_v: Native code calling glGetInteger(64)i_v(' + target + ') and it returns ' + result + ' of type ' + typeof(result) + '!');
 #endif
         return;
     }
@@ -2316,7 +2316,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if uniformIndices is a null pointer. Since calling this function does not make sense
       // if uniformIndices == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetUniformIndices(program=' + program + ', uniformCount=' + uniformCount + ', uniformNames=' + uniformNames + ', uniformIndices=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetUniformIndices(program=' + program + ', uniformCount=' + uniformCount + ', uniformNames=' + uniformNames + ', uniformIndices=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2348,7 +2348,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetActiveUniformsiv(program=' + program + ', uniformCount=' + uniformCount + ', uniformIndices=' + uniformIndices + ', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetActiveUniformsiv(program=' + program + ', uniformCount=' + uniformCount + ', uniformIndices=' + uniformIndices + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2388,7 +2388,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetActiveUniformBlockiv(program=' + program + ', uniformBlockIndex=' + uniformBlockIndex + ', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetActiveUniformBlockiv(program=' + program + ', uniformBlockIndex=' + uniformBlockIndex + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2523,7 +2523,7 @@ var LibraryGL = {
       // GLES3 specification does not specify how to behave if bufSize < 0, however in the spec wording for glGetInternalFormativ, it does say that GL_INVALID_VALUE should be raised,
       // so raise GL_INVALID_VALUE here as well.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetSynciv(sync=' + sync + ', pname=' + pname + ', bufSize=' + bufSize + ', length=' + length + ', values='+values+'): Function called with bufSize < 0!');
+      err('GL_INVALID_VALUE in glGetSynciv(sync=' + sync + ', pname=' + pname + ', bufSize=' + bufSize + ', length=' + length + ', values='+values+'): Function called with bufSize < 0!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2532,7 +2532,7 @@ var LibraryGL = {
       // GLES3 specification does not specify how to behave if values is a null pointer. Since calling this function does not make sense
       // if values == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetSynciv(sync=' + sync + ', pname=' + pname + ', bufSize=' + bufSize + ', length=' + length + ', values=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetSynciv(sync=' + sync + ', pname=' + pname + ', bufSize=' + bufSize + ', length=' + length + ', values=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2553,7 +2553,7 @@ var LibraryGL = {
   glGetInternalFormativ: function(target, internalformat, pname, bufSize, params) {
     if (bufSize < 0) {
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetInternalFormativ(target=' + target + ', internalformat=' + internalformat + ', pname=' + pname + ', bufSize=' + bufSize + ', params=' + params + '): Function called with bufSize < 0!');
+      err('GL_INVALID_VALUE in glGetInternalFormativ(target=' + target + ', internalformat=' + internalformat + ', pname=' + pname + ', bufSize=' + bufSize + ', params=' + params + '): Function called with bufSize < 0!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2562,7 +2562,7 @@ var LibraryGL = {
       // GLES3 specification does not specify how to behave if values is a null pointer. Since calling this function does not make sense
       // if values == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetInternalFormativ(target=' + target + ', internalformat=' + internalformat + ', pname=' + pname + ', bufSize=' + bufSize + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetInternalFormativ(target=' + target + ', internalformat=' + internalformat + ', pname=' + pname + ', bufSize=' + bufSize + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2591,7 +2591,7 @@ var LibraryGL = {
       if (!renderbuffer) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenRenderbuffers: GLctx.createRenderbuffer returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenRenderbuffers: GLctx.createRenderbuffer returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('renderbuffers', 'i++*4', 0, 'i32') }}};
         return;
@@ -2629,7 +2629,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetRenderbufferParameteriv(target=' + target + ', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetRenderbufferParameteriv(target=' + target + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2649,7 +2649,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetUniform*v(program=' + program + ', location=' + location + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetUniform*v(program=' + program + ', location=' + location + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -2743,14 +2743,14 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if params is a null pointer. Since calling this function does not make sense
       // if params == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetVertexAttrib*v(index=' + index + ', pname=' + pname + ', params=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetVertexAttrib*v(index=' + index + ', pname=' + pname + ', params=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
     }
 #if FULL_ES2
     if (GL.currentContext.clientBuffers[index].enabled) {
-      Module.printErr("glGetVertexAttrib*v on client-side array: not supported, bad data returned");
+      err("glGetVertexAttrib*v on client-side array: not supported, bad data returned");
     }
 #endif
     var data = GLctx.getVertexAttrib(index, pname);
@@ -2813,14 +2813,14 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if pointer is a null pointer. Since calling this function does not make sense
       // if pointer == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetVertexAttribPointerv(index=' + index + ', pname=' + pname + ', pointer=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetVertexAttribPointerv(index=' + index + ', pname=' + pname + ', pointer=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
     }
 #if FULL_ES2
     if (GL.currentContext.clientBuffers[index].enabled) {
-      Module.printErr("glGetVertexAttribPointer on client-side array: not supported, bad data returned");
+      err("glGetVertexAttribPointer on client-side array: not supported, bad data returned");
     }
 #endif
     {{{ makeSetValue('pointer', '0', 'GLctx.getVertexAttribOffset(index, pname)', 'i32') }}};
@@ -3625,7 +3625,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetShaderiv(shader=' + shader + ', pname=' + pname + ', p=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetShaderiv(shader=' + shader + ', pname=' + pname + ', p=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -3652,7 +3652,7 @@ var LibraryGL = {
       // GLES2 specification does not specify how to behave if p is a null pointer. Since calling this function does not make sense
       // if p == null, issue a GL error to notify user about it.
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0): Function called with null out pointer!');
+      err('GL_INVALID_VALUE in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0): Function called with null out pointer!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -3663,7 +3663,7 @@ var LibraryGL = {
 
     if (program >= GL.counter) {
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_VALUE in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0x' + p.toString(16) + '): The specified program object name was not generated by GL!');
+      err('GL_INVALID_VALUE in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0x' + p.toString(16) + '): The specified program object name was not generated by GL!');
 #endif
       GL.recordError(0x0501 /* GL_INVALID_VALUE */);
       return;
@@ -3672,7 +3672,7 @@ var LibraryGL = {
     var ptable = GL.programInfos[program];
     if (!ptable) {
 #if GL_ASSERTIONS
-      Module.printErr('GL_INVALID_OPERATION in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0x' + p.toString(16) + '): The specified GL object name does not refer to a program object!');
+      err('GL_INVALID_OPERATION in glGetProgramiv(program=' + program + ', pname=' + pname + ', p=0x' + p.toString(16) + '): The specified GL object name does not refer to a program object!');
 #endif
       GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
       return;
@@ -3826,7 +3826,7 @@ var LibraryGL = {
   glProgramParameteri: function(program, pname, value) {
     GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-    Module.printErr("GL_INVALID_ENUM in glProgramParameteri: WebGL does not support binary shader formats! Calls to glProgramParameteri always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
+    err("GL_INVALID_ENUM in glProgramParameteri: WebGL does not support binary shader formats! Calls to glProgramParameteri always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
 #endif
   },
 
@@ -3834,7 +3834,7 @@ var LibraryGL = {
   glGetProgramBinary: function(program, bufSize, length, binaryFormat, binary) {
     GL.recordError(0x0502/*GL_INVALID_OPERATION*/);
 #if GL_ASSERTIONS
-    Module.printErr("GL_INVALID_OPERATION in glGetProgramBinary: WebGL does not support binary shader formats! Calls to glGetProgramBinary always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
+    err("GL_INVALID_OPERATION in glGetProgramBinary: WebGL does not support binary shader formats! Calls to glGetProgramBinary always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
 #endif
   },
 
@@ -3842,7 +3842,7 @@ var LibraryGL = {
   glProgramBinary: function(program, binaryFormat, binary, length) {
     GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-    Module.printErr("GL_INVALID_ENUM in glProgramBinary: WebGL does not support binary shader formats! Calls to glProgramBinary always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
+    err("GL_INVALID_ENUM in glProgramBinary: WebGL does not support binary shader formats! Calls to glProgramBinary always fail. See https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.4");
 #endif
   },
 #endif
@@ -3871,7 +3871,7 @@ var LibraryGL = {
       if (!framebuffer) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenFramebuffers: GLctx.createFramebuffer returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenFramebuffers: GLctx.createFramebuffer returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('ids', 'i++*4', 0, 'i32') }}};
         return;
@@ -3957,7 +3957,7 @@ var LibraryGL = {
       if (!vao) {
         GL.recordError(0x0502 /* GL_INVALID_OPERATION */);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_OPERATION in glGenVertexArrays: GLctx.vao.createVertexArrayOES returned null - most likely GL context is lost!');
+        err('GL_INVALID_OPERATION in glGenVertexArrays: GLctx.vao.createVertexArrayOES returned null - most likely GL context is lost!');
 #endif
         while(i < n) {{{ makeSetValue('arrays', 'i++*4', 0, 'i32') }}};
         return;
@@ -4065,9 +4065,9 @@ var LibraryGL = {
       GLEmulation.fogColor = new Float32Array(4);
 
       // Add some emulation workarounds
-      Module.printErr('WARNING: using emscripten GL emulation. This is a collection of limited workarounds, do not expect it to work.');
+      err('WARNING: using emscripten GL emulation. This is a collection of limited workarounds, do not expect it to work.');
 #if GL_UNSAFE_OPTS == 1
-      Module.printErr('WARNING: using emscripten GL emulation unsafe opts. If weirdness happens, try -s GL_UNSAFE_OPTS=0');
+      err('WARNING: using emscripten GL emulation unsafe opts. If weirdness happens, try -s GL_UNSAFE_OPTS=0');
 #endif
 
       // XXX some of the capabilities we don't support may lead to incorrect rendering, if we do not emulate them in shaders
@@ -4401,10 +4401,10 @@ var LibraryGL = {
         GLctx.compileShader(GL.shaders[shader]);
 #if GL_DEBUG
         if (!GLctx.getShaderParameter(GL.shaders[shader], GLctx.COMPILE_STATUS)) {
-          Module.printErr('Failed to compile shader: ' + GLctx.getShaderInfoLog(GL.shaders[shader]));
-          Module.printErr('Info: ' + JSON.stringify(GL.shaderInfos[shader]));
-          Module.printErr('Original source: ' + GL.shaderOriginalSources[shader]);
-          Module.printErr('Source: ' + GL.shaderSources[shader]);
+          err('Failed to compile shader: ' + GLctx.getShaderInfoLog(GL.shaders[shader]));
+          err('Info: ' + JSON.stringify(GL.shaderInfos[shader]));
+          err('Original source: ' + GL.shaderOriginalSources[shader]);
+          err('Source: ' + GL.shaderSources[shader]);
           throw 'Shader compilation halt';
         }
 #endif
@@ -4424,7 +4424,7 @@ var LibraryGL = {
       _glDetachShader = _emscripten_glDetachShader = function _glDetachShader(program, shader) {
         var programShader = GL.programShaders[program];
         if (!programShader) {
-          Module.printErr('WARNING: _glDetachShader received invalid program: ' + program);
+          err('WARNING: _glDetachShader received invalid program: ' + program);
           return;
         }
         var index = programShader.indexOf(shader);
@@ -4437,11 +4437,11 @@ var LibraryGL = {
       _glUseProgram = _emscripten_glUseProgram = function _glUseProgram(program) {
 #if GL_DEBUG
         if (GL.debug) {
-          Module.printErr('[using program with shaders]');
+          err('[using program with shaders]');
           if (program) {
             GL.programShaders[program].forEach(function(shader) {
-              Module.printErr('  shader ' + shader + ', original source: ' + GL.shaderOriginalSources[shader]);
-              Module.printErr('         Source: ' + GL.shaderSources[shader]);
+              err('  shader ' + shader + ', original source: ' + GL.shaderOriginalSources[shader]);
+              err('         Source: ' + GL.shaderSources[shader]);
             });
           }
         }
@@ -4590,7 +4590,7 @@ var LibraryGL = {
     } else if (GL.shaders[id]) {
       _glDeleteShader(id);
     } else {
-      Module.printErr('WARNING: deleteObject received invalid id: ' + id);
+      err('WARNING: deleteObject received invalid id: ' + id);
     }
   },
   glDeleteObjectARB: 'glDeleteObject',
@@ -4620,7 +4620,7 @@ var LibraryGL = {
       }
       _glGetShaderiv(id, type, result);
     } else {
-      Module.printErr('WARNING: getObjectParameteriv received invalid id: ' + id);
+      err('WARNING: getObjectParameteriv received invalid id: ' + id);
     }
   },
   glGetObjectParameterivARB: 'glGetObjectParameteriv',
@@ -4633,7 +4633,7 @@ var LibraryGL = {
     } else if (GL.shaders[id]) {
       _glGetShaderInfoLog(id, maxLength, length, infoLog);
     } else {
-      Module.printErr('WARNING: glGetInfoLog received invalid id: ' + id);
+      err('WARNING: glGetInfoLog received invalid id: ' + id);
     }
   },
   glGetInfoLogARB: 'glGetInfoLog',
@@ -4658,7 +4658,7 @@ var LibraryGL = {
       default:
         GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-        Module.printErr('GL_INVALID_ENUM in glGetPointerv: Unsupported name ' + name + '!');
+        err('GL_INVALID_ENUM in glGetPointerv: Unsupported name ' + name + '!');
 #endif
         return;
     }
@@ -5562,7 +5562,7 @@ var LibraryGL = {
               break;
 
             default:
-              Module.printErr('WARNING: Unhandled `pname` in call to `glTexEnvf`.');
+              err('WARNING: Unhandled `pname` in call to `glTexEnvf`.');
           }
         },
 
@@ -5682,7 +5682,7 @@ var LibraryGL = {
               break;
 
             default:
-              Module.printErr('WARNING: Unhandled `pname` in call to `glTexEnvi`.');
+              err('WARNING: Unhandled `pname` in call to `glTexEnvi`.');
           }
         },
 
@@ -5702,7 +5702,7 @@ var LibraryGL = {
               break
             }
             default:
-              Module.printErr('WARNING: Unhandled `pname` in call to `glTexEnvfv`.');
+              err('WARNING: Unhandled `pname` in call to `glTexEnvfv`.');
           }
         },
 
@@ -5788,7 +5788,7 @@ var LibraryGL = {
               return;
 
             default:
-              Module.printErr('WARNING: Unhandled `pname` in call to `glGetTexEnvi`.');
+              err('WARNING: Unhandled `pname` in call to `glGetTexEnvi`.');
           }
         },
 
@@ -5955,7 +5955,7 @@ var LibraryGL = {
       var renderer = keyView.get();
       if (!renderer) {
 #if GL_DEBUG
-        Module.printErr('generating renderer for ' + JSON.stringify(attributes));
+        err('generating renderer for ' + JSON.stringify(attributes));
 #endif
         renderer = GLImmediate.createRenderer();
         GLImmediate.currentRenderer = renderer;
@@ -6526,7 +6526,7 @@ var LibraryGL = {
     // Main functions
     initted: false,
     init: function() {
-      Module.printErr('WARNING: using emscripten GL immediate mode emulation. This is very limited in what it supports');
+      err('WARNING: using emscripten GL immediate mode emulation. This is very limited in what it supports');
       GLImmediate.initted = true;
 
       if (!Module.useWebGL) return; // a 2D canvas may be currently used TODO: make sure we are actually called in that case
@@ -7018,7 +7018,7 @@ var LibraryGL = {
     var attrib = GLEmulation.getAttributeFromCapability(cap);
     if (attrib === null) {
 #if ASSERTIONS
-      Module.printErr('WARNING: unhandled clientstate: ' + cap);
+      err('WARNING: unhandled clientstate: ' + cap);
 #endif
       return;
     }
@@ -7038,7 +7038,7 @@ var LibraryGL = {
     var attrib = GLEmulation.getAttributeFromCapability(cap);
     if (attrib === null) {
 #if ASSERTIONS
-      Module.printErr('WARNING: unhandled clientstate: ' + cap);
+      err('WARNING: unhandled clientstate: ' + cap);
 #endif
       return;
     }
@@ -7207,7 +7207,7 @@ var LibraryGL = {
 
   glLoadMatrixf: function(matrix) {
 #if GL_DEBUG
-    if (GL.debug) Module.printErr('glLoadMatrixf receiving: ' + Array.prototype.slice.call(HEAPF32.subarray(matrix >> 2, (matrix >> 2) + 16)));
+    if (GL.debug) err('glLoadMatrixf receiving: ' + Array.prototype.slice.call(HEAPF32.subarray(matrix >> 2, (matrix >> 2) + 16)));
 #endif
     GLImmediate.matricesModified = true;
     GLImmediate.matrixVersion[GLImmediate.currentMatrix] = (GLImmediate.matrixVersion[GLImmediate.currentMatrix] + 1)|0;
@@ -7554,7 +7554,7 @@ var LibraryGL = {
   glShaderBinary: function() {
     GL.recordError(0x0500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-    Module.printErr("GL_INVALID_ENUM in glShaderBinary: WebGL does not support binary shader formats! Calls to glShaderBinary always fail.");
+    err("GL_INVALID_ENUM in glShaderBinary: WebGL does not support binary shader formats! Calls to glShaderBinary always fail.");
 #endif
   },
 

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -610,7 +610,7 @@ var LibraryGLFW = {
     },
 
     requestFullScreen: function() {
-      Module.printErr('GLFW.requestFullScreen() is deprecated. Please call GLFW.requestFullscreen instead.');
+      err('GLFW.requestFullScreen() is deprecated. Please call GLFW.requestFullscreen instead.');
       GLFW.requestFullScreen = function() {
         return GLFW.requestFullscreen();
       }
@@ -627,7 +627,7 @@ var LibraryGLFW = {
     },
 
     cancelFullScreen: function() {
-      Module.printErr('GLFW.cancelFullScreen() is deprecated. Please call GLFW.exitFullscreen instead.');
+      err('GLFW.cancelFullScreen() is deprecated. Please call GLFW.exitFullscreen instead.');
       GLFW.cancelFullScreen = function() {
         return GLFW.exitFullscreen();
       }

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -304,7 +304,7 @@ var LibraryGLUT = {
     },
 
     requestFullScreen: function() {
-      Module.printErr('GLUT.requestFullScreen() is deprecated. Please call GLUT.requestFullscreen instead.');
+      err('GLUT.requestFullScreen() is deprecated. Please call GLUT.requestFullscreen instead.');
       GLUT.requestFullScreen = function() {
         return GLUT.requestFullscreen();
       }
@@ -321,7 +321,7 @@ var LibraryGLUT = {
     },
 
     cancelFullScreen: function() {
-      Module.printErr('GLUT.cancelFullScreen() is deprecated. Please call GLUT.exitFullscreen instead.');
+      err('GLUT.cancelFullScreen() is deprecated. Please call GLUT.exitFullscreen instead.');
       GLUT.cancelFullScreen = function() {
         return GLUT.exitFullscreen();
       }

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -249,7 +249,7 @@ var LibraryPThread = {
     //                    ready to host pthreads. Optional. This is used to mitigate bug https://bugzilla.mozilla.org/show_bug.cgi?id=1049079
     allocateUnusedWorkers: function(numWorkers, onFinishedLoading) {
       if (typeof SharedArrayBuffer === 'undefined') return; // No multithreading support, no-op.
-      Module['print']('Preallocating ' + numWorkers + ' workers for a pthread spawn pool.');
+      out('Preallocating ' + numWorkers + ' workers for a pthread spawn pool.');
 
       var numWorkersLoaded = 0;
       var pthreadMainJs = 'pthread-main.js';
@@ -284,7 +284,7 @@ var LibraryPThread = {
                 case 10: returnValue = funcTable[funcIdx](d.p0, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7, d.p8); break;
                 default:
                   if (d.proxiedCall) {
-                    Module['printErr']("worker sent an unknown proxied call idx " + d.proxiedCall);
+                    err("worker sent an unknown proxied call idx " + d.proxiedCall);
                     console.error(e.data);
                   }
                   break;
@@ -335,9 +335,9 @@ var LibraryPThread = {
                 onFinishedLoading();
               }
             } else if (d.cmd === 'print') {
-              Module['print']('Thread ' + d.threadId + ': ' + d.text);
+              out('Thread ' + d.threadId + ': ' + d.text);
             } else if (d.cmd === 'printErr') {
-              Module['printErr']('Thread ' + d.threadId + ': ' + d.text);
+              err('Thread ' + d.threadId + ': ' + d.text);
             } else if (d.cmd === 'alert') {
               alert('Thread ' + d.threadId + ': ' + d.text);
             } else if (d.cmd === 'exit') {
@@ -353,12 +353,12 @@ var LibraryPThread = {
             } else if (e.data.target === 'setimmediate') {
               worker.postMessage(e.data); // Worker wants to postMessage() to itself to implement setImmediate() emulation.
             } else {
-              Module['printErr']("worker sent an unknown command " + d.cmd);
+              err("worker sent an unknown command " + d.cmd);
             }
           };
 
           worker.onerror = function(e) {
-            Module['printErr']('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+            err('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
           };
         }(worker));
 
@@ -538,11 +538,11 @@ var LibraryPThread = {
   pthread_create__deps: ['_spawn_thread', 'pthread_getschedparam', 'pthread_self'],
   pthread_create: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer === 'undefined') {
-      Module['printErr']('Current environment does not support SharedArrayBuffer, pthreads are not available!');
+      err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
       return {{{ cDefine('EAGAIN') }}};
     }
     if (!pthread_ptr) {
-      Module['printErr']('pthread_create called with a null thread pointer!');
+      err('pthread_create called with a null thread pointer!');
       return {{{ cDefine('EINVAL') }}};
     }
 
@@ -562,7 +562,7 @@ var LibraryPThread = {
       try {
         if (name == '#canvas') {
           if (!Module['canvas']) {
-            Module['printErr']('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
+            err('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
             return {{{ cDefine('EINVAL') }}};
           }
           name = Module['canvas'].id;
@@ -574,15 +574,15 @@ var LibraryPThread = {
         } else {
           var canvas = (Module['canvas'] && Module['canvas'].id === name) ? Module['canvas'] : document.getElementByID(name);
           if (!canvas) {
-            Module['printErr']('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
+            err('pthread_create: could not find canvas with ID "' + name + '" to transfer to thread!');
             return {{{ cDefine('EINVAL') }}};
           }
           if (canvas.controlTransferredOffscreen) {
-            Module['printErr']('pthread_create: cannot transfer canvas with ID "' + name + '" to thread, since the current thread does not have control over it!');
+            err('pthread_create: cannot transfer canvas with ID "' + name + '" to thread, since the current thread does not have control over it!');
             return {{{ cDefine('EPERM') }}}; // Operation not permitted, some other thread is accessing the canvas.
           }
           if (!canvas.transferControlToOffscreen) {
-            Module['printErr']('pthread_create: cannot transfer control of canvas "' + name + '" to pthread, because current browser does not support OffscreenCanvas!');
+            err('pthread_create: cannot transfer control of canvas "' + name + '" to pthread, because current browser does not support OffscreenCanvas!');
             return {{{ cDefine('ENOSYS') }}}; // Function not implemented, browser doesn't have support for this.
           }
           offscreenCanvas = canvas.transferControlToOffscreen();
@@ -592,7 +592,7 @@ var LibraryPThread = {
         transferList.push(offscreenCanvas);
         offscreenCanvases[offscreenCanvas.id] = offscreenCanvas;
       } catch(e) {
-        Module['printErr']('pthread_create: failed to transfer control of canvas "' + name + '" to OffscreenCanvas! Error: ' + e);
+        err('pthread_create: failed to transfer control of canvas "' + name + '" to OffscreenCanvas! Error: ' + e);
         return {{{ cDefine('EINVAL') }}}; // Hitting this might indicate an implementation bug or some other internal error
       }
     }
@@ -704,26 +704,26 @@ var LibraryPThread = {
   pthread_join__deps: ['_cleanup_thread', '_pthread_testcancel_js', 'emscripten_main_thread_process_queued_calls'],
   pthread_join: function(thread, status) {
     if (!thread) {
-      Module['printErr']('pthread_join attempted on a null thread pointer!');
+      err('pthread_join attempted on a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     if (ENVIRONMENT_IS_PTHREAD && selfThreadId == thread) {
-      Module['printErr']('PThread ' + thread + ' is attempting to join to itself!');
+      err('PThread ' + thread + ' is attempting to join to itself!');
       return ERRNO_CODES.EDEADLK;
     }
     else if (!ENVIRONMENT_IS_PTHREAD && PThread.mainThreadBlock == thread) {
-      Module['printErr']('Main thread ' + thread + ' is attempting to join to itself!');
+      err('Main thread ' + thread + ' is attempting to join to itself!');
       return ERRNO_CODES.EDEADLK;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_join attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_join attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
 
     var detached = Atomics.load(HEAPU32, (thread + {{{ C_STRUCTS.pthread.detached }}} ) >> 2);
     if (detached) {
-      Module['printErr']('Attempted to join thread ' + thread + ', which was already detached!');
+      err('Attempted to join thread ' + thread + ', which was already detached!');
       return ERRNO_CODES.EINVAL; // The thread is already detached, can no longer join it!
     }
     for (;;) {
@@ -752,16 +752,16 @@ var LibraryPThread = {
     if (signal < 0 || signal >= 65/*_NSIG*/) return ERRNO_CODES.EINVAL;
     if (thread == PThread.MAIN_THREAD_ID) {
       if (signal == 0) return 0; // signal == 0 is a no-op.
-      Module['printErr']('Main thread (id=' + thread + ') cannot be killed with pthread_kill!');
+      err('Main thread (id=' + thread + ') cannot be killed with pthread_kill!');
       return ERRNO_CODES.ESRCH;
     }
     if (!thread) {
-      Module['printErr']('pthread_kill attempted on a null thread pointer!');
+      err('pthread_kill attempted on a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_kill attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_kill attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
     if (signal != 0) {
@@ -774,16 +774,16 @@ var LibraryPThread = {
   pthread_cancel__deps: ['_cancel_thread'],
   pthread_cancel: function(thread) {
     if (thread == PThread.MAIN_THREAD_ID) {
-      Module['printErr']('Main thread (id=' + thread + ') cannot be canceled!');
+      err('Main thread (id=' + thread + ') cannot be canceled!');
       return ERRNO_CODES.ESRCH;
     }
     if (!thread) {
-      Module['printErr']('pthread_cancel attempted on a null thread pointer!');
+      err('pthread_cancel attempted on a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_cancel attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_cancel attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
     Atomics.compareExchange(HEAPU32, (thread + {{{ C_STRUCTS.pthread.threadStatus }}} ) >> 2, 0, 2); // Signal the thread that it needs to cancel itself.
@@ -794,12 +794,12 @@ var LibraryPThread = {
 
   pthread_detach: function(thread) {
     if (!thread) {
-      Module['printErr']('pthread_detach attempted on a null thread pointer!');
+      err('pthread_detach attempted on a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_detach attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_detach attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
     var threadStatus = Atomics.load(HEAPU32, (thread + {{{ C_STRUCTS.pthread.threadStatus }}} ) >> 2);
@@ -856,12 +856,12 @@ var LibraryPThread = {
     if (!policy && !schedparam) return ERRNO_CODES.EINVAL;
 
     if (!thread) {
-      Module['printErr']('pthread_getschedparam called with a null thread pointer!');
+      err('pthread_getschedparam called with a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_getschedparam attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_getschedparam attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
 
@@ -875,12 +875,12 @@ var LibraryPThread = {
 
   pthread_setschedparam: function(thread, policy, schedparam) {
     if (!thread) {
-      Module['printErr']('pthread_setschedparam called with a null thread pointer!');
+      err('pthread_setschedparam called with a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_setschedparam attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_setschedparam attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
 
@@ -927,12 +927,12 @@ var LibraryPThread = {
 
   pthread_setschedprio: function(thread, prio) {
     if (!thread) {
-      Module['printErr']('pthread_setschedprio called with a null thread pointer!');
+      err('pthread_setschedprio called with a null thread pointer!');
       return ERRNO_CODES.ESRCH;
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self != thread) {
-      Module['printErr']('pthread_setschedprio attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_setschedprio attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
     if (prio < 0) return ERRNO_CODES.EINVAL;
@@ -965,12 +965,12 @@ var LibraryPThread = {
 
   // pthread_sigmask - examine and change mask of blocked signals
   pthread_sigmask: function(how, set, oldset) {
-    Module['printErr']('pthread_sigmask() is not supported: this is a no-op.');
+    err('pthread_sigmask() is not supported: this is a no-op.');
     return 0;
   },
 
   pthread_atfork: function(prepare, parent, child) {
-    Module['printErr']('fork() is not supported: pthread_atfork is a no-op.');
+    err('fork() is not supported: pthread_atfork is a no-op.');
     return 0;
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -779,7 +779,7 @@ var LibrarySDL = {
           break;
       }
       if (SDL.events.length >= 10000) {
-        Module.printErr('SDL event queue full, dropping events');
+        err('SDL event queue full, dropping events');
         SDL.events = SDL.events.slice(0, 10000);
       }
       // If we have a handler installed, this will push the events to the app
@@ -887,7 +887,7 @@ var LibrarySDL = {
       switch (event.type) {
         case 'keydown': case 'keyup': {
           var down = event.type === 'keydown';
-          //Module.print('Received key event: ' + event.keyCode);
+          //out('Received key event: ' + event.keyCode);
           var key = SDL.lookupKeyCodeForEvent(event);
           var scan;
           if (key >= 1024) {
@@ -1078,7 +1078,7 @@ var LibrarySDL = {
             info.audio.volume = info.volume; // For <audio> element
             if (info.audio.webAudioGainNode) info.audio.webAudioGainNode['gain']['value'] = info.volume; // For WebAudio playback
           } catch(e) {
-            Module.printErr('setGetVolume failed to set audio volume: ' + e);
+            err('setGetVolume failed to set audio volume: ' + e);
           }
         }
       }
@@ -1130,7 +1130,7 @@ var LibrarySDL = {
         audio.webAudioNode['start'](0, audio.currentPosition);
         audio.startTime = SDL.audioContext['currentTime'] - audio.currentPosition;
       } catch(e) {
-        Module.printErr('playWebAudio failed: ' + e);
+        err('playWebAudio failed: ' + e);
       }
     },
 
@@ -1148,7 +1148,7 @@ var LibrarySDL = {
           audio.webAudioNode.stop(0); // 0 is a default parameter, but WebKit is confused by it #3861
           audio.webAudioNode = undefined;
         } catch(e) {
-          Module.printErr('pauseWebAudio failed: ' + e);
+          err('pauseWebAudio failed: ' + e);
         }
       }
       audio.paused = true;
@@ -1507,17 +1507,17 @@ var LibrarySDL = {
   },
 
   SDL_VideoQuit: function() {
-    Module.print('SDL_VideoQuit called (and ignored)');
+    out('SDL_VideoQuit called (and ignored)');
   },
 
   SDL_QuitSubSystem: function(flags) {
-    Module.print('SDL_QuitSubSystem called (and ignored)');
+    out('SDL_QuitSubSystem called (and ignored)');
   },
 
   SDL_Quit__deps: ['SDL_AudioQuit'],
   SDL_Quit: function() {
     _SDL_AudioQuit();
-    Module.print('SDL_Quit called (and ignored)');
+    out('SDL_Quit called (and ignored)');
   },
 
   // Copy data from the canvas backing to a C++-accessible storage
@@ -2275,7 +2275,7 @@ var LibrarySDL = {
         filename = PATH.resolve(filename);
         var raw = Module["preloadedImages"][filename];
         if (!raw) {
-          if (raw === null) Module.printErr('Trying to reuse preloaded image, but freePreloadedMediaOnUse is set!');
+          if (raw === null) err('Trying to reuse preloaded image, but freePreloadedMediaOnUse is set!');
 #if STB_IMAGE
           var lengthBytes = lengthBytesUTF8(filename)+1;
           var name = Module['_malloc'](lengthBytes);
@@ -2345,7 +2345,7 @@ var LibrarySDL = {
             data[destPtr++] = 255;
           }
         } else {
-          Module.printErr('cannot handle bpp ' + raw.bpp);
+          err('cannot handle bpp ' + raw.bpp);
           return 0;
         }
         surfData.ctx.putImageData(imageData, 0, 0);
@@ -2379,7 +2379,7 @@ var LibrarySDL = {
   },
 
   IMG_Quit: function() {
-    Module.print('IMG_Quit called (and ignored)');
+    out('IMG_Quit called (and ignored)');
   },
 
   // SDL_Audio
@@ -2769,14 +2769,14 @@ var LibrarySDL = {
       filename = PATH.resolve(rwops.filename);
       var raw = Module["preloadedAudios"][filename];
       if (!raw) {
-        if (raw === null) Module.printErr('Trying to reuse preloaded audio, but freePreloadedMediaOnUse is set!');
+        if (raw === null) err('Trying to reuse preloaded audio, but freePreloadedMediaOnUse is set!');
         if (!Module.noAudioDecoding) warnOnce('Cannot find preloaded audio ' + filename);
 
         // see if we can read the file-contents from the in-memory FS
         try {
           bytes = FS.readFile(filename);
         } catch (e) {
-          Module.printErr('Couldn\'t find file for: ' + filename);
+          err('Couldn\'t find file for: ' + filename);
           return 0;
         }
       }
@@ -2911,7 +2911,7 @@ var LibrarySDL = {
         }
       }
       if (channel == -1) {
-        Module.printErr('All ' + SDL.numChannels + ' channels in use!');
+        err('All ' + SDL.numChannels + ' channels in use!');
         return -1;
       }
     }
@@ -3006,7 +3006,7 @@ var LibrarySDL = {
   Mix_PlayMusic: function(id, loops) {
     // Pause old music if it exists.
     if (SDL.music.audio) {
-      if (!SDL.music.audio.paused) Module.printErr('Music is already playing. ' + SDL.music.source);
+      if (!SDL.music.audio.paused) err('Music is already playing. ' + SDL.music.source);
       SDL.music.audio.pause();
     }
     var info = SDL.audios[id];
@@ -3102,7 +3102,7 @@ var LibrarySDL = {
     if (info && info.audio) {
       info.audio.pause();
     } else {
-      //Module.printErr('Mix_Pause: no sound found for channel: ' + channel);
+      //err('Mix_Pause: no sound found for channel: ' + channel);
     }
   },
 
@@ -3260,7 +3260,7 @@ var LibrarySDL = {
   TTF_FontLineSkip: 'TTF_FontHeight', // XXX
 
   TTF_Quit: function() {
-    Module.print('TTF_Quit called (and ignored)');
+    out('TTF_Quit called (and ignored)');
   },
 
   // SDL gfx

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -8,7 +8,7 @@ var funs = {
       __sigalrm_handler = func;
     } else {
 #if ASSERTIONS
-      Module.printErr('Calling stub instead of signal()');
+      err('Calling stub instead of signal()');
 #endif
     }
     return 0;
@@ -35,25 +35,25 @@ var funs = {
   sigaction: function(signum, act, oldact) {
     //int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of sigaction()');
+    err('Calling stub instead of sigaction()');
 #endif
     return 0;
   },
   sigprocmask: function() {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of sigprocmask()');
+    err('Calling stub instead of sigprocmask()');
 #endif
     return 0;
   },
   __libc_current_sigrtmin: function() {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of __libc_current_sigrtmin');
+    err('Calling stub instead of __libc_current_sigrtmin');
 #endif
     return 0;
   },
   __libc_current_sigrtmax: function() {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of __libc_current_sigrtmax');
+    err('Calling stub instead of __libc_current_sigrtmax');
 #endif
     return 0;
   },
@@ -63,7 +63,7 @@ var funs = {
     // Makes no sense in a single-process environment.
 	  // Should kill itself somtimes depending on `pid`
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of kill()');
+    err('Calling stub instead of kill()');
 #endif
     ___setErrNo(ERRNO_CODES.EPERM);
     return -1;
@@ -72,14 +72,14 @@ var funs = {
   killpg__deps: ['$ERRNO_CODES', '__setErrNo'],
   killpg: function() {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of killpg()');
+    err('Calling stub instead of killpg()');
 #endif
     ___setErrNo(ERRNO_CODES.EPERM);
     return -1;
   },
   siginterrupt: function() {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of siginterrupt()');
+    err('Calling stub instead of siginterrupt()');
 #endif
     return 0;
   },
@@ -87,7 +87,7 @@ var funs = {
   raise__deps: ['$ERRNO_CODES', '__setErrNo'],
   raise: function(sig) {
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of raise()');
+    err('Calling stub instead of raise()');
 #endif
   ___setErrNo(ERRNO_CODES.ENOSYS);
 #if ASSERTIONS
@@ -119,7 +119,7 @@ var funs = {
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/pause.html
     // We don't support signals, so we return immediately.
 #if ASSERTIONS
-    Module.printErr('Calling stub instead of pause()');
+    err('Calling stub instead of pause()');
 #endif
     ___setErrNo(ERRNO_CODES.EINTR);
     return -1;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -158,14 +158,14 @@ var SyscallsLibrary = {
       SYSCALLS.varargs += 4;
       var ret = {{{ makeGetValue('SYSCALLS.varargs', '-4', 'i32') }}};
 #if SYSCALL_DEBUG
-      Module.printErr('    (raw: "' + ret + '")');
+      err('    (raw: "' + ret + '")');
 #endif
       return ret;
     },
     getStr: function() {
       var ret = Pointer_stringify(SYSCALLS.get());
 #if SYSCALL_DEBUG
-      Module.printErr('    (str: "' + ret + '")');
+      err('    (str: "' + ret + '")');
 #endif
       return ret;
     },
@@ -174,7 +174,7 @@ var SyscallsLibrary = {
       var stream = FS.getStream(SYSCALLS.get());
       if (!stream) throw new FS.ErrnoError(ERRNO_CODES.EBADF);
 #if SYSCALL_DEBUG
-      Module.printErr('    (stream: "' + stream.path + '")');
+      err('    (stream: "' + stream.path + '")');
 #endif
       return stream;
     },
@@ -182,7 +182,7 @@ var SyscallsLibrary = {
       var socket = SOCKFS.getSocket(SYSCALLS.get());
       if (!socket) throw new FS.ErrnoError(ERRNO_CODES.EBADF);
 #if SYSCALL_DEBUG
-      Module.printErr('    (socket: "' + socket.path + '")');
+      err('    (socket: "' + socket.path + '")');
 #endif
       return socket;
     },
@@ -193,7 +193,7 @@ var SyscallsLibrary = {
       if (info.errno) throw new FS.ErrnoError(info.errno);
       info.addr = DNS.lookup_addr(info.addr) || info.addr;
 #if SYSCALL_DEBUG
-      Module.printErr('    (socketaddress: "' + [info.addr, info.port] + '")');
+      err('    (socketaddress: "' + [info.addr, info.port] + '")');
 #endif
       return info;
     },
@@ -203,7 +203,7 @@ var SyscallsLibrary = {
       if (low >= 0) assert(high === 0);
       else assert(high === -1);
 #if SYSCALL_DEBUG
-      Module.printErr('    (i64: "' + low + '")');
+      err('    (i64: "' + low + '")');
 #endif
       return low;
     },
@@ -315,7 +315,7 @@ var SyscallsLibrary = {
   __syscall54: function(which, varargs) { // ioctl
 #if NO_FILESYSTEM
 #if SYSCALL_DEBUG
-    Module.printErr('no-op in ioctl syscall due to NO_FILESYSTEM');
+    err('no-op in ioctl syscall due to NO_FILESYSTEM');
 #endif
     return 0;
 #else
@@ -325,7 +325,7 @@ var SyscallsLibrary = {
       case {{{ cDefine('TCGETS') }}}: {
         if (!stream.tty) return -ERRNO_CODES.ENOTTY;
 #if SYSCALL_DEBUG
-        Module.printErr('warning: not filling tio struct');
+        err('warning: not filling tio struct');
 #endif
         return 0;
       }
@@ -403,7 +403,7 @@ var SyscallsLibrary = {
   },
   __syscall77: function(which, varargs) { // getrusage
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var who = SYSCALLS.get(), usage = SYSCALLS.get();
     _memset(usage, 0, {{{ C_STRUCTS.rusage.__size__ }}});
@@ -881,7 +881,7 @@ var SyscallsLibrary = {
   },
   __syscall178: function(which, varargs) { // rt_sigqueueinfo
 #if SYSCALL_DEBUG
-    Module.printErr('warning: ignoring SYS_rt_sigqueueinfo');
+    err('warning: ignoring SYS_rt_sigqueueinfo');
 #endif
     return 0;
   },
@@ -904,7 +904,7 @@ var SyscallsLibrary = {
   },
   __syscall191: function(which, varargs) { // ugetrlimit
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var resource = SYSCALLS.get(), rlim = SYSCALLS.get();
     {{{ makeSetValue('rlim', C_STRUCTS.rlimit.rlim_cur, '-1', 'i32') }}};  // RLIM_INFINITY
@@ -999,7 +999,7 @@ var SyscallsLibrary = {
   __syscall209: '__syscall211',     // getresuid
   __syscall211: function(which, varargs) { // getresgid32
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var ruid = SYSCALLS.get(), euid = SYSCALLS.get(), suid = SYSCALLS.get();
     {{{ makeSetValue('ruid', '0', '0', 'i32') }}};
@@ -1047,7 +1047,7 @@ var SyscallsLibrary = {
   __syscall221: function(which, varargs) { // fcntl64
 #if NO_FILESYSTEM
 #if SYSCALL_DEBUG
-    Module.printErr('no-op in fcntl64 syscall due to NO_FILESYSTEM');
+    err('no-op in fcntl64 syscall due to NO_FILESYSTEM');
 #endif
     return 0;
 #else
@@ -1094,7 +1094,7 @@ var SyscallsLibrary = {
         return -1;
       default: {
 #if SYSCALL_DEBUG
-        Module.printErr('warning: fctl64 unrecognized command ' + cmd);
+        err('warning: fctl64 unrecognized command ' + cmd);
 #endif
         return -ERRNO_CODES.EINVAL;
       }
@@ -1103,7 +1103,7 @@ var SyscallsLibrary = {
   },
   __syscall265: function(which, varargs) { // clock_nanosleep
 #if SYSCALL_DEBUG
-    Module.printErr('warning: ignoring SYS_clock_nanosleep');
+    err('warning: ignoring SYS_clock_nanosleep');
 #endif
     return 0;
   },
@@ -1133,7 +1133,7 @@ var SyscallsLibrary = {
   },
   __syscall295: function(which, varargs) { // openat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), flags = SYSCALLS.get(), mode = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1141,7 +1141,7 @@ var SyscallsLibrary = {
   },
   __syscall296: function(which, varargs) { // mkdirat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), mode = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1149,7 +1149,7 @@ var SyscallsLibrary = {
   },
   __syscall297: function(which, varargs) { // mknodat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), mode = SYSCALLS.get(), dev = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1157,7 +1157,7 @@ var SyscallsLibrary = {
   },
   __syscall298: function(which, varargs) { // fchownat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), owner = SYSCALLS.get(), group = SYSCALLS.get(), flags = SYSCALLS.get();
     assert(flags === 0);
@@ -1178,7 +1178,7 @@ var SyscallsLibrary = {
   },
   __syscall301: function(which, varargs) { // unlinkat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), flags = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1193,7 +1193,7 @@ var SyscallsLibrary = {
   },
   __syscall302: function(which, varargs) { // renameat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var olddirfd = SYSCALLS.get(), oldpath = SYSCALLS.getStr(), newdirfd = SYSCALLS.get(), newpath = SYSCALLS.getStr();
     oldpath = SYSCALLS.calculateAt(olddirfd, oldpath);
@@ -1206,7 +1206,7 @@ var SyscallsLibrary = {
   },
   __syscall304: function(which, varargs) { // symlinkat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var target = SYSCALLS.get(), newdirfd = SYSCALLS.get(), linkpath = SYSCALLS.get();
     linkpath = SYSCALLS.calculateAt(newdirfd, linkpath);
@@ -1215,7 +1215,7 @@ var SyscallsLibrary = {
   },
   __syscall305: function(which, varargs) { // readlinkat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), buf = SYSCALLS.get(), bufsize = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1223,7 +1223,7 @@ var SyscallsLibrary = {
   },
   __syscall306: function(which, varargs) { // fchmodat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), mode = SYSCALLS.get(), flags = SYSCALLS.get();
     assert(flags === 0);
@@ -1233,7 +1233,7 @@ var SyscallsLibrary = {
   },
   __syscall307: function(which, varargs) { // faccessat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), amode = SYSCALLS.get(), flags = SYSCALLS.get();
     assert(flags === 0);
@@ -1245,7 +1245,7 @@ var SyscallsLibrary = {
   },
   __syscall320: function(which, varargs) { // utimensat
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), times = SYSCALLS.get(), flags = SYSCALLS.get();
     assert(flags === 0);
@@ -1268,7 +1268,7 @@ var SyscallsLibrary = {
   },
   __syscall330: function(which, varargs) { // dup3
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var old = SYSCALLS.getStreamFromFD(), suggestFD = SYSCALLS.get(), flags = SYSCALLS.get();
     assert(!flags);
@@ -1280,21 +1280,21 @@ var SyscallsLibrary = {
   },
   __syscall333: function(which, varargs) { // preadv
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var stream = SYSCALLS.getStreamFromFD(), iov = SYSCALLS.get(), iovcnt = SYSCALLS.get(), offset = SYSCALLS.get();
     return SYSCALLS.doReadv(stream, iov, iovcnt, offset);
   },
   __syscall334: function(which, varargs) { // pwritev
 #if SYSCALL_DEBUG
-    Module.printErr('warning: untested syscall');
+    err('warning: untested syscall');
 #endif
     var stream = SYSCALLS.getStreamFromFD(), iov = SYSCALLS.get(), iovcnt = SYSCALLS.get(), offset = SYSCALLS.get();
     return SYSCALLS.doWritev(stream, iov, iovcnt, offset);
   },
   __syscall337: function(which, varargs) { // recvmmsg
 #if SYSCALL_DEBUG
-    Module.printErr('warning: ignoring SYS_recvmmsg');
+    err('warning: ignoring SYS_recvmmsg');
 #endif
     return 0;
   },
@@ -1310,7 +1310,7 @@ var SyscallsLibrary = {
   },
   __syscall345: function(which, varargs) { // sendmmsg
 #if SYSCALL_DEBUG
-    Module.printErr('warning: ignoring SYS_sendmmsg');
+    err('warning: ignoring SYS_sendmmsg');
 #endif
     return 0;
   },
@@ -1682,14 +1682,14 @@ for (var x in SyscallsLibrary) {
 #endif
   pre += 'SYSCALLS.varargs = varargs;\n';
 #if SYSCALL_DEBUG
-  pre += "Module.printErr('syscall! ' + [" + which + ", '" + SYSCALL_CODE_TO_NAME[which] + "']);\n";
+  pre += "err('syscall! ' + [" + which + ", '" + SYSCALL_CODE_TO_NAME[which] + "']);\n";
   pre += "var canWarn = true;\n";
   pre += "var ret = (function() {\n";
   post += "})();\n";
   post += "if (ret < 0 && canWarn) {\n";
-  post += "  Module.printErr('error: syscall may have failed with ' + (-ret) + ' (' + ERRNO_MESSAGES[-ret] + ')');\n";
+  post += "  err('error: syscall may have failed with ' + (-ret) + ' (' + ERRNO_MESSAGES[-ret] + ')');\n";
   post += "}\n";
-  post += "Module.printErr('syscall return: ' + ret);\n";
+  post += "err('syscall return: ' + ret);\n";
   post += "return ret;\n";
 #endif
   pre += 'try {\n';
@@ -1698,7 +1698,7 @@ for (var x in SyscallsLibrary) {
   "  if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);\n";
 #if SYSCALL_DEBUG
   handler +=
-  "  Module.printErr('error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +
+  "  err('error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +
   "  canWarn = false;\n";
 #endif
   handler +=

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -821,7 +821,7 @@ var SyscallsLibrary = {
         var buffer = ___syscall146.buffers[stream];
         assert(buffer);
         if (curr === 0 || curr === {{{ charCode('\n') }}}) {
-          (stream === 1 ? Module['print'] : Module['printErr'])(UTF8ArrayToString(buffer, 0));
+          (stream === 1 ? out : err)(UTF8ArrayToString(buffer, 0));
           buffer.length = 0;
         } else {
           buffer.push(curr);

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -107,7 +107,7 @@ var LibraryTracing = {
         EmscriptenTrace.worker.postMessage({ 'cmd': 'post',
                                              'entry': entry });
       } else if (EmscriptenTrace.postEnabled && EmscriptenTrace.testingEnabled) {
-        Module.print('Tracing ' + entry);
+        out('Tracing ' + entry);
       }
     },
 

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -151,7 +151,7 @@ mergeInto(LibraryManager.library, {
       },
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
-          Module['print'](UTF8ArrayToString(tty.output, 0));
+          out(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {
           if (val != 0) tty.output.push(val); // val == 0 would cut text output off in the middle.
@@ -159,7 +159,7 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
-          Module['print'](UTF8ArrayToString(tty.output, 0));
+          out(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }
       }
@@ -167,7 +167,7 @@ mergeInto(LibraryManager.library, {
     default_tty1_ops: {
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
-          Module['printErr'](UTF8ArrayToString(tty.output, 0));
+          err(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {
           if (val != 0) tty.output.push(val);
@@ -175,7 +175,7 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
-          Module['printErr'](UTF8ArrayToString(tty.output, 0));
+          err(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }
       }

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -200,7 +200,7 @@ var LibraryWebVR = {
           if (e instanceof ExitStatus) {
             return;
           } else {
-            if (e && typeof e === 'object' && e.stack) Module.printErr('exception thrown in render loop of VR display ' + displayHandle.toString() + ': ' + [e, e.stack]);
+            if (e && typeof e === 'object' && e.stack) err('exception thrown in render loop of VR display ' + displayHandle.toString() + ': ' + [e, e.stack]);
             throw e;
           }
         }

--- a/src/modules.js
+++ b/src/modules.js
@@ -305,9 +305,14 @@ function exportRuntime() {
     // if requested to be exported, export it
     if (name in EXPORTED_RUNTIME_METHODS_SET) {
       var exported = name;
+      // the exported name may differ from the internal name
       if (isFSPrefixed(exported)) {
         // this is a filesystem value, FS.x exported as FS_x
         exported = 'FS.' + exported.substr(3);
+      } else if (exported === 'print') {
+        exported = 'out';
+      } else if (exported === 'printErr') {
+        exported = 'err';
       }
       return 'Module["' + name + '"] = ' + exported + ';';
     }
@@ -401,6 +406,8 @@ function exportRuntime() {
     'stackRestore',
     'stackAlloc',
     'establishStackSpace',
+    'print',
+    'printErr',
   ];
   if (SUPPORT_BASE64_EMBEDDING) {
     runtimeElements.push('intArrayFromBase64');

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1467,8 +1467,8 @@ function makeEval(code) {
   var ret = '';
   if (NO_DYNAMIC_EXECUTION == 2) {
     // Warn on evals, but proceed.
-    ret += "Module.printErr('Warning: NO_DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:');\n";
-    ret += "Module.printErr(stackTrace());\n";
+    ret += "err('Warning: NO_DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:');\n";
+    ret += "err(stackTrace());\n";
   }
   ret += code;
   return ret;

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -236,7 +236,7 @@ Module['callMain'] = function callMain(args) {
       if (e && typeof e === 'object' && e.stack) {
         toLog = [e, e.stack];
       }
-      Module.printErr('exception thrown: ' + toLog);
+      err('exception thrown: ' + toLog);
       Module['quit'](1, e);
     }
   } finally {
@@ -253,7 +253,7 @@ function run(args) {
 
   if (runDependencies > 0) {
 #if RUNTIME_LOGGING
-    Module.printErr('run() called, but dependencies remain, so not running');
+    err('run() called, but dependencies remain, so not running');
 #endif
     return;
   }
@@ -380,9 +380,9 @@ function exit(status, implicit) {
     // if exit() was called, we may warn the user if the runtime isn't actually being shut down
     if (!implicit) {
 #if NO_EXIT_RUNTIME
-      Module.printErr('exit(' + status + ') called, but NO_EXIT_RUNTIME is set, so halting execution but not exiting the runtime or preventing further async execution (build with NO_EXIT_RUNTIME=0, if you want a true shutdown)');
+      err('exit(' + status + ') called, but NO_EXIT_RUNTIME is set, so halting execution but not exiting the runtime or preventing further async execution (build with NO_EXIT_RUNTIME=0, if you want a true shutdown)');
 #else
-      Module.printErr('exit(' + status + ') called, but noExitRuntime is set due to an async operation, so halting execution but not exiting the runtime or preventing further async execution (you can use emscripten_force_exit, if you want to force a true shutdown)');
+      err('exit(' + status + ') called, but noExitRuntime is set due to an async operation, so halting execution but not exiting the runtime or preventing further async execution (you can use emscripten_force_exit, if you want to force a true shutdown)');
 #endif // NO_EXIT_RUNTIME
     }
 #endif // ASSERTIONS
@@ -418,8 +418,8 @@ function abort(what) {
   if (ENVIRONMENT_IS_PTHREAD) console.error('Pthread aborting at ' + new Error().stack);
 #endif
   if (what !== undefined) {
-    Module.print(what);
-    Module.printErr(what);
+    out(what);
+    err(what);
     what = JSON.stringify(what)
   } else {
     what = '';

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -321,10 +321,10 @@ function checkUnflushedContent() {
   // How we flush the streams depends on whether we are in NO_FILESYSTEM
   // mode (which has its own special function for this; otherwise, all
   // the code is inside libc)
-  var print = Module['print'];
-  var printErr = Module['printErr'];
+  var print = out;
+  var printErr = err;
   var has = false;
-  Module['print'] = Module['printErr'] = function(x) {
+  out = err = function(x) {
     has = true;
   }
   try { // it doesn't matter if it fails
@@ -351,8 +351,8 @@ function checkUnflushedContent() {
     }
 #endif
   } catch(e) {}
-  Module['print'] = print;
-  Module['printErr'] = printErr;
+  out = print;
+  err = printErr;
   if (has) {
     warnOnce('stdio streams had content in them that was not flushed. you should set NO_EXIT_RUNTIME to 0 (see the FAQ), or make sure to emit a newline when you printf etc.');
   }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -9,8 +9,8 @@
 //    is up at http://kripken.github.io/emscripten-site/docs/api_reference/preamble.js.html
 
 #if BENCHMARK
-Module.realPrint = Module.print;
-Module.print = Module.printErr = function(){};
+Module.realPrint = out;
+out = outErr = function(){};
 #endif
 
 #if SAFE_HEAP

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -10,7 +10,7 @@
 
 #if BENCHMARK
 Module.realPrint = out;
-out = outErr = function(){};
+out = err = function(){};
 #endif
 
 #if SAFE_HEAP

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -30,7 +30,7 @@ var SAFE_HEAP_COUNTER = 0;
 
 function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #if SAFE_HEAP_LOG
-  Module.print('SAFE_HEAP store: ' + [dest, value, bytes, isFloat, SAFE_HEAP_COUNTER++]);
+  out('SAFE_HEAP store: ' + [dest, value, bytes, isFloat, SAFE_HEAP_COUNTER++]);
 #endif
   if (dest <= 0) abort('segmentation fault storing ' + bytes + ' bytes to address ' + dest);
   if (dest % bytes !== 0) abort('alignment error storing to address ' + dest + ', which was expected to be aligned to a multiple of ' + bytes);
@@ -61,7 +61,7 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
   var ret = getValue(dest, type, 1);
   if (unsigned) ret = unSign(ret, parseInt(type.substr(1)), 1);
 #if SAFE_HEAP_LOG
-  Module.print('SAFE_HEAP load: ' + [dest, ret, bytes, isFloat, unsigned, SAFE_HEAP_COUNTER++]);
+  out('SAFE_HEAP load: ' + [dest, ret, bytes, isFloat, unsigned, SAFE_HEAP_COUNTER++]);
 #endif
   return ret;
 }
@@ -987,7 +987,7 @@ function enlargeMemory() {
 
   if (HEAP32[DYNAMICTOP_PTR>>2] > LIMIT) {
 #if ASSERTIONS
-    Module.printErr('Cannot enlarge memory, asked to go up to ' + HEAP32[DYNAMICTOP_PTR>>2] + ' bytes, but the limit is ' + LIMIT + ' bytes!');
+    err('Cannot enlarge memory, asked to go up to ' + HEAP32[DYNAMICTOP_PTR>>2] + ' bytes, but the limit is ' + LIMIT + ' bytes!');
 #endif
     return false;
   }
@@ -1016,9 +1016,9 @@ function enlargeMemory() {
   var replacement = Module['reallocBuffer'](TOTAL_MEMORY);
   if (!replacement || replacement.byteLength != TOTAL_MEMORY) {
 #if ASSERTIONS
-    Module.printErr('Failed to grow the heap from ' + OLD_TOTAL_MEMORY + ' bytes to ' + TOTAL_MEMORY + ' bytes, not enough memory!');
+    err('Failed to grow the heap from ' + OLD_TOTAL_MEMORY + ' bytes to ' + TOTAL_MEMORY + ' bytes, not enough memory!');
     if (replacement) {
-      Module.printErr('Expected to get back a buffer of size ' + TOTAL_MEMORY + ' bytes, but instead got back a buffer of size ' + replacement.byteLength);
+      err('Expected to get back a buffer of size ' + TOTAL_MEMORY + ' bytes, but instead got back a buffer of size ' + replacement.byteLength);
     }
 #endif
     // restore the state to before this call, we failed
@@ -1033,7 +1033,7 @@ function enlargeMemory() {
 
 #if ASSERTIONS
   if (!Module["usingWasm"]) {
-    Module.printErr('Warning: Enlarging memory arrays, this is not fast! ' + [OLD_TOTAL_MEMORY, TOTAL_MEMORY]);
+    err('Warning: Enlarging memory arrays, this is not fast! ' + [OLD_TOTAL_MEMORY, TOTAL_MEMORY]);
   }
 #endif
 
@@ -1060,7 +1060,7 @@ try {
 
 var TOTAL_STACK = Module['TOTAL_STACK'] || {{{ TOTAL_STACK }}};
 var TOTAL_MEMORY = Module['TOTAL_MEMORY'] || {{{ TOTAL_MEMORY }}};
-if (TOTAL_MEMORY < TOTAL_STACK) Module.printErr('TOTAL_MEMORY should be larger than TOTAL_STACK, was ' + TOTAL_MEMORY + '! (TOTAL_STACK=' + TOTAL_STACK + ')');
+if (TOTAL_MEMORY < TOTAL_STACK) err('TOTAL_MEMORY should be larger than TOTAL_STACK, was ' + TOTAL_MEMORY + '! (TOTAL_STACK=' + TOTAL_STACK + ')');
 
 // Initialize the runtime's memory
 #if ASSERTIONS
@@ -1214,7 +1214,7 @@ if (totalMemory === SPLIT_MEMORY) totalMemory *= 2;
 if (totalMemory !== TOTAL_MEMORY) {
   TOTAL_MEMORY = totalMemory;
 #if ASSERTIONS == 2
-  Module.printErr('increasing TOTAL_MEMORY to ' + TOTAL_MEMORY + ' to be a multiple>1 of the split memory size ' + SPLIT_MEMORY + ')');
+  err('increasing TOTAL_MEMORY to ' + TOTAL_MEMORY + ' to be a multiple>1 of the split memory size ' + SPLIT_MEMORY + ')');
 #endif
 }
 
@@ -1782,17 +1782,17 @@ function addRunDependency(id) {
         for (var dep in runDependencyTracking) {
           if (!shown) {
             shown = true;
-            Module.printErr('still waiting on run dependencies:');
+            err('still waiting on run dependencies:');
           }
-          Module.printErr('dependency: ' + dep);
+          err('dependency: ' + dep);
         }
         if (shown) {
-          Module.printErr('(end of list)');
+          err('(end of list)');
         }
       }, 10000);
     }
   } else {
-    Module.printErr('warning: run dependency added without ID');
+    err('warning: run dependency added without ID');
   }
 #endif
 }
@@ -1807,7 +1807,7 @@ function removeRunDependency(id) {
     assert(runDependencyTracking[id]);
     delete runDependencyTracking[id];
   } else {
-    Module.printErr('warning: run dependency removed without ID');
+    err('warning: run dependency removed without ID');
   }
 #endif
   if (runDependencies == 0) {
@@ -1835,7 +1835,7 @@ var PGOMonitor = {
       var func = this.allGenerated[i];
       if (!this.called[func]) dead.push(func);
     }
-    Module.print('-s DEAD_FUNCTIONS=\'' + JSON.stringify(dead) + '\'\n');
+    out('-s DEAD_FUNCTIONS=\'' + JSON.stringify(dead) + '\'\n');
   }
 };
 Module['PGOMonitor'] = PGOMonitor;
@@ -2053,7 +2053,7 @@ function integrateWasmJS() {
     // TODO: in shorter term, just copy up to the last static init write
     var oldBuffer = Module['buffer'];
     if (newBuffer.byteLength < oldBuffer.byteLength) {
-      Module['printErr']('the new buffer in mergeMemory is smaller than the previous one. in native wasm, we should grow memory here');
+      err('the new buffer in mergeMemory is smaller than the previous one. in native wasm, we should grow memory here');
     }
     var oldView = new Int8Array(oldBuffer);
     var newView = new Int8Array(newBuffer);
@@ -2140,7 +2140,7 @@ function integrateWasmJS() {
       }
     }
     if (typeof Module['asm'] !== 'function') {
-      Module['printErr']('asm evalling did not set the module properly');
+      err('asm evalling did not set the module properly');
       return false;
     }
     return Module['asm'](global, env, providedBuffer);
@@ -2155,12 +2155,12 @@ function integrateWasmJS() {
       abort('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.');
 #endif
 #endif
-      Module['printErr']('no native wasm support detected');
+      err('no native wasm support detected');
       return false;
     }
     // prepare memory import
     if (!(Module['wasmMemory'] instanceof WebAssembly.Memory)) {
-      Module['printErr']('no native wasm Memory in use');
+      err('no native wasm Memory in use');
       return false;
     }
     env['memory'] = Module['wasmMemory'];
@@ -2210,14 +2210,14 @@ function integrateWasmJS() {
       try {
         return Module['instantiateWasm'](info, receiveInstance);
       } catch(e) {
-        Module['printErr']('Module.instantiateWasm callback failed with error: ' + e);
+        err('Module.instantiateWasm callback failed with error: ' + e);
         return false;
       }
     }
 
 #if BINARYEN_ASYNC_COMPILATION
 #if RUNTIME_LOGGING
-    Module['printErr']('asynchronously preparing wasm');
+    err('asynchronously preparing wasm');
 #endif
 #if ASSERTIONS
     // Async compilation can be confusing when an error on the page overwrites Module
@@ -2238,7 +2238,7 @@ function integrateWasmJS() {
       getBinaryPromise().then(function(binary) {
         return WebAssembly.instantiate(binary, info);
       }).then(receiver).catch(function(reason) {
-        Module['printErr']('failed to asynchronously prepare wasm: ' + reason);
+        err('failed to asynchronously prepare wasm: ' + reason);
         abort(reason);
       });
     }
@@ -2252,8 +2252,8 @@ function integrateWasmJS() {
         .catch(function(reason) {
           // We expect the most common failure cause to be a bad MIME type for the binary,
           // in which case falling back to ArrayBuffer instantiation should work.
-          Module['printErr']('wasm streaming compile failed: ' + reason);
-          Module['printErr']('falling back to ArrayBuffer instantiation');
+          err('wasm streaming compile failed: ' + reason);
+          err('falling back to ArrayBuffer instantiation');
           instantiateArrayBuffer(receiveInstantiatedSource);
         });
     } else {
@@ -2265,9 +2265,9 @@ function integrateWasmJS() {
     try {
       instance = new WebAssembly.Instance(new WebAssembly.Module(getBinary()), info)
     } catch (e) {
-      Module['printErr']('failed to compile wasm module: ' + e);
+      err('failed to compile wasm module: ' + e);
       if (e.toString().indexOf('imported Memory with incompatible size') >= 0) {
-        Module['printErr']('Memory size incompatibility issues may be due to changing TOTAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set TOTAL_MEMORY at runtime to something smaller than it was at compile time).');
+        err('Memory size incompatibility issues may be due to changing TOTAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set TOTAL_MEMORY at runtime to something smaller than it was at compile time).');
       }
       return false;
     }
@@ -2279,7 +2279,7 @@ function integrateWasmJS() {
 #if BINARYEN_METHOD != 'native-wasm'
   function doWasmPolyfill(global, env, providedBuffer, method) {
     if (typeof WasmJS !== 'function') {
-      Module['printErr']('WasmJS not detected - polyfill not bundled?');
+      err('WasmJS not detected - polyfill not bundled?');
       return false;
     }
 
@@ -2443,7 +2443,7 @@ function integrateWasmJS() {
       var curr = methods[i];
 
 #if RUNTIME_LOGGING
-      Module['printErr']('trying binaryen method: ' + curr);
+      err('trying binaryen method: ' + curr);
 #endif
 
       finalMethod = curr;
@@ -2468,7 +2468,7 @@ function integrateWasmJS() {
 #endif
 
 #if RUNTIME_LOGGING
-    Module['printErr']('binaryen method succeeded.');
+    err('binaryen method succeeded.');
 #endif
 
     return exports;

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -141,11 +141,11 @@ worker.onmessage = function worker_onmessage(event) {
   var data = event.data;
   switch (data.target) {
     case 'stdout': {
-      out(data.content);
+      Module['print'](data.content);
       break;
     }
     case 'stderr': {
-      err(data.content);
+      Module['printErr'](data.content);
       break;
     }
     case 'window': {

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -141,11 +141,11 @@ worker.onmessage = function worker_onmessage(event) {
   var data = event.data;
   switch (data.target) {
     case 'stdout': {
-      Module.print(data.content);
+      out(data.content);
       break;
     }
     case 'stderr': {
-      Module.printErr(data.content);
+      err(data.content);
       break;
     }
     case 'window': {

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -129,7 +129,7 @@ window.close = function window_close() {
 };
 
 window.alert = function(text) {
-  Module.printErr('alert forever: ' + text);
+  err('alert forever: ' + text);
   while (1){};
 };
 

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -346,11 +346,11 @@ Module.canvas = document.createElement('canvas');
 
 Module.setStatus = function(){};
 
-Module.print = function Module_print(x) {
+out = function Module_print(x) {
   //dump('OUT: ' + x + '\n');
   postMessage({ target: 'stdout', content: x });
 };
-Module.printErr = function Module_printErr(x) {
+err = function Module_printErr(x) {
   //dump('ERR: ' + x + '\n');
   postMessage({ target: 'stderr', content: x });
 };

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -56,8 +56,8 @@ function threadAlert() {
   var text = Array.prototype.slice.call(arguments).join(' ');
   postMessage({cmd: 'alert', text: text, threadId: selfThreadId});
 }
-Module['print'] = threadPrint;
-Module['printErr'] = threadPrintErr;
+out = threadPrint;
+err = threadPrintErr;
 this.alert = threadAlert;
 
 // #if WASM

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -176,7 +176,7 @@ this.onmessage = function(e) {
         _emscripten_current_thread_process_queued_calls();
       }
     } else {
-      Module['printErr']('pthread-main.js received unknown command ' + e.data.cmd);
+      err('pthread-main.js received unknown command ' + e.data.cmd);
       console.error(e.data);
     }
   } catch(e) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -148,7 +148,7 @@ if (ENVIRONMENT_IS_NODE) {
   // deprecated, and in the future it will exit with error status.
   process['on']('unhandledRejection', function(reason, p) {
 #if ASSERTIONS
-    Module['printErr']('node.js exiting due to unhandled promise rejection');
+    err('node.js exiting due to unhandled promise rejection');
 #endif
     process['exit'](1);
   });
@@ -287,17 +287,22 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #endif // ASSERTIONS
 }
 
+// Set up the out() and err() hooks, which are how we can print to stdout or
+// stderr, respectively.
+// If the user provided Module.print or printErr, use that. Otherwise,
 // console.log is checked first, as 'print' on the web will open a print dialogue
 // printErr is preferable to console.warn (works better in shells)
 // bind(console) is necessary to fix IE/Edge closed dev tools panel behavior.
-Module['print'] = typeof console !== 'undefined' ? console.log.bind(console) : (typeof print !== 'undefined' ? print : null);
-Module['printErr'] = typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn.bind(console)) || Module['print']);
+var out = Module['print'] || (typeof console !== 'undefined' ? console.log.bind(console) : (typeof print !== 'undefined' ? print : null));
+var err = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn.bind(console)) || out));
+
+#if ASSERTIONS
+Module['print'] = Module['printErr'] = function() {
+  throw new Error('Module.print|printErr are deprecated - just call out() or err()');
+};
+#endif
 
 // *** Environment setup code ***
-
-// Closure helpers
-Module.print = Module['print'];
-Module.printErr = Module['printErr'];
 
 // Merge back in the overrides
 for (key in moduleOverrides) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -296,10 +296,17 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 var out = Module['print'] || (typeof console !== 'undefined' ? console.log.bind(console) : (typeof print !== 'undefined' ? print : null));
 var err = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn.bind(console)) || out));
 
+// Export Module.print|printErr here, if requested.
+{{{ 'print' in EXPORTED_RUNTIME_METHODS_SET ? "Module['print'] = out;" : '' }}}
+{{{ 'printErr' in EXPORTED_RUNTIME_METHODS_SET ? "Module['printErr'] = err;" : '' }}}
 #if ASSERTIONS
-Module['print'] = Module['printErr'] = function() {
-  throw new Error('Module.print|printErr are deprecated - just call out() or err()');
+function badPrintUsage() {
+  throw new Error('Calling Module.print|printErr is deprecated - just call out() or err() (but you can still define them on Module beforehand and they will be used');
 };
+// These may be set if the user provided them, or if the user asked them to be exported.
+// Otherwise, it is an error to call them.
+if (!Module['print']) Module['print'] = badPrintUsage;
+if (!Module['printErr']) Module['printErr'] = badPrintUsage;
 #endif
 
 // *** Environment setup code ***

--- a/src/shell.js
+++ b/src/shell.js
@@ -307,6 +307,8 @@ function badPrintUsage() {
 // Otherwise, it is an error to call them.
 if (!Module['print']) Module['print'] = badPrintUsage;
 if (!Module['printErr']) Module['printErr'] = badPrintUsage;
+if (!Module.print) Module.print = badPrintUsage;
+if (!Module.printErr) Module.printErr = badPrintUsage;
 #endif
 
 // *** Environment setup code ***

--- a/src/shell.js
+++ b/src/shell.js
@@ -296,21 +296,6 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 var out = Module['print'] || (typeof console !== 'undefined' ? console.log.bind(console) : (typeof print !== 'undefined' ? print : null));
 var err = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn.bind(console)) || out));
 
-// Export Module.print|printErr here, if requested.
-{{{ 'print' in EXPORTED_RUNTIME_METHODS_SET ? "Module['print'] = out;" : '' }}}
-{{{ 'printErr' in EXPORTED_RUNTIME_METHODS_SET ? "Module['printErr'] = err;" : '' }}}
-#if ASSERTIONS
-function badPrintUsage() {
-  throw new Error('Calling Module.print|printErr is deprecated - just call out() or err() (but you can still define them on Module beforehand and they will be used');
-};
-// These may be set if the user provided them, or if the user asked them to be exported.
-// Otherwise, it is an error to call them.
-if (!Module['print']) Module['print'] = badPrintUsage;
-if (!Module['printErr']) Module['printErr'] = badPrintUsage;
-if (!Module.print) Module.print = badPrintUsage;
-if (!Module.printErr) Module.printErr = badPrintUsage;
-#endif
-
 // *** Environment setup code ***
 
 // Merge back in the overrides

--- a/src/shell_sharedlib.js
+++ b/src/shell_sharedlib.js
@@ -3,9 +3,6 @@
   var Module = {};
   var args = [];
   Module.arguments = [];
-  out = parentModule.print;
-  err = parentModule.printErr;
-
   Module.cleanups = [];
 
   var gb = 0;

--- a/src/shell_sharedlib.js
+++ b/src/shell_sharedlib.js
@@ -3,8 +3,8 @@
   var Module = {};
   var args = [];
   Module.arguments = [];
-  Module.print = parentModule.print;
-  Module.printErr = parentModule.printErr;
+  out = parentModule.print;
+  err = parentModule.printErr;
 
   Module.cleanups = [];
 

--- a/src/support.js
+++ b/src/support.js
@@ -47,7 +47,7 @@ function warnOnce(text) {
   if (!warnOnce.shown) warnOnce.shown = {};
   if (!warnOnce.shown[text]) {
     warnOnce.shown[text] = 1;
-    Module.printErr(text);
+    err(text);
   }
 }
 
@@ -110,7 +110,7 @@ function loadDynamicLibrary(lib) {
       var curr = Module[sym], next = libModule[sym];
       // don't warn on functions - might be odr, linkonce_odr, etc.
       if (!(typeof curr === 'function' && typeof next === 'function')) {
-        Module.printErr("warning: trying to dynamically load symbol '" + sym + "' (from '" + lib + "') that already exists (duplicate symbol? or weak linking, which isn't supported yet?)"); // + [curr, ' vs ', next]);
+        err("warning: trying to dynamically load symbol '" + sym + "' (from '" + lib + "') that already exists (duplicate symbol? or weak linking, which isn't supported yet?)"); // + [curr, ' vs ', next]);
       }
     }
 #endif
@@ -331,7 +331,7 @@ function addFunction(func, sig) {
 #endif // WASM_BACKEND
 #if ASSERTIONS
   if (typeof sig === 'undefined') {
-    Module.printErr('warning: addFunction(): You should provide a wasm function signature string as a second argument. This is not necessary for asm.js and asm2wasm, but is required for the LLVM wasm backend, so it is recommended for full portability.');
+    err('warning: addFunction(): You should provide a wasm function signature string as a second argument. This is not necessary for asm.js and asm2wasm, but is required for the LLVM wasm backend, so it is recommended for full portability.');
   }
 #endif // ASSERTIONS
 #if EMULATED_FUNCTION_POINTERS == 0

--- a/system/lib/al.c
+++ b/system/lib/al.c
@@ -45,7 +45,7 @@ void* emscripten_GetAlcProcAddress(ALCchar *name) {
   else if (!strcmp(name, "alcResetDeviceSOFT")) { return emscripten_alcResetDeviceSOFT; }
 
   EM_ASM_({
-    Module.printErr("bad name in alcGetProcAddress: " + Pointer_stringify($0));
+    err("bad name in alcGetProcAddress: " + Pointer_stringify($0));
   }, name);
   return 0;
 }
@@ -132,7 +132,7 @@ void* emscripten_GetAlProcAddress(ALchar *name) {
   // Extensions
 
   EM_ASM_({
-    Module.printErr("bad name in alGetProcAddress: " + Pointer_stringify($0));
+    err("bad name in alGetProcAddress: " + Pointer_stringify($0));
   }, name);
   return 0;
 }

--- a/system/lib/fetch/asmfs.cpp
+++ b/system/lib/fetch/asmfs.cpp
@@ -131,7 +131,7 @@ static void link_inode(inode *node, inode *parent)
 {
 	char parentName[PATH_MAX];
 	inode_abspath(parent, parentName, PATH_MAX);
-	EM_ASM(Module['printErr']('link_inode: node "' + Pointer_stringify($0) + '" to parent "' + Pointer_stringify($1) + '".'), node->name, parentName);
+	EM_ASM(err('link_inode: node "' + Pointer_stringify($0) + '" to parent "' + Pointer_stringify($1) + '".'), node->name, parentName);
 	// When linking a node, it can't be part of the filesystem tree (but it can have children of its own)
 	assert(!node->parent);
 	assert(!node->sibling);
@@ -163,7 +163,7 @@ static inode *find_predecessor_sibling(inode *node, inode *parent)
 
 static void unlink_inode(inode *node)
 {
-	EM_ASM(Module['printErr']('unlink_inode: node ' + Pointer_stringify($0) + ' from its parent ' + Pointer_stringify($1) + '.'), node->name, node->parent->name);
+	EM_ASM(err('unlink_inode: node ' + Pointer_stringify($0) + ' from its parent ' + Pointer_stringify($1) + '.'), node->name, node->parent->name);
 	inode *parent = node->parent;
 	if (!parent) return;
 	node->parent = 0;
@@ -263,7 +263,7 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 	{
 		bool is_directory = false;
 		const char *child_path = path_cmp(path_to_file, node->name, &is_directory);
-		EM_ASM_INT( { Module['printErr']('path_cmp ' + Pointer_stringify($0) + ', ' + Pointer_stringify($1) + ', ' + Pointer_stringify($2) + ' .') }, path_to_file, node->name, child_path);
+		EM_ASM_INT( { err('path_cmp ' + Pointer_stringify($0) + ', ' + Pointer_stringify($1) + ', ' + Pointer_stringify($2) + ' .') }, path_to_file, node->name, child_path);
 		if (child_path)
 		{
 			if (is_directory && node->type != INODE_DIR) return 0; // "A component used as a directory in pathname is not, in fact, a directory"
@@ -295,15 +295,15 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 			node = node->sibling;
 		}
 	}
-	EM_ASM(Module['printErr']('path_to_file ' + Pointer_stringify($0) + ' .'), path_to_file);
+	EM_ASM(err('path_to_file ' + Pointer_stringify($0) + ' .'), path_to_file);
 	const char *basename_pos = basename_part(path_to_file);
-	EM_ASM(Module['printErr']('basename_pos ' + Pointer_stringify($0) + ' .'), basename_pos);
+	EM_ASM(err('basename_pos ' + Pointer_stringify($0) + ' .'), basename_pos);
 	while(*path_to_file && path_to_file < basename_pos)
 	{
 		node = create_inode(INODE_DIR, mode);
 		path_to_file += strcpy_inodename(node->name, path_to_file) + 1;
 		link_inode(node, root);
-		EM_ASM(Module['print']('create_directory_hierarchy_for_file: created directory ' + Pointer_stringify($0) + ' under parent ' + Pointer_stringify($1) + '.'), 
+		EM_ASM(out('create_directory_hierarchy_for_file: created directory ' + Pointer_stringify($0) + ' under parent ' + Pointer_stringify($1) + '.'), 
 			node->name, node->parent->name);
 		root = node;
 	}
@@ -326,7 +326,7 @@ static inode *find_parent_inode(inode *root, const char *path, int *out_errno)
 {
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
-	EM_ASM(Module['printErr']('find_parent_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+	EM_ASM(err('find_parent_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
 
 	assert(out_errno); // Passing in error is mandatory.
 
@@ -403,7 +403,7 @@ static inode *find_inode(inode *root, const char *path, int *out_errno)
 {
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
-	EM_ASM(Module['printErr']('find_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+	EM_ASM(err('find_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
 
 	assert(out_errno); // Passing in error is mandatory.
 
@@ -487,7 +487,7 @@ void emscripten_dump_fs_tree(inode *root, char *path)
 {
 	char str[256];
 	sprintf(str,"%s:", path);
-	EM_ASM(Module['print'](Pointer_stringify($0)), str);
+	EM_ASM(out(Pointer_stringify($0)), str);
 
 	// Print out:
 	// file mode | number of links | owner name | group name | file size in bytes | file last modified time | path name
@@ -513,14 +513,14 @@ void emscripten_dump_fs_tree(inode *root, char *path)
 			child->size,
 			child->name,
 			child->type == INODE_DIR ? '/' : ' ');
-		EM_ASM(Module['print'](Pointer_stringify($0)), str);
+		EM_ASM(out(Pointer_stringify($0)), str);
 
 		totalSize += child->size;
 		child = child->sibling;
 	}
 
 	sprintf(str, "total %llu bytes\n", totalSize);
-	EM_ASM(Module['print'](Pointer_stringify($0)), str);
+	EM_ASM(out(Pointer_stringify($0)), str);
 
 	child = root->child;
 	char *path_end = path + strlen(path);
@@ -538,13 +538,13 @@ void emscripten_dump_fs_tree(inode *root, char *path)
 
 void emscripten_dump_fs_root()
 {
-	EM_ASM({ Module['printErr']('emscripten_dump_fs_root()') });
+	EM_ASM({ err('emscripten_dump_fs_root()') });
 	char path[PATH_MAX] = "/";
 	emscripten_dump_fs_tree(filesystem_root(), path);
 }
 
 #define RETURN_ERRNO(errno, error_reason) do { \
-		EM_ASM(Module['printErr'](Pointer_stringify($0) + '() returned errno ' + #errno + '(' + $1 + '): ' + error_reason + '!'), __FUNCTION__, errno); \
+		EM_ASM(err(Pointer_stringify($0) + '() returned errno ' + #errno + '(' + $1 + '): ' + error_reason + '!'), __FUNCTION__, errno); \
 		return -errno; \
 	} while(0)
 
@@ -566,7 +566,7 @@ static void print_stream(void *bytes, int numBytes, bool stdout)
 		if (buffer[i] == '\n')
 		{
 			buffer[i] = 0;
-			EM_ASM_INT( { Module['print'](Pointer_stringify($0)) }, buffer+new_buffer_start);
+			EM_ASM_INT( { out(Pointer_stringify($0)) }, buffer+new_buffer_start);
 			new_buffer_start = i+1;
 		}
 	}
@@ -583,7 +583,7 @@ long __syscall3(int which, ...) // read
 	void *buf = va_arg(vl, void *);
 	size_t count = va_arg(vl, size_t);
 	va_end(vl);
-	EM_ASM(Module['printErr']('read(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
+	EM_ASM(err('read(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
 
 	iovec io = { buf, count };
 	return __syscall145(145/*readv*/, fd, &io, 1);
@@ -597,7 +597,7 @@ long __syscall4(int which, ...) // write
 	void *buf = va_arg(vl, void *);
 	size_t count = va_arg(vl, size_t);
 	va_end(vl);
-	EM_ASM(Module['printErr']('write(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
+	EM_ASM(err('write(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
 
 	iovec io = { buf, count };
 	return __syscall146(146/*writev*/, fd, &io, 1);
@@ -605,7 +605,7 @@ long __syscall4(int which, ...) // write
 
 static long open(const char *pathname, int flags, int mode)
 {
-	EM_ASM(Module['printErr']('open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ')'),
+	EM_ASM(err('open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ')'),
 		pathname, flags, mode);
 
 	int accessMode = (flags & O_ACCMODE);
@@ -619,7 +619,7 @@ static long open(const char *pathname, int flags, int mode)
 //	if ((flags & O_EXCL) && !(flags & O_CREAT)) RETURN_ERRNO(EINVAL, "open() with O_EXCL flag needs to always be paired with O_CREAT");
 	// However existing earlier unit tests in Emscripten expect that O_EXCL is simply ignored when O_CREAT was not passed. So do that for now.
 	if ((flags & O_EXCL) && !(flags & O_CREAT)) {
-		EM_ASM(Module['printErr']('warning: open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ': flag O_EXCL should always be paired with O_CREAT. Ignoring O_EXCL)'), pathname, flags, mode);
+		EM_ASM(err('warning: open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ': flag O_EXCL should always be paired with O_CREAT. Ignoring O_EXCL)'), pathname, flags, mode);
 		flags &= ~O_EXCL;
 	}
 
@@ -768,7 +768,7 @@ long __syscall5(int which, ...) // open
 
 static long close(int fd)
 {
-	EM_ASM(Module['printErr']('close(fd=' + $0 + ')'), fd);
+	EM_ASM(err('close(fd=' + $0 + ')'), fd);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -801,7 +801,7 @@ long __syscall9(int which, ...) // link
 	const char *oldpath = va_arg(vl, const char *);
 	const char *newpath = va_arg(vl, const char *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('link(oldpath="' + Pointer_stringify($0) + '", newpath="' + Pointer_stringify($1) + '")'), oldpath, newpath);
+	EM_ASM(err('link(oldpath="' + Pointer_stringify($0) + '", newpath="' + Pointer_stringify($1) + '")'), oldpath, newpath);
 
 	RETURN_ERRNO(ENOTSUP, "TODO: link() is a stub and not yet implemented in ASMFS");
 }
@@ -812,7 +812,7 @@ long __syscall10(int which, ...) // unlink
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('unlink(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('unlink(pathname="' + Pointer_stringify($0) + '")'), pathname);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -854,7 +854,7 @@ long __syscall12(int which, ...) // chdir
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('chdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('chdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -882,7 +882,7 @@ long __syscall14(int which, ...) // mknod
 	mode_t mode = va_arg(vl, mode_t);
 	int dev = va_arg(vl, int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('mknod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ', dev=' + $2 + ')'), pathname, mode, dev);
+	EM_ASM(err('mknod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ', dev=' + $2 + ')'), pathname, mode, dev);
 
 	RETURN_ERRNO(ENOTSUP, "TODO: mknod() is a stub and not yet implemented in ASMFS");
 }
@@ -894,7 +894,7 @@ long __syscall15(int which, ...) // chmod
 	const char *pathname = va_arg(vl, const char *);
 	int mode = va_arg(vl, int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('chmod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('chmod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -923,7 +923,7 @@ long __syscall33(int which, ...) // access
 	const char *pathname = va_arg(vl, const char *);
 	int mode = va_arg(vl, int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('access(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('access(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -954,7 +954,7 @@ long __syscall33(int which, ...) // access
 
 long __syscall36(int which, ...) // sync
 {
-	EM_ASM(Module['printErr']('sync()'));
+	EM_ASM(err('sync()'));
 
 	// Spec mandates that "sync() is always successful".
 	return 0;
@@ -969,7 +969,7 @@ long __syscall39(int which, ...) // mkdir
 	const char *pathname = va_arg(vl, const char *);
 	mode_t mode = va_arg(vl, mode_t);
 	va_end(vl);
-	EM_ASM(Module['printErr']('mkdir(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('mkdir(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1009,7 +1009,7 @@ long __syscall40(int which, ...) // rmdir
 	va_start(vl, which);
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('rmdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('rmdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1045,7 +1045,7 @@ long __syscall41(int which, ...) // dup
 	va_start(vl, which);
 	unsigned int fd = va_arg(vl, unsigned int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('dup(fd=' + $0 + ')'), fd);
+	EM_ASM(err('dup(fd=' + $0 + ')'), fd);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1068,7 +1068,7 @@ long __syscall54(int which, ...) // ioctl/sysctl
 	int request = va_arg(vl, int);
 	char *argp = va_arg(vl, char *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('ioctl(fd=' + $0 + ', request=' + $1 + ', argp=0x' + $2 + ')'), fd, request, argp);
+	EM_ASM(err('ioctl(fd=' + $0 + ', request=' + $1 + ', argp=0x' + $2 + ')'), fd, request, argp);
 	RETURN_ERRNO(ENOTSUP, "TODO: ioctl() is a stub and not yet implemented in ASMFS");
 }
 
@@ -1109,7 +1109,7 @@ long __syscall140(int which, ...) // llseek
 	off_t *result = va_arg(vl, off_t *);
 	unsigned int whence = va_arg(vl, unsigned int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('llseek(fd=' + $0 + ', offset_high=' + $1 + ', offset_low=' + $2 + ', result=0x' + ($3).toString(16) + ', whence=' + $4 + ')'),
+	EM_ASM(err('llseek(fd=' + $0 + ', offset_high=' + $1 + ', offset_low=' + $2 + ', result=0x' + ($3).toString(16) + ', whence=' + $4 + ')'),
 		fd, offset_high, offset_low, result, whence);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
@@ -1149,7 +1149,7 @@ long __syscall145(int which, ...) // readv
 	const iovec *iov = va_arg(vl, const iovec*);
 	int iovcnt = va_arg(vl, int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('readv(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
+	EM_ASM(err('readv(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1199,7 +1199,7 @@ long __syscall146(int which, ...) // writev
 	const iovec *iov = va_arg(vl, const iovec*);
 	int iovcnt = va_arg(vl, int);
 	va_end(vl);
-	EM_ASM(Module['printErr']('writev(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
+	EM_ASM(err('writev(fd=' + $0 + ', iov=0x' + ($1).toString(16) + ', iovcnt=' + $2 + ')'), fd, iov, iovcnt);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (fd != 1/*stdout*/ && fd != 2/*stderr*/) // TODO: Resolve the hardcoding of stdin,stdout & stderr
@@ -1271,7 +1271,7 @@ long __syscall183(int which, ...) // getcwd
 	char *buf = va_arg(vl, char *);
 	size_t size = va_arg(vl, size_t);
 	va_end(vl);
-	EM_ASM(Module['printErr']('getcwd(buf=0x' + $0 + ', size= ' + $1 + ')'), buf, size);
+	EM_ASM(err('getcwd(buf=0x' + $0 + ', size= ' + $1 + ')'), buf, size);
 
 	if (!buf && size > 0) RETURN_ERRNO(EFAULT, "buf points to a bad address");
 	if (buf && size == 0) RETURN_ERRNO(EINVAL, "The size argument is zero and buf is not a null pointer");
@@ -1327,7 +1327,7 @@ long __syscall195(int which, ...) // SYS_stat64
 	const char *pathname = va_arg(vl, const char *);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('SYS_stat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+	EM_ASM(err('SYS_stat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1364,7 +1364,7 @@ long __syscall196(int which, ...) // SYS_lstat64
 	const char *pathname = va_arg(vl, const char *);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('SYS_lstat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+	EM_ASM(err('SYS_lstat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
 
 	int len = strlen(pathname);
 	if (len > MAX_PATHNAME_LENGTH) RETURN_ERRNO(ENAMETOOLONG, "pathname was too long");
@@ -1393,7 +1393,7 @@ long __syscall197(int which, ...) // SYS_fstat64
 	int fd = va_arg(vl, int);
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
-	EM_ASM(Module['printErr']('SYS_fstat64(fd="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), fd, buf);
+	EM_ASM(err('SYS_fstat64(fd="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), fd, buf);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "fd isn't a valid open file descriptor");
@@ -1419,7 +1419,7 @@ long __syscall220(int which, ...) // getdents64 (get directory entries 64-bit)
 	va_end(vl);
 	unsigned int dirents_size = count / sizeof(dirent); // The number of dirent structures that can fit into the provided buffer.
 	dirent *de_end = de + dirents_size;
-	EM_ASM(Module['printErr']('getdents64(fd=' + $0 + ', de=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, de, count);
+	EM_ASM(err('getdents64(fd=' + $0 + ', de=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, de, count);
 
 	FileDescriptor *desc = (FileDescriptor*)fd;
 	if (!desc || desc->magic != EM_FILEDESCRIPTOR_MAGIC) RETURN_ERRNO(EBADF, "Invalid file descriptor fd");

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -60,7 +60,7 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 	const bool isMainBrowserThread = emscripten_is_main_browser_thread() != 0;
 	if (isMainBrowserThread && synchronous && (performXhr || readFromIndexedDB || writeToIndexedDB))
 	{
-		EM_ASM(Module['printErr']('emscripten_fetch("' + Pointer_stringify($0) + '") failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.'), 
+		EM_ASM(err('emscripten_fetch("' + Pointer_stringify($0) + '") failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.'), 
 			url);
 		return 0;
 	}

--- a/system/lib/split_malloc.cpp
+++ b/system/lib/split_malloc.cpp
@@ -81,7 +81,7 @@ struct Space {
     space = create_mspace_with_base((void*)start, size, 0);
     if (index == 0) {
       if (!space) {
-        EM_ASM({ Module.printErr("failed to create space in the first split memory chunk - SPLIT_MEMORY might need to be larger"); });
+        EM_ASM({ err("failed to create space in the first split memory chunk - SPLIT_MEMORY might need to be larger"); });
       }
     }
     assert(space);
@@ -133,7 +133,7 @@ static void* get_memory(size_t size, bool malloc=true, size_t alignment=-1, bool
     static bool warned = false;
     if (!warned) {
       EM_ASM({
-        Module.print("trying to get " + $0 + ", a size >= than SPLIT_MEMORY (" + $1 + "), increase SPLIT_MEMORY if you want that to work");
+        out("trying to get " + $0 + ", a size >= than SPLIT_MEMORY (" + $1 + "), increase SPLIT_MEMORY if you want that to work");
       }, size, split_memory);
       warned = true;
     }
@@ -159,7 +159,7 @@ static void* get_memory(size_t size, bool malloc=true, size_t alignment=-1, bool
         return ret;
       }
       if (must_succeed) {
-        EM_ASM({ Module.printErr("failed to allocate in a new space after memory growth, perhaps increase SPLIT_MEMORY?"); });
+        EM_ASM({ err("failed to allocate in a new space after memory growth, perhaps increase SPLIT_MEMORY?"); });
         abort();
       }
     } else {
@@ -240,7 +240,7 @@ void* sbrk(intptr_t increment) {
   if (start == -1) {
     start = (size_t)malloc(SBRK_CHUNK);
     if (!start) {
-      EM_ASM({ Module.printErr("sbrk() failed to get space"); });
+      EM_ASM({ err("sbrk() failed to get space"); });
       abort();
     }
     curr = start;

--- a/tests/benchmark_utf16.cpp
+++ b/tests/benchmark_utf16.cpp
@@ -10,7 +10,7 @@ double test(const unsigned short *str) {
     var t0 = _emscripten_get_now();
     var str = Module.UTF16ToString($0);
     var t1 = _emscripten_get_now();
-    Module.print('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
+    out('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
     return (t1-t0);
   }, str);
   return res;

--- a/tests/benchmark_utf8.cpp
+++ b/tests/benchmark_utf8.cpp
@@ -10,7 +10,7 @@ double test(const char *str) {
     var t0 = _emscripten_get_now();
     var str = Module.UTF8ToString($0);
     var t1 = _emscripten_get_now();
-//    Module.print('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
+//    out('t: ' + (t1 - t0) + ', len(result): ' + str.length + ', result: ' + str.slice(0, 100));
     return (t1-t0);
   }, str);
   return res;

--- a/tests/browser_test_hello_world.c
+++ b/tests/browser_test_hello_world.c
@@ -6,9 +6,9 @@ int main() {
   EM_ASM({
     Module.prints = [];
 
-    var real = Module['print'];
+    var real = out;
 
-    Module['print'] = function(x) {
+    out = function(x) {
       real(x);
       Module.prints.push(x);
     }

--- a/tests/cases/emptyalloca.ll
+++ b/tests/cases/emptyalloca.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
 target triple = "asmjs-unknown-emscripten"
 
-@.str = private unnamed_addr constant [30 x i8] c"Module.print('hello, world!')\00", align 1
+@.str = private unnamed_addr constant [21 x i8] c"out('hello, world!')\00", align 1
 
 ; Function Attrs: nounwind
 define internal void @_Z9doNothingPi(i32* %arr) #0 {
@@ -17,7 +17,7 @@ define i32 @main() #1 {
   call void @llvm.memset.p0i8.i32(i8* %1, i8 0, i32 0, i32 4, i1 false)
   %2 = getelementptr inbounds [0 x i32], [0 x i32]* %arr, i32 0, i32 0
   call void @_Z9doNothingPi(i32* %2)
-  call void @emscripten_asm_const(i8* getelementptr inbounds ([30 x i8], [30 x i8]* @.str, i32 0, i32 0))
+  call void @emscripten_asm_const(i8* getelementptr inbounds ([21 x i8], [21 x i8]* @.str, i32 0, i32 0))
   ret i32 0
 }
 

--- a/tests/core/FS_exports.cpp
+++ b/tests/core/FS_exports.cpp
@@ -18,7 +18,7 @@ int main() {
 #endif
   EM_ASM({
     // use eval, so that the compiler can't see FS usage statically
-    eval('Module.print("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents["file.txt"])))');
+    eval('out("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents["file.txt"])))');
   });
 }
 

--- a/tests/core/dyncall.c
+++ b/tests/core/dyncall.c
@@ -2,7 +2,7 @@
 
 void waka(int x, int y, int z) {
   EM_ASM({
-    Module['print']('received ' + [$0, $1, $2] + '.');
+    out('received ' + [$0, $1, $2] + '.');
   }, x, y, z);
 }
 

--- a/tests/core/dyncall_specific.c
+++ b/tests/core/dyncall_specific.c
@@ -2,7 +2,7 @@
 
 void waka(int x, int y, int z) {
   EM_ASM({
-    Module['print']('received ' + [$0, $1, $2] + '.');
+    out('received ' + [$0, $1, $2] + '.');
   }, x, y, z);
 }
 

--- a/tests/core/getValue_setValue.cpp
+++ b/tests/core/getValue_setValue.cpp
@@ -4,12 +4,12 @@ int main() {
 #ifdef DIRECT
   EM_ASM({
     setValue(8, 1234, 'i32');
-    Module['print']('|' + getValue(8, 'i32') + '|');
+    out('|' + getValue(8, 'i32') + '|');
   });
 #else
   EM_ASM({
     Module['setValue'](8, 1234, 'i32');
-    Module['print']('|' + Module['getValue'](8, 'i32') + '|');
+    out('|' + Module['getValue'](8, 'i32') + '|');
   });
 #endif
 }

--- a/tests/core/legacy_exported_runtime_numbers.cpp
+++ b/tests/core/legacy_exported_runtime_numbers.cpp
@@ -3,11 +3,11 @@
 int main() {
 #ifdef DIRECT
   EM_ASM({
-    Module['print']('|' + ALLOC_DYNAMIC + '|');
+    out('|' + ALLOC_DYNAMIC + '|');
   });
 #else
   EM_ASM({
-    Module['print']('|' + Module['ALLOC_DYNAMIC'] + '|');
+    out('|' + Module['ALLOC_DYNAMIC'] + '|');
   });
 #endif
 }

--- a/tests/core/modularize_closure_pre.c
+++ b/tests/core/modularize_closure_pre.c
@@ -2,7 +2,7 @@
 
 int main() {
   EM_ASM({
-    Module['print'](Module['on_module']);
+    out(Module['on_module']);
   });
 }
 

--- a/tests/core/stackAlloc.cpp
+++ b/tests/core/stackAlloc.cpp
@@ -25,6 +25,6 @@ int main() {
     notInRange(y, z, z + direction*size);
     notInRange(z, x, x + direction*size);
     notInRange(z, y, y + direction*size);
-    Module['print']('ok.');
+    out('ok.');
   });
 }

--- a/tests/core/test_demangle_stacks.cpp
+++ b/tests/core/test_demangle_stacks.cpp
@@ -11,7 +11,7 @@ class Class {
     volatile int w = 1;
     if (w) {
       EM_ASM({
-        Module['print'](stackTrace());
+        out(stackTrace());
       });
       abort();
     }

--- a/tests/core/test_dlmalloc_partial_2.c
+++ b/tests/core/test_dlmalloc_partial_2.c
@@ -4,8 +4,8 @@
 void *malloc(size_t size) { return (void *)123; }
 int main() {
   void *x = malloc(10);
-  EM_ASM({ Module.print("got 0x" + $0.toString(16)) }, x);
+  EM_ASM({ out("got 0x" + $0.toString(16)) }, x);
   free(0);
-  EM_ASM({ Module.print("freed a fake") });
+  EM_ASM({ out("freed a fake") });
   return 1;
 }

--- a/tests/core/test_em_asm.cpp
+++ b/tests/core/test_em_asm.cpp
@@ -3,24 +3,24 @@
 
 int main() {
   printf("BEGIN\n");
-  EM_ASM({ Module['print']("no args works"); });
+  EM_ASM({ out("no args works"); });
 
   // The following two lines are deprecated, test them still.
-  printf("  EM_ASM_INT_V returned: %d\n", EM_ASM_INT_V({ Module['print']("no args returning int"); return 12; }));
-  printf("  EM_ASM_DOUBLE_V returned: %f\n", EM_ASM_DOUBLE_V({ Module['print']("no args returning double"); return 12.25; }));
+  printf("  EM_ASM_INT_V returned: %d\n", EM_ASM_INT_V({ out("no args returning int"); return 12; }));
+  printf("  EM_ASM_DOUBLE_V returned: %f\n", EM_ASM_DOUBLE_V({ out("no args returning double"); return 12.25; }));
 
-  printf("  EM_ASM_INT returned: %d\n", EM_ASM_INT({ Module['print']("no args returning int"); return 12; }));
-  printf("  EM_ASM_DOUBLE returned: %f\n", EM_ASM_DOUBLE({ Module['print']("no args returning double"); return 12.25; }));
+  printf("  EM_ASM_INT returned: %d\n", EM_ASM_INT({ out("no args returning int"); return 12; }));
+  printf("  EM_ASM_DOUBLE returned: %f\n", EM_ASM_DOUBLE({ out("no args returning double"); return 12.25; }));
 
 #define TEST() \
-  FUNC({ Module['print']("  takes ints: " + $0);}, 5); \
-  FUNC({ Module['print']("  takes doubles: " + $0);}, 5.0675); \
-  FUNC({ Module['print']("  takes strings: " + Pointer_stringify($0)); return 7.75; }, "string arg"); \
-  FUNC({ Module['print']("  takes multiple ints: " + $0 + ", " + $1); return 6; }, 5, 7); \
-  FUNC({ Module['print']("  mixed arg types: " + $0 + ", " + Pointer_stringify($1) + ", " + $2); return 8.125; }, 3, "hello", 4.75); \
-  FUNC({ Module['print']("  ignores unused args"); return 5.5; }, 0);     \
-  FUNC({ Module['print']("  skips unused args: " + $1); return 6; }, 5, 7); \
-  FUNC({ Module['print']("  " + $0 + " + " + $2); return $0 + $2; }, 5.5, 7.0, 14.375);
+  FUNC({ out("  takes ints: " + $0);}, 5); \
+  FUNC({ out("  takes doubles: " + $0);}, 5.0675); \
+  FUNC({ out("  takes strings: " + Pointer_stringify($0)); return 7.75; }, "string arg"); \
+  FUNC({ out("  takes multiple ints: " + $0 + ", " + $1); return 6; }, 5, 7); \
+  FUNC({ out("  mixed arg types: " + $0 + ", " + Pointer_stringify($1) + ", " + $2); return 8.125; }, 3, "hello", 4.75); \
+  FUNC({ out("  ignores unused args"); return 5.5; }, 0);     \
+  FUNC({ out("  skips unused args: " + $1); return 6; }, 5, 7); \
+  FUNC({ out("  " + $0 + " + " + $2); return $0 + $2; }, 5.5, 7.0, 14.375);
 
 #define FUNC_WITH(macro, format, ...) printf("    returned: " format "\n", macro(__VA_ARGS__));
 #define FUNC(...) FUNC_WITH(EM_ASM_, "%d", __VA_ARGS__)

--- a/tests/core/test_em_asm_parameter_pack.cpp
+++ b/tests/core/test_em_asm_parameter_pack.cpp
@@ -3,7 +3,7 @@ template <typename... Args>
 int call(Args... args) {
   return(EM_ASM_INT(
     {
-      Module.print(Array.prototype.join.call(arguments, ','));
+      out(Array.prototype.join.call(arguments, ','));
     },
     args...
   ));

--- a/tests/core/test_em_asm_unicode.cpp
+++ b/tests/core/test_em_asm_unicode.cpp
@@ -1,5 +1,5 @@
 #include <emscripten.h>
 
 int main() {
-  EM_ASM( Module.print("hello world…") );
+  EM_ASM( out("hello world…") );
 }

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -1,43 +1,43 @@
 #include <emscripten.h>
 #include <stdio.h>
 
-EM_JS(void, noarg, (void), { Module['print']("no args works"); });
+EM_JS(void, noarg, (void), { out("no args works"); });
 EM_JS(int, noarg_int, (void), {
-  Module['print']("no args returning int");
+  out("no args returning int");
   return 12;
 });
 EM_JS(double, noarg_double, (void), {
-  Module['print']("no args returning double");
+  out("no args returning double");
   return 12.25;
 });
-EM_JS(void, intarg, (int x), { Module['print']("  takes ints: " + x);});
-EM_JS(void, doublearg, (double d), { Module['print']("  takes doubles: " + d);});
+EM_JS(void, intarg, (int x), { out("  takes ints: " + x);});
+EM_JS(void, doublearg, (double d), { out("  takes doubles: " + d);});
 EM_JS(double, stringarg, (char* str), {
-  Module['print']("  takes strings: " + Pointer_stringify(str));
+  out("  takes strings: " + Pointer_stringify(str));
   return 7.75;
 });
 EM_JS(int, multi_intarg, (int x, int y), {
-  Module['print']("  takes multiple ints: " + x + ", " + y);
+  out("  takes multiple ints: " + x + ", " + y);
   return 6;
 });
 EM_JS(double, multi_mixedarg, (int x, const char* str, double d), {
-  Module['print']("  mixed arg types: " + x + ", " + Pointer_stringify(str) + ", " + d);
+  out("  mixed arg types: " + x + ", " + Pointer_stringify(str) + ", " + d);
   return 8.125;
 });
 EM_JS(int, unused_args, (int unused), {
-  Module['print']("  ignores unused args");
+  out("  ignores unused args");
   return 5.5;
 });
 EM_JS(double, skip_args, (int x, int y), {
-  Module['print']("  skips unused args: " + y);
+  out("  skips unused args: " + y);
   return 6;
 });
 EM_JS(double, add_outer, (double x, double y, double z), {
-  Module['print']("  " + x + " + " + z);
+  out("  " + x + " + " + z);
   return x + z;
 });
 EM_JS(int, user_separator, (void), {
-  Module['print']("  can use <::> separator in user code");
+  out("  can use <::> separator in user code");
   return 15;
 });
 EM_JS(int, user_comma, (void), {
@@ -45,7 +45,7 @@ EM_JS(int, user_comma, (void), {
   x = {};
   y = 3;
   x[y] = [1, 2, 3];
-  Module['print']("  can have commas in user code: " + x[y]);
+  out("  can have commas in user code: " + x[y]);
   return x[y][1];
 });
 

--- a/tests/core/test_embind_5.cpp
+++ b/tests/core/test_embind_5.cpp
@@ -7,20 +7,20 @@ using namespace emscripten;
 class MyFoo {
 public:
   MyFoo() {
-    EM_ASM({Module.print("constructing my foo");});
+    EM_ASM({out("constructing my foo");});
   }
   virtual void doit() {
-    EM_ASM({Module.print("doing it");});
+    EM_ASM({out("doing it");});
   }
 };
 
 class MyBar : public MyFoo {
 public:
   MyBar() {
-    EM_ASM({Module.print("constructing my bar");});
+    EM_ASM({out("constructing my bar");});
   }
   void doit() override {
-    EM_ASM({Module.print("doing something else");});
+    EM_ASM({out("doing something else");});
   }
 };
 
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
       var bar = new Module.MyBar();
       bar.doit();
     } catch(e) {
-      Module.print(e);
+      out(e);
     }
   );
   return 0;

--- a/tests/core/test_emmalloc.cpp
+++ b/tests/core/test_emmalloc.cpp
@@ -28,7 +28,7 @@ void check_where_we_would_malloc(size_t size, void* expected) {
 
 void stage(const char* name) {
   EM_ASM({
-    Module.print('\n>> ' + Pointer_stringify($0) + '\n');
+    out('\n>> ' + Pointer_stringify($0) + '\n');
   }, name);
 }
 

--- a/tests/core/test_emscripten_api.cpp
+++ b/tests/core/test_emscripten_api.cpp
@@ -9,7 +9,7 @@ void save_me_aimee() { printf("mann\n"); }
 
 int main() {
   // EMSCRIPTEN_COMMENT("hello from the source");
-  emscripten_run_script("Module.print('hello world' + '!')");
+  emscripten_run_script("out('hello world' + '!')");
   printf("*%d*\n", emscripten_run_script_int("5*20"));
   printf("*%s*\n", emscripten_run_script_string("'five'+'six'"));
   emscripten_run_script("Module['_save_me_aimee']()");

--- a/tests/core/test_inlinejs.c
+++ b/tests/core/test_inlinejs.c
@@ -12,13 +12,13 @@ double get() {
 }
 
 int main() {
-  asm("Module.print('Inline JS is very cool')");
+  asm("out('Inline JS is very cool')");
   printf("%.2f\n", get());
 
   // Test that passing multiple input and output variables works.
   int src1 = 1, src2 = 2, src3 = 3;
   int dst1 = 0, dst2 = 0, dst3 = 0;
-  // TODO asm("Module.print(%3); Module.print(%4); Module.print(%5); %0 = %3; %1
+  // TODO asm("out(%3); out(%4); out(%5); %0 = %3; %1
   // = %4; %2 = %5;" : "=r"(dst1),"=r"(dst2),"=r"(dst3):
   // "r"(src1),"r"(src2),"r"(src3));
   // TODO printf("%d\n%d\n%d\n", dst1, dst2, dst3);

--- a/tests/core/test_inlinejs2.c
+++ b/tests/core/test_inlinejs2.c
@@ -7,8 +7,8 @@ int mix(int x, int y) {
 }
 
 void mult() {
-  asm("var $_$1 = Math.abs(-100); $_$1 *= 2; Module.print($_$1)");  // multiline
-  asm __volatile__("Module.print('done')");
+  asm("var $_$1 = Math.abs(-100); $_$1 *= 2; out($_$1)");  // multiline
+  asm __volatile__("out('done')");
 }
 
 int main(int argc, char **argv) {

--- a/tests/core/test_inlinejs3.c
+++ b/tests/core/test_inlinejs3.c
@@ -2,22 +2,22 @@
 #include <emscripten.h>
 
 void loop_iter() {
-  EM_ASM(Module.print('loop iter!'));
+  EM_ASM(out('loop iter!'));
 }
 
 int main(int argc, char **argv) {
-  EM_ASM(Module.print('hello dere1'));
-  EM_ASM("Module.print('hello dere2');");
+  EM_ASM(out('hello dere1'));
+  EM_ASM("out('hello dere2');");
   emscripten_debugger(); // does nothing in shells; check for validation error though
   for (int i = 0; i < 3; i++) {
-    EM_ASM(Module.print('hello dere3'); Module.print('hello dere' + 4););
+    EM_ASM(out('hello dere3'); out('hello dere' + 4););
   }
-  EM_ASM_({ Module.print('hello input ' + $0) }, 123);
-  EM_ASM_ARGS({ Module.print('hello input ' + $0) }, 456);
+  EM_ASM_({ out('hello input ' + $0) }, 123);
+  EM_ASM_ARGS({ out('hello input ' + $0) }, 456);
   int sum = 0;
   for (int i = 0; i < argc * 3; i++) {
     sum += EM_ASM_INT({
-                        Module.print('i: ' + [ $0, ($1).toFixed(2) ]);
+                        out('i: ' + [ $0, ($1).toFixed(2) ]);
                         return $0 * 2;
                       },
                       i, double(i) / 12);

--- a/tests/core/test_lower_intrinsics.c
+++ b/tests/core/test_lower_intrinsics.c
@@ -22,7 +22,7 @@ int main() {
   TEST2(pow);
 
   EM_ASM({
-    Module.print('ok.');
+    out('ok.');
   });
 }
 

--- a/tests/core/test_main_module_static_align.cpp
+++ b/tests/core/test_main_module_static_align.cpp
@@ -6,8 +6,8 @@ int main() {
   emscripten_log(EM_LOG_WARN, "16-byte aligned char: %d.", int(&aligned));
   EM_ASM({
     // whether the char was properly aligned affects tempDoublePtr, which is after the static aligns
-    Module['print']('tempDoublePtr: ' + tempDoublePtr + '.');
-    Module['print']('tempDoublePtr alignment: ' + (tempDoublePtr % 16) + '.');
+    out('tempDoublePtr: ' + tempDoublePtr + '.');
+    out('tempDoublePtr alignment: ' + (tempDoublePtr % 16) + '.');
   });
 }
 

--- a/tests/core/test_main_thread_async_em_asm.cpp
+++ b/tests/core/test_main_thread_async_em_asm.cpp
@@ -6,6 +6,6 @@ int main()
 	// Test that on main browser thread, MAIN_THREAD_ASYNC_EM_ASM() will get
 	// synchronously executed.
 	printf("Before MAIN_THREAD_ASYNC_EM_ASM\n");
-	MAIN_THREAD_ASYNC_EM_ASM(Module.print('Inside MAIN_THREAD_ASYNC_EM_ASM: ' + $0 + ' ' + $1), 42, 3.5);
+	MAIN_THREAD_ASYNC_EM_ASM(out('Inside MAIN_THREAD_ASYNC_EM_ASM: ' + $0 + ' ' + $1), 42, 3.5);
 	printf("After MAIN_THREAD_ASYNC_EM_ASM\n");
 }

--- a/tests/core/test_runtime_stacksave.c
+++ b/tests/core/test_runtime_stacksave.c
@@ -4,8 +4,8 @@
 int main() {
   int x = EM_ASM_INT({ return stackSave(); });
   int y = EM_ASM_INT({ return stackSave(); });
-  EM_ASM_INT({ Module.print($0); }, &x);
-  EM_ASM_INT({ Module.print($0); }, &y);
+  EM_ASM_INT({ out($0); }, &x);
+  EM_ASM_INT({ out($0); }, &y);
   assert(x == y);
-  EM_ASM({ Module.print('success'); });
+  EM_ASM({ out('success'); });
 }

--- a/tests/core/test_utf.c
+++ b/tests/core/test_utf.c
@@ -8,7 +8,7 @@ int main() {
   emscripten_run_script(
       "cheez = _malloc(100);"
       "Module.stringToUTF8(\"μ†ℱ ╋ℯ╳╋ 😇\", cheez, 100);"
-      "Module.print([Pointer_stringify(cheez), Module.getValue(cheez, "
+      "out([Pointer_stringify(cheez), Module.getValue(cheez, "
       "'i8')&0xff, Module.getValue(cheez+1, 'i8')&0xff, "
       "Module.getValue(cheez+2, 'i8')&0xff, Module.getValue(cheez+3, "
       "'i8')&0xff].join(','));");

--- a/tests/embind/embind.benchmark.js
+++ b/tests/embind/embind.benchmark.js
@@ -15,7 +15,7 @@ function _increment_counter_benchmark_js(N) {
     }
     var b = _emscripten_get_now();
     var ctr2 = _get_counter();
-    Module.print("JS increment_counter " + N + " iters: " + (b-a) + " msecs. result: " + (ctr2-ctr));
+    out("JS increment_counter " + N + " iters: " + (b-a) + " msecs. result: " + (ctr2-ctr));
 }
 
 function _increment_class_counter_benchmark_embind_js(N) {
@@ -34,7 +34,7 @@ function _increment_class_counter_benchmark_embind_js(N) {
         foo['incr_class_counter']();
     }
     var b = _emscripten_get_now();
-    Module.print("JS embind increment_class_counter " + N + " iters: " + (b-a) + " msecs. result: " + foo['class_counter_val']());
+    out("JS embind increment_class_counter " + N + " iters: " + (b-a) + " msecs. result: " + foo['class_counter_val']());
     foo['delete']();
 }
 
@@ -54,7 +54,7 @@ function _returns_input_benchmark_js() {
         t += _returns_input(i);
     }
     var b = _emscripten_get_now();
-    Module.print("JS returns_input 100000 iters: " + (b-a) + " msecs. result: " + t);
+    out("JS returns_input 100000 iters: " + (b-a) + " msecs. result: " + t);
 }
 
 function _sum_int_benchmark_js() {
@@ -73,7 +73,7 @@ function _sum_int_benchmark_js() {
         r += _sum_int(i, 2, 3, 4, 5, 6, 7, 8, 9);
     }
     var b = _emscripten_get_now();
-    Module.print("JS sum_int 100000 iters: " + (b-a) + " msecs. result: " + r);
+    out("JS sum_int 100000 iters: " + (b-a) + " msecs. result: " + r);
 }
 
 function _sum_float_benchmark_js() {
@@ -92,7 +92,7 @@ function _sum_float_benchmark_js() {
         r += _sum_float(i, 2, 3, 4, 5, 6, 7, 8, 9);
     }
     var b = _emscripten_get_now();
-    Module.print("JS sum_float 100000 iters: " + (b-a) + " msecs. result: " + r);
+    out("JS sum_float 100000 iters: " + (b-a) + " msecs. result: " + r);
 }
 
 function _increment_counter_benchmark_embind_js(N) {
@@ -112,7 +112,7 @@ function _increment_counter_benchmark_embind_js(N) {
     }
     var b = _emscripten_get_now();
     var ctr2 = _get_counter();
-    Module.print("JS embind increment_counter " + N + " iters: " + (b-a) + " msecs. result: " + (ctr2-ctr));
+    out("JS embind increment_counter " + N + " iters: " + (b-a) + " msecs. result: " + (ctr2-ctr));
 }
 
 function _returns_input_benchmark_embind_js() {
@@ -131,7 +131,7 @@ function _returns_input_benchmark_embind_js() {
         t += Module['returns_input'](i);
     }
     var b = _emscripten_get_now();
-    Module.print("JS embind returns_input 100000 iters: " + (b-a) + " msecs. result: " + t);
+    out("JS embind returns_input 100000 iters: " + (b-a) + " msecs. result: " + t);
 }
 
 function _sum_int_benchmark_embind_js() {
@@ -150,7 +150,7 @@ function _sum_int_benchmark_embind_js() {
         r += Module['sum_int'](i, 2, 3, 4, 5, 6, 7, 8, 9);
     }
     var b = _emscripten_get_now();
-    Module.print("JS embind sum_int 100000 iters: " + (b-a) + " msecs. result: " + r);
+    out("JS embind sum_int 100000 iters: " + (b-a) + " msecs. result: " + r);
 }
 
 function _sum_float_benchmark_embind_js() {
@@ -169,7 +169,7 @@ function _sum_float_benchmark_embind_js() {
         r += Module['sum_float'](i, 2, 3, 4, 5, 6, 7, 8, 9);
     }
     var b = _emscripten_get_now();
-    Module.print("JS embind sum_float 100000 iters: " + (b-a) + " msecs. result: " + r);
+    out("JS embind sum_float 100000 iters: " + (b-a) + " msecs. result: " + r);
 }
 
 function _move_gameobjects_benchmark_embind_js() {
@@ -198,7 +198,7 @@ function _move_gameobjects_benchmark_embind_js() {
         objects[i]['delete']();
     }
     
-    Module.print("JS embind move_gameobjects " + N + " iters: " + (b-a) + " msecs. Result: " + (accum[0] + accum[1] + accum[2]));
+    out("JS embind move_gameobjects " + N + " iters: " + (b-a) + " msecs. Result: " + (accum[0] + accum[1] + accum[2]));
 }
 
 function _pass_gameobject_ptr_benchmark_embind_js() {
@@ -219,7 +219,7 @@ function _pass_gameobject_ptr_benchmark_embind_js() {
         objects[i]['delete']();
     }
     
-    Module.print("JS embind pass_gameobject_ptr " + N + " iters: " + (b-a) + " msecs.");
+    out("JS embind pass_gameobject_ptr " + N + " iters: " + (b-a) + " msecs.");
 }
 
 function _call_through_interface0() {
@@ -231,7 +231,7 @@ function _call_through_interface0() {
     var start = _emscripten_get_now();
     Module['callInterface0'](N, obj);
     var elapsed = _emscripten_get_now() - start;
-    Module.print("C++ -> JS void through interface " + N + " iters: " + elapsed + " msecs.");
+    out("C++ -> JS void through interface " + N + " iters: " + elapsed + " msecs.");
     obj.delete();
 }
 
@@ -245,7 +245,7 @@ function _call_through_interface1() {
     var start = _emscripten_get_now();
     Module['callInterface1'](N, obj);
     var elapsed = _emscripten_get_now() - start;
-    Module.print("C++ -> JS std::wstring through interface " + N + " iters: " + elapsed + " msecs.");
+    out("C++ -> JS std::wstring through interface " + N + " iters: " + elapsed + " msecs.");
     obj.delete();
 }
 
@@ -264,12 +264,12 @@ function _call_through_interface2() {
     var start = _emscripten_get_now();
     Module['callInterface2'](N, obj);
     var elapsed = _emscripten_get_now() - start;
-    Module.print("C++ -> JS typed array instantiation " + N + " iters: " + elapsed + " msecs.");
+    out("C++ -> JS typed array instantiation " + N + " iters: " + elapsed + " msecs.");
 
     var start = _emscripten_get_now();
     Module['callInterface3'](N, obj);
     var elapsed = _emscripten_get_now() - start;
-    Module.print("C++ -> JS memory_view instantiation" + N + " iters: " + elapsed + " msecs.");
+    out("C++ -> JS memory_view instantiation" + N + " iters: " + elapsed + " msecs.");
     obj.delete();
 }
 
@@ -281,5 +281,5 @@ function _returns_val_benchmark() {
         v = Module['returns_val'](v);
     }
     var elapsed = _emscripten_get_now() - start;
-    Module.print("returns_val " + N + " iters: " + elapsed + " msecs");
+    out("returns_val " + N + " iters: " + elapsed + " msecs");
 }

--- a/tests/emscripten_api_browser_infloop.cpp
+++ b/tests/emscripten_api_browser_infloop.cpp
@@ -28,10 +28,10 @@ struct Class {
 
     EM_ASM({
       var initial = stackSave();
-      Module.print('seeing initial stack of ' + initial);
+      out('seeing initial stack of ' + initial);
       setTimeout(function() {
         var current = stackSave();
-        Module.print('seeing later stack of   ' + current);
+        out('seeing later stack of   ' + current);
         assert(current === initial);
       }, 0);
     });

--- a/tests/emterpreter_advise.cpp
+++ b/tests/emterpreter_advise.cpp
@@ -3,7 +3,7 @@
 #include <assert.h>
 
 void print(const char *c) {
-  EM_ASM_({ Module.print($0) }, c);
+  EM_ASM_({ out($0) }, c);
 }
 
 void sleeper() {

--- a/tests/emterpreter_advise_funcptr.cpp
+++ b/tests/emterpreter_advise_funcptr.cpp
@@ -3,11 +3,11 @@
 #include <assert.h>
 
 void print1(const char *c, int x) {
-  EM_ASM({ Module.print([$0, $1]) }, c, x);
+  EM_ASM({ out([$0, $1]) }, c, x);
 }
 
 void print2(const char *c, int x, int y) {
-  EM_ASM({ Module.print([$0, $1, $2]) }, c, x, y);
+  EM_ASM({ out([$0, $1, $2]) }, c, x, y);
 }
 
 typedef void (*func_v)();

--- a/tests/emterpreter_async_sleep2_safeheap.cpp
+++ b/tests/emterpreter_async_sleep2_safeheap.cpp
@@ -11,9 +11,9 @@ void fix() {
 
 void EMSCRIPTEN_KEEPALIVE callback() {
   EM_ASM({
-    Module.print('callback...');
+    out('callback...');
     Module['dynCall_v']($0);
-    Module.print('callback fixed.');
+    out('callback fixed.');
   }, (int)&fix);
 }
 

--- a/tests/emterpreter_async_virtual_2.cpp
+++ b/tests/emterpreter_async_virtual_2.cpp
@@ -24,11 +24,11 @@ bool device_CON::Read(unsigned char * data,unsigned short * size) {
     printf("device_CON::Read (this = %i) Sleep--> \n", (int)this);
     EM_ASM({
       Module.the_this = $0;
-      Module.print('first this ' + Module.the_this);
+      out('first this ' + Module.the_this);
     }, this);
     emscripten_sleep(1000);
     EM_ASM({
-      Module.print('second this ' + $0);
+      out('second this ' + $0);
       assert(Module.the_this === $0, 'this must be unchanged');
     }, this);
     printf("<--Sleep (this = %i)\n", (int)this);

--- a/tests/file_db.cpp
+++ b/tests/file_db.cpp
@@ -12,7 +12,7 @@ int main() {
 
   EM_ASM(
     FS.saveFilesToDB(['waka.txt', 'moar.txt'], function() {
-      Module.print('save ok');
+      out('save ok');
       var xhr = new XMLHttpRequest();
       xhr.open('GET', 'http://localhost:8888/report_result?1');
       xhr.send();
@@ -29,7 +29,7 @@ int main() {
       }
       assert(stringy(FS.analyzePath('waka.txt').object.contents) == 'az');
       var secret = stringy(FS.analyzePath('moar.txt').object.contents);
-      Module.print('load: ' + secret);
+      out('load: ' + secret);
       var xhr = new XMLHttpRequest();
       xhr.open('GET', 'http://localhost:8888/report_result?' + secret);
       xhr.send();

--- a/tests/filesystem/src.js
+++ b/tests/filesystem/src.js
@@ -16,18 +16,18 @@ FS.symlink('../def', '/abc/relativeLink');
 FS.ignorePermissions = false;
 
 function explore(path) {
-  Module.print(path);
+  out(path);
   var ret = FS.analyzePath(path);
-  Module.print('  isRoot: ' + ret.isRoot);
-  Module.print('  exists: ' + ret.exists);
-  Module.print('  error: ' + ret.error);
-  Module.print('  path: ' + ret.path);
-  Module.print('  name: ' + ret.name);
-  Module.print('  object.contents: ' + (ret.object && JSON.stringify(Object.keys(ret.object.contents || {}))));
-  Module.print('  parentExists: ' + ret.parentExists);
-  Module.print('  parentPath: ' + ret.parentPath);
-  Module.print('  parentObject.contents: ' + (ret.parentObject && JSON.stringify(Object.keys(ret.parentObject.contents))));
-  Module.print('');
+  out('  isRoot: ' + ret.isRoot);
+  out('  exists: ' + ret.exists);
+  out('  error: ' + ret.error);
+  out('  path: ' + ret.path);
+  out('  name: ' + ret.name);
+  out('  object.contents: ' + (ret.object && JSON.stringify(Object.keys(ret.object.contents || {}))));
+  out('  parentExists: ' + ret.parentExists);
+  out('  parentPath: ' + ret.parentPath);
+  out('  parentObject.contents: ' + (ret.parentObject && JSON.stringify(Object.keys(ret.parentObject.contents))));
+  out('');
 }
 
 FS.currentPath = '/abc';

--- a/tests/fs/test_lz4fs.cpp
+++ b/tests/fs/test_lz4fs.cpp
@@ -136,7 +136,7 @@ int main() {
 
       meta = JSON.parse(meta);
 
-      Module.print('loading into filesystem');
+      out('loading into filesystem');
       FS.mkdir('/files');
       LZ4.loadPackage({ 'metadata': meta, 'data': data });
 
@@ -154,7 +154,7 @@ int main() {
     meta_xhr.open("GET", "files.js.metadata", true);
     meta_xhr.responseType = "text";
     meta_xhr.onload = function() {
-      Module.print('got metadata');
+      out('got metadata');
       meta = meta_xhr.response;
       maybeReady();
     };
@@ -164,7 +164,7 @@ int main() {
     data_xhr.open("GET", "files.data", true);
     data_xhr.responseType = "arraybuffer";
     data_xhr.onload = function() {
-      Module.print('got data');
+      out('got data');
       data = data_xhr.response;
       maybeReady();
     };

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -6,22 +6,22 @@ int main() {
 
   EM_ASM(
     FS.trackingDelegate['willMovePath'] = function(oldpath, newpath) {
-      Module.print('About to move "' + oldpath + '" to "' + newpath + '"');
+      out('About to move "' + oldpath + '" to "' + newpath + '"');
     };
     FS.trackingDelegate['onMovePath'] = function(oldpath, newpath) {
-      Module.print('Moved "' + oldpath + '" to "' + newpath + '"');
+      out('Moved "' + oldpath + '" to "' + newpath + '"');
     };
     FS.trackingDelegate['willDeletePath'] = function(path) {
-      Module.print('About to delete "' + path + '"');
+      out('About to delete "' + path + '"');
     };
     FS.trackingDelegate['onDeletePath'] = function(path) {
-      Module.print('Deleted "' + path + '"');
+      out('Deleted "' + path + '"');
     };
     FS.trackingDelegate['onOpenFile'] = function(path, flags) { 
-      Module.print('Opened "' + path + '" with flags ' + flags);
+      out('Opened "' + path + '" with flags ' + flags);
     };
     FS.trackingDelegate['onWriteToFile'] = function(path) {
-      Module.print('Wrote to file "' + path + '"');
+      out('Wrote to file "' + path + '"');
     };
   );
 

--- a/tests/fs/test_workerfs_package.cpp
+++ b/tests/fs/test_workerfs_package.cpp
@@ -50,7 +50,7 @@ int main() {
 
       meta = JSON.parse(meta);
 
-      Module.print('loading into filesystem');
+      out('loading into filesystem');
       FS.mkdir('/files');
       FS.mount(WORKERFS, {
         packages: [{ metadata: meta, blob: blob }]
@@ -63,7 +63,7 @@ int main() {
     meta_xhr.open("GET", "files.js.metadata", true);
     meta_xhr.responseType = "text";
     meta_xhr.onload = function() {
-      Module.print('got metadata');
+      out('got metadata');
       meta = meta_xhr.response;
       maybeReady();
     };
@@ -73,7 +73,7 @@ int main() {
     data_xhr.open("GET", "files.data", true);
     data_xhr.responseType = "blob";
     data_xhr.onload = function() {
-      Module.print('got data');
+      out('got data');
       blob = data_xhr.response;
       maybeReady();
     };

--- a/tests/fs_after_main.cpp
+++ b/tests/fs_after_main.cpp
@@ -50,17 +50,17 @@ int main() {
   fclose(f);
   printf("Looping...\n");
   EM_ASM({
-    Module['print']('js');
+    out('js');
     var counter = 0;
     function looper() {
-      Module['print']('js looping');
+      out('js looping');
       Module['_looper']();
       counter++;
       if (counter < 5) {
-        Module['print']('js queueing');
+        out('js queueing');
         setTimeout(looper, 1);
       } else {
-        Module['print']('js finishing');
+        out('js finishing');
         setTimeout(Module['_finish'], 1);
       }
     }

--- a/tests/fs_after_main.cpp
+++ b/tests/fs_after_main.cpp
@@ -37,9 +37,9 @@ int main() {
   EM_ASM({
     (function() {
       // exiting main should not cause any weirdness with printing
-      var realPrint = Module['print'];
+      var realPrint = out;
       Module['extraSecretBuffer'] = '';
-      Module['print'] = function(x) {
+      out = function(x) {
         Module['extraSecretBuffer'] += x;
         realPrint(x);
       };

--- a/tests/glut_touchevents.c
+++ b/tests/glut_touchevents.c
@@ -47,8 +47,8 @@ int main(int argc, char *argv[])
             // so we fake them by creating a plain-vanilla UIEvent and then
             // filling in the fields that we look for with appropriate values.
             var rect = Module["canvas"].getBoundingClientRect();
-            Module['print']('rect corner: ' + rect.left + ',' + rect.top);
-            Module['print']('wanted: ' + wantedX + ',' + wantedY);
+            out('rect corner: ' + rect.left + ',' + rect.top);
+            out('wanted: ' + wantedX + ',' + wantedY);
             var x = wantedX + rect.left;
             var y = wantedY + rect.top;
             var touch = {

--- a/tests/hello_world_em_asm.c
+++ b/tests/hello_world_em_asm.c
@@ -1,7 +1,7 @@
 #include <emscripten.h>
 
 int main() {
-  EM_ASM({ Module.print("hello, world!\n"); });
+  EM_ASM({ out("hello, world!\n"); });
   return 0;
 }
 

--- a/tests/interop/test_add_function_post.js
+++ b/tests/interop/test_add_function_post.js
@@ -1,4 +1,4 @@
 var newFuncPtr = addFunction(function(num) {
-    Module['print']('Hello ' + num + ' from JS!');
+    out('Hello ' + num + ' from JS!');
 }, 'vi');
 Module['callMain']([newFuncPtr.toString()]);

--- a/tests/mem_init.cpp
+++ b/tests/mem_init.cpp
@@ -6,9 +6,9 @@ extern "C" {
 int noted = 1;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
-  EM_ASM({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ out([$0, $1]) }, n, noted);
   noted = noted | n;
-  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ out(['noted is now', $0]) }, noted);
   if (noted == 3) {
     REPORT_RESULT(noted);
   }

--- a/tests/pthread/hello_thread.c
+++ b/tests/pthread/hello_thread.c
@@ -3,7 +3,7 @@
 
 void *thread_main(void *arg)
 {
-	EM_ASM(Module.print('hello from thread!'));
+	EM_ASM(out('hello from thread!'));
 #ifdef REPORT_RESULT
 	REPORT_RESULT(1);
 #endif

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -34,7 +34,7 @@ void *ThreadMain(void *arg)
 	assert(globalDouble == 5.0);
 	assert(globalU64 == 5);
 	struct Test *t = (struct Test*)arg;
-	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
+	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
 
 	for(int i = 0; i < 99999; ++i)
 		for(int j = 0; j < N; ++j)
@@ -75,7 +75,7 @@ void *ThreadMain(void *arg)
 				break;
 			}
 		}
-	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
+	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
 	pthread_exit(0);
 }
 
@@ -99,7 +99,7 @@ void RunTest(int test)
 		default: memset(sharedData, 0, sizeof(sharedData)); break;
 	}
 
-	EM_ASM(Module['print']('Main: Starting test ' + $0), test);
+	EM_ASM(out('Main: Starting test ' + $0), test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -120,7 +120,7 @@ void RunTest(int test)
 	}
 
 	int val = sharedData[0];
-	EM_ASM(Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
+	EM_ASM(out('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
 	if (test != 6)
 	{
 		for(int i = 1; i < N; ++i)
@@ -162,6 +162,6 @@ int main()
 	int result = (totalRead != totalWritten) ? 1 : 0;
 	REPORT_RESULT(result);
 #else
-	EM_ASM(Module['print']('Main: Test successfully finished.'));
+	EM_ASM(out('Main: Test successfully finished.'));
 #endif
 }

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -46,7 +46,7 @@ void *ThreadMain(void *arg)
 	assert(globalDouble == 5.0);
 	assert(globalU64 == 5);
 	struct Test *t = (struct Test*)arg;
-	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
+	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
 
 	for(int i = 0; i < 99999; ++i)
 		for(int j = 0; j < N; ++j)
@@ -86,7 +86,7 @@ void *ThreadMain(void *arg)
 				break;
 			}
 		}
-	EM_ASM(Module['print']('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
+	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': finished, exit()ing.'), t->threadId, t->op);
 	pthread_exit(0);
 }
 
@@ -110,7 +110,7 @@ void RunTest(int test)
 		default: memset(sharedData, 0, sizeof(sharedData)); break;
 	}
 
-	EM_ASM(Module['print']('Main: Starting test ' + $0), test);
+	EM_ASM(out('Main: Starting test ' + $0), test);
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
@@ -131,7 +131,7 @@ void RunTest(int test)
 	}
 
 	int val = sharedData[0];
-	EM_ASM(Module['print']('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
+	EM_ASM(out('Main: Test ' + $0 + ' finished. Result: ' + $1), test, val);
 	if (test != 6)
 	{
 		for(int i = 1; i < N; ++i)
@@ -180,6 +180,6 @@ int main()
 	int result = (totalRead != totalWritten) ? 1 : 0;
 	REPORT_RESULT(result);
 #else
-	EM_ASM(Module['print']('Main: Test successfully finished.'));
+	EM_ASM(out('Main: Test successfully finished.'));
 #endif
 }

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -11,7 +11,7 @@
 volatile int res = 43;
 static void cleanup_handler(void *arg)
 {
-  EM_ASM(Module['print']('Called clean-up handler with arg ' + $0), arg);
+  EM_ASM(out('Called clean-up handler with arg ' + $0), arg);
   int a = (int)arg;
   res -= a;
 }
@@ -19,7 +19,7 @@ static void cleanup_handler(void *arg)
 static void *thread_start(void *arg)
 {
   pthread_cleanup_push(cleanup_handler, (void*)42);
-  EM_ASM(Module['print']('Thread started!'));
+  EM_ASM(out('Thread started!'));
   for(;;)
   {
     pthread_testcancel();
@@ -43,7 +43,7 @@ int main()
 
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
-  EM_ASM(Module['print']('Canceling thread..'););
+  EM_ASM(out('Canceling thread..'););
   s = pthread_cancel(thr);
   assert(s == 0);
 
@@ -52,7 +52,7 @@ int main()
     int result = emscripten_atomic_load_u32((const void*)&res);
     if (result == 1)
     {
-      EM_ASM_INT( { Module['print']('After canceling, shared variable = ' + $0 + '.'); }, result);
+      EM_ASM_INT( { out('After canceling, shared variable = ' + $0 + '.'); }, result);
 #ifdef REPORT_RESULT
       REPORT_RESULT(1);
 #endif

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -30,11 +30,11 @@ void *inc_count(void *t)
       pthread_cond_signal(&count_threshold_cv);
  //     printf("inc_count(): thread %ld, count = %d  Threshold reached.\n", 
  //            my_id, count);
-      EM_ASM(Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', Threshold reached.'), my_id, count);
+      EM_ASM(out('inc_count(): thread ' + $0 + ', count = ' + $1 + ', Threshold reached.'), my_id, count);
       }
 //    printf("inc_count(): thread %ld, count = %d, unlocking mutex\n", 
 //	   my_id, count);
-    EM_ASM(Module['print']('inc_count(): thread ' + $0 + ', count = ' + $1 + ', unlocking mutex.'), my_id, count);
+    EM_ASM(out('inc_count(): thread ' + $0 + ', count = ' + $1 + ', unlocking mutex.'), my_id, count);
     pthread_mutex_unlock(&count_mutex);
 
     /* Do some "work" so threads can alternate on mutex lock */
@@ -48,7 +48,7 @@ void *watch_count(void *t)
   long my_id = (long)t;
 
 //  printf("Starting watch_count(): thread %ld\n", my_id);
-  EM_ASM(Module['print']('Starting watch_count(): thread ' + $0), my_id);
+  EM_ASM(out('Starting watch_count(): thread ' + $0), my_id);
 
   /*
   Lock mutex and wait for signal.  Note that the pthread_cond_wait 
@@ -61,10 +61,10 @@ void *watch_count(void *t)
   while (count<COUNT_LIMIT) {
     pthread_cond_wait(&count_threshold_cv, &count_mutex);
 //    printf("watch_count(): thread %ld Condition signal received.\n", my_id);
-    EM_ASM(Module['print']('watch_count(): thread ' + $0 + ' Condition signal received.'), my_id);
+    EM_ASM(out('watch_count(): thread ' + $0 + ' Condition signal received.'), my_id);
     count += 125;
 //    printf("watch_count(): thread %ld count now = %d.\n", my_id, count);
-    EM_ASM(Module['print']('watch_count(): thread ' + $0 + ', count now = ' + $1), my_id, count);
+    EM_ASM(out('watch_count(): thread ' + $0 + ', count now = ' + $1), my_id, count);
     }
   pthread_mutex_unlock(&count_mutex);
   pthread_exit(NULL);

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -23,7 +23,7 @@ void *ThreadMain(void *arg)
 
 #define N 100
 
-	EM_ASM(Module['printErr']('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
+	EM_ASM(err('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
 
 	unsigned int n[N];
 	for(unsigned int i = 0; i < N; ++i)
@@ -44,9 +44,9 @@ void *ThreadMain(void *arg)
 	int numGood = 0;
 	for(unsigned int i = 0; i < N; ++i)
 		if (n[i] == i) ++numGood;
-		else EM_ASM(Module['printErr']('n['+$0+']='+$1), i, n[i]);
+		else EM_ASM(err('n['+$0+']='+$1), i, n[i]);
 
-	EM_ASM(Module['print']('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
+	EM_ASM(out('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
 	pthread_exit((void*)numGood);
 }
 
@@ -61,7 +61,7 @@ void CreateThread(int i)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	static int counter = 1;
 	global_shared_data[i] = (counter++ * 12141231) & 0x7FFFFFFF; // Arbitrary random'ish data for perturbing the sort for this thread task.
-//	EM_ASM(Module['print']('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'), i, global_shared_data[i]);
+//	EM_ASM(out('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'), i, global_shared_data[i]);
 	int rc = pthread_create(&thread[i], &attr, ThreadMain, (void*)i);
 	assert(rc == 0);
 	pthread_attr_destroy(&attr);
@@ -92,7 +92,7 @@ int main()
 				int status;
 				int rc = pthread_join(thread[i], (void**)&status);
 				assert(rc == 0);
-				EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
+				EM_ASM(err('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
 				assert(status == N);
 				thread[i] = 0;
 				if (numThreadsToCreate > 0)

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -8,7 +8,7 @@ volatile int result = 0;
 
 static void *thread2_start(void *arg)
 {
-  EM_ASM(Module['print']('thread2_start!'));
+  EM_ASM(out('thread2_start!'));
   ++result;
 
   pthread_exit(0);
@@ -16,7 +16,7 @@ static void *thread2_start(void *arg)
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(Module['print']('thread1_start!'));
+  EM_ASM(out('thread1_start!'));
   pthread_t thr;
   pthread_create(&thr, NULL, thread2_start, 0);
   pthread_join(thr, 0);

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -7,7 +7,7 @@
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(Module['print']('thread1_start!'));
+  EM_ASM(out('thread1_start!'));
 
   FILE *handle = fopen("file1.txt", "r");
   assert(handle);

--- a/tests/pthread/test_pthread_global_data_initialization.c
+++ b/tests/pthread/test_pthread_global_data_initialization.c
@@ -6,29 +6,29 @@ int globalData = 1;
 
 void *thread_main(void *arg)
 {
-  EM_ASM(Module.print('hello from pthread 1: ' + $0), globalData);
+  EM_ASM(out('hello from pthread 1: ' + $0), globalData);
   assert(globalData == 10);
 
   globalData = 20;
-  EM_ASM(Module.print('hello from pthread 2: ' + $0), globalData);
+  EM_ASM(out('hello from pthread 2: ' + $0), globalData);
   assert(globalData == 20);
 	return 0;
 }
 
 int main()
 {
-  EM_ASM(Module.print('hello from main 1: ' + $0), globalData);
+  EM_ASM(out('hello from main 1: ' + $0), globalData);
   assert(globalData == 1);
 
   globalData = 10;
-  EM_ASM(Module.print('hello from main 2: ' + $0), globalData);
+  EM_ASM(out('hello from main 2: ' + $0), globalData);
   assert(globalData == 10);
 
 	pthread_t thread;
 	pthread_create(&thread, NULL, thread_main, NULL);
   pthread_join(thread, 0);
 
-  EM_ASM(Module.print('hello from main 3: ' + $0), globalData);
+  EM_ASM(out('hello from main 3: ' + $0), globalData);
   assert(globalData == 20);
 #ifdef REPORT_RESULT
   REPORT_RESULT(globalData);

--- a/tests/pthread/test_pthread_join.cpp
+++ b/tests/pthread/test_pthread_join.cpp
@@ -18,9 +18,9 @@ int fib(int n)
 static void *thread_start(void *arg)
 {
   int n = (int)arg;
-  EM_ASM(Module['print']('Thread: Computing fib('+$0+')...'), n);
+  EM_ASM(out('Thread: Computing fib('+$0+')...'), n);
   int fibn = fib(n);
-  EM_ASM(Module['print']('Thread: Computation done. fib('+$0+') = '+$1+'.'), n, fibn);
+  EM_ASM(out('Thread: Computation done. fib('+$0+') = '+$1+'.'), n, fibn);
   pthread_exit((void*)fibn);
 }
 
@@ -42,14 +42,14 @@ int main()
   pthread_t thr;
 
   int n = 20;
-  EM_ASM(Module['print']('Main: Spawning thread to compute fib('+$0+')...'), n);
+  EM_ASM(out('Main: Spawning thread to compute fib('+$0+')...'), n);
   int s = pthread_create(&thr, NULL, thread_start, (void*)n);
   assert(s == 0);
-  EM_ASM(Module['print']('Main: Waiting for thread to join.'));
+  EM_ASM(out('Main: Waiting for thread to join.'));
   int result = 0;
   s = pthread_join(thr, (void**)&result);
   assert(s == 0);
-  EM_ASM(Module['print']('Main: Thread joined with result: '+$0+'.'), result);
+  EM_ASM(out('Main: Thread joined with result: '+$0+'.'), result);
 #ifdef REPORT_RESULT
   REPORT_RESULT(result);
 #endif

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -72,7 +72,7 @@ int main()
   // Finally test that the thread is not doing any work and it is dead.
   assert(sharedVar == 0);
   assert(emscripten_atomic_load_u32((void*)&sharedVar) == 0);
-  EM_ASM(Module['print']('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'), sharedVar);
+  EM_ASM(out('Main: Done. Successfully killed thread. sharedVar: '+$0+'.'), sharedVar);
 #ifdef REPORT_RESULT
   REPORT_RESULT(sharedVar);
 #endif

--- a/tests/pthread/test_pthread_thread_local_storage.cpp
+++ b/tests/pthread/test_pthread_thread_local_storage.cpp
@@ -20,7 +20,7 @@ void *ThreadMain(void *arg)
 		for(int i = 0; i < NUM_KEYS; ++i)
 		{
 			local_keys[i] = (uintptr_t)pthread_getspecific(keys[i]);
-//			EM_ASM(Module['printErr']('Thread ' + $0 + ': Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
+//			EM_ASM(err('Thread ' + $0 + ': Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
 		}
 
 		for(int i = 0; i < NUM_KEYS; ++i)
@@ -33,7 +33,7 @@ void *ThreadMain(void *arg)
 	for(int i = 0; i < NUM_KEYS; ++i)
 	{
 		local_keys[i] = (uintptr_t)pthread_getspecific(keys[i]);
-//		EM_ASM(Module['printErr']('Thread ' + $0 + ' final verify: Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
+//		EM_ASM(err('Thread ' + $0 + ' final verify: Read value ' + $1 + ' from TLS for key at index ' + $2), pthread_self(), (int)local_keys[i], i);
 		if (local_keys[i] != NUM_ITERS)
 			pthread_exit((void*)1);
 	}
@@ -74,7 +74,7 @@ int main()
 				int status;
 				int rc = pthread_join(thread[i], (void**)&status);
 				assert(rc == 0);
-				EM_ASM(Module['printErr']('Main: Joined thread idx ' + $0 + ' with status ' + $1), i, (int)status);
+				EM_ASM(err('Main: Joined thread idx ' + $0 + ' with status ' + $1), i, (int)status);
 				assert(status == 0);
 				thread[i] = 0;
 				if (numThreadsToCreate > 0)

--- a/tests/runtime_misuse.cpp
+++ b/tests/runtime_misuse.cpp
@@ -7,9 +7,9 @@ int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
   EM_ASM({ Module.noted = $0 }, (int)&noted);
-  EM_ASM({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ out([$0, $1]) }, n, noted);
   noted += n;
-  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ out(['noted is now', $0]) }, noted);
   return (char*)"silly-string";
 }
 

--- a/tests/runtime_misuse_2.cpp
+++ b/tests/runtime_misuse_2.cpp
@@ -7,14 +7,14 @@ int noted = 0;
 
 char* EMSCRIPTEN_KEEPALIVE note(int n) {
   EM_ASM({ Module.noted = $0 }, (int)&noted);
-  EM_ASM({ Module.print([$0, $1]) }, n, noted);
+  EM_ASM({ out([$0, $1]) }, n, noted);
   noted += n;
-  EM_ASM({ Module.print(['noted is now', $0]) }, noted);
+  EM_ASM({ out(['noted is now', $0]) }, noted);
   return (char*)"silly-string";
 }
 
 void free(void*) { // free is valid to call even after the runtime closes, so useful as a hack here for this test
-  EM_ASM({ Module.print(['reporting', $0]) }, noted);
+  EM_ASM({ out(['reporting', $0]) }, noted);
 }
 
 }

--- a/tests/sdl2_unwasteful.cpp
+++ b/tests/sdl2_unwasteful.cpp
@@ -21,16 +21,16 @@ static void main_loop(void)
         EM_ASM({
             Module.the_ctx = Module.SDL2.ctx;
             Module.the_image = Module.SDL2.image;
-            Module.print('start with ' + [Module.the_ctx, Module.the_image]);
+            out('start with ' + [Module.the_ctx, Module.the_image]);
             assert(!!Module.the_ctx && (typeof Module.the_ctx === 'object'), 'typeof ctx');
             assert(!!Module.the_image && (typeof Module.the_image === 'object'), 'typeof image');
-            Module.print('set values');
+            out('set values');
         });
     } else if (runs > 1) {
         EM_ASM({
             assert(Module.the_ctx === Module.SDL2.ctx, 'ctx');
             assert(Module.the_image === Module.SDL2.image, 'image');
-            Module.print('check ok ' + $0);
+            out('check ok ' + $0);
         }, runs);
     }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -773,7 +773,7 @@ window.close = function() {
           open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
             function keydown(c) {
              %s
-              //Module.print('push keydown');
+              //out('push keydown');
               var event = document.createEvent("KeyboardEvent");
               event.initKeyEvent("keydown", true, true, window,
                                  0, 0, 0, 0,
@@ -784,7 +784,7 @@ window.close = function() {
 
             function keyup(c) {
              %s
-              //Module.print('push keyup');
+              //out('push keyup');
               var event = document.createEvent("KeyboardEvent");
               event.initKeyEvent("keyup", true, true, window,
                                  0, 0, 0, 0,
@@ -2094,7 +2094,7 @@ void *getBindBuffer() {
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
       Module.preRun = function() {
         addRunDependency();
-        Module.print('preRun called, added a dependency...');
+        out('preRun called, added a dependency...');
         setTimeout(function() {
           Module.okk = 10;
           removeRunDependency()
@@ -2172,7 +2172,7 @@ void *getBindBuffer() {
       var wrapped = cwrap('note', 'string', ['number']); // returns a string to suppress cwrap optimization
       function doCwrapCall(n) {
         var str = wrapped(n);
-        Module.print('got ' + str);
+        out('got ' + str);
         assert(str === 'silly-string');
       }
       function doDirectCall(n) {
@@ -2185,7 +2185,7 @@ void *getBindBuffer() {
         doCcall(1);
         ok = true; // should fail and not reach here, runtime is not ready yet so ccall will abort
       } catch(e) {
-        Module.print('expected fail 1');
+        out('expected fail 1');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
@@ -2196,7 +2196,7 @@ void *getBindBuffer() {
         doCwrapCall(2);
         ok = true; // should fail and not reach here, runtime is not ready yet so cwrap call will abort
       } catch(e) {
-        Module.print('expected fail 2');
+        out('expected fail 2');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
@@ -2207,7 +2207,7 @@ void *getBindBuffer() {
         doDirectCall(3);
         ok = true; // should fail and not reach here, runtime is not ready yet so any code execution
       } catch(e) {
-        Module.print('expected fail 3');
+        out('expected fail 3');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
@@ -3649,7 +3649,7 @@ window.close = function() {
       }
       // show stderr for the viewer's fun
       Module.printErr = function(x) {
-        Module.print('<<< ' + x + ' >>>');
+        out('<<< ' + x + ' >>>');
         console.log(x);
       };
     </script>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1570,7 +1570,7 @@ keydown(100);keyup(100); // trigger the end
           FS.createLazyFile('/', "bigfile", "http://localhost:11111/bogus_file_path", true, false);
       };
       var doTrace = true;
-      Module["print"] =    function(s) { self.postMessage({channel: "stdout", line: s}); };
+      out =    function(s) { self.postMessage({channel: "stdout", line: s}); };
       Module["stderr"] =   function(s) { self.postMessage({channel: "stderr", char: s, trace: ((doTrace && s === 10) ? new Error().stack : null)}); doTrace = false; };
     """)
     prejs_file.close()
@@ -3162,8 +3162,8 @@ window.close = function() {
         strcpy(ret, temp);
         temp[1] = 'x';
         EM_ASM({
-          Module.realPrint = Module.print;
-          Module.print = function(x) {
+          Module.realPrint = out;
+          out = function(x) {
             if (!Module.printed) Module.printed = x;
             Module.realPrint(x);
           };
@@ -3648,7 +3648,7 @@ window.close = function() {
         };
       }
       // show stderr for the viewer's fun
-      Module.printErr = function(x) {
+      err = function(x) {
         out('<<< ' + x + ' >>>');
         console.log(x);
       };

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1570,8 +1570,8 @@ keydown(100);keyup(100); // trigger the end
           FS.createLazyFile('/', "bigfile", "http://localhost:11111/bogus_file_path", true, false);
       };
       var doTrace = true;
-      out =    function(s) { self.postMessage({channel: "stdout", line: s}); };
-      Module["stderr"] =   function(s) { self.postMessage({channel: "stderr", char: s, trace: ((doTrace && s === 10) ? new Error().stack : null)}); doTrace = false; };
+      Module["print"] = function(s) { self.postMessage({channel: "stdout", line: s}); };
+      Module["printErr"] = function(s) { self.postMessage({channel: "stderr", char: s, trace: ((doTrace && s === 10) ? new Error().stack : null)}); doTrace = false; };
     """)
     prejs_file.close()
     # vs. os.path.join(self.get_dir(), filename)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2528,7 +2528,7 @@ def process(filename):
       class Foo {
       public:
         Foo() {
-          EM_ASM( Module.print("Constructing lib object.") );
+          EM_ASM( out("Constructing lib object.") );
         }
       };
       Foo global;
@@ -2543,13 +2543,13 @@ def process(filename):
       class Bar {
       public:
         Bar() {
-          EM_ASM( Module.print("Constructing main object.") );
+          EM_ASM( out("Constructing main object.") );
         }
       };
       Bar global;
       int main() {
         dlopen("liblib.so", RTLD_NOW);
-        EM_ASM( Module.print("All done.") );
+        EM_ASM( out("All done.") );
         return 0;
       }
       '''
@@ -2828,7 +2828,7 @@ def process(filename):
         memset(mem, 1, num);
         EM_ASM({
           var value = HEAP8[64*1024*1024];
-          Module.print('verify middle of memory is non-zero: ' + value);
+          out('verify middle of memory is non-zero: ' + value);
           assert(value === 1);
         });
         free(mem);
@@ -3460,7 +3460,7 @@ Module = {
           alignFunctionTables();
           Module['FUNCTION_TABLE_v'].push(0, 0, 0, 0, 0);
           var newSize = alignFunctionTables();
-          //Module.print('new size of function tables: ' + newSize);
+          //out('new size of function tables: ' + newSize);
           // when masked, the two function pointers 1 and 2 should not happen to fall back to the right place
           assert(((newSize+1) & 3) !== 1 || ((newSize+2) & 3) !== 2);
           loadDynamicLibrary('liblib.so');
@@ -3512,9 +3512,9 @@ Module = {
       #include "header.h"
       int main(int argc, char **argv) {
         volatile charfunc f = emscripten_run_script;
-        f("Module.print('one')");
+        f("out('one')");
         f = get();
-        f("Module.print('two')");
+        f("out('two')");
         return 0;
       }
     ''', '''
@@ -4378,7 +4378,7 @@ def process(filename):
     Module = {
       data: [10, 20, 40, 30],
       stdin: function() { return Module.data.pop() || null },
-      stdout: function(x) { Module.print('got: ' + x) }
+      stdout: function(x) { out('got: ' + x) }
     };
   \'\'\' + open(filename, 'r').read()
   open(filename, 'w').write(src)
@@ -5107,7 +5107,7 @@ PORT: 3979
     open(os.path.join(self.get_dir(), 'mylib1.js'), 'w').write('''
       mergeInto(LibraryManager.library, {
         printey: function() {
-          Module.print('hello from lib!');
+          out('hello from lib!');
         }
       });
     ''')
@@ -5833,7 +5833,7 @@ def process(filename):
     \'\'\'
       FS.createDataFile('/', 'paper.pdf', eval(Module.read('paper.pdf.js')), true, false, false);
       Module.callMain(Module.arguments);
-      Module.print("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']).map(function(x) { return unSign(x, 8) })));
+      out("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']).map(function(x) { return unSign(x, 8) })));
     \'\'\'
   )
   src.close()
@@ -5886,7 +5886,7 @@ def process(filename):
     ))
   ).replace(
     '// {{POST_RUN_ADDITIONS}}',
-    "Module.print('Data: ' + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.analyzePath('image.raw').object)));"
+    "out('Data: ' + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.analyzePath('image.raw').object)));"
   )
   open(filename, 'w').write(src)
 '''
@@ -6152,35 +6152,35 @@ def process(filename):
     post = '''
 def process(filename):
   src = open(filename, 'r').read() + \'\'\'
-      Module.print('*');
+      out('*');
       var ret;
-      ret = Module['ccall']('get_int', 'number'); Module.print([typeof ret, ret].join(','));
-      ret = ccall('get_float', 'number'); Module.print([typeof ret, ret.toFixed(2)].join(','));
-      ret = ccall('get_bool', 'boolean'); Module.print([typeof ret, ret].join(','));
-      ret = ccall('get_string', 'string'); Module.print([typeof ret, ret].join(','));
-      ret = ccall('print_int', null, ['number'], [12]); Module.print(typeof ret);
-      ret = ccall('print_float', null, ['number'], [14.56]); Module.print(typeof ret);
-      ret = ccall('print_bool', null, ['boolean'], [true]); Module.print(typeof ret);
-      ret = ccall('print_string', null, ['string'], ["cheez"]); Module.print(typeof ret);
-      ret = ccall('print_string', null, ['array'], [[97, 114, 114, 45, 97, 121, 0]]); Module.print(typeof ret); // JS array
-      ret = ccall('print_string', null, ['array'], [new Uint8Array([97, 114, 114, 45, 97, 121, 0])]); Module.print(typeof ret); // typed array
-      ret = ccall('multi', 'number', ['number', 'number', 'number', 'string'], [2, 1.4, 3, 'more']); Module.print([typeof ret, ret].join(','));
+      ret = Module['ccall']('get_int', 'number'); out([typeof ret, ret].join(','));
+      ret = ccall('get_float', 'number'); out([typeof ret, ret.toFixed(2)].join(','));
+      ret = ccall('get_bool', 'boolean'); out([typeof ret, ret].join(','));
+      ret = ccall('get_string', 'string'); out([typeof ret, ret].join(','));
+      ret = ccall('print_int', null, ['number'], [12]); out(typeof ret);
+      ret = ccall('print_float', null, ['number'], [14.56]); out(typeof ret);
+      ret = ccall('print_bool', null, ['boolean'], [true]); out(typeof ret);
+      ret = ccall('print_string', null, ['string'], ["cheez"]); out(typeof ret);
+      ret = ccall('print_string', null, ['array'], [[97, 114, 114, 45, 97, 121, 0]]); out(typeof ret); // JS array
+      ret = ccall('print_string', null, ['array'], [new Uint8Array([97, 114, 114, 45, 97, 121, 0])]); out(typeof ret); // typed array
+      ret = ccall('multi', 'number', ['number', 'number', 'number', 'string'], [2, 1.4, 3, 'more']); out([typeof ret, ret].join(','));
       var p = ccall('malloc', 'pointer', ['number'], [4]);
       setValue(p, 650, 'i32');
-      ret = ccall('pointer', 'pointer', ['pointer'], [p]); Module.print([typeof ret, getValue(ret, 'i32')].join(','));
-      Module.print('*');
+      ret = ccall('pointer', 'pointer', ['pointer'], [p]); out([typeof ret, getValue(ret, 'i32')].join(','));
+      out('*');
       // part 2: cwrap
       var noThirdParam = Module['cwrap']('get_int', 'number');
-      Module.print(noThirdParam());
+      out(noThirdParam());
       var multi = Module['cwrap']('multi', 'number', ['number', 'number', 'number', 'string']);
-      Module.print(multi(2, 1.4, 3, 'atr'));
-      Module.print(multi(8, 5.4, 4, 'bret'));
-      Module.print('*');
+      out(multi(2, 1.4, 3, 'atr'));
+      out(multi(8, 5.4, 4, 'bret'));
+      out('*');
       // part 3: avoid stack explosion and check it's restored correctly
       for (var i = 0; i < TOTAL_STACK/60; i++) {
         ccall('multi', 'number', ['number', 'number', 'number', 'string'], [0, 0, 0, '123456789012345678901234567890123456789012345678901234567890']);
       }
-      Module.print('stack is ok.');
+      out('stack is ok.');
       ccall('call_ccall_again', null);
   \'\'\'
   open(filename, 'w').write(src)
@@ -6747,7 +6747,7 @@ someweirdtext
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
     open('post.js', 'w').write('''
       function printLerp() {
-          Module.print('lerp ' + Module.lerp(100, 200, 66) + '.');
+          out('lerp ' + Module.lerp(100, 200, 66) + '.');
       }
     ''')
     src = r'''
@@ -6775,7 +6775,7 @@ someweirdtext
         try {
           Module.compute(new Uint8Array([1,2,3]));
         } catch(e) {
-          Module.print(e);
+          out(e);
         }
       }
     ''')
@@ -6801,7 +6801,7 @@ someweirdtext
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
     open('post.js', 'w').write('''
       function printFirstElement() {
-        Module.print(Module.getBufferView()[0]);
+        out(Module.getBufferView()[0]);
       }
     ''')
     src = r'''
@@ -7210,7 +7210,7 @@ Success!
     '''
     open('post.js', 'w').write('''
       addOnExit(function () {
-        Module.print('I see exit status: ' + EXITSTATUS);
+        out('I see exit status: ' + EXITSTATUS);
       });
       Module['callMain']();
     ''')
@@ -7293,7 +7293,7 @@ try {
   ccall('main', 'number', ['number', 'string'], [2, 'waka']);
   var never = true;
 } catch(e) {
-  Module.print(e);
+  out(e);
   assert(!never);
 }
 ''')
@@ -7578,9 +7578,9 @@ extern "C" {
               typeof STACKTOP === 'number' &&
               typeof DYNAMIC_BASE === 'number' &&
               typeof DYNAMICTOP_PTR === 'number') {
-             Module.print('able to run memprof');
+             out('able to run memprof');
            } else {
-             Module.print('missing the required variables to run memprof');
+             out('missing the required variables to run memprof');
            }
         }
       });
@@ -7593,9 +7593,9 @@ extern "C" {
     open(self.in_dir('pre.js'), 'w').write('''
       Module = {};
       Module['preRun'] = function() {
-          Module.print(typeof FS.filesystems['MEMFS']);
-          Module.print(typeof FS.filesystems['IDBFS']);
-          Module.print(typeof FS.filesystems['NODEFS']);
+          out(typeof FS.filesystems['MEMFS']);
+          out(typeof FS.filesystems['IDBFS']);
+          out(typeof FS.filesystems['NODEFS']);
       };
     ''')
     self.emcc_args += ['--pre-js', 'pre.js']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6887,7 +6887,7 @@ someweirdtext
       # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
       open('export.js', 'w').write('''
 // test purposes: remove printErr output, whose order is unpredictable when compared to print
-Module.printErr = Module['printErr'] = function(){};
+err = err = function(){};
 ''')
       self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=["_malloc"]', '--post-js', 'glue.js', '--post-js', 'export.js']
       if allow_memory_growth:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1689,7 +1689,7 @@ int f() {
       if (Object.keys(Module).length) throw 'This code should run before anything else!';
     ''')
     open(os.path.join(self.get_dir(), 'after.js'), 'w').write('''
-      Module.print(MESSAGE);
+      out(MESSAGE);
     ''')
 
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--pre-js', 'before.js', '--post-js', 'after.js', '-s', 'BINARYEN_ASYNC_COMPILATION=0']).communicate()
@@ -1865,8 +1865,8 @@ int f() {
     ''')
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
       var Module = {
-        preRun: function() { Module.print('pre-run') },
-        postRun: function() { Module.print('post-run') }
+        preRun: function() { out('pre-run') },
+        postRun: function() { out('post-run') }
       };
     ''')
 
@@ -1899,9 +1899,9 @@ int f() {
     # Use postInit
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
       var Module = {
-        preRun: function() { Module.print('pre-run') },
-        postRun: function() { Module.print('post-run') },
-        preInit: function() { Module.print('pre-init') }
+        preRun: function() { out('pre-run') },
+        postRun: function() { out('post-run') },
+        preInit: function() { out('pre-init') }
       };
     ''')
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--pre-js', 'pre.js']).communicate()
@@ -1917,11 +1917,11 @@ int f() {
     ''')
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
       var Module = {
-        preRun: function() { Module.print('pre-run') },
+        preRun: function() { out('pre-run') },
       };
     ''')
     open(os.path.join(self.get_dir(), 'pre2.js'), 'w').write('''
-      Module.postRun = function() { Module.print('post-run') };
+      Module.postRun = function() { out('post-run') };
     ''')
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--pre-js', 'pre.js', '--pre-js', 'pre2.js']).communicate()
     self.assertContained('pre-run\nhello from main\npost-run\n', run_js(os.path.join(self.get_dir(), 'a.out.js')))
@@ -1936,11 +1936,11 @@ int f() {
     ''')
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
       var Module = {
-        preRun: [function() { Module.print('pre-run') }],
+        preRun: [function() { out('pre-run') }],
       };
     ''')
     open(os.path.join(self.get_dir(), 'pre2.js'), 'w').write('''
-      Module.preRun.push(function() { Module.print('prepre') });
+      Module.preRun.push(function() { out('prepre') });
     ''')
     Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--pre-js', 'pre.js', '--pre-js', 'pre2.js']).communicate()
     self.assertContained('prepre\npre-run\nhello from main\n', run_js(os.path.join(self.get_dir(), 'a.out.js')))
@@ -2460,29 +2460,29 @@ done.
       #include <stdio.h>
       #include <emscripten.h>
       void two(char c) {
-        EM_ASM(Module.print(stackTrace()));
+        EM_ASM(out(stackTrace()));
       }
       void one(int x) {
         two(x % 17);
       }
       int main() {
-        EM_ASM(Module.print(demangle('__Znwj'))); // check for no aborts
-        EM_ASM(Module.print(demangle('_main')));
-        EM_ASM(Module.print(demangle('__Z2f2v')));
-        EM_ASM(Module.print(demangle('__Z12abcdabcdabcdi')));
-        EM_ASM(Module.print(demangle('__ZL12abcdabcdabcdi')));
-        EM_ASM(Module.print(demangle('__Z4testcsifdPvPiPc')));
-        EM_ASM(Module.print(demangle('__ZN4test5moarrEcslfdPvPiPc')));
-        EM_ASM(Module.print(demangle('__ZN4Waka1f12a234123412345pointEv')));
-        EM_ASM(Module.print(demangle('__Z3FooIiEvv')));
-        EM_ASM(Module.print(demangle('__Z3FooIidEvi')));
-        EM_ASM(Module.print(demangle('__ZN3Foo3BarILi5EEEvv')));
-        EM_ASM(Module.print(demangle('__ZNK10__cxxabiv120__si_class_type_info16search_below_dstEPNS_19__dynamic_cast_infoEPKvib')));
-        EM_ASM(Module.print(demangle('__Z9parsewordRPKciRi')));
-        EM_ASM(Module.print(demangle('__Z5multiwahtjmxyz')));
-        EM_ASM(Module.print(demangle('__Z1aA32_iPA5_c')));
-        EM_ASM(Module.print(demangle('__ZN21FWakaGLXFleeflsMarfooC2EjjjPKvbjj')));
-        EM_ASM(Module.print(demangle('__ZN5wakaw2Cm10RasterBaseINS_6watwat9PolocatorEE8merbine1INS4_2OREEEvPKjj'))); // we get this wrong, but at least emit a '?'
+        EM_ASM(out(demangle('__Znwj'))); // check for no aborts
+        EM_ASM(out(demangle('_main')));
+        EM_ASM(out(demangle('__Z2f2v')));
+        EM_ASM(out(demangle('__Z12abcdabcdabcdi')));
+        EM_ASM(out(demangle('__ZL12abcdabcdabcdi')));
+        EM_ASM(out(demangle('__Z4testcsifdPvPiPc')));
+        EM_ASM(out(demangle('__ZN4test5moarrEcslfdPvPiPc')));
+        EM_ASM(out(demangle('__ZN4Waka1f12a234123412345pointEv')));
+        EM_ASM(out(demangle('__Z3FooIiEvv')));
+        EM_ASM(out(demangle('__Z3FooIidEvi')));
+        EM_ASM(out(demangle('__ZN3Foo3BarILi5EEEvv')));
+        EM_ASM(out(demangle('__ZNK10__cxxabiv120__si_class_type_info16search_below_dstEPNS_19__dynamic_cast_infoEPKvib')));
+        EM_ASM(out(demangle('__Z9parsewordRPKciRi')));
+        EM_ASM(out(demangle('__Z5multiwahtjmxyz')));
+        EM_ASM(out(demangle('__Z1aA32_iPA5_c')));
+        EM_ASM(out(demangle('__ZN21FWakaGLXFleeflsMarfooC2EjjjPKvbjj')));
+        EM_ASM(out(demangle('__ZN5wakaw2Cm10RasterBaseINS_6watwat9PolocatorEE8merbine1INS4_2OREEEvPKjj'))); // we get this wrong, but at least emit a '?'
         one(17);
         return 0;
       }
@@ -3027,7 +3027,7 @@ extern "C" int jslibfunc(int x);
 int main() {
   printf("c calling: %d\n", jslibfunc(6));
   EM_ASM({
-    Module.print('js calling: ' + Module['_jslibfunc'](5) + '.');
+    out('js calling: ' + Module['_jslibfunc'](5) + '.');
   });
 }
 ''')
@@ -3262,10 +3262,10 @@ int main() {
         int main() {
           EM_ASM({
             try {
-              Module.print('first');
+              out('first');
               abort();
             } catch (e) {
-              Module.print('second');
+              out('second');
               abort();
               throw e;
             }
@@ -4843,16 +4843,16 @@ namespace
   EMSCRIPTEN_KEEPALIVE
   void callback()
   {
-    EM_ASM({ Module.print('callback pre()') });
+    EM_ASM({ out('callback pre()') });
     ::emscripten_force_exit(42);
-    EM_ASM({ Module.print('callback post()') });
+    EM_ASM({ out('callback post()') });
     }
 }
 
 int
 main()
 {
-  EM_ASM({ setTimeout(function() { Module.print("calling callback()"); _callback() }, 100) });
+  EM_ASM({ setTimeout(function() { out("calling callback()"); _callback() }, 100) });
   ::emscripten_exit_with_live_runtime();
   return 123;
 }
@@ -5729,7 +5729,7 @@ Descriptor desc;
       print('----', filename, full)
       Popen([PYTHON, EMCC, path_from_root('tests', filename), '-O1', '-profiling', '-o', 'left.js', '-s', 'WASM=0']).communicate()
       src = open('left.js').read()
-      open('right.js', 'w').write(src.replace('function _main() {', 'function _main() { Module.print("replaced"); '))
+      open('right.js', 'w').write(src.replace('function _main() {', 'function _main() { out("replaced"); '))
 
       self.assertContained('hello, world!', run_js('left.js'))
       self.assertContained('hello, world!', run_js('right.js'))
@@ -5813,7 +5813,7 @@ print(os.environ.get('NM'))
 #include <emscripten.h>
 int main() {
   EM_ASM({
-    Module['onExit'] = function(status) { Module.print('exiting now, status ' + status) };
+    Module['onExit'] = function(status) { out('exiting now, status ' + status) };
   });
   return 14;
 }
@@ -5981,9 +5981,9 @@ int main(int argc, char** argv) {
         volatile fp f = 0;
         EM_ASM({
           if (typeof FUNCTION_TABLE_v !== 'undefined') {
-            Module.print('function table: ' + FUNCTION_TABLE_v);
+            out('function table: ' + FUNCTION_TABLE_v);
           } else {
-            Module.print('no visible function tables');
+            out('no visible function tables');
           }
         });
         if (f) f();
@@ -6004,8 +6004,8 @@ int main(int argc, char** argv) {
     src = r'''
       #include <emscripten.h>
       typedef void (*fp)();
-      void one() { EM_ASM( Module.print('one') ); }
-      void two() { EM_ASM( Module.print('two') ); }
+      void one() { EM_ASM( out('one') ); }
+      void two() { EM_ASM( out('two') ); }
       void test() {
         volatile fp f = one;
         f();
@@ -6019,7 +6019,7 @@ int main(int argc, char** argv) {
           var one = $0;
           var two = $1;
           if (typeof FUNCTION_TABLE_v === 'undefined') {
-            Module.print('no');
+            out('no');
             return;
           }
           var temp = FUNCTION_TABLE_v[one];
@@ -6683,19 +6683,19 @@ int main() {
     do {
       var t = Module._malloc(1024*1024);
       allocs[getIndex(t)].push(t);
-      Module.print('allocating, got in ' + getIndex(t));
+      out('allocating, got in ' + getIndex(t));
     } while (getIndex(t) === 0);
     assert(getIndex(t) === 1, 'allocated into second chunk');
     do {
       var t = Module._malloc(1024*1024);
       allocs[getIndex(t)].push(t);
-      Module.print('more allocating, got in ' + getIndex(t));
+      out('more allocating, got in ' + getIndex(t));
     } while (getIndex(t) === 1);
     assert(getIndex(t) === 2, 'into third chunk');
     do {
       var t = Module._malloc(1024*1024);
       allocs[getIndex(t)].push(t);
-      Module.print('more allocating, got in ' + getIndex(t));
+      out('more allocating, got in ' + getIndex(t));
     } while (getIndex(t) === 2);
     assert(getIndex(t) === 3, 'into third chunk');
     // write values
@@ -6712,7 +6712,7 @@ int main() {
     for (var i = 0; i < allocs[2].length; i++) {
       assert(HEAPU8[allocs[2][i]] === ((i*i) & 255));
     }
-    Module.print('success.');
+    out('success.');
   }, &x);
 }
 ''')
@@ -6757,7 +6757,7 @@ int main() {
   }
   printf("allocations in second chunk: %d\n", counter);
   assert(counter > 20);
-  EM_ASM( Module.print('success.') );
+  EM_ASM( out('success.') );
 }
 ''')
     for opts in [0, 1, 2]:
@@ -6795,7 +6795,7 @@ int main() {
   assert(sbrk(-10) == (void*)two);
   int bad = sbrk(split_memory * 2);
   assert(bad == -1);
-  EM_ASM( Module.print('success.') );
+  EM_ASM( out('success.') );
 }
 ''')
     for opts in [0, 1, 2]:
@@ -6892,8 +6892,8 @@ int main() {
     }
     Module.print = p;
     Module.printErr = e;
-    if (fail) Module.print('FAIL. ' + fail);
-    else Module.print('success.');
+    if (fail) out('FAIL. ' + fail);
+    else out('success.');
   ));
 }
 ''')
@@ -6918,13 +6918,13 @@ int main() {
     }
     do {
       var t = Module._malloc(1024*1024);
-      Module.print('allocating, got in ' + getIndex(t));
+      out('allocating, got in ' + getIndex(t));
     } while (getIndex(t) === 0);
     assert(getIndex(t) === 1, 'allocated into first chunk');
     assert(buffers[1]); // has been allocated now
     do {
       var t = Module._malloc(1024*1024);
-      Module.print('allocating, got in ' + getIndex(t));
+      out('allocating, got in ' + getIndex(t));
     } while (getIndex(t) === 1);
     assert(getIndex(t) === 2, 'allocated into second chunk');
     assert(buffers[2]); // has been allocated now
@@ -6939,7 +6939,7 @@ int main() {
       Module._free(more[i]);
     }
     assert(!buffers[2]); // has been freed again
-    Module.print('success.');
+    out('success.');
   });
 }
 ''')
@@ -6980,7 +6980,7 @@ int main() {
     assert(getIndex(t) === 3, 'should skip chunk 2, since it is used by us, but seeing ' + getIndex(t));
     assert(HEAPU8[p+0] === 12 && HEAPU8[p+50] === 98);
     assert(existing[33] === 201);
-    Module.print('success.');
+    out('success.');
   });
 }
 ''')
@@ -7203,7 +7203,7 @@ int main() {
 
 int main() {
   EM_ASM({
-    Module.print('inputs: ' + $0 + ', ' + $1 + '.');
+    out('inputs: ' + $0 + ', ' + $1 + '.');
   }, int64_t(0x12345678ABCDEF1FLL));
 }
 ''')
@@ -7328,10 +7328,10 @@ int main() {
       #include <emscripten.h>
       int main() {
         EM_ASM({
-          Module.print('environment is WEB? ' + ENVIRONMENT_IS_WEB);
-          Module.print('environment is WORKER? ' + ENVIRONMENT_IS_WORKER);
-          Module.print('environment is NODE? ' + ENVIRONMENT_IS_NODE);
-          Module.print('environment is SHELL? ' + ENVIRONMENT_IS_SHELL);
+          out('environment is WEB? ' + ENVIRONMENT_IS_WEB);
+          out('environment is WORKER? ' + ENVIRONMENT_IS_WORKER);
+          out('environment is NODE? ' + ENVIRONMENT_IS_NODE);
+          out('environment is SHELL? ' + ENVIRONMENT_IS_SHELL);
         });
       }
 ''')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6858,7 +6858,7 @@ int main() {
     }
     assert(TOTAL_MEMORY >= SPLIT_MEMORY*3);
     var p = out;
-    var e = outErr;
+    var e = err;
     err = out = function(){};
     var fail = false;
     if (!buffers[1]) allocateSplitChunk(1); // we will slice into this

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6857,9 +6857,9 @@ int main() {
       return x >> SPLIT_MEMORY_BITS;
     }
     assert(TOTAL_MEMORY >= SPLIT_MEMORY*3);
-    var p = Module.print;
-    var e = Module.printErr;
-    Module.printErr = Module.print = function(){};
+    var p = out;
+    var e = outErr;
+    err = out = function(){};
     var fail = false;
     if (!buffers[1]) allocateSplitChunk(1); // we will slice into this
     if (!buffers[2]) allocateSplitChunk(2); // we will slice into this
@@ -6890,8 +6890,8 @@ int main() {
         }
       }
     }
-    Module.print = p;
-    Module.printErr = e;
+    out = p;
+    err = e;
     if (fail) out('FAIL. ' + fail);
     else out('success.');
   ));

--- a/tests/test_webgl_context_attributes_common.c
+++ b/tests/test_webgl_context_attributes_common.c
@@ -282,19 +282,19 @@ extern int webglAlphaSupported(void);
 static void checkContextAttributesSupport() {
   if (!webglAntialiasSupported()) {
     resultAA = 1;
-    EM_ASM(Module['print']('warning: no antialiasing\n'));
+    EM_ASM(out('warning: no antialiasing\n'));
   }
   if (!webglDepthSupported()) {
     resultDepth = 1;
-    EM_ASM(Module['print']('warning: no depth\n'));
+    EM_ASM(out('warning: no depth\n'));
   }
   if (!webglStencilSupported()) {
     resultStencil = 1;
-    EM_ASM(Module['print']('warning: no stencil\n'));
+    EM_ASM(out('warning: no stencil\n'));
   }
   if (!webglAlphaSupported()) {
     resultAlpha = 1;
-    EM_ASM(Module['print']('warning: no alpha\n'));
+    EM_ASM(out('warning: no alpha\n'));
   }
 }
 

--- a/tests/unicode_library.js
+++ b/tests/unicode_library.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
 printey: function() {
-  Module.print('Unicode snowman ☃ says hello!');
+  out('Unicode snowman ☃ says hello!');
 }
 });

--- a/tests/unistd/io.c
+++ b/tests/unistd/io.c
@@ -33,7 +33,7 @@ int main() {
       },
       write: function(stream, buffer, offset, length, pos) {
         for (var i = 0; i < length; i++) {
-          Module.print('TO DEVICE: ' + buffer[offset+i]);
+          out('TO DEVICE: ' + buffer[offset+i]);
         }
         return i;
       }

--- a/tests/utf32.cpp
+++ b/tests/utf32.cpp
@@ -18,7 +18,7 @@ int main() {
 
 		EM_ASM({
 			var str = Module.UTF32ToString($0);
-			Module.print(str);
+			out(str);
 			var numBytesWritten = Module.stringToUTF32(str, $1, $2);
 			if (numBytesWritten != 23*4) throw 'stringToUTF32 wrote an invalid length ' + numBytesWritten;
 		}, wstr.c_str(), memory, (wstr.length()+1)*sizeof(utf32));
@@ -33,7 +33,7 @@ int main() {
 
 		EM_ASM({
 			var str = Module.UTF32ToString($0);
-			Module.print(str);
+			out(str);
 			var numBytesWritten = Module.stringToUTF32(str, $1, $2);
 			if (numBytesWritten != 5*4) throw 'stringToUTF32 wrote an invalid length ' + numBytesWritten;
 		}, wstr.c_str(), memory, 6*sizeof(utf32));
@@ -45,7 +45,7 @@ int main() {
 
 		EM_ASM({
 			var str = Module.UTF16ToString($0);
-			Module.print(str);
+			out(str);
 			var numBytesWritten = Module.stringToUTF16(str, $1, $2);
 			if (numBytesWritten != 25*2) throw 'stringToUTF16 wrote an invalid length ' + numBytesWritten;
 		}, wstr.c_str(), memory, (2*wstr.length()+1)*sizeof(utf16));
@@ -60,7 +60,7 @@ int main() {
 
 		EM_ASM({
 			var str = Module.UTF16ToString($0);
-			Module.print(str);
+			out(str);
 			var numBytesWritten = Module.stringToUTF16(str, $1, $2);
 			if (numBytesWritten != 5*2) throw 'stringToUTF16 wrote an invalid length ' + numBytesWritten;
 		}, wstr.c_str(), memory, 6*sizeof(utf16));

--- a/tests/utf8.cpp
+++ b/tests/utf8.cpp
@@ -11,7 +11,7 @@ int main() {
   char asciiString2[128] = {};
   EM_ASM({
     var str = Module.AsciiToString($0);
-    Module.print(str);
+    out(str);
     Module.stringToAscii(str, $1);
   }, asciiString, asciiString2);
   assert(!strcmp(asciiString, asciiString2));
@@ -19,7 +19,7 @@ int main() {
   char asciiString3[128] = {};
   EM_ASM({
     var str = Module.UTF8ToString($0);
-    Module.print(str);
+    out(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
     if (numBytesWritten != 12) throw 'stringToUTF8 wrote an invalid length ' + numBytesWritten;
   }, asciiString, asciiString3, 128);
@@ -29,7 +29,7 @@ int main() {
   char utf8String2[128] = {};
   EM_ASM({
     var str = Module.UTF8ToString($0);
-    Module.print(str);
+    out(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
     if (numBytesWritten != 69) throw 'stringToUTF8 wrote an invalid length ' + numBytesWritten;
   }, utf8String, utf8String2, 128);
@@ -42,7 +42,7 @@ int main() {
   // Test that text gets properly cut off if output buffer is too small.
   EM_ASM({
     var str = Module.UTF8ToString($0);
-    Module.print(str);
+    out(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
     if (numBytesWritten != 9) throw 'stringToUTF8 wrote an invalid length ' + numBytesWritten;
   }, utf8String, utf8String2, 10);
@@ -51,7 +51,7 @@ int main() {
   // Zero-length string.
   EM_ASM({
     var str = Module.UTF8ToString($0);
-    Module.print(str);
+    out(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
     if (numBytesWritten != 0) throw 'stringToUTF8 wrote an invalid length ' + numBytesWritten;
   }, utf8String, utf8String2, 1);
@@ -61,7 +61,7 @@ int main() {
   utf8String2[0] = 'X';
   EM_ASM({
     var str = Module.UTF8ToString($0);
-    Module.print(str);
+    out(str);
     var numBytesWritten = Module.stringToUTF8(str, $1, $2);
     if (numBytesWritten != 0) throw 'stringToUTF8 wrote an invalid length ' + numBytesWritten;
   }, utf8String, utf8String2, 0);

--- a/tests/wasm/trap-f2i.cpp
+++ b/tests/wasm/trap-f2i.cpp
@@ -4,14 +4,14 @@ int main() {
   {
     volatile double d = 17179870521;
     EM_ASM({
-      Module.print('|' + $0 + '|')
+      out('|' + $0 + '|')
     }, int(d));
   }
   {
     // unsigned
     volatile double d = 4294967295.0;
     EM_ASM({
-      Module.print('|' + ($0 >>> 0) + '|')
+      out('|' + ($0 >>> 0) + '|')
     }, unsigned(d));
   }
 }

--- a/tests/wasm/trap-idiv.cpp
+++ b/tests/wasm/trap-idiv.cpp
@@ -4,7 +4,7 @@ int main() {
   volatile int i = 1;
   volatile int j = 0;
   EM_ASM({
-    Module.print('|' + $0 + '|')
+    out('|' + $0 + '|')
   }, i / j);
 }
 

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -3,64 +3,64 @@
 
 var sme = new TheModule.Parent(42);
 sme.mulVal(2);
-Theout('*')
-Theout(sme.getVal());
+out('*')
+out(sme.getVal());
 sme.parentFunc(90);
-Theout(typeof sme.getAsConst());
-Theout(typeof sme.voidStar(sme));
-Theout(sme.get_immutableAttr());
-Theout(typeof sme.getBoolean());
-Theout(sme.getBoolean());
+out(typeof sme.getAsConst());
+out(typeof sme.voidStar(sme));
+out(sme.get_immutableAttr());
+out(typeof sme.getBoolean());
+out(sme.getBoolean());
 
-Theout('c1');
+out('c1');
 
 var c1 = new TheModule.Child1();
-Theout(c1.getVal());
+out(c1.getVal());
 c1.mulVal(2);
-Theout(c1.getVal());
-Theout(c1.getValSqr());
-Theout(c1.getValSqr(3));
-Theout(c1.getValTimes()); // default argument should be 1
-Theout(c1.getValTimes(2));
-Theout(sme.getBoolean());
+out(c1.getVal());
+out(c1.getValSqr());
+out(c1.getValSqr(3));
+out(c1.getValTimes()); // default argument should be 1
+out(c1.getValTimes(2));
+out(sme.getBoolean());
 c1.parentFunc(90);
 
-Theout('c1 v2');
+out('c1 v2');
 
 c1 = new TheModule.Child1(8); // now with a parameter, we should handle the overloading automatically and properly and use constructor #2
-Theout(c1.getVal());
+out(c1.getVal());
 c1.mulVal(2);
-Theout(c1.getVal());
-Theout(c1.getValSqr());
-Theout(c1.getValSqr(3));
-Theout(sme.getBoolean());
+out(c1.getVal());
+out(c1.getValSqr());
+out(c1.getValSqr(3));
+out(sme.getBoolean());
 
-Theout('c2')
+out('c2')
 
 var c2 = new TheModule.Child2();
-Theout(c2.getVal());
+out(c2.getVal());
 c2.mulVal(2);
-Theout(c2.getVal());
-Theout(c2.getValCube());
+out(c2.getVal());
+out(c2.getValCube());
 var succeeded;
 try {
   succeeded = 0;
-  Theout(c2.doSomethingSecret()); // should fail since private
+  out(c2.doSomethingSecret()); // should fail since private
   succeeded = 1;
 } catch(e) {}
-Theout(succeeded);
+out(succeeded);
 try {
   succeeded = 0;
-  Theout(c2.getValSqr()); // function from the other class
+  out(c2.getValSqr()); // function from the other class
   succeeded = 1;
 } catch(e) {}
-Theout(succeeded);
+out(succeeded);
 try {
   succeeded = 0;
   c2.getValCube(); // sanity
   succeeded = 1;
 } catch(e) {}
-Theout(succeeded);
+out(succeeded);
 
 TheModule.Child2.prototype.printStatic(); // static calls go through the prototype
 
@@ -73,13 +73,13 @@ c2.virtualFunc2();
 var c3 = new TheModule.Child2JS;
 
 c3.virtualFunc = function() {
-  Theout('*js virtualf replacement*');
+  out('*js virtualf replacement*');
 };
 c3.virtualFunc2 = function() {
-  Theout('*js virtualf2 replacement*');
+  out('*js virtualf2 replacement*');
 };
 c3.virtualFunc3 = function(x) {
-  Theout('*js virtualf3 replacement ' + x + '*');
+  out('*js virtualf3 replacement ' + x + '*');
 };
 
 c3.virtualFunc();
@@ -89,7 +89,7 @@ c3.virtualFunc3(123); // this one is not replaced!
 try {
   c3.virtualFunc4(123);
 } catch(e) {
-  Theout('caught: ' + e);
+  out('caught: ' + e);
 }
 
 // Test virtual method dispatch from c++
@@ -98,93 +98,93 @@ TheModule.Child2.prototype.runVirtualFunc3(c3, 43);
 c2.virtualFunc(); // original should remain the same
 TheModule.Child2.prototype.runVirtualFunc(c2);
 c2.virtualFunc2();
-Theout('*ok*');
+out('*ok*');
 
 // Part 2
 
 var suser = new TheModule.StringUser("hello", 43);
 suser.Print(41, "world");
 suser.PrintFloat(12.3456);
-Theout(suser.returnAString());
+out(suser.returnAString());
 
 var bv = new TheModule.RefUser(10);
 var bv2 = new TheModule.RefUser(11);
-Theout(bv2.getValue(bv));
+out(bv2.getValue(bv));
 
-Theout(typeof bv2.getMe());
-Theout(bv2.getMe().getValue(bv));
-Theout(bv2.getMe().getValue(bv2));
+out(typeof bv2.getMe());
+out(bv2.getMe().getValue(bv));
+out(bv2.getMe().getValue(bv2));
 
-Theout(typeof bv2.getCopy());
-Theout(bv2.getCopy().getValue(bv));
-Theout(bv2.getCopy().getValue(bv2));
+out(typeof bv2.getCopy());
+out(bv2.getCopy().getValue(bv));
+out(bv2.getCopy().getValue(bv2));
 
 bv2.getAnother().PrintFloat(21.12);
 
-Theout(new TheModule.Inner().get());
-Theout('getAsArray: ' + new TheModule.Inner().getAsArray(12));
+out(new TheModule.Inner().get());
+out('getAsArray: ' + new TheModule.Inner().getAsArray(12));
 new TheModule.Inner().mul(2);
 
-Theout(TheModule.enum_value1);
-Theout(TheModule.enum_value2);
+out(TheModule.enum_value1);
+out(TheModule.enum_value2);
 
 // Enums from classes are accessed via the class.
 enumClassInstance = new TheModule.EnumClass();
-Theout([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
+out([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
 
 // Enums from namespaces are accessed via the top-level module, as with classes defined
 // in namespaces, see `Inner` above.
-Theout(TheModule.e_namespace_val);
+out(TheModule.e_namespace_val);
 
 typeTester = new TheModule.TypeTestClass();
 
-Theout('return char ' + typeTester.ReturnCharMethod());
+out('return char ' + typeTester.ReturnCharMethod());
 typeTester.AcceptCharMethod((2<<6)-1);
 // Prints -1 because the c++ code accepts unsigned char.
 typeTester.AcceptCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-Theout('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
+out('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
 typeTester.AcceptUnsignedCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-Theout('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
+out('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
 typeTester.AcceptUnsignedShortMethod((2<<15)-1);
 
 // Prints -1 because all integers are signed in javascript.
-Theout('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
+out('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
 typeTester.AcceptUnsignedLongMethod((2<<31)-1);
 var voidPointerUser = new TheModule.VoidPointerUser();
 
 voidPointerUser.SetVoidPointer(3);
-Theout('void * ' + voidPointerUser.GetVoidPointer());
+out('void * ' + voidPointerUser.GetVoidPointer());
 
 // Array tests
 
 var arrayClass = new TheModule.ArrayClass();
-Theout('int_array[0] == ' + arrayClass.get_int_array(0));
-Theout('int_array[7] == ' + arrayClass.get_int_array(7));
+out('int_array[0] == ' + arrayClass.get_int_array(0));
+out('int_array[7] == ' + arrayClass.get_int_array(7));
 arrayClass.set_int_array(0, 42);
 arrayClass.set_int_array(7, 43);
-Theout('int_array[0] == ' + arrayClass.get_int_array(0));
-Theout('int_array[7] == ' + arrayClass.get_int_array(7));
+out('int_array[0] == ' + arrayClass.get_int_array(0));
+out('int_array[7] == ' + arrayClass.get_int_array(7));
 
 try {
   arrayClass.set_int_array(-1, struct);
 } catch (e) {
-  Theout('idx -1: ' + e);
+  out('idx -1: ' + e);
 }
 
 try {
   arrayClass.set_int_array(8, struct);
 } catch (e) {
-  Theout('idx 8: ' + e);
+  out('idx 8: ' + e);
 }
 
-Theout('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-Theout('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-Theout('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-Theout('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+out('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+out('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+out('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+out('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 // Verify that bounds checking is *not* enabled when not asked for.
 // This actually causes an illegal memory access, but as it's only a read, and the return
@@ -196,15 +196,15 @@ arrayClass.set_struct_array(0, struct);
 struct = new TheModule.StructInArray(14, 18);
 arrayClass.set_struct_array(7, struct);
 
-Theout('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-Theout('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-Theout('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-Theout('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+out('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+out('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+out('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+out('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 struct = new TheModule.StructInArray(100, 101);
 arrayClass.set_struct_ptr_array(0, struct);
-Theout('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
-Theout('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
+out('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
+out('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
 
 // receiving arrays
 
@@ -265,11 +265,11 @@ if (isMemoryGrowthAllowed) {
   }
 
   if (intArray.length !== numCopiedEntries) {
-    Theout('ERROR: An array was not copied to HEAP32 after memory reallocation');
+    out('ERROR: An array was not copied to HEAP32 after memory reallocation');
   }
 }
 
 //
 
-Theout('\ndone.')
+out('\ndone.')
 

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -3,64 +3,64 @@
 
 var sme = new TheModule.Parent(42);
 sme.mulVal(2);
-TheModule.print('*')
-TheModule.print(sme.getVal());
+Theout('*')
+Theout(sme.getVal());
 sme.parentFunc(90);
-TheModule.print(typeof sme.getAsConst());
-TheModule.print(typeof sme.voidStar(sme));
-TheModule.print(sme.get_immutableAttr());
-TheModule.print(typeof sme.getBoolean());
-TheModule.print(sme.getBoolean());
+Theout(typeof sme.getAsConst());
+Theout(typeof sme.voidStar(sme));
+Theout(sme.get_immutableAttr());
+Theout(typeof sme.getBoolean());
+Theout(sme.getBoolean());
 
-TheModule.print('c1');
+Theout('c1');
 
 var c1 = new TheModule.Child1();
-TheModule.print(c1.getVal());
+Theout(c1.getVal());
 c1.mulVal(2);
-TheModule.print(c1.getVal());
-TheModule.print(c1.getValSqr());
-TheModule.print(c1.getValSqr(3));
-TheModule.print(c1.getValTimes()); // default argument should be 1
-TheModule.print(c1.getValTimes(2));
-TheModule.print(sme.getBoolean());
+Theout(c1.getVal());
+Theout(c1.getValSqr());
+Theout(c1.getValSqr(3));
+Theout(c1.getValTimes()); // default argument should be 1
+Theout(c1.getValTimes(2));
+Theout(sme.getBoolean());
 c1.parentFunc(90);
 
-TheModule.print('c1 v2');
+Theout('c1 v2');
 
 c1 = new TheModule.Child1(8); // now with a parameter, we should handle the overloading automatically and properly and use constructor #2
-TheModule.print(c1.getVal());
+Theout(c1.getVal());
 c1.mulVal(2);
-TheModule.print(c1.getVal());
-TheModule.print(c1.getValSqr());
-TheModule.print(c1.getValSqr(3));
-TheModule.print(sme.getBoolean());
+Theout(c1.getVal());
+Theout(c1.getValSqr());
+Theout(c1.getValSqr(3));
+Theout(sme.getBoolean());
 
-TheModule.print('c2')
+Theout('c2')
 
 var c2 = new TheModule.Child2();
-TheModule.print(c2.getVal());
+Theout(c2.getVal());
 c2.mulVal(2);
-TheModule.print(c2.getVal());
-TheModule.print(c2.getValCube());
+Theout(c2.getVal());
+Theout(c2.getValCube());
 var succeeded;
 try {
   succeeded = 0;
-  TheModule.print(c2.doSomethingSecret()); // should fail since private
+  Theout(c2.doSomethingSecret()); // should fail since private
   succeeded = 1;
 } catch(e) {}
-TheModule.print(succeeded);
+Theout(succeeded);
 try {
   succeeded = 0;
-  TheModule.print(c2.getValSqr()); // function from the other class
+  Theout(c2.getValSqr()); // function from the other class
   succeeded = 1;
 } catch(e) {}
-TheModule.print(succeeded);
+Theout(succeeded);
 try {
   succeeded = 0;
   c2.getValCube(); // sanity
   succeeded = 1;
 } catch(e) {}
-TheModule.print(succeeded);
+Theout(succeeded);
 
 TheModule.Child2.prototype.printStatic(); // static calls go through the prototype
 
@@ -73,13 +73,13 @@ c2.virtualFunc2();
 var c3 = new TheModule.Child2JS;
 
 c3.virtualFunc = function() {
-  TheModule.print('*js virtualf replacement*');
+  Theout('*js virtualf replacement*');
 };
 c3.virtualFunc2 = function() {
-  TheModule.print('*js virtualf2 replacement*');
+  Theout('*js virtualf2 replacement*');
 };
 c3.virtualFunc3 = function(x) {
-  TheModule.print('*js virtualf3 replacement ' + x + '*');
+  Theout('*js virtualf3 replacement ' + x + '*');
 };
 
 c3.virtualFunc();
@@ -89,7 +89,7 @@ c3.virtualFunc3(123); // this one is not replaced!
 try {
   c3.virtualFunc4(123);
 } catch(e) {
-  TheModule.print('caught: ' + e);
+  Theout('caught: ' + e);
 }
 
 // Test virtual method dispatch from c++
@@ -98,93 +98,93 @@ TheModule.Child2.prototype.runVirtualFunc3(c3, 43);
 c2.virtualFunc(); // original should remain the same
 TheModule.Child2.prototype.runVirtualFunc(c2);
 c2.virtualFunc2();
-TheModule.print('*ok*');
+Theout('*ok*');
 
 // Part 2
 
 var suser = new TheModule.StringUser("hello", 43);
 suser.Print(41, "world");
 suser.PrintFloat(12.3456);
-TheModule.print(suser.returnAString());
+Theout(suser.returnAString());
 
 var bv = new TheModule.RefUser(10);
 var bv2 = new TheModule.RefUser(11);
-TheModule.print(bv2.getValue(bv));
+Theout(bv2.getValue(bv));
 
-TheModule.print(typeof bv2.getMe());
-TheModule.print(bv2.getMe().getValue(bv));
-TheModule.print(bv2.getMe().getValue(bv2));
+Theout(typeof bv2.getMe());
+Theout(bv2.getMe().getValue(bv));
+Theout(bv2.getMe().getValue(bv2));
 
-TheModule.print(typeof bv2.getCopy());
-TheModule.print(bv2.getCopy().getValue(bv));
-TheModule.print(bv2.getCopy().getValue(bv2));
+Theout(typeof bv2.getCopy());
+Theout(bv2.getCopy().getValue(bv));
+Theout(bv2.getCopy().getValue(bv2));
 
 bv2.getAnother().PrintFloat(21.12);
 
-TheModule.print(new TheModule.Inner().get());
-TheModule.print('getAsArray: ' + new TheModule.Inner().getAsArray(12));
+Theout(new TheModule.Inner().get());
+Theout('getAsArray: ' + new TheModule.Inner().getAsArray(12));
 new TheModule.Inner().mul(2);
 
-TheModule.print(TheModule.enum_value1);
-TheModule.print(TheModule.enum_value2);
+Theout(TheModule.enum_value1);
+Theout(TheModule.enum_value2);
 
 // Enums from classes are accessed via the class.
 enumClassInstance = new TheModule.EnumClass();
-TheModule.print([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
+Theout([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
 
 // Enums from namespaces are accessed via the top-level module, as with classes defined
 // in namespaces, see `Inner` above.
-TheModule.print(TheModule.e_namespace_val);
+Theout(TheModule.e_namespace_val);
 
 typeTester = new TheModule.TypeTestClass();
 
-TheModule.print('return char ' + typeTester.ReturnCharMethod());
+Theout('return char ' + typeTester.ReturnCharMethod());
 typeTester.AcceptCharMethod((2<<6)-1);
 // Prints -1 because the c++ code accepts unsigned char.
 typeTester.AcceptCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-TheModule.print('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
+Theout('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
 typeTester.AcceptUnsignedCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-TheModule.print('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
+Theout('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
 typeTester.AcceptUnsignedShortMethod((2<<15)-1);
 
 // Prints -1 because all integers are signed in javascript.
-TheModule.print('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
+Theout('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
 typeTester.AcceptUnsignedLongMethod((2<<31)-1);
 var voidPointerUser = new TheModule.VoidPointerUser();
 
 voidPointerUser.SetVoidPointer(3);
-TheModule.print('void * ' + voidPointerUser.GetVoidPointer());
+Theout('void * ' + voidPointerUser.GetVoidPointer());
 
 // Array tests
 
 var arrayClass = new TheModule.ArrayClass();
-TheModule.print('int_array[0] == ' + arrayClass.get_int_array(0));
-TheModule.print('int_array[7] == ' + arrayClass.get_int_array(7));
+Theout('int_array[0] == ' + arrayClass.get_int_array(0));
+Theout('int_array[7] == ' + arrayClass.get_int_array(7));
 arrayClass.set_int_array(0, 42);
 arrayClass.set_int_array(7, 43);
-TheModule.print('int_array[0] == ' + arrayClass.get_int_array(0));
-TheModule.print('int_array[7] == ' + arrayClass.get_int_array(7));
+Theout('int_array[0] == ' + arrayClass.get_int_array(0));
+Theout('int_array[7] == ' + arrayClass.get_int_array(7));
 
 try {
   arrayClass.set_int_array(-1, struct);
 } catch (e) {
-  TheModule.print('idx -1: ' + e);
+  Theout('idx -1: ' + e);
 }
 
 try {
   arrayClass.set_int_array(8, struct);
 } catch (e) {
-  TheModule.print('idx 8: ' + e);
+  Theout('idx 8: ' + e);
 }
 
-TheModule.print('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-TheModule.print('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-TheModule.print('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-TheModule.print('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+Theout('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+Theout('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+Theout('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+Theout('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 // Verify that bounds checking is *not* enabled when not asked for.
 // This actually causes an illegal memory access, but as it's only a read, and the return
@@ -196,15 +196,15 @@ arrayClass.set_struct_array(0, struct);
 struct = new TheModule.StructInArray(14, 18);
 arrayClass.set_struct_array(7, struct);
 
-TheModule.print('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-TheModule.print('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-TheModule.print('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-TheModule.print('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+Theout('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+Theout('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+Theout('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+Theout('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 struct = new TheModule.StructInArray(100, 101);
 arrayClass.set_struct_ptr_array(0, struct);
-TheModule.print('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
-TheModule.print('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
+Theout('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
+Theout('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
 
 // receiving arrays
 
@@ -265,11 +265,11 @@ if (isMemoryGrowthAllowed) {
   }
 
   if (intArray.length !== numCopiedEntries) {
-    TheModule.print('ERROR: An array was not copied to HEAP32 after memory reallocation');
+    Theout('ERROR: An array was not copied to HEAP32 after memory reallocation');
   }
 }
 
 //
 
-TheModule.print('\ndone.')
+Theout('\ndone.')
 

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -3,64 +3,64 @@
 
 var sme = new TheModule.Parent(42);
 sme.mulVal(2);
-out('*')
-out(sme.getVal());
+console.log('*')
+console.log(sme.getVal());
 sme.parentFunc(90);
-out(typeof sme.getAsConst());
-out(typeof sme.voidStar(sme));
-out(sme.get_immutableAttr());
-out(typeof sme.getBoolean());
-out(sme.getBoolean());
+console.log(typeof sme.getAsConst());
+console.log(typeof sme.voidStar(sme));
+console.log(sme.get_immutableAttr());
+console.log(typeof sme.getBoolean());
+console.log(sme.getBoolean());
 
-out('c1');
+console.log('c1');
 
 var c1 = new TheModule.Child1();
-out(c1.getVal());
+console.log(c1.getVal());
 c1.mulVal(2);
-out(c1.getVal());
-out(c1.getValSqr());
-out(c1.getValSqr(3));
-out(c1.getValTimes()); // default argument should be 1
-out(c1.getValTimes(2));
-out(sme.getBoolean());
+console.log(c1.getVal());
+console.log(c1.getValSqr());
+console.log(c1.getValSqr(3));
+console.log(c1.getValTimes()); // default argument should be 1
+console.log(c1.getValTimes(2));
+console.log(sme.getBoolean());
 c1.parentFunc(90);
 
-out('c1 v2');
+console.log('c1 v2');
 
 c1 = new TheModule.Child1(8); // now with a parameter, we should handle the overloading automatically and properly and use constructor #2
-out(c1.getVal());
+console.log(c1.getVal());
 c1.mulVal(2);
-out(c1.getVal());
-out(c1.getValSqr());
-out(c1.getValSqr(3));
-out(sme.getBoolean());
+console.log(c1.getVal());
+console.log(c1.getValSqr());
+console.log(c1.getValSqr(3));
+console.log(sme.getBoolean());
 
-out('c2')
+console.log('c2')
 
 var c2 = new TheModule.Child2();
-out(c2.getVal());
+console.log(c2.getVal());
 c2.mulVal(2);
-out(c2.getVal());
-out(c2.getValCube());
+console.log(c2.getVal());
+console.log(c2.getValCube());
 var succeeded;
 try {
   succeeded = 0;
-  out(c2.doSomethingSecret()); // should fail since private
+  console.log(c2.doSomethingSecret()); // should fail since private
   succeeded = 1;
 } catch(e) {}
-out(succeeded);
+console.log(succeeded);
 try {
   succeeded = 0;
-  out(c2.getValSqr()); // function from the other class
+  console.log(c2.getValSqr()); // function from the other class
   succeeded = 1;
 } catch(e) {}
-out(succeeded);
+console.log(succeeded);
 try {
   succeeded = 0;
   c2.getValCube(); // sanity
   succeeded = 1;
 } catch(e) {}
-out(succeeded);
+console.log(succeeded);
 
 TheModule.Child2.prototype.printStatic(); // static calls go through the prototype
 
@@ -73,13 +73,13 @@ c2.virtualFunc2();
 var c3 = new TheModule.Child2JS;
 
 c3.virtualFunc = function() {
-  out('*js virtualf replacement*');
+  console.log('*js virtualf replacement*');
 };
 c3.virtualFunc2 = function() {
-  out('*js virtualf2 replacement*');
+  console.log('*js virtualf2 replacement*');
 };
 c3.virtualFunc3 = function(x) {
-  out('*js virtualf3 replacement ' + x + '*');
+  console.log('*js virtualf3 replacement ' + x + '*');
 };
 
 c3.virtualFunc();
@@ -89,7 +89,7 @@ c3.virtualFunc3(123); // this one is not replaced!
 try {
   c3.virtualFunc4(123);
 } catch(e) {
-  out('caught: ' + e);
+  console.log('caught: ' + e);
 }
 
 // Test virtual method dispatch from c++
@@ -98,93 +98,93 @@ TheModule.Child2.prototype.runVirtualFunc3(c3, 43);
 c2.virtualFunc(); // original should remain the same
 TheModule.Child2.prototype.runVirtualFunc(c2);
 c2.virtualFunc2();
-out('*ok*');
+console.log('*ok*');
 
 // Part 2
 
 var suser = new TheModule.StringUser("hello", 43);
 suser.Print(41, "world");
 suser.PrintFloat(12.3456);
-out(suser.returnAString());
+console.log(suser.returnAString());
 
 var bv = new TheModule.RefUser(10);
 var bv2 = new TheModule.RefUser(11);
-out(bv2.getValue(bv));
+console.log(bv2.getValue(bv));
 
-out(typeof bv2.getMe());
-out(bv2.getMe().getValue(bv));
-out(bv2.getMe().getValue(bv2));
+console.log(typeof bv2.getMe());
+console.log(bv2.getMe().getValue(bv));
+console.log(bv2.getMe().getValue(bv2));
 
-out(typeof bv2.getCopy());
-out(bv2.getCopy().getValue(bv));
-out(bv2.getCopy().getValue(bv2));
+console.log(typeof bv2.getCopy());
+console.log(bv2.getCopy().getValue(bv));
+console.log(bv2.getCopy().getValue(bv2));
 
 bv2.getAnother().PrintFloat(21.12);
 
-out(new TheModule.Inner().get());
-out('getAsArray: ' + new TheModule.Inner().getAsArray(12));
+console.log(new TheModule.Inner().get());
+console.log('getAsArray: ' + new TheModule.Inner().getAsArray(12));
 new TheModule.Inner().mul(2);
 
-out(TheModule.enum_value1);
-out(TheModule.enum_value2);
+console.log(TheModule.enum_value1);
+console.log(TheModule.enum_value2);
 
 // Enums from classes are accessed via the class.
 enumClassInstance = new TheModule.EnumClass();
-out([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
+console.log([enumClassInstance.GetEnum(), TheModule.EnumClass.e_val].join(','));
 
 // Enums from namespaces are accessed via the top-level module, as with classes defined
 // in namespaces, see `Inner` above.
-out(TheModule.e_namespace_val);
+console.log(TheModule.e_namespace_val);
 
 typeTester = new TheModule.TypeTestClass();
 
-out('return char ' + typeTester.ReturnCharMethod());
+console.log('return char ' + typeTester.ReturnCharMethod());
 typeTester.AcceptCharMethod((2<<6)-1);
 // Prints -1 because the c++ code accepts unsigned char.
 typeTester.AcceptCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-out('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
+console.log('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
 typeTester.AcceptUnsignedCharMethod((2<<7)-1);
 
 // Prints -1 because all integers are signed in javascript.
-out('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
+console.log('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
 typeTester.AcceptUnsignedShortMethod((2<<15)-1);
 
 // Prints -1 because all integers are signed in javascript.
-out('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
+console.log('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
 typeTester.AcceptUnsignedLongMethod((2<<31)-1);
 var voidPointerUser = new TheModule.VoidPointerUser();
 
 voidPointerUser.SetVoidPointer(3);
-out('void * ' + voidPointerUser.GetVoidPointer());
+console.log('void * ' + voidPointerUser.GetVoidPointer());
 
 // Array tests
 
 var arrayClass = new TheModule.ArrayClass();
-out('int_array[0] == ' + arrayClass.get_int_array(0));
-out('int_array[7] == ' + arrayClass.get_int_array(7));
+console.log('int_array[0] == ' + arrayClass.get_int_array(0));
+console.log('int_array[7] == ' + arrayClass.get_int_array(7));
 arrayClass.set_int_array(0, 42);
 arrayClass.set_int_array(7, 43);
-out('int_array[0] == ' + arrayClass.get_int_array(0));
-out('int_array[7] == ' + arrayClass.get_int_array(7));
+console.log('int_array[0] == ' + arrayClass.get_int_array(0));
+console.log('int_array[7] == ' + arrayClass.get_int_array(7));
 
 try {
   arrayClass.set_int_array(-1, struct);
 } catch (e) {
-  out('idx -1: ' + e);
+  console.log('idx -1: ' + e);
 }
 
 try {
   arrayClass.set_int_array(8, struct);
 } catch (e) {
-  out('idx 8: ' + e);
+  console.log('idx 8: ' + e);
 }
 
-out('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-out('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-out('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-out('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+console.log('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+console.log('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+console.log('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+console.log('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 // Verify that bounds checking is *not* enabled when not asked for.
 // This actually causes an illegal memory access, but as it's only a read, and the return
@@ -196,15 +196,15 @@ arrayClass.set_struct_array(0, struct);
 struct = new TheModule.StructInArray(14, 18);
 arrayClass.set_struct_array(7, struct);
 
-out('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
-out('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
-out('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
-out('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
+console.log('struct_array[0].attr1 == ' + arrayClass.get_struct_array(0).get_attr1());
+console.log('struct_array[0].attr2 == ' + arrayClass.get_struct_array(0).get_attr2());
+console.log('struct_array[7].attr1 == ' + arrayClass.get_struct_array(7).get_attr1());
+console.log('struct_array[7].attr2 == ' + arrayClass.get_struct_array(7).get_attr2());
 
 struct = new TheModule.StructInArray(100, 101);
 arrayClass.set_struct_ptr_array(0, struct);
-out('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
-out('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
+console.log('struct_ptr_array[0]->attr1 == ' + arrayClass.get_struct_ptr_array(0).get_attr1());
+console.log('struct_ptr_array[0]->attr2 == ' + arrayClass.get_struct_ptr_array(0).get_attr2());
 
 // receiving arrays
 
@@ -265,11 +265,11 @@ if (isMemoryGrowthAllowed) {
   }
 
   if (intArray.length !== numCopiedEntries) {
-    out('ERROR: An array was not copied to HEAP32 after memory reallocation');
+    console.log('ERROR: An array was not copied to HEAP32 after memory reallocation');
   }
 }
 
 //
 
-out('\ndone.')
+console.log('\ndone.')
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -468,7 +468,7 @@ def push_stacktop(zero):
   return (' sp = EMTSTACKTOP;' if not ASYNC else ' sp = EMTSTACKTOP + 8 | 0;') if not zero else ''
 
 def pop_stacktop(zero):
-  return '//Module.print("exit");\n' + ((' EMTSTACKTOP = sp; ' if not ASYNC else 'EMTSTACKTOP = sp - 8 | 0; ') if not zero else '')
+  return '//out("exit");\n' + ((' EMTSTACKTOP = sp; ' if not ASYNC else 'EMTSTACKTOP = sp - 8 | 0; ') if not zero else '')
 
 def handle_async_pre_call():
   return 'HEAP32[sp - 4 >> 2] = pc;' if ASYNC else ''
@@ -643,7 +643,7 @@ def make_emterpreter(zero=False):
   lx = (inst >> 8) & 255;
   ly = (inst >> 16) & 255;
   lz = inst >>> 24;
-  //Module.print([pc, inst&255, ''' + json.dumps(OPCODES) + '''[inst&255], lx, ly, lz, HEAPU8[pc + 4],HEAPU8[pc + 5],HEAPU8[pc + 6],HEAPU8[pc + 7]]);
+  //out([pc, inst&255, ''' + json.dumps(OPCODES) + '''[inst&255], lx, ly, lz, HEAPU8[pc + 4],HEAPU8[pc + 5],HEAPU8[pc + 6],HEAPU8[pc + 7]]);
 '''
 
   if not INNERTERPRETER_LAST_OPCODE:
@@ -677,7 +677,7 @@ def make_emterpreter(zero=False):
 
   return process(r'''
 function emterpret%s(pc) {
- //Module.print('emterpret: ' + pc + ',' + EMTSTACKTOP);
+ //out('emterpret: ' + pc + ',' + EMTSTACKTOP);
  pc = pc | 0;
  var %sinst = 0, lx = 0, ly = 0, lz = 0;
 %s

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -426,7 +426,7 @@ if has_preloaded:
           if (that.audio) {
             Module['removeRunDependency']('fp ' + that.name); // workaround for chromium bug 124926 (still no audio with this, but at least we don't hang)
           } else {
-            Module.printErr('Preloading file ' + that.name + ' failed');
+            err('Preloading file ' + that.name + ' failed');
           }
         }, false, true); // canOwn this data in the filesystem, it is a slide into the heap that will never change
 '''
@@ -524,7 +524,7 @@ if has_preloaded:
       use_data = '''
         // copy the entire loaded file into a spot in the heap. Files will refer to slices in that. They cannot be freed though
         // (we may be allocating before malloc is ready, during startup).
-        if (Module['SPLIT_MEMORY']) Module.printErr('warning: you should run the file packager with --no-heap-copy when SPLIT_MEMORY is used, otherwise copying into the heap may fail due to the splitting');
+        if (Module['SPLIT_MEMORY']) err('warning: you should run the file packager with --no-heap-copy when SPLIT_MEMORY is used, otherwise copying into the heap may fail due to the splitting');
         var ptr = Module['getMemory'](byteArray.length);
         Module['HEAPU8'].set(byteArray, ptr);
         DataRequest.prototype.byteArray = Module['HEAPU8'].subarray(ptr, ptr+byteArray.length);
@@ -575,7 +575,7 @@ if has_preloaded:
     var REMOTE_PACKAGE_BASE = '%s';
     if (typeof Module['locateFilePackage'] === 'function' && !Module['locateFile']) {
       Module['locateFile'] = Module['locateFilePackage'];
-      Module.printErr('warning: you defined Module.locateFilePackage, that has been renamed to Module.locateFile (using your locateFilePackage for now)');
+      err('warning: you defined Module.locateFilePackage, that has been renamed to Module.locateFile (using your locateFilePackage for now)');
     }
     var REMOTE_PACKAGE_NAME = typeof Module['locateFile'] === 'function' ?
                               Module['locateFile'](REMOTE_PACKAGE_BASE) :

--- a/tools/update_js.py
+++ b/tools/update_js.py
@@ -18,9 +18,25 @@ for x in all_children('src') + all_children('tests') + all_children('tools') + a
   fixed = fixed.replace('Module["print"](', 'out(')
   fixed = fixed.replace('Module[\'print\'](', 'out(')
   fixed = fixed.replace('Module.print(', 'out(')
+
   fixed = fixed.replace('Module["printErr"](', 'err(')
   fixed = fixed.replace('Module[\'printErr\'](', 'err(')
   fixed = fixed.replace('Module.printErr(', 'err(')
+
+  fixed = fixed.replace(' = Module["print"]', ' = out')
+  fixed = fixed.replace(' = Module[\'print\']', ' = out')
+  fixed = fixed.replace('Module["print"] = ', 'out = ')
+  fixed = fixed.replace('Module[\'print\'] = ', 'out = ')
+  fixed = fixed.replace(' = Module.print', ' = out')
+  fixed = fixed.replace('Module.print = ', 'out = ')
+
+  fixed = fixed.replace(' = Module["printErr"]', ' = err')
+  fixed = fixed.replace(' = Module[\'printErr\']', ' = err')
+  fixed = fixed.replace('Module["printErr"] = ', 'err = ')
+  fixed = fixed.replace('Module[\'printErr\'] = ', 'err = ')
+  fixed = fixed.replace(' = Module.printErr', ' = err')
+  fixed = fixed.replace('Module.printErr = ', 'err = ')
+
   if fixed != orig:
     open(x, 'w').write(fixed)
 

--- a/tools/update_js.py
+++ b/tools/update_js.py
@@ -18,7 +18,7 @@ for x in all_children('src') + all_children('tests') + all_children('tools') + a
   fixed = fixed.replace('Module["print"](', 'out(')
   fixed = fixed.replace('Module[\'print\'](', 'out(')
   fixed = fixed.replace('Module.print(', 'out(')
-  fixed = fixed.replace('Module[printErr"](', 'err(')
+  fixed = fixed.replace('Module["printErr"](', 'err(')
   fixed = fixed.replace('Module[\'printErr\'](', 'err(')
   fixed = fixed.replace('Module.printErr(', 'err(')
   if fixed != orig:

--- a/tools/update_js.py
+++ b/tools/update_js.py
@@ -7,10 +7,10 @@ import os
 def all_children(subdir):
   return [os.path.join(dp, f) for dp, dn, fn in os.walk(subdir) for f in fn]
 
-for x in all_children('src') + all_children('tests') + all_children('tools') + ['emscripten.py', 'emcc.py']:
+for x in all_children('src') + all_children('tests') + all_children('tools') + all_children('system/lib') + ['emscripten.py', 'emcc.py']:
   if 'update_js.py' in x:
     continue
-  if not (x.endswith('.py') or x.endswith('.c') or x.endswith('.cpp') or x.endswith('.h') or x.endswith('.js')):
+  if not (x.endswith('.py') or x.endswith('.c') or x.endswith('.cpp') or x.endswith('.h') or x.endswith('.js') or x.endswith('.ll')):
     continue
   print x
   orig = open(x).read()

--- a/tools/update_js.py
+++ b/tools/update_js.py
@@ -1,0 +1,26 @@
+'''
+Performs a search-replace in all of js/
+'''
+
+import os
+
+def all_children(subdir):
+  return [os.path.join(dp, f) for dp, dn, fn in os.walk(subdir) for f in fn]
+
+for x in all_children('src') + all_children('tests') + all_children('tools') + ['emscripten.py', 'emcc.py']:
+  if 'update_js.py' in x:
+    continue
+  if not (x.endswith('.py') or x.endswith('.c') or x.endswith('.cpp') or x.endswith('.h') or x.endswith('.js')):
+    continue
+  print x
+  orig = open(x).read()
+  fixed = orig[:]
+  fixed = fixed.replace('Module["print"](', 'out(')
+  fixed = fixed.replace('Module[\'print\'](', 'out(')
+  fixed = fixed.replace('Module.print(', 'out(')
+  fixed = fixed.replace('Module[printErr"](', 'err(')
+  fixed = fixed.replace('Module[\'printErr\'](', 'err(')
+  fixed = fixed.replace('Module.printErr(', 'err(')
+  if fixed != orig:
+    open(x, 'w').write(fixed)
+


### PR DESCRIPTION
This JS change replaces calls to `Module['print']` (to print to stdout) and `Module['printErr']` (to print to stderr) with calls to `out()` and `err()` respectively, which are defined in the main scope directly. This allows the optimizer to dce things more effectively, and shrinks our hello world JS by over 1% (with and without closure).

More generally, we have too many things that we use on `Module` when we don't need to. It makes sense to allow users to define `Module['print']` (as how we emit to stdout), and to optionally be where we export that function if the user requested it, but it is silly to constantly looking up `Module['print']` everywhere - it increases size and adds overhead. In other words, `Module` makes sense as an interface to receiving stuff or sending stuff, but not internal work.

Also, using Module everywhere makes it harder to do some bigger refactorings for code size that I have some ideas about, so removing this unhelpful complexity is a step in the right direction.

There are two possible changes people might see here:
 * If you change `Module['print']` during program execution, we don't notice that. This was never documented as intended to work, but probably worked in most cases. We did have a test or two that depended on this. The docs have been updated to mention this.
 * If you expect `Module['print']` to always exist, it won't unless it is explicitly exported. That is in line with the other exporting changes we've been making. As with those changes, we will show a clear error in an assertions builds in that case, with instructions for how to fix it.

Almost all of this patch is autogenerated (using `tools/update_js.py`). For the main non-autogenerated portion, see `src/shell.js`.

Note that we can't use `print(), printErr()` as the names since those are used in some shell environments (we use those as stdout and stderr if they are defined, in fact).