### PR TITLE
MODULARIZE / scriptDirectory improvements

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2618,11 +2618,10 @@ function %(EXPORT_NAME)s(%(EXPORT_NAME)s) {
   }
 
   if not shared.Settings.MODULARIZE_INSTANCE:
-    # Included code may refer to Module (e.g. from file packager), so alias it.
-    # _scriptDir is used to since when MODULARIZE this JS may be executed later,
-    # after document.currentScript is gone, so we save it for later (when
-    # MODULARIZE_INSTANCE, an instance is created immediately anyhow, like in
-    # non-modularize mode)
+    # When MODULARIZE this JS may be executed later,
+    # after document.currentScript is gone, so we save it.
+    # (when MODULARIZE_INSTANCE, an instance is created
+    # immediately anyhow, like in non-modularize mode)
     src = '''
 var %(EXPORT_NAME)s = (function() {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;

--- a/emcc.py
+++ b/emcc.py
@@ -2605,13 +2605,13 @@ def modularize():
   f = open(final, 'w')
 
   src = '''
-function %(EXPORT_NAME)s(%(EXPORT_NAME)s) {
+var %(EXPORT_NAME)s = function(%(EXPORT_NAME)s) {
   %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
 
 %(src)s
 
   return %(EXPORT_NAME)s;
-}
+};
 ''' % {
     'EXPORT_NAME': shared.Settings.EXPORT_NAME,
     'src': src
@@ -2623,7 +2623,7 @@ function %(EXPORT_NAME)s(%(EXPORT_NAME)s) {
     # (when MODULARIZE_INSTANCE, an instance is created
     # immediately anyhow, like in non-modularize mode)
     src = '''
