### PR TITLE
Deprecate emscripten_has_threading_support

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -510,19 +510,11 @@ var LibraryPThread = {
     }
   },
 
-#if USE_PTHREADS
   _num_logical_cores__deps: ['emscripten_force_num_logical_cores'],
   _num_logical_cores: '; if (ENVIRONMENT_IS_PTHREAD) __num_logical_cores = PthreadWorkerInit.__num_logical_cores; else { PthreadWorkerInit.__num_logical_cores = __num_logical_cores = allocate(1, "i32*", ALLOC_STATIC); HEAPU32[__num_logical_cores>>2] = navigator["hardwareConcurrency"] || ' + {{{ PTHREAD_HINT_NUM_CORES }}} + '; }',
-#else
-  _num_logical_cores: '{{{ makeStaticAlloc(1) }}}',
-#endif
 
   emscripten_has_threading_support: function() {
-#if USE_PTHREADS
-    return typeof SharedArrayBuffer !== 'undefined';
-#else
-    return 0;
-#endif
+    return true;
   },
 
   emscripten_num_logical_cores__deps: ['_num_logical_cores'],

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -9,9 +9,9 @@
 extern "C" {
 #endif
 
-// Returns true if the current browser is able to spawn threads with pthread_create(), and the compiled page was built with
-// threading support enabled. If this returns 0, calls to pthread_create() will fail with return code EAGAIN.
-int emscripten_has_threading_support(void);
+// Deprecated: Use __EMSCRIPTEN_PTHREADS__ instread to detect thread support
+// at compile time.
+int emscripten_has_threading_support(void) __attribute__ ((deprecated));;
 
 // Returns the number of logical cores on the system.
 int emscripten_num_logical_cores(void);

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -133,15 +133,6 @@ int main()
 	globalDouble = 5.0;
 	globalU64 = 5;
 
-	if (!emscripten_has_threading_support())
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(0);
-#endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
 

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -151,15 +151,6 @@ int main()
 	emscripten_atomic_fence();
 	__sync_synchronize();
 
-	if (!emscripten_has_threading_support())
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(0);
-#endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
 

--- a/tests/pthread/test_pthread_barrier.cpp
+++ b/tests/pthread/test_pthread_barrier.cpp
@@ -67,14 +67,11 @@ int main(int argc, char **argv)
     assert(ret == 0); 
 
     for(int i = 0; i < THREADS; ++i) pthread_create(&thr[i], NULL, &thread_main, (void*)i);
-    if (emscripten_has_threading_support())
+    for(int i = 0; i < THREADS; ++i)
     {
-        for(int i = 0; i < THREADS; ++i)
-        {
-            int totalSum = 0;
-            pthread_join(thr[i], (void**)&totalSum);
-            assert(totalSum == expectedTotalSum);
-        }
+        int totalSum = 0;
+        pthread_join(thr[i], (void**)&totalSum);
+        assert(totalSum == expectedTotalSum);
     }
 
 #ifdef REPORT_RESULT

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -32,15 +32,6 @@ pthread_t thr;
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(1);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
   EM_ASM(out('Canceling thread..'););

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -66,15 +66,6 @@ int main()
 {
    int result = 0;
 
-   if (!emscripten_has_threading_support())
-   {
-#ifdef REPORT_RESULT
-      REPORT_RESULT(907640832);
-#endif
-      printf("Skipped: Threading is not supported.\n");
-      return 0;
-   }
-
    pthread_cleanup_push(cleanup_handler1, (void*)9998);
    pthread_cleanup_push(cleanup_handler1, (void*)9999);
 

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -88,15 +88,6 @@ int main (int argc, char *argv[])
   pthread_create(&threads[1], &attr, inc_count, (void *)t2);
   pthread_create(&threads[2], &attr, inc_count, (void *)t3);
 
-  if (emscripten_has_threading_support())
-  {
-    /* Wait for all threads to complete */
-    for (i=0; i<NUM_THREADS; i++) {
-      pthread_join(threads[i], NULL);
-    }
-    printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
-  }
-
   /* Clean up and exit */
   pthread_attr_destroy(&attr);
   pthread_mutex_destroy(&count_mutex);

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -69,16 +69,6 @@ void CreateThread(int i)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(0);
-#endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
-	// Create initial threads.
 	for(int i = 0; i < NUM_THREADS; ++i)
 		CreateThread(i);
 

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -25,15 +25,6 @@ static void *thread1_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(1);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   pthread_t thr;
   pthread_create(&thr, NULL, thread1_start, 0);
 

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -25,15 +25,6 @@ static void *thread1_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   FILE *handle = fopen("file1.txt", "w");
   fputs("hello!", handle);
   fclose(handle);

--- a/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
@@ -91,13 +91,10 @@ int main()
 		assert(y == HILO(5, 3));
 		assert(x == HILO(6, 4));
 		volatile T n = HILO(2, 1);
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			printf("n: %llx\n", n);
-			assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		printf("n: %llx\n", n);
+		assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
 	}
 	{
 		T x = HILO(15, 13);
@@ -105,32 +102,26 @@ int main()
 		assert(y == HILO(15, 13));
 		assert(x == HILO(5, 3));
 		volatile T n = HILO(NUM_THREADS*10000ULL+5ULL, NUM_THREADS*10000ULL+3ULL);
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			printf("n: %llx\n", n);
-			assert(n == HILO(5,3));
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		printf("n: %llx\n", n);
+		assert(n == HILO(5,3));
 	}
 	{
 		T x = HILO(32768 + 5, 5);
 		T y = __sync_fetch_and_or(&x, HILO(65536 + 9, 9));
 		assert(y == HILO(32768 + 5, 5));
 		assert(x == HILO(32768 + 65536 + 13, 13));
-		if (emscripten_has_threading_support())
+		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
-			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+			fetch_and_or_data = HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS);
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				fetch_and_or_data = HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(1 << i);
-					pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_or_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
+				threadArg[i] = DUP(1 << i);
+				pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_or_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
 		}
 	}
 	{
@@ -138,19 +129,16 @@ int main()
 		T y = __sync_fetch_and_and(&x, HILO(32768 + 9, 9));
 		assert(y == HILO(32768 + 5, 5));
 		assert(x == HILO(32768 + 1, 1));
-		if (emscripten_has_threading_support())
+		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
-			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+			fetch_and_and_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				fetch_and_and_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(~(1UL<<i));
-					pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_and_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
+				threadArg[i] = DUP(~(1UL<<i));
+				pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_and_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
 		}
 	}
 	{
@@ -158,19 +146,16 @@ int main()
 		T y = __sync_fetch_and_xor(&x, HILO(16384 + 9, 9));
 		assert(y == HILO(32768 + 5, 5));
 		assert(x == HILO(32768 + 16384 + 12, 12));
-		if (emscripten_has_threading_support())
+		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
-			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+			fetch_and_xor_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				fetch_and_xor_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(~(1UL<<i));
-					pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_xor_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
+				threadArg[i] = DUP(~(1UL<<i));
+				pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_xor_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp
@@ -91,13 +91,10 @@ int main()
 		assert(y == HILO(6, 4));
 		assert(x == HILO(6, 4));
 		volatile T n = HILO(2, 1);
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			printf("n: %llx\n", n);
-			assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		printf("n: %llx\n", n);
+		assert(n == HILO(NUM_THREADS*10000ULL+2ULL, NUM_THREADS*10000ULL+1ULL));
 	}
 	{
 		T x = HILO(15, 13);
@@ -105,13 +102,10 @@ int main()
 		assert(y == HILO(5, 3));
 		assert(x == HILO(5, 3));
 		volatile T n = HILO(NUM_THREADS*10000ULL+5ULL, NUM_THREADS*10000ULL+3ULL);
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			printf("n: %llx\n", n);
-			assert(n == HILO(5,3));
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		printf("n: %llx\n", n);
+		assert(n == HILO(5,3));
 	}
 	{
 		T x = HILO(32768 + 5, 5);
@@ -121,16 +115,13 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			or_and_fetch_data = HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-			if (emscripten_has_threading_support())
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(1 << i);
-					pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(or_and_fetch_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
+				threadArg[i] = DUP(1 << i);
+				pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(or_and_fetch_data == HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1));
 		}
 	}
 	{
@@ -138,19 +129,16 @@ int main()
 		T y = __sync_and_and_fetch(&x, HILO(32768 + 9, 9));
 		assert(y == HILO(32768 + 1, 1));
 		assert(x == HILO(32768 + 1, 1));
-		if (emscripten_has_threading_support())
+		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
-			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+			and_and_fetch_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				and_and_fetch_data = HILO(65536 + (1<<(NUM_THREADS+1))-1, (1<<(NUM_THREADS+1))-1);
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(~(1UL<<i));
-					pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(and_and_fetch_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
+				threadArg[i] = DUP(~(1UL<<i));
+				pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(and_and_fetch_data == HILO(65536 + (1<<NUM_THREADS), 1<<NUM_THREADS));
 		}
 	}
 	{
@@ -158,19 +146,16 @@ int main()
 		T y = __sync_xor_and_fetch(&x, HILO(16384 + 9, 9));
 		assert(y == HILO(32768 + 16384 + 12, 12));
 		assert(x == HILO(32768 + 16384 + 12, 12));
-		if (emscripten_has_threading_support())
+		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
-			for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
+			xor_and_fetch_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
+			for(int i = 0; i < NUM_THREADS; ++i)
 			{
-				xor_and_fetch_data = HILO(32768 + (1<<NUM_THREADS), 1<<NUM_THREADS);
-				for(int i = 0; i < NUM_THREADS; ++i)
-				{
-					threadArg[i] = DUP(~(1UL<<i));
-					pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)&threadArg[i]);
-				}
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(xor_and_fetch_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
+				threadArg[i] = DUP(~(1UL<<i));
+				pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)&threadArg[i]);
 			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(xor_and_fetch_data == HILO(32768 + ((1<<(NUM_THREADS+1))-1), (1<<(NUM_THREADS+1))-1));
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
@@ -87,12 +87,9 @@ int main()
 		assert(y == 5);
 		assert(x == 15);
 		volatile int n = 1;
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(n == NUM_THREADS*10000+1);
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_add, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		assert(n == NUM_THREADS*10000+1);
 	}
 	{
 		T x = 5;
@@ -100,12 +97,9 @@ int main()
 		assert(y == 5);
 		assert(x == -5);
 		volatile int n = 1;
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(n == 1-NUM_THREADS*10000);
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_sub, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		assert(n == 1-NUM_THREADS*10000);
 	}
 	{
 		T x = 5;
@@ -115,12 +109,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_or_data = (1<<NUM_THREADS);
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)(1<<i));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_or_data == (1<<(NUM_THREADS+1))-1);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_or, (void*)(1<<i));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_or_data == (1<<(NUM_THREADS+1))-1);
 		}
 	}
 	{
@@ -131,12 +122,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_and_data = (1<<(NUM_THREADS+1))-1;
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)(~(1<<i)));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_and_data == 1<<NUM_THREADS);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_and, (void*)(~(1<<i)));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_and_data == 1<<NUM_THREADS);
 		}
 	}
 	{
@@ -147,12 +135,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			fetch_and_xor_data = 1<<NUM_THREADS;
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)(~(1<<i)));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(fetch_and_xor_data == (1<<(NUM_THREADS+1))-1);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_fetch_and_xor, (void*)(~(1<<i)));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(fetch_and_xor_data == (1<<(NUM_THREADS+1))-1);
 		}
 	}
 

