### PR TITLE
Simplify extract_archive_contents

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1384,7 +1384,6 @@ def extract_archive_contents(archive_file):
 
   # create temp dir
   temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
-  safe_ensure_dirs(temp_dir)
 
   # extract file in temp dir
   proc = run_process([LLVM_AR, 'xo', archive_file], stdout=PIPE, stderr=STDOUT, cwd=temp_dir)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1367,7 +1367,7 @@ def extract_archive_contents(archive_file):
   # ignore empty lines
   contents = [l for l in lines if len(l)]
   if len(contents) == 0:
-    logging.debug('Archive %s appears to be empty (recommendation: link an .so instead of .a)' % f)
+    logging.debug('Archive %s appears to be empty (recommendation: link an .so instead of .a)' % archive_file)
     return {
       'returncode': 0,
       'dir': None,


### PR DESCRIPTION
ar files can only contain basenames so we don't need to
worry about the case where the stored files live in
sub-directory.

Remove the finally for setting cwd and replace with
`cwd=` argument to the run_process.

Remove the try/catch and simply have ar failures be
hard failures.