### PR TITLE
Note that we test the compiler in node.js only, and others may not work

### DIFF
--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -35,13 +35,10 @@ TEMP_DIR = '{{{ TEMP }}}'
 # Pick the JS engine to use for running the compiler. This engine must exist, or
 # nothing can be compiled.
 #
-# Recommendation: If you already have node installed, use that. Otherwise, build v8 or
-#                 spidermonkey from source. Any of these three is fine, as long as it's
-#                 a recent version (especially for v8 and spidermonkey).
+# This should be left on node.js, as that is the VM we test running the
+# compiler in. Other VMs may or may not work.
 
 COMPILER_ENGINE = NODE_JS
-#COMPILER_ENGINE = V8_ENGINE
-#COMPILER_ENGINE = SPIDERMONKEY_ENGINE
 
 
 # All JS engines to use when running the automatic tests. Not all the engines in this list


### PR DESCRIPTION
(indeed, it seems like currently no others do, as we use 'global[..]' which is a node.js-ism)