### PR TITLE
Remove redundant setting of PTHREAD_POOL_SIZE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1191,8 +1191,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
 
       if shared.Settings.USE_PTHREADS:
-        if not any(s.startswith('PTHREAD_POOL_SIZE=') for s in settings_changes):
-          settings_changes.append('PTHREAD_POOL_SIZE=0')
         options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
         newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
         shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem


### PR DESCRIPTION
The default of 0 is already set in `src/settings.js` so also
adding it here seems redundant at best.