### PR TITLE
Add initial support for chrome testing in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
       # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
       # CircleCI actively kills memory-over-consuming process
       # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI
-  test-browser:
+  test-browser-firefox:
     <<: *test-defaults
     environment:
       # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
@@ -179,6 +179,37 @@ jobs:
       - EMTEST_DETECT_TEMPFILE_LEAKS=0
       - DISPLAY=:0
       - GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
+  test-browser-chrome:
+    <<: *defaults
+    working_directory: ~/
+    steps:
+      - checkout:
+          path: emscripten/
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/
+      - run:
+          name: install package dependencies
+          command: |
+            apt-get update -q
+            # install chromium-browser in order to ensure we have all the
+            # dependecies for chrome.
+            apt-get install -q -y unzip xvfb chromium-browser
+      - run:
+          name: download chrome
+          command: |
+            wget http://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/583421/chrome-linux.zip
+            unzip -q chrome-linux.zip
+      - run:
+          name: run tests
+          command: |
+            # --no-sandbox becasue we are running as root and chrome requires
+            # this flag for now: https://crbug.com/638180
+            CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox"
+            CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer\""
+            export EMSCRIPTEN_BROWSER="xvfb-run $HOME/chrome-linux/chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
+            # Just run a subset of the tests for now.  To be expanded.
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_a*
   test-ab:
     <<: *test-defaults
     environment:
@@ -251,7 +282,10 @@ workflows:
       - test-other:
           requires:
             - build
-      - test-browser:
+      - test-browser-firefox:
+          requires:
+            - build
+      - test-browser-chrome:
           requires:
             - build
       - test-ab:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
             # this flag for now: https://crbug.com/638180
             CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox"
             CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer\""
-            export EMSCRIPTEN_BROWSER="xvfb-run $HOME/chrome-linux/chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
+            export EMTEST_BROWSER="xvfb-run $HOME/chrome-linux/chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
             # Just run a subset of the tests for now.  To be expanded.
             EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_a*
   test-ab:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,9 @@ jobs:
       - GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
   test-browser-chrome:
     <<: *defaults
+    environment:
+      - EMTEST_LACKS_SOUND_HARDWARE=1
+      - EMTEST_DETECT_TEMPFILE_LEAKS=0
     working_directory: ~/
     steps:
       - checkout:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -84,11 +84,6 @@ def has_browser():
   return EMTEST_BROWSER != '0'
 
 
-# returns what browser is being used (None means the default)
-def get_browser():
-  return EMTEST_BROWSER
-
-
 # Generic decorator that calls a function named 'condition' on the test class and
 # skips the test if that function returns true
 def skip_if(func, condition, explanation=''):
@@ -861,7 +856,9 @@ class BrowserCore(RunnerCore):
     self.harness_port = int(os.getenv('EMTEST_BROWSER_HARNESS_PORT', '9999'))
     if not has_browser():
       return
-    if EMTEST_BROWSER:
+    if not EMTEST_BROWSER:
+      print("Using default system browser")
+    else:
       cmd = shlex.split(EMTEST_BROWSER)
 
       def run_in_other_browser(url):
@@ -869,8 +866,6 @@ class BrowserCore(RunnerCore):
 
       webbrowser.open_new = run_in_other_browser
       print("Using Emscripten browser: " + str(cmd))
-    else:
-      print("Using default system browser")
     self.browser_timeout = 30
     self.harness_queue = multiprocessing.Queue()
     self.harness_server = multiprocessing.Process(target=harness_server_func, args=(self.harness_queue, self.harness_port))

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -47,7 +47,7 @@ else:
 __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(__rootpath__)
 
-from tools.shared import EM_BUILD_VERBOSE, EM_CONFIG, TEMP_DIR, EMCC, DEBUG, PYTHON, LLVM_TARGET, ASM_JS_TARGET, EMSCRIPTEN_TEMP_DIR, CANONICAL_TEMP_DIR, WASM_TARGET, SPIDERMONKEY_ENGINE, WINDOWS
+from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, DEBUG, PYTHON, LLVM_TARGET, ASM_JS_TARGET, EMSCRIPTEN_TEMP_DIR, CANONICAL_TEMP_DIR, WASM_TARGET, SPIDERMONKEY_ENGINE, WINDOWS
 from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, limit_size, try_delete, to_cc, asbytes, safe_copy, Settings
 from tools.line_endings import check_line_endings
 from tools import jsrun, shared
