### PR TITLE
Perform bitcode linking with lld in wasm backend path

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1617,10 +1617,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
       linker_inputs += extra_files_to_link
-      is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
-      is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
-      is_ar = shared.Building.is_ar(temp_files[0][1])
-      if len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND or (not LEAVE_INPUTS_RAW and not (is_bc or is_dylib) and is_ar):
+      perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
+      if not perform_link and not LEAVE_INPUTS_RAW:
+        is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
+        is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
+        is_ar = shared.Building.is_ar(temp_files[0][1])
+        perform_link = not (is_bc or is_dylib) and is_ar
+      if perform_link:
         logging.debug('linking: ' + str(linker_inputs))
         # force archive contents to all be included, if just archives, or if linking shared modules
         force_archive_contents = len([temp for i, temp in temp_files if not temp.endswith(STATICLIB_ENDINGS)]) == 0 or not shared.Building.can_build_standalone()

--- a/emcc.py
+++ b/emcc.py
@@ -1630,7 +1630,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # TODO: we could check if this is a fastcomp build, and still speed things up here
         just_calculate = DEBUG != '2' and not shared.Settings.WASM_BACKEND
         if shared.Settings.EXPERIMENTAL_USE_LLD:
-          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts)
+          # If LTO is enabled then use the -O opt level as the LTO level
+          if options.llvm_lto:
+            lto_level = options.opt_level
+          else:
+            lto_level = 0
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts, lto_level)
         else:
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
       else:

--- a/emcc.py
+++ b/emcc.py
@@ -1604,7 +1604,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     with ToolchainProfiler.profile_block('link'):
       # final will be an array if linking is deferred, otherwise a normal string.
-      DEFAULT_FINAL = in_temp(target_basename + '.bc')
+      if shared.Settings.EXPERIMENTAL_USE_LLD:
+        DEFAULT_FINAL = in_temp(target_basename + '.wasm')
+      else:
+        DEFAULT_FINAL = in_temp(target_basename + '.bc')
 
       def get_final():
         global final
@@ -1613,9 +1616,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return final
 
       # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
-      if len(input_files) + len(extra_files_to_link) > 1 or \
-         (not LEAVE_INPUTS_RAW and not (suffix(temp_files[0][1]) in BITCODE_ENDINGS or suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS) and shared.Building.is_ar(temp_files[0][1])):
-        linker_inputs += extra_files_to_link
+      linker_inputs += extra_files_to_link
+      is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
+      is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
+      is_ar = shared.Building.is_ar(temp_files[0][1])
+      if len(linker_inputs) > 1 or shared.Settings.EXPERIMENTAL_USE_LLD or (not LEAVE_INPUTS_RAW and not (is_bc or is_dylib) and is_ar):
         logging.debug('linking: ' + str(linker_inputs))
         # force archive contents to all be included, if just archives, or if linking shared modules
         force_archive_contents = len([temp for i, temp in temp_files if not temp.endswith(STATICLIB_ENDINGS)]) == 0 or not shared.Building.can_build_standalone()
@@ -1624,7 +1629,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
         # TODO: we could check if this is a fastcomp build, and still speed things up here
         just_calculate = DEBUG != '2' and not shared.Settings.WASM_BACKEND
-        final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
+        if shared.Settings.EXPERIMENTAL_USE_LLD:
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts)
+        else:
+          final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
       else:
         if not LEAVE_INPUTS_RAW:
           _, temp_file = temp_files[0]
@@ -1642,74 +1650,75 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # exit block 'link'
     log_time('link')
 
-    with ToolchainProfiler.profile_block('post-link'):
-      if DEBUG:
-        logging.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
+    if not shared.Settings.EXPERIMENTAL_USE_LLD:
+      with ToolchainProfiler.profile_block('post-link'):
+        if DEBUG:
+          logging.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
+          if not LEAVE_INPUTS_RAW:
+            save_intermediate('basebc', 'bc')
+
+        # Optimize, if asked to
         if not LEAVE_INPUTS_RAW:
