### PR TITLE
Add an assertion for checking the .buffer after requesting a WebAssembly.Memory that is shared

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1189,6 +1189,9 @@ if (!ENVIRONMENT_IS_PTHREAD) {
   Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE, 'shared': true });
 #endif
   buffer = Module['wasmMemory'].buffer;
+#if ASSERTIONS
+  assert(buffer instanceof SharedArrayBuffer, 'requested a WebAssembly.Memory with the shared flag, but the buffer is not a SharedArrayBuffer (in Chrome, you need to set the wasm-threads flag, it is not enough to have SharedArrayBuffer enabled)');
+#endif
 }
 
 updateGlobalBufferViews();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1189,9 +1189,7 @@ if (!ENVIRONMENT_IS_PTHREAD) {
   Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE, 'shared': true });
 #endif
   buffer = Module['wasmMemory'].buffer;
-#if ASSERTIONS
-  assert(buffer instanceof SharedArrayBuffer, 'requested a WebAssembly.Memory with the shared flag, but the buffer is not a SharedArrayBuffer (in Chrome, you need to set the wasm-threads flag, it is not enough to have SharedArrayBuffer enabled)');
-#endif
+  assert(buffer instanceof SharedArrayBuffer, 'requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
 }
 
 updateGlobalBufferViews();


### PR DESCRIPTION
In Chrome, SharedArrayBuffer is enabled by default but not wasm-threads, and in that case, the the Memory is created but the buffer is just a non-shared Buffer. With this assertion, we show a clear error instead of later hitting an exception on trying to use the buffer.

See https://github.com/kripken/emscripten/issues/7018#issuecomment-414484864

Btw, should Chrome throw an error instead of even creating a non-shared buffer, if we try to create it with `shared: true`?