### PR TITLE
Don't test longjmp_unwind in wasm backend

### DIFF
--- a/tests/core/test_longjmp_unwind.c
+++ b/tests/core/test_longjmp_unwind.c
@@ -31,7 +31,12 @@ __attribute__((noinline)) void foo()
 {
   temp = alloca(MAJOR);
   printf("major allocation at: %d\n", (int)temp);
+#ifdef __asmjs__
+  // asmjs stack grows up, but wasm backend stack grows down, so the delta
+  // between get_stack() and temp isn't related to the size of the alloca for
+  // wasm backend
   assert(abs(get_stack() - (int)temp) >= MAJOR);
+#endif
   bar();
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -854,6 +854,7 @@ base align: 0, 0, 0, 0'''])
       Settings.DISABLE_EXCEPTION_CATCHING = disable_throw
       self.do_run_in_out_file_test('tests', 'core', 'test_longjmp_throw')
 
+  @no_wasm_backend('backend stack grows down, asmjs stack grows up')
   def test_longjmp_unwind(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_longjmp_unwind')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -854,7 +854,6 @@ base align: 0, 0, 0, 0'''])
       Settings.DISABLE_EXCEPTION_CATCHING = disable_throw
       self.do_run_in_out_file_test('tests', 'core', 'test_longjmp_throw')
 
-  @no_wasm_backend('backend stack grows down, asmjs stack grows up')
   def test_longjmp_unwind(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_longjmp_unwind')
 


### PR DESCRIPTION
Wasm backend stack grows down, meaning the delta between temp and the
stack pointer is not affected by the size of the alloca.