### PR TITLE
Return an absolute path in Cache.get

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -86,7 +86,7 @@ class Cache(object):
   # the given creator function
   def get(self, shortname, creator, extension='.bc', what=None, force=False):
     if not shortname.endswith(extension): shortname += extension
-    cachename = os.path.join(self.dirname, shortname)
+    cachename = os.path.abspath(os.path.join(self.dirname, shortname))
 
     self.acquire_cache_lock()
     try:


### PR DESCRIPTION
We may move around before using that file later (e.g. in the js compiler).

Fixes #6909