### PR TITLE
Fix asm2f.test_simd15

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5646,7 +5646,8 @@ return malloc(size);
 
   @SIMD
   def test_simd15(self):
-    if self.run_name == 'asm1': self.skipTest('legalizing -O1 output is much harder, and not worth it - we work on -O0 and -O2+')
+    if any(opt in self.emcc_args for opt in ('-O1', '-Os', '-Oz')):
+      self.skipTest('legalizing -O1/s/z output is much harder, and not worth it - we work on -O0 and -O2+')
     self.emcc_args = self.emcc_args + ['-msse', '-msse2']
     test_path = path_from_root('tests', 'core', 'test_simd15')
     src, output = (test_path + s for s in ('.c', '.out'))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7845,6 +7845,7 @@ def make_run(name, emcc_args=None, env=None):
 
     assert emcc_args is not None
     self.emcc_args = emcc_args[:]
+    Settings.load(self.emcc_args)
     Building.LLVM_OPTS = 0
 
     Building.COMPILER_TEST_OPTS += [
@@ -7858,12 +7859,6 @@ def make_run(name, emcc_args=None, env=None):
     for arg in self.emcc_args:
       if arg.startswith('-O'):
         Building.COMPILER_TEST_OPTS.append(arg) # so bitcode is optimized too, this is for cpp to ll
-
-    # forward  -s K=V
-    for i in range(len(self.emcc_args)):
-      if self.emcc_args[i] == '-s':
-        key, value = self.emcc_args[i + 1].split('=', 1)
-        self.settings_mods[key] = json.loads(value)
 
   TT.setUp = setUp
 


### PR DESCRIPTION
With #6801 we no longer serialize all current settings we want to pass. This uncovered a bug: before for `-Oz` tests, the test runner's Settings would have `INLINING_LIMIT=0`, and we would forward this to our invocation of emcc. `emcc.py`'s `parse_args` has the behavior that `-Oz` (and `-Os`) overwrite the `INLINING_LIMIT` setting, which we used to later clobber with `-s INLINING_LIMIT=0`.
So, by no longer forwarding every bit of Settings state, we're actually testing `-Oz`'s behavior, which has the inlining limit. And that causes test_simd15 to fail.

The fix here is: `emcc test_simd15.c -Oz -msse -msse2` didn't used to work outside the test runner, it shouldn't work in the test runner, so skip it.