### PR TITLE
emscripten_version_cmake_variable

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -125,6 +125,20 @@ if (EMSCRIPTEN_FORCE_COMPILERS)
 		endif()
 	endif()
 
+	# Capture the Emscripten version to EMSCRIPTEN_VERSION variable.
+	if (NOT EMSCRIPTEN_VERSION)
+		execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result OUTPUT_VARIABLE _cmake_compiler_output ERROR_QUIET)
+		if (NOT _cmake_compiler_result EQUAL 0)
+			message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"! Process returned with error code ${_cmake_compiler_result}.")
+		endif()
+		string(REGEX MATCH "emcc \\(.*\\) ([0-9\\.]+)" _dummy_unused "${_cmake_compiler_output}")
+		if (NOT CMAKE_MATCH_1)
+			message(FATAL_ERROR "Failed to regex parse Emscripten compiler version from version string: ${_cmake_compiler_output}")
+		endif()
+
+		set(EMSCRIPTEN_VERSION "${CMAKE_MATCH_1}")
+	endif()
+
 	set(CMAKE_C_COMPILER_ID_RUN TRUE)
 	set(CMAKE_C_COMPILER_FORCED TRUE)
 	set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/tests/cmake/emscripten_version/CMakeLists.txt
+++ b/tests/cmake/emscripten_version/CMakeLists.txt
@@ -1,0 +1,16 @@
+# EMSCRIPTEN_VERSION CMake variable is introduced in Emscripten version 1.38.6, so test that the value is at least that new.
+
+if ("${EMSCRIPTEN_VERSION}" VERSION_GREATER 1.38.5)
+	message(STATUS "Emscripten version is at least 1.38.6")
+else()
+	message(FATAL_ERROR "EMSCRIPTEN_VERSION is not present, or is older than 1.38.6: '${EMSCRIPTEN_VERSION}'")
+endif()
+
+# A particular gotcha about Emscripten version testing: do not use the following code:
+
+#    if (${EMSCRIPTEN_VERSION} VERSION_GREATER "1.38.5")
+
+# because this would fail when running on an Emscripten version older than 1.38.6. That is, note the needed double quotes
+# around ${EMSCRIPTEN_VERSION}. This is because in older Emscripten versions, the EMSCRIPTEN_VERSION CMake variable did
+# not yet exist, so the above if statement would expand to an empty left hand side: if ( VERSION_GREATER_EQUAL 1.38.6)
+# which would be a syntax error. if ("" VERSION_GREATER_EQUAL 1.38.6) is fine however.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -695,6 +695,14 @@ f.close()
       assert tools.shared.Building.is_bitcode(os.path.join(tempdirname, 'myprefix_static_lib.somecustomsuffix'))
       assert tools.shared.Building.is_ar(os.path.join(tempdirname, 'myprefix_static_lib.somecustomsuffix'))
 
+  # Tests that the CMake variable EMSCRIPTEN_VERSION is properly provided to user CMake scripts
+  def test_cmake_emscripten_version(self):
+    if os.name == 'nt': emcmake = path_from_root('emcmake.bat')
+    else: emcmake = path_from_root('emcmake')
+
+    with temp_directory() as tempdirname:
+      subprocess.check_call([emcmake, 'cmake', path_from_root('tests', 'cmake', 'emscripten_version')])
+
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't try to produce an output file.


### PR DESCRIPTION
Add `EMSCRIPTEN_VERSION` variable to user CMake scripts so that they can do

`if ("${EMSCRIPTEN_VERSION}" VERSION_GREATER_EQUAL 1.38.6)`

to check for a particular Emscripten version.