### PR TITLE
Wasm-only mode is not a requirement for async compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1304,8 +1304,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if 'MEM_INIT_METHOD' in settings_changes:
           exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
         options.memory_init_file = True
-        # async compilation requires wasm-only mode, and also not interpreting (the interpreter needs sync input)
-        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and shared.Building.is_wasm_only() and 'interpret' not in shared.Settings.BINARYEN_METHOD:
+        # async compilation requires not interpreting (the interpreter modes needs sync input)
+        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
           # async compilation requires a swappable module - we swap it in when it's ready
           shared.Settings.SWAPPABLE_ASM_MODULE = 1
         else:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3704,7 +3704,7 @@ window.close = function() {
       (['-O3'], 1),
       (['-s', 'BINARYEN_ASYNC_COMPILATION=1'], 1), # force it on
       (['-O1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'], 0), # force it off
-      (['-s', 'BINARYEN_ASYNC_COMPILATION=1', '-s', 'BINARYEN_METHOD="native-wasm,asmjs"'], 0), # try to force it on, but have it disabled
+      (['-s', 'BINARYEN_ASYNC_COMPILATION=1', '-s', 'BINARYEN_METHOD="interpret-binary"'], 0), # try to force it on, but have it disabled
     ]:
       print(opts, expect)
       self.btest('binaryen_async.c', expected=str(expect), args=common_args + opts)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2915,6 +2915,7 @@ myreade(){
            '-o', 'proxyfs_test.js', 'proxyfs_test.c',
            '--embed-file', 'proxyfs_embed.txt', '--pre-js', 'proxyfs_pre.js',
            '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]',
+           '-s', 'BINARYEN_ASYNC_COMPILATION=0',
            '-s', 'MAIN_MODULE=1']).communicate()
     # Following shutil.copyfile just prevent 'require' of node.js from caching js-object.
     # See https://nodejs.org/api/modules.html
@@ -7851,8 +7852,8 @@ int main() {
 
   def test_binaryen_warn_sync(self):
     if SPIDERMONKEY_ENGINE not in JS_ENGINES: self.skipTest('cannot run without spidermonkey')
-    # using a fallback to asm.js will disable async
-    for method in ['native-wasm,asmjs', 'native-wasm', None]:
+    # interpreting will disable async
+    for method in ['interpret-binary', 'native-wasm', None]:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1']
       if method is not None:
         cmd += ['-s', 'BINARYEN_METHOD="' + method + '"']
@@ -7860,7 +7861,7 @@ int main() {
       err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
       print(err)
       warning = 'BINARYEN_ASYNC_COMPILATION disabled due to user options. This will reduce performance and compatibility'
-      if method and ',' in method:
+      if method and 'interpret' in method:
         self.assertContained(warning, err)
       else:
         self.assertNotContained(warning, err)


### PR DESCRIPTION
Fixes #5567.

To be conservative, we disabled async compilation any time that asm2wasm was not emitting wasm-only code. That meant that if we had a fallback to asm.js, or used an asm.js feature like the emterpreter, async compilation was disabled. Things like `EMULATE_FUNCTION_POINTER_CASTS` also disable wasm-only mode for now (but perhaps shouldn't). However, this wasn't an actual hard limitation - turns out that just some tests needed to be updated. (Where we do need to disable async compilation is in things like using the binaryen interpreter to run the wasm, as there we do need to synchronously load the wasm, at least in how the current interpreter integration works - low priority, anyhow.)
