### PR TITLE
Move setjmp/longjmp helper functions and globals to compiler_rt_wasm library

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -61,7 +61,7 @@ def run():
         i += 1
 
   if DEBUG:
-    print('Invoking ' + str(newargs))
+    print('Invoking ' + str(newargs), file=sys.stderr)
   try:
     return subprocess.call(newargs, stdin=sys.stdin)
   finally:

--- a/emcc.py
+++ b/emcc.py
@@ -1120,6 +1120,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
         forced_stdlibs += ['libcxxabi']
 
+      # These is needed by setjmp as well as C++ esceptions.
+      # TODO(sbc): Do this conditionally
+      shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
+
       if not shared.Settings.ONLY_MY_CODE:
         if type(shared.Settings.EXPORTED_FUNCTIONS) in (list, tuple):
           # always need malloc and free to be kept alive and exported, for internal use and other modules

--- a/emscripten.py
+++ b/emscripten.py
@@ -79,7 +79,7 @@ def emscript(infile, outfile, libraries, compiler_engine, temp_files,
 
     with ToolchainProfiler.profile_block('get_and_parse_backend'):
       backend_output = compile_js(infile, temp_files, DEBUG)
-      funcs, metadata, mem_init = parse_backend_output(backend_output, DEBUG)
+      funcs, metadata, mem_init = parse_fastcomp_output(backend_output, DEBUG)
       fixup_metadata_tables(metadata)
       funcs = fixup_functions(funcs, metadata)
     with ToolchainProfiler.profile_block('compiler_glue'):
@@ -117,7 +117,7 @@ def compile_js(infile, temp_files, DEBUG):
   return backend_output
 
 
-def parse_backend_output(backend_output, DEBUG):
+def parse_fastcomp_output(backend_output, DEBUG):
   start_funcs_marker = '// EMSCRIPTEN_START_FUNCTIONS'
   end_funcs_marker = '// EMSCRIPTEN_END_FUNCTIONS'
   metadata_split_marker = '// EMSCRIPTEN_METADATA'
@@ -134,8 +134,8 @@ def parse_backend_output(backend_output, DEBUG):
   mem_init = mem_init.replace('Runtime.', '')
 
   try:
-    #if DEBUG: logging.debug("METAraw %s", metadata_raw)
-    metadata = json.loads(metadata_raw, object_pairs_hook=OrderedDict)
+    metadata = json.loads(metadata_raw)
+    if DEBUG: logging.debug("Metadata: " + pprint.pformat(metadata))
   except Exception as e:
     logging.error('emscript: failure to parse metadata output from compiler backend. raw output is: \n' + metadata_raw)
     raise e
@@ -1866,9 +1866,8 @@ def finalize_wasm(temp_files, infile, outfile, DEBUG):
 
 
 def create_metadata_wasm(metadata_raw, DEBUG):
-  if DEBUG: logging.debug("Metadata raw: " + metadata_raw)
   metadata = load_metadata(metadata_raw)
-  if DEBUG: logging.debug("Metadata parsed: " + pprint.pformat(metadata))
+  if DEBUG: logging.debug("Metadata: " + pprint.pformat(metadata))
   return metadata
 
 

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -1,0 +1,22 @@
+// Supprot functions for emscripten setjmp/longjmp and excecption handling
+// support.
+// See: https://llvm.org/doxygen/WebAssemblyLowerEmscriptenEHSjLj_8cpp.html
+
+int __THREW__;
+int __threwValue;
+int __tempRet0;
+
+void setThrew(int threw, int value) {
+  if (__THREW__ == 0) {
+    __THREW__ = threw;
+    __threwValue = value;
+  }
+}
+
+void setTempRet0(int value) {
+  __tempRet0 = value;
+}
+
+void getTempRet0(int value) {
+  __tempRet0 = value;
+}

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1912,6 +1912,7 @@ class Building(object):
     for a in Building.llvm_backend_args():
       cmd += ['-mllvm', a]
 
+
     # emscripten-wasm-finalize currently depends on the presence of debug
     # symbols for renaming of the __invoke symbols
     # TODO(sbc): Re-enable once emscripten-wasm-finalize is fixed or we
@@ -1924,6 +1925,10 @@ class Building(object):
     else:
       for export in expand_response(Settings.EXPORTED_FUNCTIONS):
         cmd += ['--export', export[1:]] # Strip the leading underscore
+        # For certainly symbols we also need to use --undefined so that the
+        # symbol is required to exist and will be pulled from .a file if needed.
+        if export in ('_setTempRet0', '_setThrew'):
+          cmd += ['-u', export[1:]] # Strip the leading underscore
 
     logging.debug('emcc: lld-linking: %s to %s', files, target)
     t = time.time()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1912,7 +1912,6 @@ class Building(object):
     for a in Building.llvm_backend_args():
       cmd += ['-mllvm', a]
 
-
     # emscripten-wasm-finalize currently depends on the presence of debug
     # symbols for renaming of the __invoke symbols
     # TODO(sbc): Re-enable once emscripten-wasm-finalize is fixed or we

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -447,6 +447,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'ashldi3.c', 'fixdfdi.c', 'floatdidf.c', 'lshrdi3.c', 'moddi3.c',
                  'trunctfdf2.c', 'trunctfsf2.c', 'umoddi3.c', 'fixunsdfdi.c', 'muldi3.c',
                  'divdi3.c', 'divmoddi4.c', 'udivdi3.c', 'udivmoddi4.c'])
+    files += files_in_path(path_components=['system', 'lib', 'compiler-rt'],
+             filenames=['extras.c'])
     return create_wasm_rt_lib(libname, files)
 
   def create_wasm_libc_rt(libname):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -448,7 +448,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'trunctfdf2.c', 'trunctfsf2.c', 'umoddi3.c', 'fixunsdfdi.c', 'muldi3.c',
                  'divdi3.c', 'divmoddi4.c', 'udivdi3.c', 'udivmoddi4.c'])
     files += files_in_path(path_components=['system', 'lib', 'compiler-rt'],
-             filenames=['extras.c'])
+                           filenames=['extras.c'])
     return create_wasm_rt_lib(libname, files)
 
   def create_wasm_libc_rt(libname):


### PR DESCRIPTION
Previously these have been generated by LLVM during codegen
but this doesn't work once we have separate compilation.

See LLVM change: https://reviews.llvm.org/D49208