### PR TITLE
fix_test_response_file_on_windows

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6510,7 +6510,8 @@ def process(filename):
 
   def test_response_file(self):
     with open('rsp_file', 'w') as f:
-      f.write('-o %s/response_file.o.js %s' % (self.get_dir(), path_from_root('tests', 'hello_world.cpp')))
+      response_data = '-o %s/response_file.o.js %s' % (self.get_dir(), path_from_root('tests', 'hello_world.cpp'))
+      f.write(response_data.replace('\\', '\\\\'))
     run_process([PYTHON, EMCC, "@rsp_file"] + self.emcc_args)
     self.do_run('' , 'hello, world', basename='response_file', no_build=True)
 
@@ -6521,7 +6522,8 @@ def process(filename):
     # by emscripten, except when using the wasm backend (lld) in which case it
     # should pass the original flag to the linker.
     with open('rsp_file', 'w') as f:
-      f.write(objfile + ' --export=foo')
+      response_data = objfile + ' --export=foo'
+      f.write(response_data.replace('\\', '\\\\'))
     run_process([PYTHON, EMCC, "-Wl,@rsp_file", '-o', os.path.join(self.get_dir(), 'response_file.o.js')] + self.emcc_args)
     self.do_run('' , 'hello, world', basename='response_file', no_build=True)
 


### PR DESCRIPTION
Fix tests test_response_file and test_linker_response_file on Windows. Currently response files are loaded by parsing them via 'shlex.split()', which means that properly formed response files must escape any backslash characters as \\, since shlex.parse will treat \r and \n as control characters.

As an example, in that test the original contents of the generated response file would be

```
-o C:\Users\clb\AppData\Local\Temp\emscripten_test_default_5a0qkc/response_file.o.js C:\code\emsdk\emscripten\incoming\tests\hello_world.cpp
```

which would result in an error

```
ERROR:root:C:codeemsdkemscriptenincomingtestshello_world.cpp: No such file or directory ("C:codeemsdkemscriptenincomingtestshello_world.cpp" was expected to be an input file, based on the commandline arguments provided)
```

when running the test on Windows.

Another way to approach this might be to change the semantics of how response files are interpreted, but it is probably nicer to keep the way they are, so that they can retain `\n` and `\t` in case that may be necessary some day.