### PR TITLE
Core test suite mode name cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,11 @@ jobs:
   test-ab:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_a* ALL.test_b*
+      - TEST_TARGET=asm*.test_a* asm*.test_b*
   test-c:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_c*
+      - TEST_TARGET=asm*.test_c*
   test-d:
     <<: *test-defaults
     environment:
@@ -96,19 +96,19 @@ jobs:
   test-e:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_e*
+      - TEST_TARGET=asm*.test_e*
   test-f:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_f*
+      - TEST_TARGET=asm*.test_f*
   test-ghi:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_g* ALL.test_h* ALL.test_i*
+      - TEST_TARGET=asm*.test_g* asm*.test_h* asm*.test_i*
   test-jklmno:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_j* ALL.test_k* ALL.test_l* ALL.test_m* ALL.test_n* ALL.test_o*
+      - TEST_TARGET=asm*.test_j* asm*.test_k* asm*.test_l* asm*.test_m* asm*.test_n* asm*.test_o*
   test-p:
     <<: *test-defaults
     environment:
@@ -116,12 +116,12 @@ jobs:
   test-qrst:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t* skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full
+      - TEST_TARGET=asm*.test_q* asm*.test_r* asm*.test_s* asm*.test_t* skip:asm*.test_sse1_full skip:asm*.test_sse2_full skip:asm*.test_sse3_full skip:asm*.test_ssse3_full skip:asm*.test_sse4_1_full
       # SSE tests fail because of the lack of native headers on emsdk-bundled clang
   test-uvwxyz:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=ALL.test_u* ALL.test_w* ALL.test_v* ALL.test_x* ALL.test_y* ALL.test_z*
+      - TEST_TARGET=asm*.test_u* asm*.test_w* asm*.test_v* asm*.test_x* asm*.test_y* asm*.test_z*
   test-binaryen0:
     <<: *test-defaults
     environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ language: python
 env:
   - TEST_TARGET=other
   - TEST_TARGET=browser
-  - TEST_TARGET="ALL.test_a* ALL.test_b*"
-  - TEST_TARGET=ALL.test_c*
+  - TEST_TARGET="asm*.test_a* asm*.test_b*"
+  - TEST_TARGET=asm*.test_c*
   - TEST_TARGET="default.test_d* asm1.test_d* asm2.test_d* asm2f.test_d* asm2g.test_d* asm3.test_d*"
-  - TEST_TARGET=ALL.test_e*
-  - TEST_TARGET=ALL.test_f*
-  - TEST_TARGET="ALL.test_g* ALL.test_h* ALL.test_i*"
-  - TEST_TARGET="ALL.test_j* ALL.test_k* ALL.test_l* ALL.test_m* ALL.test_n* ALL.test_o*"
+  - TEST_TARGET=asm*.test_e*
+  - TEST_TARGET=asm*.test_f*
+  - TEST_TARGET="asm*.test_g* asm*.test_h* asm*.test_i*"
+  - TEST_TARGET="asm*.test_j* asm*.test_k* asm*.test_l* asm*.test_m* asm*.test_n* asm*.test_o*"
   - TEST_TARGET="default.test_p* asm1.test_p* asm2.test_p* asm2f.test_p* asm2g.test_p* asm3.test_p*"
-  - TEST_TARGET="ALL.test_q* ALL.test_r* ALL.test_s* ALL.test_t*"
-  - TEST_TARGET="ALL.test_u* ALL.test_v* ALL.test_w* ALL.test_x* ALL.test_y* ALL.test_z*"
+  - TEST_TARGET="asm*.test_q* asm*.test_r* asm*.test_s* asm*.test_t*"
+  - TEST_TARGET="asm*.test_u* asm*.test_v* asm*.test_w* asm*.test_x* asm*.test_y* asm*.test_z*"
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN cd /root/ \
 
 ARG TEST_TARGET
 RUN export EMSCRIPTEN_BROWSER=0 \
