### PR TITLE
fix integer overflow warnings when '--safe_firefox_profile' is passed to emrun

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -257,18 +257,18 @@ user_pref("browser.tabs.warnOnClose", false);
 user_pref("dom.allow_scripts_to_close_windows", true);
 // Set various update timers to a large value in the future in order to not
 // trigger a large mass of update HTTP traffic on each Firefox run on the clean profile.
-// "01/01/2100" is 4102437600 as seconds since Unix epoch.
-user_pref("app.update.lastUpdateTime.addon-background-update-timer", 4102437600);
-user_pref("app.update.lastUpdateTime.background-update-timer", 4102437600);
-user_pref("app.update.lastUpdateTime.blocklist-background-update-timer", 4102437600);
-user_pref("app.update.lastUpdateTime.browser-cleanup-thumbnails", 4102437600);
-user_pref("app.update.lastUpdateTime.experiments-update-timer", 4102437600);
-user_pref("app.update.lastUpdateTime.search-engine-update-timer", 4102437600);
-user_pref("app.update.lastUpdateTime.xpi-signature-verification", 4102437600);
-user_pref("extensions.getAddons.cache.lastUpdate", 4102437600);
-user_pref("media.gmp-eme-adobe.lastUpdate", 4102437600);
-user_pref("media.gmp-gmpopenh264.lastUpdate", 4102437600);
-user_pref("datareporting.healthreport.nextDataSubmissionTime", 4102437600439);
+// 2147483647 seconds since Unix epoch is sometime in the year 2038, and this is the max integer accepted by Firefox.
+user_pref("app.update.lastUpdateTime.addon-background-update-timer", 2147483647);
+user_pref("app.update.lastUpdateTime.background-update-timer", 2147483647);
+user_pref("app.update.lastUpdateTime.blocklist-background-update-timer", 2147483647);
+user_pref("app.update.lastUpdateTime.browser-cleanup-thumbnails", 2147483647);
+user_pref("app.update.lastUpdateTime.experiments-update-timer", 2147483647);
+user_pref("app.update.lastUpdateTime.search-engine-update-timer", 2147483647);
+user_pref("app.update.lastUpdateTime.xpi-signature-verification", 2147483647);
+user_pref("extensions.getAddons.cache.lastUpdate", 2147483647);
+user_pref("media.gmp-eme-adobe.lastUpdate", 2147483647);
+user_pref("media.gmp-gmpopenh264.lastUpdate", 2147483647);
+user_pref("datareporting.healthreport.nextDataSubmissionTime", "2147483647000");
 // Detect directly when executing if asm.js does not validate by throwing an error.
 user_pref("javascript.options.throw_on_asmjs_validation_failure", true);
 // Sending Firefox Health Report Telemetry data is not desirable, since these are automated runs.


### PR DESCRIPTION
Please find the following warnings near the end of the browser test output, e.g. [this one](https://circleci.com/gh/kripken/emscripten/31910?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link):
```
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:56: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:57: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:58: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:59: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:60: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:61: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:62: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:63: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:64: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:65: prefs parse error: integer literal overflowed
/tmp/temp_emrun_firefox_profile_l55h8voj/prefs.js:66: prefs parse error: integer literal overflowed
```