### PR TITLE
[wasm backend] Add compiler-rt libs just like any otheras

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1916,13 +1916,6 @@ class Building(object):
 
   @staticmethod
   def link_lld(files, target, opts=[], lto_level=0):
-    def wasm_rt_fail(archive_file):
-      def wrapped():
-        raise FatalError('Expected {} to already be built'.format(archive_file))
-      return wrapped
-
-    libc_rt_lib = Cache.get('wasm_libc_rt.a', wasm_rt_fail('wasm_libc_rt.a'), 'a')
-    compiler_rt_lib = Cache.get('wasm_compiler_rt.a', wasm_rt_fail('wasm_compiler_rt.a'), 'a')
     cmd = [
         WASM_LD,
         '-z',
@@ -1937,7 +1930,7 @@ class Building(object):
         '--export',
         '__wasm_call_ctors',
         '--lto-O%d' % lto_level,
-    ] + files + [libc_rt_lib, compiler_rt_lib]
+    ] + files
 
     if Settings.WASM_MEM_MAX != -1:
       cmd.append('--max-memory=%d' % Settings.WASM_MEM_MAX)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -614,9 +614,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       force = force.union(deps)
   ret.sort(key=lambda x: x.endswith('.a')) # make sure to put .a files at the end.
 
-  # Handle backend compiler_rt separately because it is not a bitcode system lib like the others.
-  # Here, just ensure that it's in the cache.
-  if shared.Settings.WASM and shared.Settings.WASM_BACKEND:
+  if shared.Settings.WASM_BACKEND:
     ret.append(shared.Cache.get('wasm_compiler_rt.a', lambda: create_wasm_compiler_rt('wasm_compiler_rt.a'), extension='a'))
     ret.append(shared.Cache.get('wasm_libc_rt.a', lambda: create_wasm_libc_rt('wasm_libc_rt.a'), extension='a'))
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -617,8 +617,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   # Handle backend compiler_rt separately because it is not a bitcode system lib like the others.
   # Here, just ensure that it's in the cache.
   if shared.Settings.WASM and shared.Settings.WASM_BACKEND:
-    shared.Cache.get('wasm_compiler_rt.a', lambda: create_wasm_compiler_rt('wasm_compiler_rt.a'), extension='a')
-    shared.Cache.get('wasm_libc_rt.a', lambda: create_wasm_libc_rt('wasm_libc_rt.a'), extension='a')
+    ret.append(shared.Cache.get('wasm_compiler_rt.a', lambda: create_wasm_compiler_rt('wasm_compiler_rt.a'), extension='a'))
+    ret.append(shared.Cache.get('wasm_libc_rt.a', lambda: create_wasm_libc_rt('wasm_libc_rt.a'), extension='a'))
 
   for actual in ret:
     if os.path.basename(actual) == 'libcxxabi.bc':


### PR DESCRIPTION
I'm not sure where these were being special cases really.
Previously there were being added by calculate() and then
assumed to exist.  But calculate() isn't called in all cases,
and in those cases these cache accesses would fail.