### PR TITLE
Fixed '.tar.bz2' files always being downloaded during fetch_project.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -356,3 +356,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Carl Woffenden <cwoffenden@gmail.com> (copyright owned by Numfum GmbH)
 * Patrick Berger <patrick.berger@xmail.net> (copyright owned by Compusoft Group)
 * Alexander Frank Lehmann <alexander.frank.lehmann@compusoftgroup.com> (copyright owned by Compusoft Group)
+* Tommy Nguyen <tn0502@gmail.com>

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -785,8 +785,9 @@ class Ports(object):
     # retrieve the same port at once
 
     shared.Cache.acquire_cache_lock()
+    extension = '.tar.bz2' if is_tarbz2 else '.zip'
     try:
-      if not os.path.exists(fullname + '.zip'):
+      if not os.path.exists(fullname + extension):
         retrieve()
 
       if not os.path.exists(fullname):
@@ -795,7 +796,7 @@ class Ports(object):
       if not check_tag():
         logging.warning('local copy of port is not correct, retrieving from remote server')
         shared.try_delete(fullname)
-        shared.try_delete(fullname + '.zip')
+        shared.try_delete(fullname + extension)
         retrieve()
         unpack()
 


### PR DESCRIPTION
It looks like we always check for the existence of '.zip' file regardless of whether it's a .tar.bz2. After this patch, Emscripten will no longer download the source files for every compilation unit.