### PR TITLE
Fix other.test_demangle after ABI change to size_t from int to long

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2499,7 +2499,7 @@ done.
 
     run_process([PYTHON, EMCC, 'src.cpp', '-s', 'DEMANGLE_SUPPORT=1'])
     output = run_js('a.out.js')
-    self.assertContained('''operator new(unsigned int)
+    self.assertContained('''operator new(unsigned long)
 _main
 f2()
 abcdabcdabcd(int)


### PR DESCRIPTION
Followup to #5916. Looks like aside from this the bots are all green.

cc @sunfishcode 