### PR TITLE
Allow FETCH=1 with work with WASM=1

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1113,8 +1113,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
 
       if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
-        if shared.Settings.WASM:
-          exit_with_error('ASMFS not yet compatible with wasm (shared.make_fetch_worker is asm.js-specific)')
         input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
         newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
         next_arg_index += 1
@@ -1124,8 +1122,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           exit_with_error('-s ASMFS=1 requires either -s USE_PTHREADS=1 or -s USE_PTHREADS=2 to be set!')
 
       if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
-        if shared.Settings.WASM:
-          exit_with_error('FETCH not yet compatible with wasm (shared.make_fetch_worker is asm.js-specific)')
         input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
         next_arg_index += 1
         options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
@@ -1909,6 +1905,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
       if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
+        if shared.Settings.WASM:
+          exit_with_error('FETCH+USE_PTHREADS not yet compatible with wasm (shared.make_fetch_worker is asm.js-specific)')
         shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
 
     # exit block 'memory initializer'

--- a/tests/fetch/stream_file.cpp
+++ b/tests/fetch/stream_file.cpp
@@ -15,11 +15,11 @@ int main()
   emscripten_fetch_attr_init(&attr);
   strcpy(attr.requestMethod, "GET");
   attr.onsuccess = [](emscripten_fetch_t *fetch) {
+    printf("Finished downloading %llu bytes\n", fetch->totalBytes);
+    printf("Data checksum: %08X\n", checksum);
     assert(fetch->data == 0); // The data was streamed via onprogress, no bytes available here.
     assert(fetch->numBytes == 0);
     assert(fetch->totalBytes == 134217728);
-    printf("Finished downloading %llu bytes\n", fetch->totalBytes);
-    printf("Data checksum: %08X\n", checksum);
     assert(checksum == 0xA7F8E858U);
     emscripten_fetch_close(fetch);
 
@@ -28,15 +28,15 @@ int main()
 #endif
   };
   attr.onprogress = [](emscripten_fetch_t *fetch) {
-    assert(fetch->data != 0);
-    assert(fetch->numBytes > 0);
-    assert(fetch->dataOffset + fetch->numBytes <= fetch->totalBytes);
-    assert(fetch->totalBytes <= 134217728);
     printf("Downloading.. %.2f%s complete. Received chunk [%llu, %llu[\n", 
       (fetch->totalBytes > 0) ? ((fetch->dataOffset + fetch->numBytes) * 100.0 / fetch->totalBytes) : (double)(fetch->dataOffset + fetch->numBytes),
       (fetch->totalBytes > 0) ? "%" : " bytes",
       fetch->dataOffset,
       fetch->dataOffset + fetch->numBytes);
+    assert(fetch->data != 0);
+    assert(fetch->numBytes > 0);
+    assert(fetch->dataOffset + fetch->numBytes <= fetch->totalBytes);
+    assert(fetch->totalBytes <= 134217728);
 
     for(int i = 0; i < fetch->numBytes; ++i)
       checksum = ((checksum << 8) | (checksum >> 24)) * fetch->data[i] + fetch->data[i];

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1049,8 +1049,10 @@ class BrowserCore(RunnerCore):
 
 ''' % (self.test_port, basename))
 
-  def btest(self, filename, expected=None, reference=None, force_c=False, reference_slack=0, manual_reference=False, post_build=None,
-            args=[], outfile='test.html', message='.', also_proxied=False, url_suffix='', timeout=None):
+  def btest(self, filename, expected=None, reference=None, force_c=False,
+            reference_slack=0, manual_reference=False, post_build=None,
+            args=[], outfile='test.html', message='.', also_proxied=False,
+            url_suffix='', timeout=None, also_asmjs=False):
     # if we are provided the source and not a path, use that
     filename_is_src = '\n' in filename
     src = filename if filename_is_src else ''
@@ -1092,9 +1094,12 @@ class BrowserCore(RunnerCore):
     if not isinstance(expected, list):
       expected = [expected]
     self.run_browser(outfile + url_suffix, message, ['/report_result?' + e for e in expected], timeout=timeout)
-    if self.also_asmjs and 'WASM=0' not in args:
+
+    # Tests can opt into being run under asmjs as well
+    if 'WASM=0' not in args and (also_asmjs or self.also_asmjs):
       self.btest(filename, expected, reference, force_c, reference_slack, manual_reference, post_build,
                  args + ['-s', 'WASM=0'], outfile, message, also_proxied=False, timeout=timeout)
+
     if also_proxied:
       print('proxied...')
       if reference:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3767,16 +3767,25 @@ window.close = function() {
   # Tests emscripten_fetch() usage to XHR data directly to memory without persisting results to IndexedDB.
   def test_fetch_to_memory(self):
     # Test error reporting in the negative case when the file URL doesn't exist. (http 404)
-    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-DFILE_DOES_NOT_EXIST'])
+    self.btest('fetch/to_memory.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-DFILE_DOES_NOT_EXIST'],
+               also_asmjs=True)
 
     # Test the positive case when the file URL exists. (http 200)
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'])
+    self.btest('fetch/to_memory.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
+               also_asmjs=True)
 
   # Tests emscripten_fetch() usage to persist an XHR into IndexedDB and subsequently load up from there.
   def test_fetch_cached_xhr(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/cached_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'])
+    self.btest('fetch/cached_xhr.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
+               also_asmjs=True)
 
   # Tests that response headers get set on emscripten_fetch_t values.
   def test_fetch_response_headers(self):
@@ -3787,14 +3796,16 @@ window.close = function() {
   def test_fetch_stream_file(self):
     # Strategy: create a large 128MB file, and compile with a small 16MB Emscripten heap, so that the tested file
     # won't fully fit in the heap. This verifies that streaming works properly.
-    f = open('largefile.txt', 'w')
     s = '12345678'
     for i in range(14):
       s = s[::-1] + s # length of str will be 2^17=128KB
-    for i in range(1024):
-      f.write(s)
-    f.close()
-    self.btest('fetch/stream_file.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'TOTAL_MEMORY=536870912'])
+    with open('largefile.txt', 'w') as f:
+      for i in range(1024):
+        f.write(s)
+    self.btest('fetch/stream_file.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'TOTAL_MEMORY=536870912'],
+               also_asmjs=True)
 
   # Tests emscripten_fetch() usage in synchronous mode when used from the main thread proxied to a Worker with -s PROXY_TO_PTHREAD=1 option.
   def test_fetch_sync_xhr(self):
@@ -3804,7 +3815,10 @@ window.close = function() {
   # Tests that the Fetch API works for synchronous XHRs when used with --proxy-to-worker.
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/sync_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '--proxy-to-worker'])
+    self.btest('fetch/sync_xhr.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '--proxy-to-worker'],
+               also_asmjs=True)
 
   def test_fetch_idb_store(self):
     self.btest('fetch/idb_store.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'PROXY_TO_PTHREAD=1'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3767,16 +3767,16 @@ window.close = function() {
   # Tests emscripten_fetch() usage to XHR data directly to memory without persisting results to IndexedDB.
   def test_fetch_to_memory(self):
     # Test error reporting in the negative case when the file URL doesn't exist. (http 404)
-    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-DFILE_DOES_NOT_EXIST'])
+    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-DFILE_DOES_NOT_EXIST'])
 
     # Test the positive case when the file URL exists. (http 200)
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0'])
+    self.btest('fetch/to_memory.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'])
 
   # Tests emscripten_fetch() usage to persist an XHR into IndexedDB and subsequently load up from there.
   def test_fetch_cached_xhr(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/cached_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0'])
+    self.btest('fetch/cached_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'])
 
   # Tests that response headers get set on emscripten_fetch_t values.
   def test_fetch_response_headers(self):
@@ -3794,7 +3794,7 @@ window.close = function() {
     for i in range(1024):
       f.write(s)
     f.close()
-    self.btest('fetch/stream_file.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'TOTAL_MEMORY=536870912'])
+    self.btest('fetch/stream_file.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'TOTAL_MEMORY=536870912'])
 
   # Tests emscripten_fetch() usage in synchronous mode when used from the main thread proxied to a Worker with -s PROXY_TO_PTHREAD=1 option.
   def test_fetch_sync_xhr(self):
@@ -3804,7 +3804,7 @@ window.close = function() {
   # Tests that the Fetch API works for synchronous XHRs when used with --proxy-to-worker.
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/sync_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '--proxy-to-worker'])
+    self.btest('fetch/sync_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '--proxy-to-worker'])
 
   def test_fetch_idb_store(self):
     self.btest('fetch/idb_store.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'PROXY_TO_PTHREAD=1'])


### PR DESCRIPTION
The error looks like it should only have applied
with USE_PTHREADS in the first place.  I've updated
the fetch tests to use WASM (the default) where it
is possible.