-var %(EXPORT_NAME)s = (function() {
+%(EXPORT_NAME)s = (function() {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
 %(src)s
   return (%(src)s);
@@ -2635,7 +2635,7 @@ var %(EXPORT_NAME)s = (function() {
   else:
     # Create the MODULARIZE_INSTANCE instance
     src = '''
-var %(EXPORT_NAME)s = (%(src)s)();
+%(EXPORT_NAME)s = (%(src)s)();
 ''' % {
       'EXPORT_NAME': shared.Settings.EXPORT_NAME,
       'src': src

--- a/emcc.py
+++ b/emcc.py
@@ -2604,19 +2604,20 @@ def modularize():
   final = final + '.modular.js'
   f = open(final, 'w')
 
-  # Included code may refer to Module (e.g. from file packager), so alias it
-  f.write('''var %(EXPORT_NAME)s = function(%(EXPORT_NAME)s) {
-  %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
+  # Included code may refer to Module (e.g. from file packager), so alias it.
+  # _scriptDir is used to since when MODULARIZE this JS may be executed later,
+  # after document.currentScript is gone, so we save it for later
+  f.write('''
+var %(EXPORT_NAME)s = (function() {
+  var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
+  return (function(%(EXPORT_NAME)s) {
+    %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
 
 %(src)s
 
-  return %(EXPORT_NAME)s;
-};
-// When MODULARIZE, this JS may be executed later, after document.currentScript
-// is gone, so we save it.
-%(EXPORT_NAME)s = %(EXPORT_NAME)s.bind({
-  _scriptDir: typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined
-})%(instantiate)s;
+    return %(EXPORT_NAME)s;
+  })%(instantiate)s;
+})();
 ''' % {
     'EXPORT_NAME': shared.Settings.EXPORT_NAME,
     'src': src,

--- a/emcc.py
+++ b/emcc.py
@@ -2605,13 +2605,13 @@ def modularize():
   f = open(final, 'w')
 
   src = '''
-var %(EXPORT_NAME)s = function(%(EXPORT_NAME)s) {
+function(%(EXPORT_NAME)s) {
   %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
 
 %(src)s
 
   return %(EXPORT_NAME)s;
-};
+}
 ''' % {
     'EXPORT_NAME': shared.Settings.EXPORT_NAME,
     'src': src
@@ -2623,9 +2623,8 @@ var %(EXPORT_NAME)s = function(%(EXPORT_NAME)s) {
     # (when MODULARIZE_INSTANCE, an instance is created
     # immediately anyhow, like in non-modularize mode)
     src = '''
-%(EXPORT_NAME)s = (function() {
+var %(EXPORT_NAME)s = (function() {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
-%(src)s
   return (%(src)s);
 })();
 ''' % {
@@ -2635,7 +2634,7 @@ var %(EXPORT_NAME)s = function(%(EXPORT_NAME)s) {
   else:
     # Create the MODULARIZE_INSTANCE instance
     src = '''
-%(EXPORT_NAME)s = (%(src)s)();
+var %(EXPORT_NAME)s = (%(src)s)();
 ''' % {
       'EXPORT_NAME': shared.Settings.EXPORT_NAME,
       'src': src

--- a/emcc.py
+++ b/emcc.py
@@ -2638,6 +2638,7 @@ var %(EXPORT_NAME)s = (function() {
     src = '''
 var %(EXPORT_NAME)s = (%(src)s)();
 ''' % {
+      'EXPORT_NAME': shared.Settings.EXPORT_NAME,
       'src': src
     }
 

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -1074,6 +1074,10 @@ var wakaUnknownAfter;
  */
 var wakaUnknownBefore;
 /**
+ * @suppress {undefinedVars}
+ */
+var _scriptDir;
+/**
  * @suppress {duplicate}
  */
 var env;

--- a/src/shell.js
+++ b/src/shell.js
@@ -237,11 +237,13 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
     scriptDirectory = self.location.href;
   }
 #if MODULARIZE
-  // When MODULARIZE, this JS may be executed later, after document.currentScript
+#if MODULARIZE_INSTANCE == 0
+  // When MODULARIZE (and not _INSTANCE), this JS may be executed later, after document.currentScript
   // is gone, so we saved it, and we use it here instead of any other info.
   if (_scriptDir) {
     scriptDirectory = _scriptDir;
   }
+#endif
 #endif
   // blob urls look like blob:http://site.com/etc/etc and we cannot infer anything from them.
   // otherwise, slice off the final part of the url to find the script directory.

--- a/src/shell.js
+++ b/src/shell.js
@@ -239,8 +239,8 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #if MODULARIZE
   // When MODULARIZE, this JS may be executed later, after document.currentScript
   // is gone, so we saved it, and we use it here instead of any other info.
-  if (this['_scriptDir']) {
-    scriptDirectory = this['_scriptDir'];
+  if (_scriptDir) {
+    scriptDirectory = _scriptDir;
   }
 #endif
   // blob urls look like blob:http://site.com/etc/etc and we cannot infer anything from them.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4003,6 +4003,6 @@ window.close = function() {
             %s
           }, 1);
         </script>
-      ''' % 'Module();' if not instance else '')
+      ''' % ('Module();' if not instance else ''))
       self.run_browser('test.html', None, '/report_result?0')
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3950,7 +3950,6 @@ window.close = function() {
     src = open('test.html').read()
     # Make sure JS is loaded from subdirectory
     open('test-subdir.html', 'w').write(src.replace('test.js', 'subdir/test.js'))
-
     self.run_browser('test-subdir.html', None, '/report_result?0')
 
   # Similar to `test_browser_run_from_different_directory`, but asynchronous because of `-s MODULARIZE=1`
@@ -3963,43 +3962,39 @@ window.close = function() {
       os.mkdir('subdir')
     shutil.move('test.js', os.path.join('subdir', 'test.js'))
     shutil.move('test.wasm', os.path.join('subdir', 'test.wasm'))
-    # Make sure JS is loaded from subdirectory
-    open('test-subdir.html', 'w').write('''
-      <script src="subdir/test.js"></script>
-      <script>
-        Module();
-      </script>
-    ''')
-
-    self.run_browser('test-subdir.html', None, '/report_result?0')
+    for creation in (
+      'Module();',
+      'new Module();' # not documented as working, but we support it
+    ):
+      print(creation)
+      # Make sure JS is loaded from subdirectory
+      open('test-subdir.html', 'w').write('''
+        <script src="subdir/test.js"></script>
+        <script>
+          %s
+        </script>
+      ''' % creation)
+      self.run_browser('test-subdir.html', None, '/report_result?0')
 
   # Similar to `test_browser_run_from_different_directory`, but
   # also also we eval the initial code, so currentScript is not present. That prevents us
   # from finding the file in a subdir, but here we at least check we do not regress compared to the
   # normal case of finding in the current dir.
-  # In addition, check for new Module(), which overrides the bind() and replaces the object
-  # which saved the _scriptDir. Again, we can't get the script dir that way, but at least we
-  # should not regress compared to the normal case.
   def test_browser_modularize_no_current_script(self):
     src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
     open('test.c', 'w').write(self.with_report_result(src))
     # compile the code with the modularize feature and the preload-file option enabled
     Popen([PYTHON, EMCC, 'test.c', '-o', 'test.js', '-s', 'MODULARIZE=1']).communicate()
-    for creation in (
-      'Module();',
-      'new Module();'
-    ):
-      print(creation)
-      open('test.html', 'w').write('''
-        <script>
-          setTimeout(function() {
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', 'test.js', false);
-            xhr.send(null);
-            eval(xhr.responseText);
-            %s
-          }, 1);
-        </script>
-      ''' % creation)
-      self.run_browser('test.html', None, '/report_result?0')
+    open('test.html', 'w').write('''
+      <script>
+        setTimeout(function() {
+          var xhr = new XMLHttpRequest();
+          xhr.open('GET', 'test.js', false);
+          xhr.send(null);
+          eval(xhr.responseText);
+          Module();
+        }, 1);
+      </script>
+    ''')
+    self.run_browser('test.html', None, '/report_result?0')
 


### PR DESCRIPTION
 * Support `new Module()` (instead of just `Module()`) in finding the scriptDirectory. This is done by avoiding `.bind()`, and saving it in a closure. This seems like a potential common pitfall, so worth supporting even if it isn't the documented use (see #6903).
 * Don't emit the `_scriptDir` code for MODULARIZE_INSTANCE - we only need it in MODULARIZE.
 * Refactor the `emcc.py` code, do the extra scriptDirectory or instance stuff later, which I think is clearer.
 * Add testing for MODULARIZE_INSTANCE and scriptDirectory detection.

cc @nazar-pc 