### PR TITLE
Skip @rpaths when parsing response file.

### DIFF
--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -58,7 +58,13 @@ def substitute_response_files(args):
   """Substitute any response files found in args with their contents."""
   new_args = []
   for arg in args:
-    if arg.startswith('@'):
+    if arg.startswith('@rpath'):
+      new_args.append(arg)
+    elif arg.startswith('@loader_path'):
+      new_args.append(arg)
+    elif arg.startswith('@executable_path'):
+      new_args.append(arg)
+    elif arg.startswith('@'):
       new_args += read_response_file(arg)
     elif arg.startswith('-Wl,@'):
       for a in read_response_file(arg[5:]):


### PR DESCRIPTION
Mac OS uses install_name to assist finding dynamic lib locations. Where `@rpath` `@loader_path` and `@executable_path` may appear in path string. This fix tries not to parsing them as response files.