### PR TITLE
Verify EMSCRIPTEN_ROOT in config file

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -28,6 +28,12 @@ def wipe():
   try_delete(CONFIG_FILE)
   try_delete(SANITY_FILE)
 
+
+def add_to_config(content):
+  with open(CONFIG_FILE, 'a') as f:
+    f.write(content + '\n')
+
+
 def mtime(filename):
   return os.stat(filename).st_mtime
 
@@ -233,6 +239,25 @@ class sanity(RunnerCore):
             assert LLVM_WARNING not in output, output
     finally:
       del os.environ['EM_IGNORE_SANITY']
+
+  def test_emscripten_root(self):
+    # The correct path
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root())
+    output = self.check_working(EMCC)
+
+    # The correct path with extra stuff
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '%s'" % (path_from_root() + os.path.sep))
+    output = self.check_working(EMCC)
+
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '/bad/path'")
+    output = self.check_working(EMCC, 'Incorrect EMSCRIPTEN_ROOT in config file')
+
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root('x'))
+    output = self.check_working(EMCC, 'Incorrect EMSCRIPTEN_ROOT in config file')
 
   def test_llvm_fastcomp(self):
     WARNING = 'fastcomp in use, but LLVM has not been built with the JavaScript backend as a target'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -273,6 +273,7 @@ else:
     sys.exit(0)
 
 # The following globals can be overridden by the config file.
+EMSCRIPTEN_ROOT = __rootpath__
 NODE_JS = None
 BINARYEN_ROOT = None
 EM_POPEN_WORKAROUND = None
@@ -293,6 +294,14 @@ try:
   exec(config_text)
 except Exception as e:
   logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
+  sys.exit(1)
+
+# EMSCRIPTEN_ROOT is set in the config file so that external tools such as
+# scons can find emscripten by looking at the config.  Although its not used
+# within emscripten itself this is good to time sanity check the value.
+EMSCRIPTEN_ROOT = os.path.expanduser(os.path.normpath(EMSCRIPTEN_ROOT))
+if EMSCRIPTEN_ROOT != __rootpath__:
+  logging.error('Incorrect EMSCRIPTEN_ROOT in config file: %s (Expected %s)', EMSCRIPTEN_ROOT, __rootpath__)
   sys.exit(1)
 
 


### PR DESCRIPTION
When we load the emscripten config we already know what the value
of EMSCRIPTEN_ROOT should be.

I was considering removing EMSCRIPTEN_ROOT completely but it seems
that the scons integration using it to locate emscripten.  As far
as I know it has no other use.