### PR TITLE
Split out --closure + GL test

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1044,7 +1044,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if options.use_closure_compiler:
         shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
         if not shared.check_closure_compiler():
-          exit_with_error('fatal: closure compiler is not configured correctly')
+          exit_with_error('closure compiler is not configured correctly')
         if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
           shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
           shared.Settings.ASM_JS = 2

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1911,6 +1911,9 @@ void *getBindBuffer() {
 
   @requires_graphics_hardware
   def test_cubegeom_glew(self):
+    self.btest('cubegeom_glew.c', reference='cubegeom.png', args=['-O2', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lGLEW', '-lSDL'])
+
+  def test_cubegeom_glew_closure(self):
     self.btest('cubegeom_glew.c', reference='cubegeom.png', args=['-O2', '--closure', '1', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lGLEW', '-lSDL'])
 
   @requires_graphics_hardware

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -202,7 +202,7 @@ class sanity(RunnerCore):
           self.assertContained('CRITICAL', output) # sanity check should fail
 
   def test_closure_compiler(self):
-    CLOSURE_FATAL = 'fatal: closure compiler'
+    CLOSURE_FATAL = 'closure compiler is not configured correctly'
     CLOSURE_WARNING = 'does not exist'
 
     # Sanity check should find closure


### PR DESCRIPTION
There doesn't seem to be any reason why this test in particular
should be using the closure compiler.  It only adds an additional
dependency on JAVA.

Also remove the redundant "fatal:" prefix from the error when JAVA
is missing.