### PR TITLE
Replace unnecessary eval with int

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1231,7 +1231,7 @@ class SettingsManager(object):
           if v in ['s', 'z']:
             shrink = 1 if v == 's' else 2
             v = '2'
-          level = eval(v)
+          level = int(v)
           self.apply_opt_level(level, shrink)
       for i in range(len(args)):
         if args[i] == '-s':


### PR DESCRIPTION
Could all of the code for handling the optional `args` in `load` be removed? Nothing seems to use it and it hasn't been updated with the recent improvements to the `-s` syntax.