### PR TITLE
WebIDL operators fix

### DIFF
--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -63,6 +63,7 @@ object
 21.12
 198
 getAsArray: 24
+Inner::+= => 2
 0
 1
 34,34

--- a/tests/webidl/output_DEFAULT.txt
+++ b/tests/webidl/output_DEFAULT.txt
@@ -63,6 +63,7 @@ object
 21.12
 198
 getAsArray: 24
+Inner::+= => 2
 0
 1
 34,34

--- a/tests/webidl/output_FAST.txt
+++ b/tests/webidl/output_FAST.txt
@@ -63,6 +63,7 @@ object
 21.12
 198
 getAsArray: 24
+Inner::+= => 2
 0
 1
 34,34

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -124,6 +124,7 @@ bv2.getAnother().PrintFloat(21.12);
 console.log(new TheModule.Inner().get());
 console.log('getAsArray: ' + new TheModule.Inner().getAsArray(12));
 new TheModule.Inner().mul(2);
+new TheModule.Inner().incInPlace(new TheModule.Inner());
 
 console.log(TheModule.enum_value1);
 console.log(TheModule.enum_value2);

--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -82,10 +82,15 @@ struct VoidPointerUser {
 
 namespace Space {
   struct Inner {
-    Inner() {}
+    int value;
+    Inner() : value(1) {}
     int get() { return 198; }
     Inner& operator*=(float x) { return *this; }
     int operator[](int x) { return x*2; }
+    void operator+=(const Inner& other) {
+      value += other.value;
+      printf("Inner::+= => %d\n", value);
+    }
   };
 }
 

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -77,6 +77,7 @@ interface Inner {
   long get();
   [Operator="*=", Ref] Inner mul(float x);
   [Operator="[]"] long getAsArray(long x);
+  [Operator="+="] void incInPlace([Const, Ref] Inner i);
 };
 
 enum AnEnum {

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -1,6 +1,6 @@
 import os, shutil, logging
 
-TAG = 'version_48'
+TAG = 'version_49'
 
 def needed(settings, shared, ports):
   if not settings.WASM: return False

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -504,7 +504,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
       if class_name != func_scope:
         # this function comes from an ancestor class; for operators, we must cast it
         cast_self = 'dynamic_cast<' + type_to_c(func_scope) + '>(' + cast_self + ')'
-      maybe_deref = '*' if sig[0] in interfaces else ''
+      maybe_deref = deref_if_nonpointer(raw[0])
       if '=' in operator:
         call = '(*%s %s %s%s)' % (cast_self, operator, maybe_deref, args[0])
       elif operator == '[]':


### PR DESCRIPTION
Properly use the right helper function in WebIDL binding of operators. That function handles attributes like Ref etc., without which `operator+=(T& other)` would not work.

Fixes a bug noticed in https://github.com/kripken/box2d.js/pull/93