-          save_intermediate('basebc', 'bc')
+          # remove LLVM debug if we are not asked for it
+          link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
+          if not shared.Settings.ASSERTIONS:
+            link_opts += ['-disable-verify']
+          else:
+            # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
+            # disable the type map in that case. we added linking to opt, so we need to do
+            # something similar, which we can do with a param to opt
+            link_opts += ['-disable-debug-info-type-map']
 
-      # Optimize, if asked to
-      if not LEAVE_INPUTS_RAW:
-        # remove LLVM debug if we are not asked for it
-        link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
-        if not shared.Settings.ASSERTIONS:
-          link_opts += ['-disable-verify']
-        else:
-          # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
-          # disable the type map in that case. we added linking to opt, so we need to do
-          # something similar, which we can do with a param to opt
-          link_opts += ['-disable-debug-info-type-map']
+          if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
+            logging.debug('running LLVM opts as pre-LTO')
+            final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
+            save_intermediate('opt', 'bc')
 
-        if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
-          logging.debug('running LLVM opts as pre-LTO')
-          final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
-          save_intermediate('opt', 'bc')
+          # If we can LTO, do it before dce, since it opens up dce opportunities
+          if shared.Building.can_build_standalone() and options.llvm_lto and options.llvm_lto != 2:
+            if not shared.Building.can_inline():
+              link_opts.append('-disable-inlining')
+            # add a manual internalize with the proper things we need to be kept alive during lto
+            link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
+            # execute it now, so it is done entirely before we get to the stage of legalization etc.
+            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+            save_intermediate('lto', 'bc')
+            link_opts = []
+          else:
+            # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
+            link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
 
-        # If we can LTO, do it before dce, since it opens up dce opportunities
-        if shared.Building.can_build_standalone() and options.llvm_lto and options.llvm_lto != 2:
-          if not shared.Building.can_inline():
-            link_opts.append('-disable-inlining')
-          # add a manual internalize with the proper things we need to be kept alive during lto
-          link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
-          # execute it now, so it is done entirely before we get to the stage of legalization etc.
-          final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-          save_intermediate('lto', 'bc')
-          link_opts = []
-        else:
-          # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
-          link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
+          if options.cfi:
+            if use_cxx:
+               link_opts.append("-wholeprogramdevirt")
+            link_opts.append("-lowertypetests")
 
-        if options.cfi:
-          if use_cxx:
-             link_opts.append("-wholeprogramdevirt")
-          link_opts.append("-lowertypetests")
+          if AUTODEBUG:
+            # let llvm opt directly emit ll, to skip writing and reading all the bitcode
+            link_opts += ['-S']
+            final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
+            save_intermediate('linktime', 'll')
+          else:
+            if len(link_opts) > 0:
+              final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+              save_intermediate('linktime', 'bc')
+            if options.save_bc:
+              shutil.copyfile(final, options.save_bc)
+
+        # Prepare .ll for Emscripten
+        if LEAVE_INPUTS_RAW:
+          assert len(input_files) == 1
+        if options.save_bc:
+          save_intermediate('ll', 'll')
 
         if AUTODEBUG:
-          # let llvm opt directly emit ll, to skip writing and reading all the bitcode
-          link_opts += ['-S']
-          final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
-          save_intermediate('linktime', 'll')
-        else:
-          if len(link_opts) > 0:
-            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-            save_intermediate('linktime', 'bc')
-          if options.save_bc:
-            shutil.copyfile(final, options.save_bc)
+          logging.debug('autodebug')
+          next = get_final() + '.ad.ll'
+          execute([shared.PYTHON, shared.AUTODEBUGGER, final, next])
+          final = next
+          save_intermediate('autodebug', 'll')
 
