### PR TITLE
Remove assertion on EMSCRIPTEN_ROOT

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -251,14 +251,6 @@ class sanity(RunnerCore):
     add_to_config("EMSCRIPTEN_ROOT = '%s'" % (path_from_root() + os.path.sep))
     self.check_working(EMCC)
 
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '/bad/path'")
-    self.check_working(EMCC, 'Incorrect EMSCRIPTEN_ROOT in config file')
-
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root('x'))
-    self.check_working(EMCC, 'Incorrect EMSCRIPTEN_ROOT in config file')
-
   def test_llvm_fastcomp(self):
     WARNING = 'fastcomp in use, but LLVM has not been built with the JavaScript backend as a target'
     WARNING2 = 'you can fall back to the older (pre-fastcomp) compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -273,7 +273,6 @@ else:
     sys.exit(0)
 
 # The following globals can be overridden by the config file.
-EMSCRIPTEN_ROOT = __rootpath__
 NODE_JS = None
 BINARYEN_ROOT = None
 EM_POPEN_WORKAROUND = None
@@ -295,13 +294,6 @@ try:
 except Exception as e:
   logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
   sys.exit(1)
-
-# EMSCRIPTEN_ROOT is set in the config file so that external tools such as
-# scons can find emscripten by looking at the config.  Although its not used
-# within emscripten itself this is good to time sanity check the value.
-EMSCRIPTEN_ROOT = os.path.expanduser(os.path.normpath(EMSCRIPTEN_ROOT))
-if EMSCRIPTEN_ROOT != __rootpath__:
-  exit_with_error('Incorrect EMSCRIPTEN_ROOT in config file: %s (Expected %s)', EMSCRIPTEN_ROOT, __rootpath__)
 
 
 # Returns a suggestion where current .emscripten config file might be located


### PR DESCRIPTION
On windows we have seen failures due to C:\PROGRA~1 being the same as C:\Program Files (despite the strings differing), and there is no simple way to check that. On other platforms symbolic links may cause similar issues, so it's not worth it.

Fixes #6915
