### PR TITLE
binaryen.js is no longer bundled in binaryen

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2666,7 +2666,7 @@ class Building(object):
     paths = (os.path.join(Settings.BINARYEN_ROOT, 'bin'),
              os.path.join(Settings.BINARYEN_ROOT, 'share', 'binaryen'))
     for dirname in paths:
-      if os.path.exists(os.path.join(dirname, 'binaryen.js')):
+      if os.path.exists(os.path.join(dirname, 'wasm.js')):
         return dirname
     logging.fatal('emcc: cannot find binaryen js libraries (tried: %s)' % str(paths))
     sys.exit(1)


### PR DESCRIPTION
And emscripten doesn't need it anyhow (it's for handwritten js users).

So don't look for it, we just need to find the binaryen lib dir for wasm.js anyhow (which we use when interpreting wasm).