### PR TITLE
Avoid division by zero when using relative OpenAL sources.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -352,3 +352,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ashleigh Thomas <ashleighbcthomas@gmail.com>
 * Veniamin Petrenko <bjpbjpbjp10@gmail.com>
 * Ian Henderson <ian@ianhenderson.org>
+* Siim Kallas <siimkallas@gmail.com>

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -499,6 +499,16 @@ var LibraryOpenAL = {
       }
     },
 
+    inverseMagnitude: function(x, y, z) {
+      var length = Math.sqrt(x * x + y * y + z * z);
+
+      if (length < Number.EPSILON) {
+        return 0.0;
+      }
+
+      return 1.0 / length;
+    },
+
     updateSourceSpace: function(src) {
       if (!src.panner) {
         return;
@@ -540,13 +550,13 @@ var LibraryOpenAL = {
         var lUpZ = listener.up[2];
 
         // Normalize the Back vector
-        var invMag = 1.0 / Math.sqrt(lBackX * lBackX + lBackY * lBackY + lBackZ * lBackZ);
+        var invMag = AL.inverseMagnitude(lBackX, lBackY, lBackZ);
         lBackX *= invMag;
         lBackY *= invMag;
         lBackZ *= invMag;
 
         // ...and the Up vector
-        var invMag = 1.0 / Math.sqrt(lUpX * lUpX + lUpY * lUpY + lUpZ * lUpZ);
+        var invMag = AL.inverseMagnitude(lUpX, lUpY, lUpZ);
         lUpX *= invMag;
         lUpY *= invMag;
         lUpZ *= invMag;
@@ -557,7 +567,7 @@ var LibraryOpenAL = {
         var lRightZ = (lUpX * lBackY - lUpY * lBackX);
 
         // Back and Up might not be exactly perpendicular, so the cross product also needs normalization
-        var invMag = 1.0 / Math.sqrt(lRightX * lRightX + lRightY * lRightY + lRightZ * lRightZ);
+        var invMag = AL.inverseMagnitude(lRightX, lRightY, lRightZ);
         lRightX *= invMag;
         lRightY *= invMag;
         lRightZ *= invMag;

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -499,16 +499,6 @@ var LibraryOpenAL = {
       }
     },
 
-    inverseMagnitude: function(x, y, z) {
-      var length = Math.sqrt(x * x + y * y + z * z);
-
-      if (length < Number.EPSILON) {
-        return 0.0;
-      }
-
-      return 1.0 / length;
-    },
-
     updateSourceSpace: function(src) {
       if (!src.panner) {
         return;
@@ -549,14 +539,24 @@ var LibraryOpenAL = {
         var lUpY = listener.up[1];
         var lUpZ = listener.up[2];
 
+        function inverseMagnitude(x, y, z) {
+          var length = Math.sqrt(x * x + y * y + z * z);
+
+          if (length < Number.EPSILON) {
+            return 0.0;
+          }
+
+          return 1.0 / length;
+        }
+
         // Normalize the Back vector
-        var invMag = AL.inverseMagnitude(lBackX, lBackY, lBackZ);
+        var invMag = inverseMagnitude(lBackX, lBackY, lBackZ);
         lBackX *= invMag;
         lBackY *= invMag;
         lBackZ *= invMag;
 
         // ...and the Up vector
-        var invMag = AL.inverseMagnitude(lUpX, lUpY, lUpZ);
+        var invMag = inverseMagnitude(lUpX, lUpY, lUpZ);
         lUpX *= invMag;
         lUpY *= invMag;
         lUpZ *= invMag;
@@ -567,7 +567,7 @@ var LibraryOpenAL = {
         var lRightZ = (lUpX * lBackY - lUpY * lBackX);
 
         // Back and Up might not be exactly perpendicular, so the cross product also needs normalization
-        var invMag = AL.inverseMagnitude(lRightX, lRightY, lRightZ);
+        var invMag = inverseMagnitude(lRightX, lRightY, lRightZ);
         lRightX *= invMag;
         lRightY *= invMag;
         lRightZ *= invMag;


### PR DESCRIPTION
Fixes cases where the listener direction is [0, 0, 0]:

```
TypeError: Failed to set the 'value' property on 'AudioParam': The provided float value is non-finite.
    at Object.updateSourceSpace
```