### PR TITLE
Fixes default WS / WSS protocol on SOCKFS

### DIFF
--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -165,7 +165,7 @@ mergeInto(LibraryManager.library, {
 
             // The default value is 'ws://' the replace is needed because the compiler replaces '//' comments with '#'
             // comments without checking context, so we'd end up with ws:#, the replace swaps the '#' for '//' again.
-            var url = '{{{ WEBSOCKET_URL }}}'.replace('#', '//');
+            var url = window['location']['protocol'].replace("http", "ws") + "//";
 
             if (runtimeConfig) {
               if ('string' === typeof Module['websocket']['url']) {


### PR DESCRIPTION
When loading a page from `https` environment, and the [default value being `ws://`](https://github.com/kripken/emscripten/blob/699d457f4ff55e0422ea79517714b07d691e8dae/src/settings.js#L276), the browser throws a `Mixed Content` error.

By making the default ws protocol based on the current page environment (`http` / `https`), it fixes this problem.

What's your thoughts on this? I'd be glad to make any further changes if necessary.
Cheers!