### PR TITLE
Fixes emscripten_is_webgl_context_lost with Closure

### DIFF
--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -462,7 +462,7 @@ var emscriptenCpuProfiler = {
   detectWebGLContext: function() {
     if (Module['canvas'] && Module['canvas'].GLctxObject && Module['canvas'].GLctxObject.GLctx) return Module['canvas'].GLctxObject.GLctx;
     else if (typeof GLctx !== 'undefined') return GLctx;
-    else if (Module.ctx) return Module.ctx;
+    else if (Module['ctx']) return Module['ctx'];
     return null;
   },
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -296,7 +296,7 @@ var LibraryBrowser = {
     },
 
     createContext: function(canvas, useWebGL, setInModule, webGLContextAttributes) {
-      if (useWebGL && Module.ctx && canvas == Module.canvas) return Module.ctx; // no need to recreate GL context if it's already been created for this canvas.
+      if (useWebGL && Module['ctx'] && canvas == Module.canvas) return Module['ctx']; // no need to recreate GL context if it's already been created for this canvas.
 
       var ctx;
       var contextHandle;
@@ -326,7 +326,7 @@ var LibraryBrowser = {
       if (setInModule) {
         if (!useWebGL) assert(typeof GLctx === 'undefined', 'cannot set in module if GLctx is used, but we are a non-GL context that would replace it');
 
-        Module.ctx = ctx;
+        Module['ctx'] = ctx;
         if (useWebGL) GL.makeContextCurrent(contextHandle);
         Module.useWebGL = useWebGL;
         Browser.moduleContextCreatedCallbacks.forEach(function(callback) { callback() });
@@ -1191,7 +1191,7 @@ var LibraryBrowser = {
       }
 #endif
 
-      if (Browser.mainLoop.method === 'timeout' && Module.ctx) {
+      if (Browser.mainLoop.method === 'timeout' && Module['ctx']) {
         err('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
         Browser.mainLoop.method = ''; // just warn once per call to set main loop
       }

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -568,9 +568,9 @@ var LibraryEGL = {
 
     if (!EGL.defaultDisplayInitialized) {
       EGL.setErrorCode(0x3001 /* EGL_NOT_INITIALIZED */);
-    } else if (!Module.ctx) {
+    } else if (!Module['ctx']) {
       EGL.setErrorCode(0x3002 /* EGL_BAD_ACCESS */);
-    } else if (Module.ctx.isContextLost()) {
+    } else if (Module['ctx'].isContextLost()) {
       EGL.setErrorCode(0x300E /* EGL_CONTEXT_LOST */);
     } else {
       // According to documentation this does an implicit flush.

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -573,7 +573,7 @@ var LibraryGL = {
     makeContextCurrent: function(contextHandle) {
       var context = GL.contexts[contextHandle];
       if (!context) return false;
-      GLctx = Module.ctx = context.GLctx; // Active WebGL context object.
+      GLctx = Module['ctx'] = context.GLctx; // Active WebGL context object.
       GL.currentContext = context; // Active Emscripten GL layer context object.
       return true;
     },

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -996,11 +996,11 @@ var LibraryGLFW = {
           stencil: (GLFW.hints[0x00021006] > 0),   // GLFW_STENCIL_BITS
           alpha: (GLFW.hints[0x00021004] > 0)      // GLFW_ALPHA_BITS 
         }
-        Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
+        Module['ctx'] = Browser.createContext(Module['canvas'], true, true, contextAttributes);
       }
 
       // If context creation failed, do not return a valid window
-      if (!Module.ctx) return 0;
+      if (!Module['ctx']) return 0;
 
       // Get non alive id
       var win = new GLFW.Window(id, width, height, title, monitor, share);
@@ -1033,7 +1033,7 @@ var LibraryGLFW = {
       for (var i = 0; i < GLFW.windows.length; i++)
         if (GLFW.windows[i] !== null) return;
 
-      Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
+      Module['ctx'] = Browser.destroyContext(Module['canvas'], true, true);
     },
 
     swapBuffers: function(winid) {

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -565,13 +565,13 @@ var LibraryGLUT = {
       stencil: ((GLUT.initDisplayMode & 0x0020 /*GLUT_STENCIL*/) != 0),
       alpha: ((GLUT.initDisplayMode & 0x0008 /*GLUT_ALPHA*/) != 0)
     };
-    Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
-    return Module.ctx ? 1 /* a new GLUT window ID for the created context */ : 0 /* failure */;
+    Module['ctx'] = Browser.createContext(Module['canvas'], true, true, contextAttributes);
+    return Module['ctx'] ? 1 /* a new GLUT window ID for the created context */ : 0 /* failure */;
   },
 
   glutDestroyWindow__deps: ['$Browser'],
   glutDestroyWindow: function(name) {
-    Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
+    Module['ctx'] = Browser.destroyContext(Module['canvas'], true, true);
     return 1;
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3421,7 +3421,7 @@ var LibrarySDL = {
   SDL_GL_ExtensionSupported__proxy: 'sync',
   SDL_GL_ExtensionSupported__sig: 'ii',
   SDL_GL_ExtensionSupported: function(extension) {
-    return Module.ctx.getExtension(extension) | 0;
+    return Module['ctx'].getExtension(extension) | 0;
   },
 
   SDL_DestroyWindow: function(window) {},

--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -64,7 +64,7 @@ function renderFrame() {
       dst[i] = renderFrameData[i];
     }
   }
-  Module.ctx.putImageData(Module.canvasData, 0, 0);
+  Module['ctx'].putImageData(Module.canvasData, 0, 0);
   renderFrameData = null;
 }
 
@@ -155,7 +155,7 @@ worker.onmessage = function worker_onmessage(event) {
     case 'canvas': {
       switch (data.op) {
         case 'getContext': {
-          Module.ctx = Module.canvas.getContext(data.type, data.attributes);
+          Module['ctx'] = Module.canvas.getContext(data.type, data.attributes);
           if (data.type !== '2d') {
             // possible GL_DEBUG entry point: Module.ctx = wrapDebugGL(Module.ctx);
             Module.glClient = new WebGLClient();
@@ -165,7 +165,7 @@ worker.onmessage = function worker_onmessage(event) {
         case 'resize': {
           Module.canvas.width = data.width;
           Module.canvas.height = data.height;
-          if (Module.ctx && Module.ctx.getImageData) Module.canvasData = Module.ctx.getImageData(0, 0, data.width, data.height);
+          if (Module['ctx'] && Module['ctx'].getImageData) Module.canvasData = Module['ctx'].getImageData(0, 0, data.width, data.height);
           worker.postMessage({ target: 'canvas', boundingClientRect: cloneObject(Module.canvas.getBoundingClientRect()) });
           break;
         }

--- a/src/webGLClient.js
+++ b/src/webGLClient.js
@@ -266,7 +266,7 @@ function WebGLClient() {
   };
 
   function renderCommands(buf) {
-    ctx = Module.ctx;
+    ctx = Module['ctx'];
     i = 0;
     buffer = buf;
     var len = buffer.length;


### PR DESCRIPTION
Replaced Module.ctx with Module['ctx'] to stop emscripten_is_webgl_context_lost() (and possibly others) failing after Closure.

See issue #6877.