### PR TITLE
Emterpreter-async state fix

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -687,7 +687,7 @@ def include_asm_consts(pre, forwarded_json, metadata):
 
     if shared.Settings.EMTERPRETIFY_ASYNC and shared.Settings.ASSERTIONS:
       # we cannot have an EM_ASM on the stack when saving/loading
-      pre_asm_const += "  assert(typeof EmterpreterAsync !== 'object' || EmterpreterAsync.state !== 2, 'cannot have an EM_ASM on the stack when emterpreter pauses/resumes - we would end up running the entire EM_ASMs JS again from the start');\n"
+      pre_asm_const += "  assert(typeof EmterpreterAsync !== 'object' || EmterpreterAsync.state !== 2, 'cannot have an EM_ASM on the stack when emterpreter pauses/resumes - the JS is not emterpreted, so we would end up running it again from the start');\n"
 
     asm_const_funcs.append(r'''
 function _emscripten_asm_const_%s(%s) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -259,8 +259,8 @@ mergeInto(LibraryManager.library, {
       this.initted = true;
 #if ASSERTIONS
       abortDecorators.push(function(output, what) {
-        if (EmterpreterAsync.state === 2) {
-          return output + '\nThis error happened during an emterpreter-async stack load. Was there non-emterpreted code on the stack during save (which is unallowed)? If so, you may want to adjust EMTERPRETIFY_BLACKLIST, EMTERPRETIFY_WHITELIST. For reference, this is what the stack looked like when we tried to save it: ' + [EmterpreterAsync.state, EmterpreterAsync.saveStack];
+        if (EmterpreterAsync.state === 1 || EmterpreterAsync.state === 2) {
+          return output + '\nThis error happened during an emterpreter-async operation. Was there non-emterpreted code on the stack during save (which is unallowed)? If so, you may want to adjust EMTERPRETIFY_BLACKLIST, EMTERPRETIFY_WHITELIST. For reference, this is what the stack looked like when we tried to save it: ' + [EmterpreterAsync.state, EmterpreterAsync.saveStack];
         }
         return output;
       });

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -234,8 +234,8 @@ mergeInto(LibraryManager.library, {
     state: 0, // 0 - Nothing/normal.
               // 1 - Sleeping: This is set when we start to save the stack, and continues through the
               //     sleep, until we start to restore the stack.
-              //     If we re-enter emterpreted code while in this state - that is, before we
-              //     start to restore the stack, or in other words if we run emterpreted code while
+              //     If we re-enter any code while in this state - that is, before we
+              //     start to restore the stack, or in other words if we run code while
               //     sleeping - then we switch to state 3, "definitely sleeping". That lets us know
               //     we are no longer saving the stack. How this works is that while we save the stack
               //     we don't hit any function entries, so they are valid places to switch to state 3,

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -234,8 +234,8 @@ mergeInto(LibraryManager.library, {
     state: 0, // 0 - Nothing/normal.
               // 1 - Sleeping: This is set when we start to save the stack, and continues through the
               //     sleep, until we start to restore the stack.
-              //     If we re-enter any code while in this state - that is, before we
-              //     start to restore the stack, or in other words if we run code while
+              //     If we enter a function while in this state - that is, before we
+              //     start to restore the stack, or in other words if we call a function while
               //     sleeping - then we switch to state 3, "definitely sleeping". That lets us know
               //     we are no longer saving the stack. How this works is that while we save the stack
               //     we don't hit any function entries, so they are valid places to switch to state 3,

--- a/tests/emterpreter_async_bad.cpp
+++ b/tests/emterpreter_async_bad.cpp
@@ -32,7 +32,7 @@ void __attribute__((noinline)) middle() { // not emterpreted, so sleeping in run
 int main() {
   EM_ASM({
     window.onerror = function(err) {
-      assert(err.toString().indexOf("This error happened during an emterpreter-async stack load") > 0, "expect good error message");
+      assert(err.toString().indexOf("This error happened during an emterpreter-async operation") > 0, "expect good error message");
       // manually REPORT_RESULT; we can't call back into native code at this point, assertions would trigger
       var xhr = new XMLHttpRequest();
       xhr.open("GET", "http://localhost:8888/report_result?1");

--- a/tests/emterpreter_async_bad.cpp
+++ b/tests/emterpreter_async_bad.cpp
@@ -22,7 +22,7 @@ void __attribute__((noinline)) run_loop() {
   }
 }
 
-void __attribute__((noinline)) middle() {
+void __attribute__((noinline)) middle() { // not emterpreted, so sleeping in run_loop is bad
   run_loop();
   printf("after run_loop, counter: %d\n", counter);
   assert(counter == 10);
@@ -32,7 +32,7 @@ void __attribute__((noinline)) middle() {
 int main() {
   EM_ASM({
     window.onerror = function(err) {
-      assert(err.toString().indexOf('This error happened during an emterpreter-async save or load of the stack') > 0, 'expect good error message');
+      assert(err.toString().indexOf("This error happened during an emterpreter-async stack load") > 0, "expect good error message");
       // manually REPORT_RESULT; we can't call back into native code at this point, assertions would trigger
       var xhr = new XMLHttpRequest();
       xhr.open("GET", "http://localhost:8888/report_result?1");

--- a/tests/emterpreter_async_bad_2.cpp
+++ b/tests/emterpreter_async_bad_2.cpp
@@ -31,7 +31,7 @@ int main() {
   EM_ASM({
     window.onerror = function(err) {
       var str = err.toString();
-      assert(str.indexOf('This error happened during an emterpreter-async save or load of the stack') > 0, 'expect good error message');
+      assert(err.toString().indexOf("This error happened during an emterpreter-async operation") > 0, "expect good error message");
       assert(str.indexOf('-12') > 0, '-12 error from emterpreter-async');
       // manually REPORT_RESULT; we can't call back into native code at this point, assertions would trigger
       var xhr = new XMLHttpRequest();

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5536,6 +5536,42 @@ function _main() {
       run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_fleefl"]', '-s', 'PRECISE_F32=1'])
       self.assertContained('result: ' + out, run_js('a.out.js'))
 
+  def test_call_nonemterpreted_during_sleep(self):
+    open('src.c', 'w').write(r'''
+#include <stdio.h>
+#include <emscripten.h>
+
+EMSCRIPTEN_KEEPALIVE void emterpreted_yielder() {
+  int counter = 0;
+  while (1) {
+    printf("emterpreted_yielder() sleeping...\n");
+    emscripten_sleep_with_yield(10);
+    counter++;
+    if (counter == 3) {
+      printf("Success\n");
+      break;
+    }
+  }
+}
+
+EMSCRIPTEN_KEEPALIVE void not_emterpreted() {
+  printf("Entering not_emterpreted()\n");
+}
+
+int main() {
+  EM_ASM({
+    setTimeout(function () {
+      console.log("calling not_emterpreted()");
+      Module["_not_emterpreted"]();
+    }, 0);
+    console.log("calling emterpreted_yielder()");
+    Module["_emterpreted_yielder"]();
+  });
+}
+    ''')
+    run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_BLACKLIST=["_not_emterpreted"]'])
+    self.assertContained('Success', run_js('a.out.js'))
+
   def test_link_with_a_static(self):
     for args in [[], ['-O2']]:
       print(args)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5541,7 +5541,7 @@ function _main() {
 #include <stdio.h>
 #include <emscripten.h>
 
-EMSCRIPTEN_KEEPALIVE void emterpreted_yielder() {
+void emterpreted_yielder() {
   int counter = 0;
   while (1) {
     printf("emterpreted_yielder() sleeping...\n");
@@ -5565,8 +5565,8 @@ int main() {
       Module["_not_emterpreted"]();
     }, 0);
     console.log("calling emterpreted_yielder()");
-    Module["_emterpreted_yielder"]();
   });
+  emterpreted_yielder();
 }
     ''')
     run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_BLACKLIST=["_not_emterpreted"]'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5579,7 +5579,7 @@ int main() {
 
     print('check for invalid EM_ASM usage')
     run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_BLACKLIST=["_not_emterpreted"]', '-DBAD_EM_ASM'])