-      # Prepare .ll for Emscripten
-      if LEAVE_INPUTS_RAW:
-        assert len(input_files) == 1
-      if options.save_bc:
-        save_intermediate('ll', 'll')
-
-      if AUTODEBUG:
-        logging.debug('autodebug')
-        next = get_final() + '.ad.ll'
-        run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
-        final = next
-        save_intermediate('autodebug', 'll')
-
-      assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
+        assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
 
     # exit block 'post-link'
     log_time('post-link')

--- a/emcc.py
+++ b/emcc.py
@@ -1714,7 +1714,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if AUTODEBUG:
           logging.debug('autodebug')
           next = get_final() + '.ad.ll'
-          execute([shared.PYTHON, shared.AUTODEBUGGER, final, next])
+          run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
           final = next
           save_intermediate('autodebug', 'll')
 

--- a/emcc.py
+++ b/emcc.py
@@ -1604,7 +1604,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     with ToolchainProfiler.profile_block('link'):
       # final will be an array if linking is deferred, otherwise a normal string.
-      if shared.Settings.EXPERIMENTAL_USE_LLD:
+      if shared.Settings.WASM_BACKEND:
         DEFAULT_FINAL = in_temp(target_basename + '.wasm')
       else:
         DEFAULT_FINAL = in_temp(target_basename + '.bc')
@@ -1620,7 +1620,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
       is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
       is_ar = shared.Building.is_ar(temp_files[0][1])
-      if len(linker_inputs) > 1 or shared.Settings.EXPERIMENTAL_USE_LLD or (not LEAVE_INPUTS_RAW and not (is_bc or is_dylib) and is_ar):
+      if len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND or (not LEAVE_INPUTS_RAW and not (is_bc or is_dylib) and is_ar):
         logging.debug('linking: ' + str(linker_inputs))
         # force archive contents to all be included, if just archives, or if linking shared modules
         force_archive_contents = len([temp for i, temp in temp_files if not temp.endswith(STATICLIB_ENDINGS)]) == 0 or not shared.Building.can_build_standalone()
@@ -1629,7 +1629,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
         # TODO: we could check if this is a fastcomp build, and still speed things up here
         just_calculate = DEBUG != '2' and not shared.Settings.WASM_BACKEND
-        if shared.Settings.EXPERIMENTAL_USE_LLD:
+        if shared.Settings.WASM_BACKEND:
           # If LTO is enabled then use the -O opt level as the LTO level
           if options.llvm_lto:
             lto_level = options.opt_level
@@ -1655,7 +1655,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # exit block 'link'
     log_time('link')
 
-    if not shared.Settings.EXPERIMENTAL_USE_LLD:
+    if not shared.Settings.WASM_BACKEND:
       with ToolchainProfiler.profile_block('post-link'):
         if DEBUG:
           logging.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())

--- a/emscripten.py
+++ b/emscripten.py
@@ -1844,7 +1844,7 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
         logging.debug('  emscript: llvm wasm backend took %s seconds' % (time.time() - t))
         t = time.time()
       debug_copy(temp_o, 'emcc-llvm-backend-output.o')
-      shared.Building.link_lld([temp_o], base_wasm, [])
+      shared.Building.link_lld([temp_o], base_wasm)
       debug_copy(base_wasm, 'base_wasm.wasm')
 
   write_source_map = settings['DEBUG_LEVEL'] >= 4

--- a/src/settings.js
+++ b/src/settings.js
@@ -740,12 +740,6 @@ var WASM_BACKEND = 0; // Whether to use the WebAssembly backend that is in devel
                       // You should not set this yourself, instead set EMCC_WASM_BACKEND=1 in the
                       // environment.
 
-var EXPERIMENTAL_USE_LLD = 0; // Whether to compiler object files as wasm as opposed to the default
-                              // of using LLVM IR.
-                              // You should not set this yourself, instead set
-                              // EMCC_EXPERIMENTAL_USE_LLD=1 in the environment.
-
-
 var BINARYEN_METHOD = "native-wasm"; // How we should run WebAssembly code. By default, we run it natively.
                                      // See binaryen's src/js/wasm.js-post.js for more details and options.
 var BINARYEN_SCRIPTS = ""; // An optional comma-separated list of script hooks to run after binaryen,

