### PR TITLE
Add map.keys() to Embind

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -360,3 +360,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Thomas Schander <info@thomasschander.com> (copyright owned by Enscape GmbH)
 * Benjamin S. Rodgers <acdimalev@gmail.com>
 * Paul Shapiro <paul@mymonero.com>
+* Elmo Todurov <elmo.todurov@eesti.ee>

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -885,6 +885,14 @@ The following JavaScript can be used to interact with the above C++.
     // retrieve value from map
     console.log("Map Value: ", retMap.get(10));
 
+    // figure out which map keys are available
+    // NB! You must call `register_vector<key_type>`
+    // to make vectors available
+    var mapKeys = retMap.keys();
+    for (var i = 0; i < mapKeys.size(); i++) {
+        console.log("Map key/value: ", retVector.get(i), retMap.get(retVector.get(i)));
+    }
+
     // reset the value at the given index position
     retMap.set(10, "OtherValue");
 

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1524,6 +1524,17 @@ namespace emscripten {
             ) {
                 m[k] = v;
             }
+
+            static std::vector<typename MapType::key_type> keys(
+                const MapType& m
+            ) {
+              std::vector<typename MapType::key_type> keys;
+              keys.reserve(m.size());
+              for (const auto& pair : m) {
+                keys.push_back(pair.first);
+              }
+              return keys;
+            }
         };
     }
 
@@ -1536,6 +1547,7 @@ namespace emscripten {
             .function("size", &MapType::size)
             .function("get", internal::MapAccess<MapType>::get)
             .function("set", internal::MapAccess<MapType>::set)
+            .function("keys", internal::MapAccess<MapType>::keys)
             ;
     }
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -1064,6 +1064,18 @@ module({
            map.delete();
        });
 
+       test("std::map can get keys", function() {
+           var map = cm.embind_test_get_string_int_map();
+
+           var keys = map.keys();
+           assert.equal(map.size(), keys.size());
+           assert.equal("one", keys.get(0));
+           assert.equal("two", keys.get(1));
+           keys.delete();
+
+           map.delete();
+       });
+
        test("std::map can set keys and values", function() {
            var map = cm.embind_test_get_string_int_map();
 


### PR DESCRIPTION
Added a way to list keys of a std::map on JavaScript side. Not as nice as iterators, but simple, straightforward — and the main advantage is that it exists.

Helps #3810.