-    self.assertContained('cannot have an EM_ASM on the stack when emterpreter pauses/resumes', run_js('a.out.js'))
+    self.assertContained('cannot have an EM_ASM on the stack when emterpreter pauses/resumes', run_js('a.out.js', stderr=STDOUT, assert_returncode=None))
 
   def test_link_with_a_static(self):
     for args in [[], ['-O2']]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5577,6 +5577,10 @@ int main() {
     run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_BLACKLIST=["_not_emterpreted"]'])
     self.assertContained('Success', run_js('a.out.js'))
 
+    print('check calling of emterpreted as well')
+    run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
+    self.assertContained('Success', run_js('a.out.js'))
+
     print('check for invalid EM_ASM usage')
     run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_BLACKLIST=["_not_emterpreted"]', '-DBAD_EM_ASM'])
     self.assertContained('cannot have an EM_ASM on the stack when emterpreter pauses/resumes', run_js('a.out.js', stderr=STDOUT, assert_returncode=None))

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -7609,7 +7609,9 @@ function emterpretify(ast) {
         bump += 8; // each local is a 64-bit value
       });
       if (ASYNC) {
-        argStats.push(makeAssertionsPreludeStateChange());
+        if (ASSERTIONS) {
+          argStats.push(makeAssertionsPreludeStateChange());
+        }
         argStats = [['if', srcToExp('(asyncState|0) != 2'), ['block', argStats]]]; // 2 means restore, so do not trample the stack
       }
       func[3] = func[3].concat(argStats);


### PR DESCRIPTION
See #6820 for background. This implements the first option suggested there, which is to relax the assertion: we know that state 1 means saving the stack or sleeping, and 3 means definitely sleeping, but we don't have a way to know when saving the stack is complete in the general case, so don't assert on that.