@@ -77,17 +77,6 @@ EMTEST_SAVE_DIR = os.getenv('EMTEST_SAVE_DIR', os.getenv('EM_SAVE_DIR'))
 # generally js engines are equivalent, testing 1 is enough. set this
 # to force testing on all js engines, good to find js engine bugs
 EMTEST_ALL_ENGINES = os.getenv('EMTEST_ALL_ENGINES')
-
-
-if EMTEST_BROWSER:
-  cmd = shlex.split(EMTEST_BROWSER)
-
-  def run_in_other_browser(url):
-    Popen(cmd + [url])
-
-  if EM_BUILD_VERBOSE >= 3:
-    print("using Emscripten browser: " + str(cmd), file=sys.stderr)
-  webbrowser.open_new = run_in_other_browser
 
 
 # checks if browser testing is enabled
@@ -872,6 +861,16 @@ class BrowserCore(RunnerCore):
     self.harness_port = int(os.getenv('EMTEST_BROWSER_HARNESS_PORT', '9999'))
     if not has_browser():
       return
+    if EMTEST_BROWSER:
+      cmd = shlex.split(EMTEST_BROWSER)
+
+      def run_in_other_browser(url):
+        Popen(cmd + [url])
+
+      webbrowser.open_new = run_in_other_browser
+      print("Using Emscripten browser: " + str(cmd))
+    else:
+      print("Using default system browser")
     self.browser_timeout = 30
     self.harness_queue = multiprocessing.Queue()
     self.harness_server = multiprocessing.Process(target=harness_server_func, args=(self.harness_queue, self.harness_port))

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -15,7 +15,7 @@ import unittest
 import webbrowser
 import zlib
 
-from runner import BrowserCore, path_from_root, has_browser, get_browser
+from runner import BrowserCore, path_from_root, has_browser, EMTEST_BROWSER
 from tools import system_libs
 from tools.shared import PYTHON, EMCC, WINDOWS, FILE_PACKAGER, PIPE, SPIDERMONKEY_ENGINE, JS_ENGINES
 from tools.shared import try_delete, Building, run_process, run_js
@@ -2345,12 +2345,11 @@ void *getBindBuffer() {
     # before launching.
     os.chdir(path_from_root())
     args = [PYTHON, path_from_root('emrun'), '--timeout', '30', '--safe_firefox_profile', '--port', '6939', '--verbose', '--log_stdout', os.path.join(outdir, 'stdout.txt'), '--log_stderr', os.path.join(outdir, 'stderr.txt')]
-    browser = get_browser()
-    if browser is not None:
+    if EMTEST_BROWSER is not None:
       # If EMTEST_BROWSER carried command line arguments to pass to the browser,
       # (e.g. "firefox -profile /path/to/foo") those can't be passed via emrun,
       # so strip them out.
-      browser_cmd = shlex.split(browser)
+      browser_cmd = shlex.split(EMTEST_BROWSER)
       browser_path = browser_cmd[0]
       args += ['--browser', browser_path]
       if len(browser_cmd) > 1:
@@ -3380,7 +3379,7 @@ window.close = function() {
 
   # Test pthread_kill() operation
   def test_pthread_kill(self):
-    if get_browser() and 'chrom' in get_browser().lower():
+    if EMTEST_BROWSER and 'chrom' in EMTEST_BROWSER.lower():
       # This test hangs the chrome render process, and keep subsequent tests from passing too
       self.skipTest("pthread_kill hangs chrome renderer")
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_kill.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=2', '--separate-asm', '-s', 'PTHREAD_POOL_SIZE=8'], timeout=30)


### PR DESCRIPTION
For now, only run `browser.test_a*`.  We can expand this list
later.

