### PR TITLE
asm.js validation fix

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -193,15 +193,6 @@ class RunnerCore(unittest.TestCase):
   def is_wasm(self):
     return (self.emcc_args and 'WASM=0' not in str(self.emcc_args)) or self.is_wasm_backend()
 
-  def is_linux(self):
-    return LINUX
-
-  def is_macos(self):
-    return MACOS
-
-  def is_windows(self):
-    return WINDOWS
-
   def is_wasm_backend(self):
     return self.get_setting('WASM_BACKEND')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -76,19 +76,6 @@ def is_optimizing(args):
   return '-O' in str(args) and '-O0' not in args
 
 class T(RunnerCore): # Short name, to make it more fun to use manually on the commandline
-  def is_emterpreter(self):
-    return 'EMTERPRETIFY=1' in self.emcc_args
-  def is_split_memory(self):
-    return 'SPLIT_MEMORY=' in str(self.emcc_args)
-  def is_wasm(self):
-    return 'WASM=0' not in str(self.emcc_args) or self.is_wasm_backend()
-  def is_linux(self):
-    return LINUX
-  def is_macos(self):
-    return MACOS
-  def is_windows(self):
-    return WINDOWS
-
   # whether the test mode supports duplicate function elimination in js
   def supports_js_dfe(self):
     if self.is_wasm(): return False # wasm does this when optimizing anyhow


### PR DESCRIPTION
Our check for asm.js validation in spidermonkey is just a string check for a warning with "asm.js" in it. This hits a false positive in the warning on `addFunction` in the wasm backend (the warning mentions that the type is not needed in asm.js). To avoid this, the check can see if we are even in wasm mode, and if not, if we expect asm.js to validate - if no to either of those, there's nothing to check.

The problem was not noticed on the bots as we don't run spidermonkey there.
