### PR TITLE
Add JSCALL* settings set in emscripten.py to settings.js

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -843,6 +843,8 @@ var PTHREADS_DEBUG = 0; // If true, add in debug traces for diagnosing pthreads 
 
 var MAX_GLOBAL_ALIGN = -1; // received from the backend
 var IMPLEMENTED_FUNCTIONS = []; // received from the backend
+var JSCALL_START_INDEX = 0; // received from the backend
+var JSCALL_SIG_ORDER = {}; // received from the backend
 
 // Duplicate function elimination. This coalesces function bodies that are
 // identical, which can happen e.g. if two methods have different C/C++


### PR DESCRIPTION
Not calling Settings.copy and setting these directly causes warnings if they're not present in settings.js.