- && python /root/emscripten/tests/runner.py $TEST_TARGET skip:ALL.test_sse1_full skip:ALL.test_sse2_full skip:ALL.test_sse3_full skip:ALL.test_ssse3_full skip:ALL.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit skip:other.test_single_file skip:other.test_vorbis skip:other.test_eval_ctors
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:asm*.test_sse1_full skip:asm*.test_sse2_full skip:asm*.test_sse3_full skip:asm*.test_ssse3_full skip:asm*.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit skip:other.test_single_file skip:other.test_vorbis skip:other.test_eval_ctors
 
 # skip:other.test_emcc_v to prevent tool version differences from breaking CI

--- a/site/source/docs/getting_started/test-suite.rst
+++ b/site/source/docs/getting_started/test-suite.rst
@@ -4,7 +4,7 @@
 Emscripten Test Suite
 =====================
 
-Emscripten has a comprehensive test suite, which covers virtually all Emscripten functionality. These tests are an excellent resource for developers as they provide practical examples of most features, and are known to build successfully on the master branch. There are also :ref:`benchmark tests <emscripten-benchmark-tests>` that can be used to test how close Emscripten is getting to native speed.
+Emscripten has a comprehensive test suite, which covers virtually all Emscripten functionality. These tests are an excellent resource for developers as they provide practical examples of most features, and are known to pass on the master branch (and almost always on the incoming branch). In addition to correctness tests, there are also benchmarks that you can run.
 
 This article explains how to run the test and benchmark suite, and provides an overview of what tests are available.
 
@@ -36,12 +36,12 @@ The tests are divided into *modes*. You can run either an entire mode or an indi
 	# run all tests in a specific mode (here, asm.js -O1)
 	python tests/runner.py asm1
 
-The *core* test modes (`asm*` and `binaryen*`, defined in `tests/test_core.py`) let you run a specific test in either asm.js or wasm, and with different optimization flags. There are also non-core test modes, that run tests in more special manner (in particular, in those tests it is not possible to say "run the test with a different optimization flag" - that is what the core tests are for). The non-core test modes include
+The *core* test modes (``asm*`` and ``binaryen*``, defined in ``tests/test_core.py``) let you run a specific test in either asm.js or wasm, and with different optimization flags. There are also non-core test modes, that run tests in more special manner (in particular, in those tests it is not possible to say "run the test with a different optimization flag" - that is what the core tests are for). The non-core test modes include
 
  * `other`: Non-core tests running in the shell.
- * `browser': Tests that run in a browser
- * `sockets': Networking tests that run in a browser
- * `interactive`: Browser tests that are not fully automated, and require user interaction (these should be automated eventually)
+ * `browser`: Tests that run in a browser.
+ * `sockets`: Networking tests that run in a browser.
+ * `interactive`: Browser tests that are not fully automated, and require user interaction (these should be automated eventually).
  * `sanity`: Tests for emscripten setting itself up. This modifies your `.emscripten` file temporarily.
  * `benchmark`: Runs benchmarks, measuring speed and code size.
 
@@ -85,9 +85,6 @@ You can run a random subset of the test suite, using something like
     python tests/runner.py random100
 
 Replace ``100`` with another number as you prefer. This will run that number of random tests, and tell you the statistical likelihood of almost all the test suite passing assuming those tests do. This works just like election surveys do - given a small sample, we can predict fairly well that so-and-so percent of the public will vote for candidate A. In our case, the "candidates" are pass or fail, and we can predict how much of the test suite will pass given that sample. Assuming the sample tests all pass, we can say with high likelihood that most of the test suite will in fact pass. (Of course, this is no guarantee, and even a single test failure is serious, however, this gives a quick estimate that your patch does not cause significant and obvious breakage.)
-You can run a random set of N tests with a command like
-
-	python tests/runner.py random50
 
 Important Tests
 ===============
@@ -109,13 +106,12 @@ When you want to run the entire test suite locally, these are the important comm
 	python tests/runner.py sockets
 
 	# Run "sanity" test suite - this tests setting up emscripten during