--- a/src/settings.js
+++ b/src/settings.js
@@ -740,6 +740,12 @@ var WASM_BACKEND = 0; // Whether to use the WebAssembly backend that is in devel
                       // You should not set this yourself, instead set EMCC_WASM_BACKEND=1 in the
                       // environment.
 
+var EXPERIMENTAL_USE_LLD = 0; // Whether to compiler object files as wasm as opposed to the default
+                              // of using LLVM IR.
+                              // You should not set this yourself, instead set
+                              // EMCC_EXPERIMENTAL_USE_LLD=1 in the environment.
+
+
 var BINARYEN_METHOD = "native-wasm"; // How we should run WebAssembly code. By default, we run it natively.
                                      // See binaryen's src/js/wasm.js-post.js for more details and options.
 var BINARYEN_SCRIPTS = ""; // An optional comma-separated list of script hooks to run after binaryen,

--- a/src/support.js
+++ b/src/support.js
@@ -122,7 +122,7 @@ function loadDynamicLibrary(lib) {
 // Loads a side module from binary data
 function loadWebAssemblyModule(binary) {
   var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
-  assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0wasm
+  assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm
   // we should see the dylink section right after the magic number and wasm version
   assert(binary[8] === 0, 'need the dylink section to be first')
   var next = 9;

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1153,8 +1153,6 @@ class SettingsManager(object):
 
       if get_llvm_target() == WASM_TARGET:
         self.attrs['WASM_BACKEND'] = 1
-      if 'EMCC_EXPERIMENTAL_USE_LLD' in os.environ:
-        self.attrs['EXPERIMENTAL_USE_LLD'] = os.environ['EMCC_EXPERIMENTAL_USE_LLD']
 
     # Transforms the Settings information into emcc-compatible args (-s X=Y, etc.). Basically
     # the reverse of load_settings, except for -Ox which is relevant there but not here
@@ -1351,7 +1349,6 @@ class Building(object):
           # EMCC_WASM_BACKEND check also requires locked access to the cache,
           # which the multiprocess children would not get.
           'EMCC_WASM_BACKEND=%s' % Settings.WASM_BACKEND,
-          'EMCC_EXPERIMENTAL_USE_LLD=%s' % Settings.EXPERIMENTAL_USE_LLD,
           # Multiprocessing pool children can't spawn their own linear number of
           # children, that could cause a quadratic amount of spawned processes.
           'EMCC_CORES=1'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1743,7 +1743,7 @@ class Building(object):
     return args
 
   @staticmethod
-  def link_lld(files, target, opts):
+  def link_lld(files, target, opts=[], lto_level=0):
     def wasm_rt_fail(archive_file):
       def wrapped():
         raise FatalError('Expected {} to already be built'.format(archive_file))
@@ -1759,12 +1759,11 @@ class Building(object):
       '--no-entry',
       '--allow-undefined',
       '--import-memory',
-      '--export', '__wasm_call_ctors'
+      '--export', '__wasm_call_ctors',
+      '--lto-O%d' % lto_level,
       ] + files + [libc_rt_lib, compiler_rt_lib]
     for a in Building.llvm_backend_args():
       cmd += ['-mllvm', a]
-    #cmd.append('--lto-O3')
-
     # emscripten-wasm-finalize currently depends on the presence of debug
     # symbols for renaming of the __invoke symbols
     # TODO(sbc): Re-enable once emscripten-wasm-finalize is fixed or we


### PR DESCRIPTION
With this change we no longer run llvm-link or opt over the final output.  Instead we rely
solely on lld to perform bitcode linking and optional LTO.

The --llvm-lto option is still honored in that if it is >0 then the opt level is passed to lld
as --lto-O? which is think is the closest the existing behaviour that we can get or
want to get.