### PR TITLE
Always run via subprocess in python-selector.

### DIFF
--- a/.flake8_clean
+++ b/.flake8_clean
@@ -1,6 +1,7 @@
 emcc.py
 tools/shared.py
 tools/response_file.py
+tools/python_selector.py
 tools/wasm-sourcemap.py
 tools/clean_webconsole.py
 tools/emconfiguren.py

--- a/emcc
+++ b/emcc
@@ -9,4 +9,3 @@ import sys
 
 if __name__ == '__main__':
   python_selector.run(__file__)
-

--- a/tools/python_selector.py
+++ b/tools/python_selector.py
@@ -1,38 +1,19 @@
-'''
-Provides a way to run a script on the preferred Python version
-'''
+"""Provides a way to run a script on the preferred Python version"""
 
 import os
+import subprocess
 import sys
 
-'''
-Imports the target script by filename and calls run()
-'''
-def run_by_import(filename, main):
-  import importlib
-  return getattr(importlib.import_module(os.path.basename(filename)), main)()
 
-'''
-Opens Python 2 subprocess to run target script
-'''
-def run_by_subprocess(filename):
-  # Python on Windows does not provide `python2` but instead `py` that receives version parameter
-  py2 = ['py', '-2'] if sys.platform.startswith('win') else ['python2']
-  import subprocess
-  return subprocess.run(py2 + [os.path.realpath(filename) + '.py'] + sys.argv[1:]).returncode
-
-def on_allowed_version():
-  # we now allow python 2 or 3. eventually, we will only allow 3, and can change
-  # this. when we do that, also note that in shared.get_building_env() we'll need
-  # to specify the proper python to be executed, and need to do that carefully.
-  return True
-
-'''
-Runs filename+'.py' by opening Python 2 subprocess if required, or by importing.
-'''
-def run(filename, profile=False, main="run"):
+def run(filename):
+  """Runs filename+'.py' in subprocess of the correct python version
+  """
   if os.environ.get('EM_PROFILE_TOOLCHAIN'):
     from tools.toolchain_profiler import ToolchainProfiler
     ToolchainProfiler.record_process_start()
 
-  sys.exit(run_by_import(filename, main) if on_allowed_version() else run_by_subprocess(filename))
+  # In the future we might froce a particular python version here.
+  # Python on Windows does not provide `python2` but instead `py` that receives version parameter
+  # python = ['py', '-2'] if sys.platform.startswith('win') else ['python2']
+  python = sys.executable
+  sys.exit(subprocess.call([python, os.path.realpath(filename) + '.py'] + sys.argv[1:]))


### PR DESCRIPTION
If we run via import then we don't execute top level code that
checks for 'if __name__ == "__main__"'.  This means the scripts
behave differently depending on which method the selector chooses.

Also, since we support both 2 and 3 for now we might as well
always run under `sys.executable` which we know for sure exists
(unlike `python2` which doesn't always exist on mac for example).

For extra performance on non-windows we could use exec() here
but I don't think thats going to make a huge difference.