### PR TITLE
Don't set visibility to dlmalloc symbols to default

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -1,7 +1,7 @@
 
 /* XXX Emscripten XXX */
 #if __EMSCRIPTEN__
-#define DLMALLOC_EXPORT __attribute__((__weak__, __visibility__("default")))
+#define DLMALLOC_EXPORT __attribute__((__weak__))
 /* mmap uses malloc, so malloc can't use mmap */
 #define HAVE_MMAP 0
 /* we can only grow the heap up anyhow, so don't try to trim */


### PR DESCRIPTION
These symbols are exported via EXPORTED_FUNCTIONS just like
any other.  lld will automatically export any symbol marked
as visibility default, unlike asm2wasm.

The side effect of this is that any dlmalloc symbols that were included
in the binary (and not DCE'd) would be exported, creating a few
needless exports.