--- a/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
@@ -87,12 +87,9 @@ int main()
 		assert(y == 15);
 		assert(x == 15);
 		volatile int n = 1;
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(n == NUM_THREADS*10000+1);
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_add_and_fetch, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		assert(n == NUM_THREADS*10000+1);
 	}
 	{
 		T x = 5;
@@ -100,12 +97,9 @@ int main()
 		assert(y == -5);
 		assert(x == -5);
 		volatile int n = 1;
-		if (emscripten_has_threading_support())
-		{
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-			assert(n == 1-NUM_THREADS*10000);
-		}
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_sub_and_fetch, (void*)&n);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		assert(n == 1-NUM_THREADS*10000);
 	}
 	{
 		T x = 5;
@@ -115,12 +109,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			or_and_fetch_data = (1<<NUM_THREADS);
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)(1<<i));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(or_and_fetch_data == (1<<(NUM_THREADS+1))-1);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_or_and_fetch, (void*)(1<<i));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(or_and_fetch_data == (1<<(NUM_THREADS+1))-1);
 		}
 	}
 	{
@@ -131,12 +122,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			and_and_fetch_data = (1<<(NUM_THREADS+1))-1;
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)(~(1<<i)));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(and_and_fetch_data == 1<<NUM_THREADS);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_and_and_fetch, (void*)(~(1<<i)));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(and_and_fetch_data == 1<<NUM_THREADS);
 		}
 	}
 	{
@@ -147,12 +135,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			xor_and_fetch_data = 1<<NUM_THREADS;
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)(~(1<<i)));
-				for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-				assert(xor_and_fetch_data == (1<<(NUM_THREADS+1))-1);
-			}
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_xor_and_fetch, (void*)(~(1<<i)));
+			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+			assert(xor_and_fetch_data == (1<<(NUM_THREADS+1))-1);
 		}
 	}
 // XXX NAND support does not exist in Atomics API.

