### PR TITLE
Add test case to illustrate error with dynamic linking of static member variable

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4085,6 +4085,43 @@ Module = {
                        force_c=True)
     finally:
       del os.environ['EMCC_FORCE_STDLIBS']
+  
+  def test_dylink_static_member(self):
+    self.dylink_test(header=r'''
+      class Base {
+      public:
+          Base() : value(1) {}
+          static Base member;
+          int value;
+
+          bool operator==(const Base &rhs) const {
+            return value == rhs.value;
+          }
+      };
+    ''', main=r'''
+      #include "header.h"
+      #include <iostream>
+
+      using namespace std;
+      extern void sidey();
+      int main() {
+        cout << "starting main" << endl;
+        sidey();
+      
+        return 0;
+      }
+    ''', side=r'''
+      #include "header.h"
+      #include <iostream>
+      
+      using namespace std;
+
+      void sidey() {
+          Base temp;
+          temp.value = 5;
+          cout << "sidey:" << (Base::member == temp) << endl;
+      }
+    ''', expected=['starting main\nsidey:0'])
 
   #def test_dylink_bullet(self):
   #  Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('tests', 'bullet', 'src')]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3343,7 +3343,7 @@ ok
 
       # side settings
       self.set_setting('MAIN_MODULE', 0)
-      self.set_setting('SIDE_MODULE', 1)
+      self.set_setting('SIDE_MODULE', 2)
       side_suffix = 'js' if not self.is_wasm() else 'wasm'
       if isinstance(side, list):
         # side is just a library
@@ -4101,9 +4101,11 @@ Module = {
     ''', main=r'''
       #include "header.h"
       #include <iostream>
+      #include "emscripten.h"
 
       using namespace std;
       extern void sidey();
+      /*EMSCRIPTEN_KEEPALIVE*/ Base Base::member;
       int main() {
         cout << "starting main" << endl;
         sidey();
@@ -4113,10 +4115,11 @@ Module = {
     ''', side=r'''
       #include "header.h"
       #include <iostream>
+      #include "emscripten.h"
       
       using namespace std;
-
-      void sidey() {
+      
+      EMSCRIPTEN_KEEPALIVE void sidey() {
           Base temp;
           temp.value = 5;
           cout << "sidey:" << (Base::member == temp) << endl;


### PR DESCRIPTION
@kripken , this PR adds a test case to illustrate the issue with global static imports that we were previously discussing. Can you take a look at this? Thanks.