-  # first run, etc., and so it modifies your .emscripten file temporarily.
+	# first run, etc., and so it modifies your .emscripten file temporarily.
 	python tests/runner.py sanity
 
 	# Optionally, also run benchmarks to check for regressions
 	python tests/runner.py benchmark
 
-.. _emscripten-benchmark-tests:
 Benchmarking
 ============
 
@@ -131,7 +127,7 @@ Usually you will want to customize the python in `tests/test_benchmark.py` to ru
 Debugging test failures
 =======================
 
-Setting the :ref:`debugging-EMCC_DEBUG` is useful for debugging tests, as it emits debug output and intermediate files from the compilation process:
+Setting the :ref:`debugging-EMCC_DEBUG` is useful for debugging tests, as it emits debug output and intermediate files (the files go in **/tmp/emscripten_temp/**):
 
 .. code-block:: bash
 
@@ -147,7 +143,7 @@ Setting the :ref:`debugging-EMCC_DEBUG` is useful for debugging tests, as it emi
 	EMCC_DEBUG=2 python tests/runner.py test_hello_world
 
 
-You can also specify ``EM_SAVE_DIR=1`` in the environment to save the temporary directory that the test runner uses into **/tmp/emscripten_temp/**. This is a test suite-specific feature, and is useful for tests that create temporary files.
+You can also specify ``EM_SAVE_DIR=1`` in the environment to save the temporary directory that the test runner uses into **/tmp/emscripten_temp/** (same place where ``EMCC_DEBUG`` intermediate files go). This is a test suite-specific feature, and is useful for tests that create temporary files.
 
 The :ref:`Debugging` topic provides more guidance on how to debug Emscripten-generated code. 
 

--- a/site/source/docs/getting_started/test-suite.rst
+++ b/site/source/docs/getting_started/test-suite.rst
@@ -8,47 +8,72 @@ Emscripten has a comprehensive test suite, which covers virtually all Emscripten
 
 This article explains how to run the test and benchmark suite, and provides an overview of what tests are available.
 
-Running the whole test suite
-============================
+Running tests
+=============
 
-The whole core test suite can be run using the script `tests/runner.py <https://github.com/kripken/emscripten/blob/master/tests/runner.py>`_: 
+Run the test suite runner (`tests/runner.py <https://github.com/kripken/emscripten/blob/master/tests/runner.py>`_) with no arguments to see the help message:
 
 .. code-block:: bash
 
     python tests/runner.py
-	
-.. note:: 
 
-	- The core test suite is not the entire test suite, see :ref:`section about core test modes <emscripten-test-suite-modes>`
-	- This may take several hours.
-	- :term:`Node.js` cannot run all of the tests in the suite; if you need to run them all, you should get a recent trunk version of the `SpiderMonkey <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell>`_ shell. On Windows you can install and activate *SpiderMonkey* using the :ref:`emsdk`.
-
-Running specific tests
-======================
-
-You can also use *runner.py* to run different parts of the test suite, or individual tests. For example, you would run test named ``test_hello_world`` as shown:
+The tests are divided into *modes*. You can run either an entire mode or an individual test, or use wildcards to run some tests in some modes. For example:
 
 .. code-block:: bash
 
-    python tests/runner.py test_hello_world
-	
-Tests in the "core" test suite (``tests/test_core.py``) can be run as above. Other tests may need a prefix, for example ``browser.test_cubegeom`` for a test in ``tests/test_browser.py``. You can also specify an optional prefix for tests in core, to run them with extra options, for example ``asm2.test_hello_world`` will run ``hello_world`` using ``asm2`` opts (basically ``-O2``). See more examples in :ref:`emscripten-test-suite-list-of-tests`.
+	# run one test (in the default mode)
+	python tests/runner.py test_loop
 
-It is possible to pass a wildcard to match multiple tests by name. For example, the commands
+	# run one test in a specific mode (here, asm.js -O2)
+	python tests/runner.py asm2.test_loop
+
+	# run a test in a bunch of modes (here, all asm.js modes)
+	python tests/runner.py asm*.test_loop
+
+	# run a bunch of tests in one mode (here, all i64 tests in wasm -O3)
+	python tests/runner.py binaryen3.test_*i64*
+
+	# run all tests in a specific mode (here, asm.js -O1)
+	python tests/runner.py asm1
+
+The *core* test modes (`asm*` and `binaryen*`, defined in `tests/test_core.py`) let you run a specific test in either asm.js or wasm, and with different optimization flags. There are also non-core test modes, that run tests in more special manner (in particular, in those tests it is not possible to say "run the test with a different optimization flag" - that is what the core tests are for). The non-core test modes include
+
+ * `other`: Non-core tests running in the shell.
+ * `browser': Tests that run in a browser
+ * `sockets': Networking tests that run in a browser
+ * `interactive`: Browser tests that are not fully automated, and require user interaction (these should be automated eventually)
+ * `sanity`: Tests for emscripten setting itself up. This modifies your `.emscripten` file temporarily.
+ * `benchmark`: Runs benchmarks, measuring speed and code size.
+
+The wildcards we mentioned above work for non-core test modes too, for example:
 
 .. code-block:: bash
 
-    python tests/runner.py ALL.test_simd_* ALL.test_sse*
+	# run one browser test
+	python tests/runner.py browser.test_sdl_image
 
-would run all the SIMD related tests in the suite.
+	# run all SDL2 browser tests
+	python tests/runner.py browser.test_sdl2*
 
-Individual tests can be skipped, so
+	# run all browser tests
+	python tests/runner.py browser
+
+Skipping Tests
+==============
+
+An individual test can be skipped by passing the "skip:" prefix. E.g.
 
 .. code-block:: bash
 
-    python tests/runner.py browser.test_pthread_* skip:browser.test_pthread_gcc_atomic_fetch_and_op
+	python tests/runner.py other skip:other.test_cmake
 
-would run all the multithreading tests except the one test ``browser.test_pthread_gcc_atomic_fetch_and_op``.
+Wildcards can also be passed in skip, so
+
+.. code-block:: bash
+
+	python tests/runner.py browser skip:browser.test_pthread_*
+
+will run the whole browser suite except for all the pthread tests in it.
 
 Running a bunch of random tests
 ===============================
@@ -60,103 +85,48 @@ You can run a random subset of the test suite, using something like
     python tests/runner.py random100
 
 Replace ``100`` with another number as you prefer. This will run that number of random tests, and tell you the statistical likelihood of almost all the test suite passing assuming those tests do. This works just like election surveys do - given a small sample, we can predict fairly well that so-and-so percent of the public will vote for candidate A. In our case, the "candidates" are pass or fail, and we can predict how much of the test suite will pass given that sample. Assuming the sample tests all pass, we can say with high likelihood that most of the test suite will in fact pass. (Of course, this is no guarantee, and even a single test failure is serious, however, this gives a quick estimate that your patch does not cause significant and obvious breakage.)
+You can run a random set of N tests with a command like
 
-Core test modes
+	python tests/runner.py random50
+
+Important Tests
 ===============
 
-By default, calling the test runner without arguments will run the core test suite
+When you want to run the entire test suite locally, these are the important commands:
 
 .. code-block:: bash
 
-    python tests/runner.py
-
-The core test suite includes ``default`` (no optimizations), ``asm1`` (``-O1`` optimizations), and a bunch of other optimization and compiler flags, each of which is a different "mode". The core test suite is the bulk of the entire test suite, and it runs each test in each of those modes.
-
-You can also run a specific mode or test in a mode, or a specific test across all modes:
-
-.. code-block:: bash
-
-	# Run all tests in asm1 mode	(-O1 optimizations).
-	python tests/runner.py asm1
-
-	# Run one test in asm1 mode	(-O1 optimizations).
-	python tests/runner.py asm1.test_hello_world   
+	# Run all core asm.js and wasm tests
+	python tests/runner.py asm* binaryen*
 	
-	# Run one test in all modes.
-	python tests/runner.py ALL.test_hello_world 
-
-The core test modes are documented at the end of `/tests/test_core.py <https://github.com/kripken/emscripten/blob/1.29.12/tests/test_core.py#L7421>`_.
-
-.. _emscripten-test-suite-modes:
-
-The core tests are the bulk of the entire test suite, in both number and time to run. To speed them up, you can run them in parallel using `/tests/parallel_test_core.py <https://github.com/kripken/emscripten/blob/master/tests/parallel_test_core.py>`_. That runs the test modes using a python process pool, emitting their outputs and stderrs to ``*.out, *.err`` for each mode.
-
-
-Non-core test modes
-===================
-
-The main non-core test modes are ``other, browser, sockets, interactive, sanity``. See :ref:`emscripten-test-suite-list-of-tests` for how to run them.
-
-
-.. _emscripten-benchmark-tests:
-
-Benchmark tests
-===============
-
-You can view `Emscripten’s current benchmark test results <http://arewefastyet.com/#machine=11&view=breakdown&suite=asmjs-ubench>`_ online. These are created by compiling a sequence of benchmarks and running them several times, then reporting averaged statistics including a comparison of how fast the same code runs when compiled to a native executable.
-
-You can run the tests yourself using the following command:
-
-.. code-block:: bash
-
-    python tests/runner.py benchmark
-
-	
-.. _emscripten-test-suite-list-of-tests:
-
-Common tests
-============
-
-Below is a list of some common tests/example commands. These include a comment explaining what each test does.
-
-.. code-block:: bash
-
-	# Run all (core) tests
-	python tests/runner.py                          
-
-	# Run hello world test, in default mode
-	python tests/runner.py test_hello_world
-
-	# Run it in asm1 mode
-	python tests/runner.py asm1.test_hello_world   
-	
-	# Run it in all modes
-	python tests/runner.py ALL.test_hello_world 
-
-	# Run all (core) tests in asm1 mode	
-	python tests/runner.py asm1 
-
-	# Run all "other" tests - that have no mode	
+	# Run "other" test suite
 	python tests/runner.py other
 
-	# Run a specific test in "other"	
-	python tests/runner.py other.test_static_link 
-
-	# Run all browser tests	
+	# Run "browser" test suite - this requires a web browser
 	python tests/runner.py browser
-	
-	# Run a specific browser test	
-	python tests/runner.py browser.test_sdlglshader 
-	
-	# Run all network tests. Note that you can also run specific tests (sockets.test_*)
+
+	# Run "sockets" test suite - this requires a web browser too
 	python tests/runner.py sockets
 
-	# Run all sanity tests. Note that you can also run specific tests (sanity.test_*)	
+	# Run "sanity" test suite - this tests setting up emscripten during
+  # first run, etc., and so it modifies your .emscripten file temporarily.
 	python tests/runner.py sanity
 
-	# Run all benchmarks. Note that you can also run specific tests (benchmark.test_*)	
-	python tests/runner.py benchmark                
+	# Optionally, also run benchmarks to check for regressions
+	python tests/runner.py benchmark
 
+.. _emscripten-benchmark-tests:
+Benchmarking
+============
+
+Emscripten has a benchmark suite that measures both speed and code size. To run it, do:
+
+.. code-block:: bash
+
+	# Run all benchmarks
+	python tests/runner.py benchmark
+
+Usually you will want to customize the python in `tests/test_benchmark.py` to run the benchmarks you want, see ``benchmarkers`` in the source code.
 
 Debugging test failures
 =======================

--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -45,7 +45,7 @@ When porting native SIMD code, it should be noted that because of portability co
 Tests and Benchmarks
 ====================
 
-Emscripten repository has several tests for SIMD support. To run SIMD tests, execute e.g. "python tests/runner.py ALL.test_sse1_full" in Emscripten root directory. For the full list of tests, see test_simd* and test_sse* in `test_core.py <https://github.com/kripken/emscripten/blob/incoming/tests/test_core.py>`_.
+Emscripten repository has several tests for SIMD support. To run SIMD tests, execute e.g. "python tests/runner.py asm*.test_sse1_full" in Emscripten root directory (note that currently - 2018-7-11 - only asm.js supports SIMD, so we run the `asm*` tests). For the full list of tests, see test_simd* and test_sse* in `test_core.py <https://github.com/kripken/emscripten/blob/incoming/tests/test_core.py>`_.
 
 To run a synthetic SSE1 API benchmark, execute "python tests/benchmark_sse1.py" in Emscripten root directory.
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -68,96 +68,30 @@ except:
 
 HELP_TEXT = '''
 ==============================================================================
-This is the Emscripten test runner. To run some tests, specify which you
-want. The main 'suites' are:
+This is the Emscripten test runner. To run some tests, specify which tests you
+want, for example
 
-  asm0, asm1, and other asm* - core asm.js tests in various opt modes
-  binaryen0, binaryen1, and other binaryen* - core wasm tests in various opt modes
-  other - non-core tests (that define their own method of running, unlike core)
-  browser - runs pages in a web browser
-  other - tests separate from the main suite
-  interactive - runs interactive browser tests that need human verification, and could not be automated
-  sockets - runs websocket networking tests
-  benchmark - run before and after each set of changes before pushing to
-              master, verify no regressions
-  sanity - tests for first run, etc., modifies ~/.emscripten
+  python tests/runner.py asm1.test_hello_world
 
-To run one of those parts, do something like
+There are many options for which tests to run and how to run them. For details,
+see
 
-  python tests/runner.py test_loop
-
-That runs test_loop in the default core test mode. You can also specify the mode,
-
-  python tests/runner.py asm2.test_loop
-
-You can also run a test in a bunch of modes:
-
-  python tests/runner.py asm*.test_loop
-
-And also a bunch of tests:
-
-  python tests/runner.py binaryen3.test_*i64*
-
-That runs all core tests with 'i64' in the name in wasm -O3.
-
-All the above also works for non-core test modes, for example
-
-  python tests/runner.py browser.test_sdl_image
-
-or
-
-  python tests/runner.py browser.test_sdl2*
-
-(The only difference is that something like asm*.test_loop - running
-a test in multiple modes - only really makes sense for the core test
-modes, as for example the 'other' and 'browser' modes do not have any
-tests with identical names, while the core test modes are literally
-the same tests with various optimization modes on them.)
-
-If you specify just a mode, all tests are run in that mode, for example
-
-  python tests/runner.py sanity
-
-or
-
-  python tests/runner.py binaryen1
-
-You can run a random set of N tests with a command like
-
-  python tests/runner.py random50
-
-An individual test can be skipped by passing the "skip:" prefix. E.g.
-
-  python tests/runner.py other skip:other.test_cmake
-
-Wildcards can also be passed in skip, so
-
-  python tests/runner.py browser skip:browser.test_pthread_*
-
-will run the whole browser suite except for all the pthread tests in it.
-
-Debugging: You can run
-
-  EM_SAVE_DIR=1 python tests/runner.py test_hello_world
-
-in order to save the test runner directory, in /tmp/emscripten_temp. All files
-created by the test will be present there. You can also use EMCC_DEBUG to
-further debug the compiler itself, see emcc.
+http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 ==============================================================================
 
 '''
 
 # Core test runner class, shared between normal tests and benchmarks
 checked_sanity = False
-test_modes = [
+
+
+# The core test modes
+core_test_modes = [
   'asm0',
   'asm1',
   'asm2',
   'asm3',
   'asm2g',
-]
-default_test_mode = test_modes[0]
-nondefault_test_modes = [
   'asm2f',
   'binaryen0',
   'binaryen1',
@@ -168,6 +102,19 @@ nondefault_test_modes = [
   'asmi',
   'asm2i',
 ]
+
+# The default core test mode, used when none is specified
+default_core_test_mode = 'binaryen0'
+
+# The non-core test modes
+non_core_test_modes = [
+  'other',
+  'browser',
+  'sanity',
+  'sockets',
+  'interactive',
+]
+
 test_index = 0
 
 use_all_engines = os.environ.get('EM_ALL_ENGINES') # generally js engines are equivalent, testing 1 is enough. set this
@@ -1156,7 +1103,7 @@ def args_with_extracted_js_engine_override(args):
 def args_with_default_suite_prepended(args):
   def prepend_default(arg):
     if arg.startswith('test_'):
-      return default_test_mode + '.' + arg
+      return default_core_test_mode + '.' + arg
     return arg
   return list(map(prepend_default, args))
 
@@ -1172,8 +1119,7 @@ def get_and_import_modules():
 def get_all_tests(modules):
   # Create a list of all known tests so that we can choose from them based on a wildcard search
   all_tests = []
-  suites = test_modes + nondefault_test_modes + \
-           ['other', 'browser', 'sanity', 'sockets', 'interactive']
+  suites = core_test_modes + non_core_test_modes
   for m in modules:
     for s in suites:
       if hasattr(m, s):
@@ -1237,8 +1183,8 @@ def args_for_random_tests(args, modules):
 
 def get_random_test_parameters(arg):
   num_tests = 1
-  base_module = default_test_mode
-  relevant_modes = test_modes
+  base_module = default_core_test_mode
+  relevant_modes = core_test_modes
   if len(arg):
     num_str = arg
     if arg.startswith('other'):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -90,7 +90,7 @@ That runs test_loop in the default core test mode. You can also specify the mode
 
   python tests/runner.py asm2.test_loop
 
-You can also run a bunch of modes:
+You can also run a test in a bunch of modes:
 
   python tests/runner.py asm*.test_loop
 
@@ -100,9 +100,27 @@ And also a bunch of tests:
 
 That runs all core tests with 'i64' in the name in wasm -O3.
 
-The same works for non-core test suites, like
+All the above also works for non-core test modes, for example
 
   python tests/runner.py browser.test_sdl_image
+
+or
+
+  python tests/runner.py browser.test_sdl2*
+
+(The only difference is that something like asm*.test_loop - running
+a test in multiple modes - only really makes sense for the core test
+modes, as for example the 'other' and 'browser' modes do not have any
+tests with identical names, while the core test modes are literally
+the same tests with various optimization modes on them.)
+
+If you specify just a mode, all tests are run in that mode, for example
+
+  python tests/runner.py sanity
+
+or
+
+  python tests/runner.py binaryen1
 
 You can run a random set of N tests with a command like
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1328,9 +1328,10 @@ def run_tests(suites, unmatched_test_names):
   num_failures = 0
 
   if len(unmatched_test_names):
-    print('WARNING: could not find the following tests: ' + ' '.join(unmatched_test_names))
+    print('ERROR: could not find the following tests: ' + ' '.join(unmatched_test_names))
     num_failures += len(unmatched_test_names)
     resultMessages.append('Could not find %s tests' % (len(unmatched_test_names),))
+    return 1
 
   print('Test suites:')
   print([s[0] for s in suites])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 import tools.shared
 from tools.shared import *
 from tools.line_endings import check_line_endings
-from runner import RunnerCore, path_from_root, checked_sanity, test_modes, get_zlib_library, get_bullet_library
+from runner import RunnerCore, path_from_root, checked_sanity, core_test_modes, get_zlib_library, get_bullet_library
 
 # decorators for limiting which modes a test can run in
 
@@ -4214,7 +4214,7 @@ Have even and odd!
 
   def test_fnmatch(self):
     # Run one test without assertions, for additional coverage
-    #assert 'asm2m' in test_modes
+    #assert 'asm2m' in core_test_modes
     if self.run_name == 'asm2m':
       i = self.emcc_args.index('ASSERTIONS=1')
       assert i > 0 and self.emcc_args[i-1] == '-s'
@@ -5350,7 +5350,7 @@ return malloc(size);
 
   @no_wasm_backend('FixFunctionBitcasts pass invalidates otherwise-ok function pointer casts')
   def test_cubescript(self):
-    assert 'asm3' in test_modes
+    assert 'asm3' in core_test_modes
     if self.run_name == 'asm3':
       self.emcc_args += ['--closure', '1'] # Use closure here for some additional coverage
 
@@ -5361,7 +5361,7 @@ return malloc(size);
 
     test()
 
-    assert 'asm1' in test_modes
+    assert 'asm1' in core_test_modes
     if self.run_name == 'asm1':
       print('verifing postsets')
       generated = open('src.cpp.o.js').read()
@@ -5674,7 +5674,7 @@ return malloc(size);
 
   def test_freetype(self):
     if self.is_windows(): self.skipTest('test_freetype uses a ./configure script to build and therefore currently only runs on Linux and macOS.')
-    assert 'asm2g' in test_modes
+    assert 'asm2g' in core_test_modes
     if self.run_name == 'asm2g':
       Settings.ALIASING_FUNCTION_POINTERS = 1 - Settings.ALIASING_FUNCTION_POINTERS # flip for some more coverage here
 
@@ -5758,7 +5758,7 @@ def process(filename):
   def test_zlib(self):
     self.maybe_closure()
 
-    assert 'asm2g' in test_modes
+    assert 'asm2g' in core_test_modes
     if self.run_name == 'asm2g':
       self.emcc_args += ['-g4'] # more source maps coverage
 
@@ -5801,7 +5801,7 @@ def process(filename):
 
       # TODO: test only worked in non-fastcomp (well, this section)
       continue
-      assert 'asm2g' in test_modes
+      assert 'asm2g' in core_test_modes
       if self.run_name == 'asm2g' and not use_cmake:
         # Test forced alignment
         print('testing FORCE_ALIGNED_MEMORY', file=sys.stderr)
@@ -6547,7 +6547,7 @@ def process(filename):
       Settings.ALIASING_FUNCTION_POINTERS = 1 - Settings.ALIASING_FUNCTION_POINTERS # flip the test
       self.do_run_from_file(src, expected)
 
-    assert 'asm2' in test_modes
+    assert 'asm2' in core_test_modes
     if self.run_name == 'asm2':
       print('closure')
       self.emcc_args += ['--closure', '1']
@@ -6883,7 +6883,7 @@ someweirdtext
   @sync
   @no_wasm_backend()
   def test_webidl(self):
-    assert 'asm2' in test_modes
+    assert 'asm2' in core_test_modes
     if self.run_name == 'asm2':
       self.emcc_args += ['--closure', '1', '-g1'] # extra testing
       Settings.MODULARIZE = 1 # avoid closure minified names competing with our test code in the global name space

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7805,7 +7805,7 @@ def make_run(name, emcc_args=None, env=None):
   return TT
 
 # Main asm.js test modes
-default = make_run('default', emcc_args=['-s', 'ASM_JS=2', '-s', 'WASM=0'])
+asm0 = make_run('asm0', emcc_args=['-s', 'ASM_JS=2', '-s', 'WASM=0'])
 asm1 = make_run('asm1', emcc_args=['-O1', '-s', 'WASM=0'])
 asm2 = make_run('asm2', emcc_args=['-O2', '-s', 'WASM=0'])
 asm3 = make_run('asm3', emcc_args=['-O3', '-s', 'WASM=0'])


### PR DESCRIPTION
 * Deprecate running the asm.js tests when the test runner is run with no arguments. That's especially silly now that wasm is the default, but also kind of weird to run any tests with no arguments. Instead, with no arguments, show the help and halt.
 * Rename 'default' to 'asm0', which makes it easy to do `asm*.test_name` for running all asm.js tests.
 * Also deprecate `ALL.` which used to run the asm.js tests. ALL was useful in the past before we had proper wildcard support, but now we can just do `asm*.test_loop` etc.
 * There is still one notion of "default"-ness left, if you do `./tests/runner.py test_loop` then it runs `asm0.test_loop` (same behavior as before). Maybe it makes sense to also switch that to wasm, although I'm not sure which of the wasm modes - seems ok to leave it `asm0` to me, as it feels like the intention there is "run this test somehow".