### PR TITLE
Fix asmi.test_dlfcn* (which are not tested on the bots)

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1779,12 +1779,14 @@ var LibrarySDL = {
   SDL_WarpMouse__sig: 'vii',
   SDL_WarpMouse: function(x, y) {
     return; // TODO: implement this in a non-buggy way. Need to keep relative mouse movements correct after calling this
+    /*
     var rect = Module["canvas"].getBoundingClientRect();
     SDL.events.push({
       type: 'mousemove',
       pageX: x + (window.scrollX + rect.left),
       pageY: y + (window.scrollY + rect.top)
     });
+    */
   },
 
   SDL_ShowCursor__proxy: 'sync',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7887,7 +7887,7 @@ binaryen2s = make_run('binaryen2s', emcc_args=['-O2', '-s', 'SAFE_HEAP=1'])
 binaryen2_interpret = make_run('binaryen2_interpret', emcc_args=['-O2', '-s', 'BINARYEN_METHOD="interpret-binary"'])
 
 # emterpreter
-asmi = make_run('asmi', emcc_args=['-s', 'EMTERPRETIFY=1', '-s', 'WASM=0'])
+asmi = make_run('asmi', emcc_args=['-s', 'ASM_JS=2', '-s', 'EMTERPRETIFY=1', '-s', 'WASM=0'])
 asm2i = make_run('asm2i', emcc_args=['-O2', '-s', 'EMTERPRETIFY=1', '-s', 'WASM=0'])
 
 del T # T is just a shape for the specific subclasses, we don't test it itself


### PR DESCRIPTION
Marking it as `ASM_JS=2` tells it that we can't expect asm.js validation to happen, the same as we do in `asm0` mode.

(The actual failure is that in `-O0` we warn on `addFunction` needing a type param in the wasm backend, and mention that's not an issue in asm.js - but then "asm.js" appears in a warning, and the test runner thinks that might be an asm.js validation error...)

Also comment out some unreachable code in SDL, which shows warnings in some JS VMs, which made debugging this issue harder.