### PR TITLE
Fix flake8 warnings in tools/system_libs.py

### DIFF
--- a/.flake8_clean
+++ b/.flake8_clean
@@ -8,3 +8,4 @@ tools/emmakenxx.py
 tools/exec_llvm.py
 tools/find_bigvars.py
 tools/merge_pair.py
+tools/system_libs.py


### PR DESCRIPTION
The only functional change here is the simplification of call_process.
The deliberate use of Exception over CalledProcessError should not be needed because
shared.run_process already used Py2CalledProcessError to work around this same
issue.