--- a/tests/pthread/test_pthread_gcc_atomics.cpp
+++ b/tests/pthread/test_pthread_gcc_atomics.cpp
@@ -77,12 +77,9 @@ int main()
 		{
 			nand_and_fetch_data = 0;
 			__sync_synchronize(); // This has no effect in this code, but called in here just to test that the compiler generates a valid expression for this.
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch, (void*)-1);
-				for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
-				assert(nand_and_fetch_data == -1);
-			}
+			for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch, (void*)-1);
+			for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
+			assert(nand_and_fetch_data == -1);
 		}
 	}
 	{
@@ -94,12 +91,9 @@ int main()
 		for(int x = 0; x < 100; ++x) // Test a few times for robustness, since this test is so short-lived.
 		{
 			nand_and_fetch_data = 0;
-			if (emscripten_has_threading_support())
-			{
-				for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch_bool, (void*)-1);
-				for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
-				assert(nand_and_fetch_data == -1);
-			}
+			for(int i = 0; i < oddNThreads; ++i) pthread_create(&thread[i], NULL, thread_nand_and_fetch_bool, (void*)-1);
+			for(int i = 0; i < oddNThreads; ++i) pthread_join(thread[i], NULL);
+			assert(nand_and_fetch_data == -1);
 		}
 	}
 

