### PR TITLE
Remove FatalError excpetion type in favor of `exit_with_error`

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -294,6 +294,3 @@ if __name__ == '__main__':
   except KeyboardInterrupt:
     logger.warning("KeyboardInterrupt")
     sys.exit(1)
-  except shared.FatalError as e:
-    logger.error(str(e))
-    sys.exit(1)

--- a/emcc.py
+++ b/emcc.py
@@ -3060,6 +3060,3 @@ if __name__ == '__main__':
   except KeyboardInterrupt:
     logging.warning("KeyboardInterrupt")
     sys.exit(1)
-  except shared.FatalError as e:
-    logging.error(str(e))
-    sys.exit(1)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -29,14 +29,6 @@ MACOS = sys.platform == 'darwin'
 LINUX = sys.platform.startswith('linux')
 
 
-class FatalError(Exception):
-  """Error representing an unrecoverable error such as the failure of
-  a subprocess.
-
-  These are usually handled at the entry point of each script."""
-  pass
-
-
 def exit_with_error(msg, *args):
   logging.error(msg, *args)
   sys.exit(1)
@@ -171,7 +163,7 @@ def check_execute(cmd, *args, **kw):
     run_process(cmd, stdout=PIPE, *args, **kw)
     logging.debug("Successfuly executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError as e:
-    raise FatalError("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
+    exit_with_error("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
 
 
 def check_call(cmd, *args, **kw):
@@ -179,7 +171,7 @@ def check_call(cmd, *args, **kw):
     run_process(cmd, *args, **kw)
     logging.debug("Successfully executed %s" % " ".join(cmd))
   except subprocess.CalledProcessError:
-    raise FatalError("'%s' failed" % " ".join(cmd))
+    exit_with_error("'%s' failed" % " ".join(cmd))
 
 
 def generate_config(path, first_time=False):


### PR DESCRIPTION
I added this FatalError exception type a while back but
in retrospect its simpler and more consistent to simply
use `exit_with_error`