### PR TITLE
Support loading a global or function in a side module that is provided by a later side module

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3983,9 +3983,12 @@ Module = {
       int sideg = 49;
       int bsidef() { return 536; }
       extern void only_in_second(int x);
+      extern int second_to_third;
+      int third_to_second = 1337;
       void only_in_third(int x) {
-        printf("%d only_in_third: %d, %d\n", x, sidef(), sideg); // prints the ones from this compilation unit; they are not accessed dynamically,
-                                                                 // so it doesn't matter that overriding failed
+        // note we access our own globals directly, so
+        // it doesn't matter that overriding failed
+        printf("%d only_in_third: %d, %d, %d\n", x, sidef(), sideg, second_to_third);
         if (x == 0) {
           only_in_second(1);
         }
@@ -4016,13 +4019,15 @@ Module = {
       int sidef() { return 10; } // third will try to override these, but fail!
       int sideg = 20;
       extern void only_in_third(int x);
+      int second_to_third = 500;
+      extern int third_to_second;
       void only_in_second(int x) {
-        printf("%d only_in_second: %d, %d\n", x, sidef(), sideg);
+        printf("%d only_in_second: %d, %d, %d\n", x, sidef(), sideg, third_to_second);
         if (x == 0) {
           only_in_third(1);
         }
       }
-    ''', expected=['sidef: 10, sideg: 20.\nbsidef: 536.\n0 only_in_second: 10, 20\n1 only_in_third: 36, 49\n0 only_in_third: 36, 49\n1 only_in_second: 10, 20\n'],
+    ''', expected=['sidef: 10, sideg: 20.\nbsidef: 536.\n0 only_in_second: 10, 20, 1337\n1 only_in_third: 36, 49, 500\n0 only_in_third: 36, 49, 500\n1 only_in_second: 10, 20, 1337\n'],
          need_reverse=not self.is_wasm()) # in wasm, we can't flip as the side would have an EM_ASM, which we don't support yet TODO
 
     if self.get_setting('ASSERTIONS'):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3975,8 +3975,6 @@ Module = {
 
   @needs_dlfcn
   def test_dylink_hyper_dupe(self):
-    if not self.can_dlfcn(): return
-
     dylib_suffix = '.js' if not self.is_wasm() else '.wasm'
 
     self.set_setting('TOTAL_MEMORY', 64*1024*1024)


### PR DESCRIPTION
In asm.js we handle this by the side module's JS creating indirection functions (so that when the property is actually used later, after loading the other side module, we find it). In wasm, though, side modules are pure wasm and cannot help in their own loading in such a manner.

To get around that, this adds a JS proxy on the `env` object, which sees when the side module tries to load a missing property. If it's a global helper function (`g$` prefix in the current side module model), then we create it at that time.

Fixes at least part of #6951