### PR TITLE
Add 'ENV' to the list of runtime elements that may be exported.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -351,3 +351,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Alexander Bich <quyse0@gmail.com>
 * Ashleigh Thomas <ashleighbcthomas@gmail.com>
 * Veniamin Petrenko <bjpbjpbjp10@gmail.com>
+* Ian Henderson <ian@ianhenderson.org>

--- a/src/modules.js
+++ b/src/modules.js
@@ -376,6 +376,7 @@ function exportRuntime() {
     'writeAsciiToMemory',
     'addRunDependency',
     'removeRunDependency',
+    'ENV',
     'FS',
     'FS_createFolder',
     'FS_createPath',


### PR DESCRIPTION
Adding environment variables seems to be impossible for MODULARIZE=1 builds without exporting the ENV object.

(I ran the 100-random-test script as a sanity check; let me know if there's some specific test or tests I should run for this part of the code.)