### PR TITLE
Fix and enable other.test_bad_triple

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
   test-other:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=other skip:other.test_bad_triple skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit
+      - TEST_TARGET=other skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit
       # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
       # CircleCI actively kills memory-over-consuming process
       # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN cd /root/ \
 
 ARG TEST_TARGET
 RUN export EMTEST_BROWSER=0 \
- && python /root/emscripten/tests/runner.py $TEST_TARGET skip:asm*.test_sse1_full skip:asm*.test_sse2_full skip:asm*.test_sse3_full skip:asm*.test_ssse3_full skip:asm*.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_bad_triple skip:other.test_emcc_v skip:other.test_llvm_lit skip:other.test_single_file skip:other.test_vorbis skip:other.test_eval_ctors
+ && python /root/emscripten/tests/runner.py $TEST_TARGET skip:asm*.test_sse1_full skip:asm*.test_sse2_full skip:asm*.test_sse3_full skip:asm*.test_ssse3_full skip:asm*.test_sse4_1_full skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit skip:other.test_single_file skip:other.test_vorbis skip:other.test_eval_ctors
 
 # skip:other.test_emcc_v to prevent tool version differences from breaking CI

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3589,9 +3589,7 @@ int main()
 
   def test_bad_triple(self):
     Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
-    proc = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, check=False)
-    self.assertNotEqual(proc.returncode, 0)
-    err = proc.stderr
+    err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).stderr
     if self.is_wasm_backend():
       assert 'machine type must be wasm32' in err, err
     else:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3588,7 +3588,7 @@ int main()
     assert p.returncode == 0, 'LLVM tests must pass with exit code 0'
 
   def test_bad_triple(self):
-    Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env(), stdout=PIPE, stderr=PIPE).communicate()
+    run_process([CLANG, path_from_root('tests', 'hello_world.cpp'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env())
     err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).stderr
     if self.is_wasm_backend():
       assert 'machine type must be wasm32' in err, err

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3591,7 +3591,7 @@ int main()
     # compile a minimal program, with as few dependencies as possible, as
     # native building on CI may not always work well
     with open('minimal.cpp', 'w') as f:
-			f.write('int main() { return 0; }')
+      f.write('int main() { return 0; }')
     run_process([CLANG, 'minimal.cpp', '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env())
     err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).stderr
     if self.is_wasm_backend():

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3588,7 +3588,11 @@ int main()
     assert p.returncode == 0, 'LLVM tests must pass with exit code 0'
 
   def test_bad_triple(self):
-    run_process([CLANG, path_from_root('tests', 'hello_world.cpp'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env())
+    # compile a minimal program, with as few dependencies as possible, as
+    # native building on CI may not always work well
+    with open('minimal.cpp', 'w') as f:
+			f.write('int main() { return 0; }')
+    run_process([CLANG, 'minimal.cpp', '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env())
     err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).stderr
     if self.is_wasm_backend():
       assert 'machine type must be wasm32' in err, err


### PR DESCRIPTION
This was not tested on the bots, and we didn't notice that by mistake we refactored the condition to the opposite of the expected (it should warn about a bad triple, not return an error code).

After fixing that, I also managed to fix it on the bots: the test builds - natively - a cpp to bitcode, then checks we warn about the triple when we compile such a native bitcode to js/wasm. The problem on CI was that `stddef.h` is not present, that is, native building doesn't work using clang there for some reason. Not sure why, but in any case, we don't need that, I made the test just build an empty cpp file, which is enough.