--- a/tests/pthread/test_pthread_gcc_spinlock.cpp
+++ b/tests/pthread/test_pthread_gcc_spinlock.cpp
@@ -42,15 +42,6 @@ void *ThreadMain(void *arg)
 int main()
 {
 	int result = 0;
-	if (!emscripten_has_threading_support())
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(800);
-#endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	pthread_t thread[NUM_THREADS];
 
 	for(int i = 0; i < NUM_THREADS; ++i)

--- a/tests/pthread/test_pthread_iostream.cpp
+++ b/tests/pthread/test_pthread_iostream.cpp
@@ -17,15 +17,6 @@ int numThreadsToCreate = 1000;
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
 	assert(rc == 0);

--- a/tests/pthread/test_pthread_join.cpp
+++ b/tests/pthread/test_pthread_join.cpp
@@ -30,15 +30,6 @@ int main()
   struct timespec ts = { 1, 0 };
   nanosleep(&ts, 0);
 
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(6765);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   pthread_t thr;
 
   int n = 20;

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -33,15 +33,6 @@ void BusySleep(double msecs)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   sharedVar = 0;
   int s = pthread_create(&thr, NULL, thread_start, 0);
   assert(s == 0);

--- a/tests/pthread/test_pthread_locale.c
+++ b/tests/pthread/test_pthread_locale.c
@@ -31,19 +31,12 @@ int main (int argc, char *argv[])
   locale_t main_loc = do_test();
   locale_t child_loc;
 
-  if (!emscripten_has_threading_support())
-  {
-    child_loc = main_loc;
-  }
-  else
-  {
-    long id = 1;
-    pthread_t thread;
+  long id = 1;
+  pthread_t thread;
 
-    pthread_create(&thread, NULL, thread_test, (void *)id);
+  pthread_create(&thread, NULL, thread_test, (void *)id);
 
-    pthread_join(thread, (void**)&child_loc);
-  }
+  pthread_join(thread, (void**)&child_loc);
 
 #ifdef REPORT_RESULT
   int result = (main_loc == child_loc);

--- a/tests/pthread/test_pthread_malloc.cpp
+++ b/tests/pthread/test_pthread_malloc.cpp
@@ -35,14 +35,6 @@ static void *thread_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support()) {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
-
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
     pthread_create(&thr[i], NULL, thread_start, (void*)(i*N));

--- a/tests/pthread/test_pthread_malloc_free.cpp
+++ b/tests/pthread/test_pthread_malloc_free.cpp
@@ -28,13 +28,6 @@ static void *thread_start(void *arg)
 int main()
 {
   int result = 0;
-  if (!emscripten_has_threading_support()) {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
   {

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -97,15 +97,9 @@ int main()
 	pthread_mutex_lock(&lock);
 	pthread_mutex_unlock(&lock);
 
-	if (emscripten_has_threading_support()) {
-		// Create new threads in parallel.
-		for(int i = 0; i < NUM_THREADS; ++i)
-			CreateThread(i, threadNum++);
+	// Create new threads in parallel.
+	for(int i = 0; i < NUM_THREADS; ++i)
+		CreateThread(i, threadNum++);
 
-		emscripten_set_main_loop(WaitToJoin, 0, 0);
-	} else {
-#ifdef REPORT_RESULT
-		REPORT_RESULT(50);
-#endif
-	}
+	emscripten_set_main_loop(WaitToJoin, 0, 0);
 }

--- a/tests/pthread/test_pthread_nested_spawns.cpp
+++ b/tests/pthread/test_pthread_nested_spawns.cpp
@@ -22,11 +22,7 @@ int main(void) {
   pthread_t thread;
   puts("a");
   pthread_create(&thread, NULL, thread_func, NULL);
-  if (emscripten_has_threading_support()) {
-    pthread_join(thread, NULL);
-  } else {
-    result = 1;
-  }
+  pthread_join(thread, NULL);
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(result);

--- a/tests/pthread/test_pthread_once.cpp
+++ b/tests/pthread/test_pthread_once.cpp
@@ -28,10 +28,8 @@ int main()
 	assert(numInitialized == 0);
 	for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_main, 0);
 
-	if (emscripten_has_threading_support()) {
-		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
-		assert(numInitialized == 1);
-	}
+	for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+	assert(numInitialized == 1);
 
 #ifdef REPORT_RESULT
 	REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_printf.cpp
+++ b/tests/pthread/test_pthread_printf.cpp
@@ -16,16 +16,12 @@ int main()
 {
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
-	if (emscripten_has_threading_support()) {
-		assert(rc == 0);
+	assert(rc == 0);
 
-		rc = pthread_join(thread, NULL);
-		assert(rc == 0);
+	rc = pthread_join(thread, NULL);
+	assert(rc == 0);
 
-		printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
-	} else {
-		assert(rc == EAGAIN);
-	}
+	printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
 
 #ifdef REPORT_RESULT
 	REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
+++ b/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
@@ -26,15 +26,6 @@ void *ThreadMain(void *arg)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(0);
-#endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	pthread_t thread;
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);

--- a/tests/pthread/test_pthread_run_on_main_thread.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread.cpp
@@ -137,20 +137,17 @@ void *thread_main(void*)
 
 int main()
 {
-	if (emscripten_has_threading_support())
-	{
-		test_sync();
-		test_async_waitable();
+	test_sync();
+	test_async_waitable();
 
-		pthread_attr_t attr;
-		pthread_attr_init(&attr);
-		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-		pthread_t thread;
-		int rc = pthread_create(&thread, &attr, thread_main, 0);
-		assert(rc == 0);
-		rc = pthread_join(thread, 0);
-		assert(rc == 0);
-	}
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+	pthread_t thread;
+	int rc = pthread_create(&thread, &attr, thread_main, 0);
+	assert(rc == 0);
+	rc = pthread_join(thread, 0);
+	assert(rc == 0);
 
 	test_async();
 

--- a/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
@@ -61,20 +61,17 @@ void *thread_main(void*)
 
 int main()
 {
-	if (emscripten_has_threading_support())
-	{
-		test_sync();
-		test_async_waitable();
+	test_sync();
+	test_async_waitable();
 
-		pthread_attr_t attr;
-		pthread_attr_init(&attr);
-		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-		pthread_t thread;
-		int rc = pthread_create(&thread, &attr, thread_main, 0);
-		assert(rc == 0);
-		rc = pthread_join(thread, 0);
-		assert(rc == 0);
-	}
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+	pthread_t thread;
+	int rc = pthread_create(&thread, &attr, thread_main, 0);
+	assert(rc == 0);
+	rc = pthread_join(thread, 0);
+	assert(rc == 0);
 
 	test_async();
 

--- a/tests/pthread/test_pthread_sbrk.cpp
+++ b/tests/pthread/test_pthread_sbrk.cpp
@@ -72,13 +72,6 @@ static void *thread_start(void *arg)
 int main()
 {
   int result = 0;
-  if (!emscripten_has_threading_support()) {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
 
   int ret = pthread_barrier_init(&barrierWaitToAlloc, NULL, NUM_THREADS);
   assert(ret == 0);

--- a/tests/pthread/test_pthread_spawns.cpp
+++ b/tests/pthread/test_pthread_spawns.cpp
@@ -15,8 +15,7 @@ int main()
 	for(int x = 0; x < 100; ++x)
 	{
 		for(int i = 0; i < NUM_THREADS; ++i) pthread_create(&thread[i], NULL, thread_main, 0);
-		if (emscripten_has_threading_support())
-			for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
+		for(int i = 0; i < NUM_THREADS; ++i) pthread_join(thread[i], NULL);
 	}
 #ifdef REPORT_RESULT
 	REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_supported.cpp
+++ b/tests/pthread/test_pthread_supported.cpp
@@ -21,8 +21,7 @@ int main()
 	pthread_attr_destroy(&attr);
 	pthread_join(thread, 0);
 
-	if (emscripten_has_threading_support()) assert(rc == 0);
-	else assert(rc == EAGAIN);
+	assert(rc == 0);
 
 #ifdef REPORT_RESULT
 	REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_volatile.cpp
+++ b/tests/pthread/test_pthread_volatile.cpp
@@ -22,15 +22,6 @@ static void *thread_start(void *arg) // thread: just flip the shared flag and qu
 int main()
 {
   int result;
-  if (!emscripten_has_threading_support())
-  {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(1);
-#endif
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   pthread_t thr;
   int rc = pthread_create(&thr, NULL, thread_start, (void*)0);
   if (rc != 0)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3466,12 +3466,8 @@ window.close = function() {
 
       int main() {
         pthread_t t;
-        if (emscripten_has_threading_support()) {
-          pthread_create(&t, 0, thread_main, 0);
-          pthread_join(t, 0);
-        } else {
-          result = 1;
-        }
+        pthread_create(&t, 0, thread_main, 0);
+        pthread_join(t, 0);
         REPORT_RESULT(result);
       }
     '''))


### PR DESCRIPTION
This is a followup to the removal of USE_PTHREADS=2 (#7007).

Threading support is something we set at compile time and
can be detected with __EMSCRIPTEN_PTHREADS__.  If threading
is not support in the browser the resulting module will not
load so that is no need for a runtime detection feature.