### PR TITLE
Format changelog to avoid long lines.

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,34 +1,58 @@
 This document describes changes between tagged Emscripten SDK versions.
 
-Note that in the compiler, version numbering is used as the mechanism to invalidate internal compiler caches,
-so version numbers do not necessarily reflect the amount of changes between versions.
+Note that in the compiler, version numbering is used as the mechanism to
+invalidate internal compiler caches, so version numbers do not necessarily
+reflect the amount of changes between versions.
 
-To browse or download snapshots of old tagged versions, visit https://github.com/kripken/emscripten/releases .
+To browse or download snapshots of old tagged versions, visit
+https://github.com/kripken/emscripten/releases.
 
-Not all changes are documented here. In particular, new features, user-oriented fixes, options, command-line parameters, usage changes, deprecations, significant internal modifications and optimizations etc. generally deserve a mention. To examine the full set of changes between versions, visit the link to full changeset diff at the end of each section.
+Not all changes are documented here. In particular, new features, user-oriented
+fixes, options, command-line parameters, usage changes, deprecations,
+significant internal modifications and optimizations etc. generally deserve a
+mention. To examine the full set of changes between versions, visit the link to
+full changeset diff at the end of each section.
 
 Current Trunk
 -------------
 
 v1.38.10: 07/23/2018
 --------------------
- - Change the type of `size_t` and friends from int to long. This may have noticeable effects if you depend on the name mangling of a function that uses `size_t` (like in `EXPORTED_FUNCTIONS`), and you must rebuild source files to bitcode (so your bitcode is in sync with the system libraries after they are rebuilt with this change). Otherwise this should not have any noticeable effects for users. See #5916.
+ - Change the type of `size_t` and friends from int to long. This may have
+   noticeable effects if you depend on the name mangling of a function that uses
+   `size_t` (like in `EXPORTED_FUNCTIONS`), and you must rebuild source files to
+   bitcode (so your bitcode is in sync with the system libraries after they are
+   rebuilt with this change). Otherwise this should not have any noticeable
+   effects for users. See #5916.
 
 v1.38.9: 07/22/2018
 -------------------
- - Fix `Module.locateFile` to resolve relative paths to *.wasm, *.mem and other files relatively to the main JavaScript file rather than the current working directory (see #5368).
-   - Add second argument `prefix` to `Module.locateFile` function that contains path to JavaScript file where files are loaded from by default.
+ - Fix `Module.locateFile` to resolve relative paths to *.wasm, *.mem and other
+   files relatively to the main JavaScript file rather than the current working
+   directory (see #5368).
+   - Add second argument `prefix` to `Module.locateFile` function that contains
+     path to JavaScript file where files are loaded from by default.
    - Remove `Module.*PrefixURL` APIs (use `Module.locateFile` instead).
 
 v1.38.8: 07/06/2018
 -------------------
- - Fix a regression in 1.38.7 with binaryen no longer bundling binaryen.js (which emscripten doesn't need, that's just for handwritten JS users, but emscripten did check for its prescence).
+ - Fix a regression in 1.38.7 with binaryen no longer bundling binaryen.js
+   (which emscripten doesn't need, that's just for handwritten JS users, but
+   emscripten did check for its prescence).
 
 v1.38.7: 07/06/2018
 -------------------
- - Correctness fix for stack handling in invoke_*()s. This may add noticeable overhead to programs using C++ exceptions and (less likely) setjmp/longjmp - please report any issues. See #6666 #6702
- - Deprecate Module.ENVIRONMENT: Now that we have a compile-time option to set the environment, also having a runtime one on Module is complexity that we are better off without. When Module.ENVIRONMENT is used with ASSERTIONS it will show an error to direct users to the new option (-s ENVIRONMENT=web , or node, etc., at compile time).
- - Breaking change: Do not export print/printErr by default. Similar to other similar changes (like getValue/setValue). We now use out() and err() functions in JS to print to stdout/stderr respectively. See #6756.
+ - Correctness fix for stack handling in invoke_*()s. This may add noticeable
+   overhead to programs using C++ exceptions and (less likely) setjmp/longjmp -
+   please report any issues. See #6666 #6702
+ - Deprecate Module.ENVIRONMENT: Now that we have a compile-time option to set
+   the environment, also having a runtime one on Module is complexity that we
+   are better off without. When Module.ENVIRONMENT is used with ASSERTIONS it
+   will show an error to direct users to the new option (-s ENVIRONMENT=web , or
+   node, etc., at compile time).
+ - Breaking change: Do not export print/printErr by default. Similar to other
+   similar changes (like getValue/setValue). We now use out() and err()
+   functions in JS to print to stdout/stderr respectively. See #6756.
 
 v1.38.6: 06/13/2018
 -------------------
@@ -47,13 +71,24 @@ v1.38.3: 05/25/2018
 
 v1.38.2: 05/25/2018
 --------------------
- - Add ENVIRONMENT option to specify at compile time we only need JS to support one runtime environment (e.g., just the web). When emitting HTML, set that to web so we emit web code only. #6565
+ - Add ENVIRONMENT option to specify at compile time we only need JS to support
+   one runtime environment (e.g., just the web). When emitting HTML, set that to
+   web so we emit web code only. #6565
  - Regression in asm.js validation due to cttz optimization #6547
 
 v1.38.1: 05/17/2018
 -------------------
- - Remove special-case support for src/struct_info.compiled.json: Make it a normal cached thing like system libraries, not something checked into the source tree.
- - Breaking change: Emit WebAssembly by default. Only the default is changed - we of course still support asm.js, and will for a very long time. But changing the default makes sense as the recommended output for most use cases should be WebAssembly, given it has shipped in all major browsers and platforms and is more efficient than asm.js. Build with `-s WASM=0` to disable wasm and use asm.js if you want that (or use `-s LEGACY_VM_SUPPORT=1`, which emits output that can run in older browsers, which includes a bunch of polyfills as well as disables wasm). (#6419)
+ - Remove special-case support for src/struct_info.compiled.json: Make it a
+   normal cached thing like system libraries, not something checked into the
+   source tree.
+ - Breaking change: Emit WebAssembly by default. Only the default is changed -
+   we of course still support asm.js, and will for a very long time. But
+   changing the default makes sense as the recommended output for most use cases
+   should be WebAssembly, given it has shipped in all major browsers and
+   platforms and is more efficient than asm.js. Build with `-s WASM=0` to
+   disable wasm and use asm.js if you want that (or use `-s
+   LEGACY_VM_SUPPORT=1`, which emits output that can run in older browsers,
+   which includes a bunch of polyfills as well as disables wasm). (#6419)
 
 v1.38.0: 05/09/2018
 -------------------
@@ -64,11 +99,18 @@ v1.37.40: 05/07/2018
 
 v1.37.39: 05/01/2018
 --------------------
- - Regression: Parsing of  -s X=@file  broke if the file contains a newline (see #6436; fixed in 1.37.40)
+ - Regression: Parsing of -s X=@file  broke if the file contains a newline (see
+   #6436; fixed in 1.37.40)
 
 v1.37.38: 04/23/2018
 --------------------
- - Breaking change: Simplify exception handling, disabling it by default. Previously it was disabled by default in -O1 and above and enabled in -O0, which could be confusing. You may notice this change if you need exceptions and only run in -O0 (since if you test in -O1 or above, you'd see you need to enable exceptions manually), in which case you will receive an error at runtime saying that exceptions are disabled by default and that you should build with -s DISABLE_EXCEPTION_CATCHING=0 to enable them.
+ - Breaking change: Simplify exception handling, disabling it by default.
+   Previously it was disabled by default in -O1 and above and enabled in -O0,
+   which could be confusing. You may notice this change if you need exceptions
+   and only run in -O0 (since if you test in -O1 or above, you'd see you need to
+   enable exceptions manually), in which case you will receive an error at
+   runtime saying that exceptions are disabled by default and that you should
+   build with -s DISABLE_EXCEPTION_CATCHING=0 to enable them.
  - Fix regression in 1.37.37 on configure scripts on MacOS (see #6456)
 
 v1.37.37: 04/13/2018
@@ -80,18 +122,27 @@ v1.37.36: 03/13/2018
 
 v1.37.35: 02/23/2018
 --------------------
- - MALLOC option, allowing picking between dlmalloc (previous allocator and still the default) and emmalloc, a new allocator which is smaller and simpler.
+ - MALLOC option, allowing picking between dlmalloc (previous allocator and
+   still the default) and emmalloc, a new allocator which is smaller and
+   simpler.
  - Binaryen update that should fix all known determinism bugs.
 
 v1.37.34: 02/16/2018
 --------------------
- - `addFunction` is now supported on LLVM wasm backend, but when being used on the wasm backend, you need to provide an additional second argument, a Wasm function signature string. Each character within a signature string represents a type. The first character represents the return type of a function, and remaining characters are for parameter types.
+ - `addFunction` is now supported on LLVM wasm backend, but when being used on
+   the wasm backend, you need to provide an additional second argument, a Wasm
+   function signature string. Each character within a signature string
+   represents a type. The first character represents the return type of a
+   function, and remaining characters are for parameter types.
     - 'v': void type
     - 'i': 32-bit integer type
     - 'j': 64-bit integer type (currently does not exist in JavaScript)
     - 'f': 32-bit float type
     - 'd': 64-bit float type
-   For asm.js and asm2wasm you can provide the optional second argument, but it isn't needed. For that reason this isn't a breaking change, however, providing the second argument is recommended so that code is portable across all backends and modes.
+   For asm.js and asm2wasm you can provide the optional second argument, but it
+   isn't needed. For that reason this isn't a breaking change, however,
+   providing the second argument is recommended so that code is portable across
+   all backends and modes.
 
 v1.37.33: 02/02/2018
 --------------------
@@ -111,31 +162,71 @@ v1.37.29: 01/24/2018
 
 v1.37.28: 01/08/2018
 --------------------
- - Breaking change: Don't export the `ALLOC_*` numeric constants by default. As with previous changes, a warning will be shown in `-O0` and when `ASSERTIONS` are on if they are used.
- - Breaking change: Don't export FS methods by default. As with previous changes, a warning will be shown in `-O0` and when `ASSERTIONS` are on, which will suggest either exporting the specific methods you need, or using `FORCE_FILESYSTEM` which will auto export all the main filesystem methods. Aside from using FS methods yourself, you may notice this change when using a file package created standalone, that is, by running the file packager directly and then loading it at run time (as opposed to telling `emcc` to package the files for you, in which case it would be aware of them at compile time); you should build with `FORCE_FILESYSTEM` to ensure filesystem support for that case.
+ - Breaking change: Don't export the `ALLOC_*` numeric constants by default. As
+   with previous changes, a warning will be shown in `-O0` and when `ASSERTIONS`
+   are on if they are used.
+ - Breaking change: Don't export FS methods by default. As with previous
+   changes, a warning will be shown in `-O0` and when `ASSERTIONS` are on, which
+   will suggest either exporting the specific methods you need, or using
+   `FORCE_FILESYSTEM` which will auto export all the main filesystem methods.
+   Aside from using FS methods yourself, you may notice this change when using a
+   file package created standalone, that is, by running the file packager
+   directly and then loading it at run time (as opposed to telling `emcc` to
+   package the files for you, in which case it would be aware of them at compile
+   time); you should build with `FORCE_FILESYSTEM` to ensure filesystem support
+   for that case.
 
 v1.37.27: 12/24/2017
 --------------------
- - Breaking change: Remove the `Runtime` object, and move all the useful methods from it to simple top-level functions. Any usage of `Runtime.func` should be changed to `func`.
+ - Breaking change: Remove the `Runtime` object, and move all the useful methods
+   from it to simple top-level functions. Any usage of `Runtime.func` should be
+   changed to `func`.
 
 v1.37.26: 12/20/2017
 --------------------
- - Breaking change: Change `NO_EXIT_RUNTIME` to 1 by default. This means that by default we don't include code to shut down the runtime, flush stdio streams, run atexits, etc., which is better for code size. When `ASSERTIONS` is on, we warn at runtime if there is text buffered in the streams that should be flushed, or atexits are used.
- - Meta-DCE for JS+wasm: remove unused code between JS+wasm more aggressively. This should not break valid code, but may break code that depended on unused code being kept around (like using a function from outside the emitted JS without exporting it - only exported things are guaranteed to be kept alive through optimization).
+ - Breaking change: Change `NO_EXIT_RUNTIME` to 1 by default. This means that by
+   default we don't include code to shut down the runtime, flush stdio streams,
+   run atexits, etc., which is better for code size. When `ASSERTIONS` is on, we
+   warn at runtime if there is text buffered in the streams that should be
+   flushed, or atexits are used.
+ - Meta-DCE for JS+wasm: remove unused code between JS+wasm more aggressively.
+   This should not break valid code, but may break code that depended on unused
+   code being kept around (like using a function from outside the emitted JS
+   without exporting it - only exported things are guaranteed to be kept alive
+   through optimization).
 
 v1.37.24: 12/13/2017
 --------------------
- - Breaking change: Similar to the getValue/setValue change from before (and with the same `ASSERTIONS` warnings to help users), do not export the following runtime methods by default: ccall, cwrap, allocate, Pointer_stringify, AsciiToString, stringToAscii, UTF8ArrayToString, UTF8ToString, stringToUTF8Array, stringToUTF8, lengthBytesUTF8, stackTrace, addOnPreRun, addOnInit, addOnPreMain, addOnExit, addOnPostRun, intArrayFromString, intArrayToString, writeStringToMemory, writeArrayToMemory, writeAsciiToMemory.
+ - Breaking change: Similar to the getValue/setValue change from before (and
+   with the same `ASSERTIONS` warnings to help users), do not export the
+   following runtime methods by default: ccall, cwrap, allocate,
+   Pointer_stringify, AsciiToString, stringToAscii, UTF8ArrayToString,
+   UTF8ToString, stringToUTF8Array, stringToUTF8, lengthBytesUTF8, stackTrace,
+   addOnPreRun, addOnInit, addOnPreMain, addOnExit, addOnPostRun,
+   intArrayFromString, intArrayToString, writeStringToMemory,
+   writeArrayToMemory, writeAsciiToMemory.
 
 v1.37.23: 12/4/2017
 -------------------
- - Breaking change: Do not polyfill Math.{clz32, fround, imul, trunc} by default. A new `LEGACY_VM_SUPPORT` option enables support for legacy browsers. In `ASSERTIONS` mode, a warning is shown if a polyfill was needed, suggesting using that option.
- - Breaking change: Do not export getValue/setValue runtime methods by default. You can still use them by calling them directly in code optimized with the main file (pre-js, post-js, js libraries; if the optimizer sees they are used, it preserves them), but if you try to use them on `Module` then you must export them by adding them to `EXTRA_EXPORTED_RUNTIME_METHODS`. In `-O0` or when `ASSERTIONS` is on, a run-time error message explains that, if they are attempted to be used incorrectly.
+ - Breaking change: Do not polyfill Math.{clz32, fround, imul, trunc} by
+   default. A new `LEGACY_VM_SUPPORT` option enables support for legacy
+   browsers. In `ASSERTIONS` mode, a warning is shown if a polyfill was needed,
+   suggesting using that option.
+ - Breaking change: Do not export getValue/setValue runtime methods by default.
+   You can still use them by calling them directly in code optimized with the
+   main file (pre-js, post-js, js libraries; if the optimizer sees they are
+   used, it preserves them), but if you try to use them on `Module` then you
+   must export them by adding them to `EXTRA_EXPORTED_RUNTIME_METHODS`. In `-O0`
+   or when `ASSERTIONS` is on, a run-time error message explains that, if they
+   are attempted to be used incorrectly.
 
 v1.37.17: 7/25/2017
 ------------------
- - Updated to libc++'s "v2" ABI, which provides better alignment for string data and other improvements. This is an ABI-incompatible change, so bitcode files from previous versions will not be compatible.
- - To see a list of commits in the active development branch 'incoming', which have not yet been packaged in a release, see
+ - Updated to libc++'s "v2" ABI, which provides better alignment for string data
+   and other improvements. This is an ABI-incompatible change, so bitcode files
+   from previous versions will not be compatible.
+ - To see a list of commits in the active development branch 'incoming', which
+   have not yet been packaged in a release, see
     - Emscripten: https://github.com/kripken/emscripten/compare/1.37.13...incoming
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.37.13...incoming
     - Emscripten-Clang: https://github.com/kripken/emscripten-fastcomp-clang/compare/1.37.13...incoming
@@ -179,7 +270,14 @@ v1.37.10: 4/20/2017
  - Fixed an outlining bug on function returns (#5080)
  - Implemented new parallel test runner architecture (#5074)
  - Added Cocos2D to Emscripten ports. (-s USE_COCOS2D=1)
- - Updated Binaryen to version 32, which migrates Emscripten to use the new WebAssembly Names section. This is a forwards and backwards breaking change with respect to reading debug symbol names in Wasm callstacks. Use of the new Names section format first shipped in Emscripten 1.37.10, Binaryen version 32, Firefox 55, Firefox Nightly 2017-05-18 and Chrome 59; earlier versions still used the old format. For more information, see https://github.com/WebAssembly/design/pull/984 and https://github.com/WebAssembly/binaryen/pull/933.
+ - Updated Binaryen to version 32, which migrates Emscripten to use the new
+   WebAssembly Names section. This is a forwards and backwards breaking change
+   with respect to reading debug symbol names in Wasm callstacks. Use of the new
+   Names section format first shipped in Emscripten 1.37.10, Binaryen version
+   32, Firefox 55, Firefox Nightly 2017-05-18 and Chrome 59; earlier versions
+   still used the old format. For more information, see
+   https://github.com/WebAssembly/design/pull/984 and
+   https://github.com/WebAssembly/binaryen/pull/933.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.37.9...1.37.10
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.37.9...1.37.10
@@ -187,9 +285,14 @@ v1.37.10: 4/20/2017
 
 v1.37.9: 3/23/2017
 ------------------
- - Added new build feature -s GL_PREINITIALIZED_CONTEXT=1 which allows pages to manually precreate the GL context they use for customization purposes.
- - Added a custom callback hook Module.instantiateWasm() which allows user shell HTML file to manually perform Wasm instantiation for preloading and progress bar purposes.
- - Added a custom callback hook Module.getPreloadedPackage() to file preloader code to allow user shell HTML file to manually download .data files for preloading and progress bar purposes.
+ - Added new build feature -s GL_PREINITIALIZED_CONTEXT=1 which allows pages to
+   manually precreate the GL context they use for customization purposes.
+ - Added a custom callback hook Module.instantiateWasm() which allows user shell
+   HTML file to manually perform Wasm instantiation for preloading and progress
+   bar purposes.
+ - Added a custom callback hook Module.getPreloadedPackage() to file preloader
+   code to allow user shell HTML file to manually download .data files for
+   preloading and progress bar purposes.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.37.8...1.37.9
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.37.8...1.37.9
@@ -245,7 +348,8 @@ v1.37.3: 2/16/2017
  - Updated Binaryen to version 0x01. First official stable WebAssembly support version. (#4953)
  - Optimized memcpy and memset with unrolling and SIMD, when available.
  - Improved Emscripten toolchain profiler to track more hot code.
- - Added new linker flag -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 to allow simultaneously targeting WebGL 1 and WebGL 2.
+ - Added new linker flag -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 to allow
+   simultaneously targeting WebGL 1 and WebGL 2.
  - Optimize Emscripten use of multiprocessing pools.
  - More WebGL 2 garbage free optimizations.
  - Full list of changes:
@@ -258,9 +362,12 @@ v1.37.2: 1/31/2017
  - Fixed a build error with boolean SIMD types.
  - Improved WebAssembly support, update Binaryen to version 22.
  - Update GL, GLES, GLES2 and GLES3 headers to latest upstream Khronos versions.
- - Implement support for new garbage free WebGL 2 API entrypoints which improve performance and reduce animation related stuttering.
- - Fixed a bug where -s USE_PTHREADS builds would not have correct heap size if -s TOTAL_MEMORY is not being used.
- - Fixed array type issue that prevented glTexImage3D() and glTexSubImage3D() from working.
+ - Implement support for new garbage free WebGL 2 API entrypoints which improve
+   performance and reduce animation related stuttering.
+ - Fixed a bug where -s USE_PTHREADS builds would not have correct heap size if
+   -s TOTAL_MEMORY is not being used.
+ - Fixed array type issue that prevented glTexImage3D() and glTexSubImage3D()
+   from working.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.37.1...1.37.2
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.37.1...1.37.2
@@ -268,8 +375,10 @@ v1.37.2: 1/31/2017
 
 v1.37.1: 12/26/2016
 -------------------
- - Implemented new Fetch API for flexible multithreaded XHR and IndexedDB access.
- - Implemented initial version of new ASMFS filesystem for multithreaded filesystem operation.
+ - Implemented new Fetch API for flexible multithreaded XHR and IndexedDB
+   access.
+ - Implemented initial version of new ASMFS filesystem for multithreaded
+   filesystem operation.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.37.0...1.37.1
     - Emscripten-LLVM: no changes.
@@ -281,8 +390,10 @@ v1.37.0: 12/23/2016
  - Fix GLFW mouse button mappings (#4317, #4659)
  - Add support for --emit-symbol-map to wasm
  - Fixed handling of an invalid path in chdir (#4749)
- - Added new EMSCRIPTEN_STRICT mode, which can be enabled to opt in to removing support for deprecated behavior.
- - Remove references to Web Audio .setVelocity() function, which has been removed from the spec.
+ - Added new EMSCRIPTEN_STRICT mode, which can be enabled to opt in to removing
+   support for deprecated behavior.
+ - Remove references to Web Audio .setVelocity() function, which has been
+   removed from the spec.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.14...1.37.0
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.36.14...1.37.0
@@ -294,9 +405,12 @@ v1.36.14: 11/3/2016
  - Fixed FS.mkdirTree('/') to work.
  - Updated SDL 2 port to version 12.
  - Added more missing pthreads stubs.
- - Normalize system header includes to use the preferred form #include <emscripten/foo.h> to avoid polluting header include namespaces.
+ - Normalize system header includes to use the preferred form #include
+   <emscripten/foo.h> to avoid polluting header include namespaces.
  - Fixed a bug where transitioning to fullscreen could cause a stack overflow in GLFW.
- - Added new system CMake option -DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON to choose if static libraries should be LLVM bitcode instead of .a files.
+ - Added new system CMake option
+   -DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON to choose if static
+   libraries should be LLVM bitcode instead of .a files.
  - Improved SIMD support to be more correct to the spec.
  - Updated Binaryen to version 18. (#4674)
  - Fixed dlopen with RTLD_GLOBAL parameter.
@@ -308,7 +422,8 @@ v1.36.14: 11/3/2016
 v1.36.13: 10/21/2016
 --------------------
  - Pass optimization settings to asm2wasm.
- - Fix to exporting emscripten_builtin_malloc() and emscripten_builtin_free() when heap is split to multiple parts.
+ - Fix to exporting emscripten_builtin_malloc() and emscripten_builtin_free()
+   when heap is split to multiple parts.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.12...1.36.13
     - Emscripten-LLVM: no changes.
@@ -317,8 +432,11 @@ v1.36.13: 10/21/2016
 v1.36.12: 10/20/2016
 --------------------
  - Improved Emscripten toolchain profiler with more data. (#4566)
- - Export dlmalloc() and dlfree() as emscripten_builtin_malloc() and emscripten_builtin_free() to allow user applications to hook into memory allocation (#4603)
- - Improved asm.js -s USE_PTHREADS=2 build mode compatibility when multithreading is not supported.
+ - Export dlmalloc() and dlfree() as emscripten_builtin_malloc() and
+   emscripten_builtin_free() to allow user applications to hook into memory
+   allocation (#4603)
+ - Improved asm.js -s USE_PTHREADS=2 build mode compatibility when
+   multithreading is not supported.
  - Improved WebGL support with closure compiler (#4619)
  - Improved Bianaryen WebAssembly support
  - Added support for GL_disjoint_timer_query extension (#4575)
@@ -332,7 +450,9 @@ v1.36.12: 10/20/2016
 
 v1.36.11: 9/24/2016
 -------------------
- - Added new runtime functions emscripten_sync/async/waitable_run_in_main_runtime_thread() for proxying calls with pthreads (#4569)
+ - Added new runtime functions
+   emscripten_sync/async/waitable_run_in_main_runtime_thread() for proxying
+   calls with pthreads (#4569)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.10...1.36.11
     - Emscripten-LLVM: no changes.
@@ -341,7 +461,8 @@ v1.36.11: 9/24/2016
 v1.36.10: 9/24/2016
 -------------------
  - Improved compiler logging print messages on first run experience. (#4501)
- - Fixed log printing in glFlushMappedBufferRange() and glGetInfoLog() functions. (#4521)
+ - Fixed log printing in glFlushMappedBufferRange() and glGetInfoLog()
+   functions. (#4521)
  - Added setjmp/longjmp handling for wasm.
  - Improved support for --proxy-to-worker build mode.
  - Improved GLES3 support for glGet() features that WebGL2 does not have. (#4514)
@@ -357,7 +478,10 @@ v1.36.10: 9/24/2016
 v1.36.9: 8/24/2016
 ------------------
  - Fixed glGet for GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING to work. (#1330)
- - Move the DYNAMICTOP variable from JS global scope to inside the heap so that the value is shared to multithreaded applications. This removes the global runtime variable DYNAMICTOP in favor of a new variable DYNAMICTOP_PTR. (#4391, #4496)
+ - Move the DYNAMICTOP variable from JS global scope to inside the heap so that
+   the value is shared to multithreaded applications. This removes the global
+   runtime variable DYNAMICTOP in favor of a new variable DYNAMICTOP_PTR.
+   (#4391, #4496)
  - Implemented brk() system function.
  - Fixed --output-eol to work with --proxy-to-worker mode.
  - Improved reported error message when execution fails to stack overflow.
@@ -369,15 +493,21 @@ v1.36.9: 8/24/2016
 v1.36.8: 8/20/2016
 ------------------
  - Fixed a memory leak in ctor_evaller.py on Windows (#4446)
- - Migrate to requiring CMake 3.4.3 as the minimum version for Emscripten CMake build integration support.
+ - Migrate to requiring CMake 3.4.3 as the minimum version for Emscripten CMake
+   build integration support.
  - Fixed an issue that prevented -s INLINING_LIMIT from working (#4471)
  - Fixed a bug with Building.llvm_nm interpretation of defined symbols (#4488)
- - Add support for DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_WHITELIST options for wasm.
- - Added new emprofile.py script which can be used to profile toolchain wide performance. (#4491)
- - Added new linker flag --output-eol, which specifices what kind of line endings to generate to the output files. (#4492)
- - Fixed a Windows bug where aborting execution with Ctrl-C might hang Emscripten to an infinite loop instead. (#4494)
+ - Add support for DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_WHITELIST
+   options for wasm.
+ - Added new emprofile.py script which can be used to profile toolchain wide
+   performance. (#4491)
+ - Added new linker flag --output-eol, which specifices what kind of line
+   endings to generate to the output files. (#4492)
+ - Fixed a Windows bug where aborting execution with Ctrl-C might hang
+   Emscripten to an infinite loop instead. (#4494)
  - Implement support for touch events to GLUT (#4493)
- - Deprecated unsafe function writeStringToMemory() from src/preamble.js. Using stringToUTF8() is recommended instead. (#4497)
+ - Deprecated unsafe function writeStringToMemory() from src/preamble.js. Using
+   stringToUTF8() is recommended instead. (#4497)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.7...1.36.8
     - Emscripten-LLVM: no changes.
@@ -395,21 +525,31 @@ v1.36.6: 8/8/2016
 -----------------
  - Fixed wheelDelta for MSIE (#4316)
  - Fixed inconsistencies in fullscreen API signatures (#4310, #4318, #4379)
- - Changed the behavior of Emscripten WebGL createContext() to not forcibly set CSS style on created canvases, but let page customize the style themselves (#3406, #4194 and #4350, #4355)
- - Adjusted the reported GL_VERSION field to adapt to the OpenGL ES specifications (#4345)
+ - Changed the behavior of Emscripten WebGL createContext() to not forcibly set
+   CSS style on created canvases, but let page customize the style themselves
+   (#3406, #4194 and #4350, #4355)
+ - Adjusted the reported GL_VERSION field to adapt to the OpenGL ES
+   specifications (#4345)
  - Added support for GLES3 GL_MAJOR/MINOR_VERSION fields. (#4368)
- - Improved -s USE_PTHREADS=1 and --proxy-to-worker linker options to be mutually compatible. (#4372)
- - Improved IDBFS to not fail on Safari where IndexedDB support is spotty (#4371)
+ - Improved -s USE_PTHREADS=1 and --proxy-to-worker linker options to be
+   mutually compatible. (#4372)
+ - Improved IDBFS to not fail on Safari where IndexedDB support is spotty
+   (#4371)
  - Improved SIMD.js support when using Closure minifier. (#4374)
- - Improved glGetString to be able to read fields from WEBGL_debug_renderer_info extension. (#4381)
+ - Improved glGetString to be able to read fields from WEBGL_debug_renderer_info
+   extension. (#4381)
  - Fixed an issue with glFramebufferTextureLayer() not working correctly.
  - Fixed a bug with std::uncaught_exception() support (#4392)
  - Implemented a multiprocess lock to access the Emscripten cache. (#3850)
  - Implemented support for the pointerlockerror event in HTML5 API (#4373)
  - Report WebGL GLSL version number in GL_SHADING_LANGUAGE_VERSION string (#4365)
- - Optimized llvm_ctpop_i32() and conversion of strings from C to JS side (#4402, #4403)
- - Added support for the OffscreenCanvas proposal, and transferring canvases to offscreen in pthreads build mode, linker flag -s OFFSCREENCANVAS_SUPPORT=0/1 (#4412)
- - Fixed an issue after updating to new LLVM version that response files passed to llvm-link must have forward slashes (#4434)
+ - Optimized llvm_ctpop_i32() and conversion of strings from C to JS side
+   (#4402, #4403)
+ - Added support for the OffscreenCanvas proposal, and transferring canvases to
+   offscreen in pthreads build mode, linker flag -s OFFSCREENCANVAS_SUPPORT=0/1
+   (#4412)
+ - Fixed an issue after updating to new LLVM version that response files passed
+   to llvm-link must have forward slashes (#4434)
  - Fixed a memory leak in relooper in LLVM.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.5...1.36.6
@@ -437,7 +577,8 @@ v1.36.4: 5/9/2016
  - Fixed an issue with GLFW window and framebuffer size callbacks.
  - Added support for more missing WebGL 2 texture formats (#4277)
  - Added support for source files with no extension.
- - Updated emrun.py to latest version, adds support to precompressed content and running as just a web server without launching a browser.
+ - Updated emrun.py to latest version, adds support to precompressed content and
+   running as just a web server without launching a browser.
  - Updated experimental WebAssembly support to generate 0xb version code.
  - Automatically build Binaryen when needed.
  - Updated libc++ to SVN revision 268153. (#4288)
@@ -459,22 +600,28 @@ v1.36.3: 4/27/2016
 v1.36.2: 4/22/2016
 ------------------
  - Improve support for targeting WebAssembly with Binaryen.
- - Improve support for LLVM's WebAssembly backend (EMCC_WASM_BACKEND=1 environment variable).
+ - Improve support for LLVM's WebAssembly backend (EMCC_WASM_BACKEND=1
+   environment variable).
  - Separate out emscripten cache structure to asmjs and wasm directories.
  - Fix a bug where Emscripten would spawn too many unused python subprocesses (#4158)
  - Optimize Emscripten for large asm.js projects.
  - Added sdl2_net to Emscripten ports.
  - Updated to latest version of the SIMD polyfill (#4165)
  - Fixed an issue with missing texture formats support in GLES 3 (#4176)
- - Added a new WebAssembly linker option -s BINARYEN_IMPRECISE=1 (default=0) which mutes potential traps from WebAssembly int div/rem by zero and float-to-int conversions.
+ - Added a new WebAssembly linker option -s BINARYEN_IMPRECISE=1 (default=0)
+   which mutes potential traps from WebAssembly int div/rem by zero and
+   float-to-int conversions.
  - Added support for EXT_color_buffer_float extension.
  - Fixed behavior of SSE shift operations (#4165).
  - Fixed a bug where ctor_evaller.py (-Oz builds) would hang on Windows.
- - Fixed a bug where emscripten_set_main_loop() with EM_TIMING_SETTIMEOUT would incorrectly compute the delta times (#4200, #4208)
+ - Fixed a bug where emscripten_set_main_loop() with EM_TIMING_SETTIMEOUT would
+   incorrectly compute the delta times (#4200, #4208)
  - Update pthreads support to latest proposed spec version. (#4212, #4220)
  - Fixed an unresolved symbol linker error in embind (#4225)
- - Fix file_packager.py --use-preload-cache option to also work on Safari and iOS (#2977, #4253)
- - Added new file packager option --indexedDB-name to allow specifying the database name to use for the cache (#4219)
+ - Fix file_packager.py --use-preload-cache option to also work on Safari and
+   iOS (#2977, #4253)
+ - Added new file packager option --indexedDB-name to allow specifying the
+   database name to use for the cache (#4219)
  - Added DWARF style debugging information.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.1...1.36.2
@@ -484,15 +631,23 @@ v1.36.2: 4/22/2016
 v1.36.1: 3/8/2016
 -----------------
  - Fixed glfwSetWindowSizeCallback to conform to GLFW2 API.
- - Update OpenAL sources only when the browser window is visible to avoid occasional stuttering static glitches when the page tab is hidden. (#4107)
+ - Update OpenAL sources only when the browser window is visible to avoid
+   occasional stuttering static glitches when the page tab is hidden. (#4107)
  - Implemented LLVM math intrinsics powi, trunc and floor.
  - Added support for SDL_GL_ALPHA_SIZE in GL context initialization. (#4125)
- - Added no-op stubs for several pthread functions when building without pthreads enabled (#4130)
- - Optimize glUniform*fv and glVertexAttrib*fv functions to generate less garbage and perform much faster (#4128)
- - Added new EVAL_CTORS optimization pass which evaluates global data initializer constructors at link time, which would improve startup time and reduce code size of these ctors.
+ - Added no-op stubs for several pthread functions when building without
+   pthreads enabled (#4130)
+ - Optimize glUniform*fv and glVertexAttrib*fv functions to generate less
+   garbage and perform much faster (#4128)
+ - Added new EVAL_CTORS optimization pass which evaluates global data
+   initializer constructors at link time, which would improve startup time and
+   reduce code size of these ctors.
  - Implemented support for OpenAL AL_PITCH option.
- - Implemented new build options -s STACK_OVERFLOW_CHECK=0/1/2 which adds runtime stack overrun checks. 0: disabled, 1: minimal, between each frame, 2: at each explicit JS side stack allocation call to allocate().
- - Fixed an issue with -s SPLIT_MEMORY mode where an unsigned 32-bit memory access would come out as signed. (#4150)
+ - Implemented new build options -s STACK_OVERFLOW_CHECK=0/1/2 which adds
+   runtime stack overrun checks. 0: disabled, 1: minimal, between each frame, 2:
+   at each explicit JS side stack allocation call to allocate().
+ - Fixed an issue with -s SPLIT_MEMORY mode where an unsigned 32-bit memory
+   access would come out as signed. (#4150)
  - Fixed asm.js validation in call handlers to llvm_powi_f*.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.36.0...1.36.1
@@ -502,11 +657,15 @@ v1.36.1: 3/8/2016
 v1.36.0: 2/23/2016
 ------------------
  - Fixed an OpenAL bug where OpenAL sources would not respect global volume setting.
- - Fixed an issue where alGetListenerf() with AL_GAIN would not return the correct value. (#4091)
- - Fixed an issue where setting alListenerf() with AL_GAIN would not set the correct value. (#4092)
- - Implemented new JS optimizer "Duplicate Function Elimination" pass which collapses identical functions to save code size.
+ - Fixed an issue where alGetListenerf() with AL_GAIN would not return the
+   correct value. (#4091)
+ - Fixed an issue where setting alListenerf() with AL_GAIN would not set the
+   correct value. (#4092)
+ - Implemented new JS optimizer "Duplicate Function Elimination" pass which
+   collapses identical functions to save code size.
  - Implemented the _Exit() function.
- - Added support for SSE3 and SSSE3 intrinsics (#4099) and partially for SSE 4.1 intrinsics (#4030, #4101)
+ - Added support for SSE3 and SSSE3 intrinsics (#4099) and partially for SSE 4.1
+   intrinsics (#4030, #4101)
  - Added support for -include-pch flag (#4086)
  - Fixed a regex syntax in ccall on Chrome Canary (#4111)
  - Full list of changes:
@@ -516,27 +675,43 @@ v1.36.0: 2/23/2016
 
 v1.35.23: 2/9/2016
 ------------------
- - Provide $NM environment variable to point to llvm-nm when running emconfigure, which helps e.g. libjansson to build (#4036)
- - Fixed glGetString(GL_SHADING_LANGUAGE_VERSION) to return appropriate result depending on if running on WebGL1 vs WebGL2, instead of hardcoding the result (#4040)
- - Fixed a regression with CMake try_run() possibly failing, caused by the addition of CMAKE_CROSSCOMPILING_EMULATOR in v1.32.3.
- - Fixed CMake to work in the case when NODE_JS is an array containing parameters to be passed to Node.js. (#4045)
- - Fixed a memory issue that caused the Emscripten memory initializer file (.mem.js) to be unnecessarily retained in memory during runtime (#4044)
+ - Provide $NM environment variable to point to llvm-nm when running
+   emconfigure, which helps e.g. libjansson to build (#4036)
+ - Fixed glGetString(GL_SHADING_LANGUAGE_VERSION) to return appropriate result
+   depending on if running on WebGL1 vs WebGL2, instead of hardcoding the result
+   (#4040)
+ - Fixed a regression with CMake try_run() possibly failing, caused by the
+   addition of CMAKE_CROSSCOMPILING_EMULATOR in v1.32.3.
+ - Fixed CMake to work in the case when NODE_JS is an array containing
+   parameters to be passed to Node.js. (#4045)
+ - Fixed a memory issue that caused the Emscripten memory initializer file
+   (.mem.js) to be unnecessarily retained in memory during runtime (#4044)
  - Added support for complex valued mul and div ops.
  - Added new option "Module.environment" which allows overriding the runtime ENVIRONMENT_IS_WEB/ENVIRONMENT_IS_WORKER/ENVIRONMENT_IS_NODE/ENVIRONMENT_IS_SHELL fields.
  - Fixed an issue with SAFE_HEAP methods in async mode (#4046)
  - Fixed WebSocket constructor to work in web worker environment (#3849)
  - Fixed a potential issue with some browsers reporting gamepad axis values outside \[-1, 1\] (#3602)
- - Changed libcxxabi to be linked in last, so that it does not override weakly linked methods in libcxx (#4053)
- - Implemented new JSDCE code optimization pass which removes at JS link stage dead code that is not referenced anywhere (in addition to LLVM doing this for C++ link stage).
- - Fixed a Windows issue where embedding memory initializer as a string in JS code might cause corrupted output. (#3854)
- - Fixed an issue when spaces are present in directory names in response files (#4062)
- - Fixed a build issue when using --tracing and -s ALLOW_MEMORY_GROWTH=1 simultaneously (#4064)
+ - Changed libcxxabi to be linked in last, so that it does not override weakly
+   linked methods in libcxx (#4053)
+ - Implemented new JSDCE code optimization pass which removes at JS link stage
+   dead code that is not referenced anywhere (in addition to LLVM doing this for
+   C++ link stage).
+ - Fixed a Windows issue where embedding memory initializer as a string in JS
+   code might cause corrupted output. (#3854)
+ - Fixed an issue when spaces are present in directory names in response files
+   (#4062)
+ - Fixed a build issue when using --tracing and -s ALLOW_MEMORY_GROWTH=1
+   simultaneously (#4064)
  - Greatly updated Emscripten support for SIMD.js intrinsics (non-SSE or NEON)
- - Fixed an issue where compiler would not generate a link error when JS library function depended on a nonexisting symbol. (#4077)
+ - Fixed an issue where compiler would not generate a link error when JS library
+   function depended on a nonexisting symbol. (#4077)
  - Removed UTF16 and UTF32 marshalling code from being exported by default.
- - Removed the -s NO_BROWSER linker option and automated the detection of when that option is needed.
- - Removed the JS implemented C++ symbol name demangler, now always depend on the libcxxabi compiled one.
- - Fixed an issue where Emscripten linker would redundantly generate missing function stubs for some functions that do exist.
+ - Removed the -s NO_BROWSER linker option and automated the detection of when
+   that option is needed.
+ - Removed the JS implemented C++ symbol name demangler, now always depend on
+   the libcxxabi compiled one.
+ - Fixed an issue where Emscripten linker would redundantly generate missing
+   function stubs for some functions that do exist.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.22...1.35.23
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.35.22...1.35.23
@@ -554,10 +729,13 @@ v1.35.22: 1/13/2016
 v1.35.21: 1/13/2016
 -------------------
  - Improved support for handling GLFW2 keycodes.
- - Improved emranlib, system/bin/sdl-config and system/bin/sdl2-config to be executable in both python2 and python3.
- - Fixed build flags -s AGGRESSIVE_VARIABLE_ELIMINATION=1 and -s USE_PTHREADS=2 to correctly work when run on a browser that does not support pthreads.
+ - Improved emranlib, system/bin/sdl-config and system/bin/sdl2-config to be
+   executable in both python2 and python3.
+ - Fixed build flags -s AGGRESSIVE_VARIABLE_ELIMINATION=1 and -s USE_PTHREADS=2
+   to correctly work when run on a browser that does not support pthreads.
  - Fixed a build issue that caused sequences of \r\r\n to be emitted on Windows.
- - Fixed an issue that prevented building LLVM on Visual Studio 2015 (emscripten-fastcomp-clang #7)
+ - Fixed an issue that prevented building LLVM on Visual Studio 2015
+   (emscripten-fastcomp-clang #7)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.20...1.35.21
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.35.20...1.35.21
@@ -565,12 +743,14 @@ v1.35.21: 1/13/2016
 
 v1.35.20: 1/10/2016
 -------------------
- - Fixed -s USE_PTHREADS compilation mode to account that SharedArrayBuffer specification no longer allows futex waiting on the main thread. (#4024)
+ - Fixed -s USE_PTHREADS compilation mode to account that SharedArrayBuffer
+   specification no longer allows futex waiting on the main thread. (#4024)
  - Added new python2 vs python3 compatibility wrappers for emcmake, emconfigure, emmake and emar.
  - Fixed atomicrmw i64 codegen (#4025)
  - Optimized codegen to simplify "x != 0" to just "x" when output is a boolean.
  - Fixed a compiler crash when generating atomics code in debug builds of LLVM.
- - Fixed a compiler crash when generating SIMD.js code that utilizes non-canonical length vectors (e.g. <float x 3>)
+ - Fixed a compiler crash when generating SIMD.js code that utilizes
+   non-canonical length vectors (e.g. <float x 3>)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.19...1.35.20
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.35.19...1.35.20
@@ -620,10 +800,12 @@ v1.35.15: 1/4/2016
  - Improved file packager code so that file:// URLs work in Chrome too (#3965)
  - Fixed issues with the --memoryprofiler UI.
  - Fixed a Windows issue when generating system libraries in cache (#3939)
- - Fixed a regression from v1.35.13 where GLES2 compilation would not work when -s USE_PTHREADS=1 was passed.
+ - Fixed a regression from v1.35.13 where GLES2 compilation would not work when
+   -s USE_PTHREADS=1 was passed.
  - Added support for WebIDL arrays as input parameters to WebIDL binder.
  - Updated build support when using the LLVM wasm backend.
- - Added new linker option --threadprofiler which generates a threads dashboard on the generated page for threads status overview. (#3971)
+ - Added new linker option --threadprofiler which generates a threads dashboard
+   on the generated page for threads status overview. (#3971)
  - Improved backwards compatibility of building on GCC 4.3 - 4.6.
  - Fixed an asm.js validation issue when building against updated SIMD.js specification. (#3986)
  - Improved Rust support.
@@ -642,12 +824,18 @@ v1.35.14: 12/15/2015
 
 v1.35.13: 12/15/2015
 --------------------
- - Updated -s USE_PTHREADS code generation to reflect that the SharedInt*Array hierarchy no longer exists in the SharedArrayBuffer spec.
- - Removed references to Atomic.fence() which no longer is part of the SharedArrayBuffer specification.
- - Fixed an issue where JS code minifiers might generate bad code for cwrap (#3945)
- - Updated compiler to issue a warning when --separate-asm is being used and output suffix is .js.
- - Added new build option -s ONLY_MY_CODE which aims to eliminate most of the Emscripten runtime and generate a very minimal compiler output.
- - Added new build option -s WASM_BACKEND=0/1 which controls whether to utilize the upstream LLVM wasm emitting codegen backend.
+ - Updated -s USE_PTHREADS code generation to reflect that the SharedInt*Array
+   hierarchy no longer exists in the SharedArrayBuffer spec.
+ - Removed references to Atomic.fence() which no longer is part of the
+   SharedArrayBuffer specification.
+ - Fixed an issue where JS code minifiers might generate bad code for cwrap
+   (#3945)
+ - Updated compiler to issue a warning when --separate-asm is being used and
+   output suffix is .js.
+ - Added new build option -s ONLY_MY_CODE which aims to eliminate most of the
+   Emscripten runtime and generate a very minimal compiler output.
+ - Added new build option -s WASM_BACKEND=0/1 which controls whether to utilize
+   the upstream LLVM wasm emitting codegen backend.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.12...1.35.13
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.35.12...1.35.13
@@ -657,7 +845,8 @@ v1.35.12: 11/28/2015
 --------------------
  - Update to latest upstream LLVM trunk as of November 28th.
  - Fix Emscripten to handle new style format outputted by llvm-nm.
- - Added new build option BINARYEN_METHOD to allow choosing which wasm generation method to use.
+ - Added new build option BINARYEN_METHOD to allow choosing which wasm
+   generation method to use.
  - Updates to Binaryen support.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.11...1.35.12
@@ -680,11 +869,15 @@ v1.35.10: 11/25/2015
  - Improved filesystem performance when building in multithreaded mode (#3923)
  - Improve error detection when data file fails to load.
  - Clarified that -s NO_DYNAMIC_EXECUTION=1 and -s RELOCATABLE=1 build modes are mutually exclusive.
- - Added new build option -s NO_DYNAMIC_EXECUTION=2 which demotes eval() errors to warnings at runtime, useful for iterating fixes in a codebase for multiple eval()s  (#3930)
+ - Added new build option -s NO_DYNAMIC_EXECUTION=2 which demotes eval() errors
+   to warnings at runtime, useful for iterating fixes in a codebase for multiple
+   eval()s  (#3930)
  - Added support to Module.locateFile(filename) to locate the pthread-main.js file (#3500)
- - Changed -s USE_PTHREADS=2 and -s PRECISE_F32=2 to imply --separate-asm instead of requiring it, to be backwards compatible (#3829, #3933)
+ - Changed -s USE_PTHREADS=2 and -s PRECISE_F32=2 to imply --separate-asm
+   instead of requiring it, to be backwards compatible (#3829, #3933)
  - Fixed bad codegen for some 64-bit atomics (#3892, #3936)
- - When emitting NaN canonicalization warning, also print the location in code where it occurs.
+ - When emitting NaN canonicalization warning, also print the location in code
+   where it occurs.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.9...1.35.10
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.35.9...1.35.10
@@ -706,7 +899,8 @@ v1.35.8: 11/10/2015
  - Removed obsoleted EXPORTED_GLOBALS build option.
  - Export filesystem as global object 'FS' in Emscripten runtime.
  - Fixed realpath() function on directories.
- - Fixed round() and roundf() to work when building without -s PRECISE_F32=1 and optimize these to be faster (#3876)
+ - Fixed round() and roundf() to work when building without -s PRECISE_F32=1 and
+   optimize these to be faster (#3876)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.7...1.35.8
     - Emscripten-LLVM: no changes.
@@ -722,7 +916,8 @@ v1.35.7: 11/4/2015
 
 v1.35.6: 11/4/2015
 ------------------
- - This tag was created for technical purposes, and has no changes compared to v1.35.6.
+ - This tag was created for technical purposes, and has no changes compared to
+   v1.35.6.
 
 v1.35.5: 11/4/2015
 ------------------
@@ -770,7 +965,8 @@ v1.35.2: 10/20/2015
 v1.35.1: 10/20/2015
 -------------------
  - Fixed a bug where passing -s option to LLVM would not work.
- - Work around a WebAudio bug on WebKit "pauseWebAudio failed: TypeError: Not enough arguments" (#3861)
+ - Work around a WebAudio bug on WebKit "pauseWebAudio failed: TypeError: Not
+   enough arguments" (#3861)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.35.0...1.35.1
     - Emscripten-LLVM: no changes.
@@ -786,14 +982,21 @@ v1.35.0: 10/19/2015
 
 v1.34.12: 10/13/2015
 --------------------
- - Added new experimental build option -s SPLIT_MEMORY=1, which splits up the Emscripten HEAP to multiple smaller slabs.
+ - Added new experimental build option -s SPLIT_MEMORY=1, which splits up the
+   Emscripten HEAP to multiple smaller slabs.
  - Added SDL2_ttf to Emscripten ports.
  - Added support for building GLES3 code to target WebGL 2. (#3757, #3782)
- - Fixed certain glUniform*() functions to work properly when called in conjunction with -s USE_PTHREADS=1.
- - Fixed support for -l, -L and -I command line parameters to accept a space between the path, i.e. "-l SDL". (#3777)
+ - Fixed certain glUniform*() functions to work properly when called in
+   conjunction with -s USE_PTHREADS=1.
+ - Fixed support for -l, -L and -I command line parameters to accept a space
+   between the path, i.e. "-l SDL". (#3777)
  - Fixed SSE2 support in optimized builds.
- - Changed the default behavior of warning when absolute paths are passed to -I to be silent. To enable the absolute paths warning, pass "-Wwarn-absolute-paths" flag to emcc.
- - Added new linker option -s ABORTING_MALLOC=0 that can be used to make malloc() return 0 on failed allocation (Current default is to abort execution of the page on OOM) (#3822)
+ - Changed the default behavior of warning when absolute paths are passed to -I
+   to be silent. To enable the absolute paths warning, pass
+   "-Wwarn-absolute-paths" flag to emcc.
+ - Added new linker option -s ABORTING_MALLOC=0 that can be used to make
+   malloc() return 0 on failed allocation (Current default is to abort execution
+   of the page on OOM) (#3822)
  - Removed the default behavior of automatically decoding all preloaded assets on page startup (#3785)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.34.11...1.34.12
@@ -829,8 +1032,10 @@ v1.34.9: 9/18/2015
 ------------------
  - Fixed an issue with --llvm-lto 3 builds (#3765)
  - Optimized LZ4 compression
- - Fixed a bug where glfwCreateWindow would return success even on failure (#3764)
- - Greatly optimized the -s SAFE_HEAP=1 linker flag option by executing the heap checks in asm.js side instead.
+ - Fixed a bug where glfwCreateWindow would return success even on failure
+   (#3764)
+ - Greatly optimized the -s SAFE_HEAP=1 linker flag option by executing the heap
+   checks in asm.js side instead.
  - Fixed the return value of EM_ASM_DOUBLE (#3770)
  - Implemented getsockname syscall (#3769)
  - Don't warn on unresolved symbols when LINKABLE is specified.
@@ -848,7 +1053,8 @@ v1.34.8: 9/9/2015
  - Update emrun to latest, which improves unit test run automation with emrun.
  - Added support for LZ4 compressing file packages, used with the -s LZ4=1 linker flag. (#3754)
  - Fixed noisy build warning on "unexpected number of arguments in call to strtold" (#3760)
- - Added new linker flag --separate-asm that splits the asm.js module and the handwritten JS functions to separate files.
+ - Added new linker flag --separate-asm that splits the asm.js module and the
+   handwritten JS functions to separate files.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.34.7...1.34.8
     - Emscripten-LLVM: no changes.
@@ -858,12 +1064,16 @@ v1.34.7: 9/5/2015
 -----------------
  - Fixed uses of i64* in side modules.
  - Improved GL support when proxying, and fake WebAudio calls when proxying.
- - Added new main loop timing mode EM_TIMING_SETIMMEDIATE for rendering with vsync disabled (#3717)
- - Updated emrun to latest version, adds --safe_firefox_profile option to run emrun pages in clean isolated environment.
+ - Added new main loop timing mode EM_TIMING_SETIMMEDIATE for rendering with
+   vsync disabled (#3717)
+ - Updated emrun to latest version, adds --safe_firefox_profile option to run
+   emrun pages in clean isolated environment.
  - Implemented glGetStringi() method for WebGL2/GLES3. (#3472, #3725)
  - Automatically emit loading code for EMTERPRETIFY_FILE if emitting html.
- - Added new build option -s USE_PTHREADS=2 for running pthreads-enabled pages in browsers that do not support SharedArrayBuffer.
- - Added support for building SSE2 intrinsics based code (emmintrin.h), when -msse2 is passed to the build.
+ - Added new build option -s USE_PTHREADS=2 for running pthreads-enabled pages
+   in browsers that do not support SharedArrayBuffer.
+ - Added support for building SSE2 intrinsics based code (emmintrin.h), when
+   -msse2 is passed to the build.
  - Added exports for getting FS objects by their name (#3690)
  - Updated LLVM to latest upstream PNaCl version (Clang 3.7, July 29th).
  - Full list of changes:
@@ -874,7 +1084,8 @@ v1.34.7: 9/5/2015
 v1.34.6: 8/20/2015
 ------------------
  - Added new build option -s EMULATED_FUNCTION_POINTERS=2.
- - Fixed a bug with calling functions pointers that take float as parameter across dynamic modules.
+ - Fixed a bug with calling functions pointers that take float as parameter
+   across dynamic modules.
  - Improved dynamic linking support with -s LINKABLE=1.
  - Added new build option -s MAIN_MODULE=2.
  - Cleaned up a few redundant linker warnings (#3702, #3704)
@@ -888,12 +1099,14 @@ v1.34.5: 8/18/2015
  - Added Bullet physics, ogg and vorbis to emscripten-ports.
  - Added FreeType 2.6 to emscripten-ports.
  - Fixed CMake handling when building OpenCV.
- - Fixed and issue with exceptions being thrown in empty glBegin()-glEnd() blocks (#3693)
+ - Fixed and issue with exceptions being thrown in empty glBegin()-glEnd()
+   blocks (#3693)
  - Improved function pointer handling between dynamically linked modules
  - Fixed some OpenAL alGetSource get calls (#3669)
  - Fixed issues with building the optimizer on 32-bit Windows (#3673)
  - Increased optimizer stack size on Windows to 10MB (#3679)
- - Added support for passing multiple input files to opt, to speed up optimization and linking in opt.  
+ - Added support for passing multiple input files to opt, to speed up
+   optimization and linking in opt.  
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.34.4...1.34.5
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.34.4...1.34.5
@@ -903,7 +1116,8 @@ v1.34.4: 8/4/2015
 -----------------
  - Add special handling support for /dev/null as an input file (#3552)
  - Added basic printf support in NO_FILESYSTEM mode (#3627)
- - Update WebVR support to the latest specification, and add support for retrieving device names
+ - Update WebVR support to the latest specification, and add support for
+   retrieving device names
  - Improved --proxy-to-worker build mode with proxying (#3568, #3623)
  - Generalized EXPORT_FS_METHODS to EXPORT_RUNTIME_METHODS
  - Added node externs for closure
@@ -935,7 +1149,9 @@ v1.34.2: 7/14/2015
  - Fixed an issue with WebRTC support (#3574)
  - Fixed emcc to return a correct error process exit code when invoked with no input files
  - Fixed a compiler problem where global data might not get aligned correctly for SIMD.
- - Fixed a LLVM backend problem which caused recursive stack behavior when linking large codebases, which was seen to cause a stack overflow crash on Windows.
+ - Fixed a LLVM backend problem which caused recursive stack behavior when
+   linking large codebases, which was seen to cause a stack overflow crash on
+   Windows.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.34.1...1.34.2
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.34.1...1.34.2
@@ -952,11 +1168,13 @@ v1.34.1: 6/18/2015
 
 v1.34.0: 6/16/2015
 ------------------
- - Fixed an issue when generating .a files from object files that reside on separate drives on Windows (#3525).
+ - Fixed an issue when generating .a files from object files that reside on
+   separate drives on Windows (#3525).
  - Added a missing dependency for GLFW (#3530).
  - Removed the Emterpreter YIELDLIST option.
  - Added support for enabling memory growth before the runtime is ready.
- - Added a new feature to store the memory initializer in a string literal inside the generated .js file.
+ - Added a new feature to store the memory initializer in a string literal
+   inside the generated .js file.
  - Fixed a code miscompilation issue with a constexpr in fcmp.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.33.2...1.34.0
@@ -975,7 +1193,8 @@ v1.33.2: 6/9/2015
 
 v1.33.1: 6/3/2015
 -----------------
- - Added support for multithreading with the POSIX threads API (pthreads), used when compiling and linking with the -s USE_PTHREADS=1 flag (#3266).
+ - Added support for multithreading with the POSIX threads API (pthreads), used
+   when compiling and linking with the -s USE_PTHREADS=1 flag (#3266).
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.33.0...1.33.1
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.33.0...1.33.1
@@ -984,8 +1203,10 @@ v1.33.1: 6/3/2015
 v1.33.0: 5/29/2015
 ------------------
  - Fix an issue with writing to /dev/null (#3454).
- - Added a hash to objects inside .a files to support to linking duplicate symbol names inside .a files (#2142).
- - Provide extensions ANGLE_instanced_arrays and EXT_draw_buffers as aliases to the WebGL ones.
+ - Added a hash to objects inside .a files to support to linking duplicate
+   symbol names inside .a files (#2142).
+ - Provide extensions ANGLE_instanced_arrays and EXT_draw_buffers as aliases to
+   the WebGL ones.
  - Fixed LLVM/Clang to build again on Windows after previous LLVM upgrade.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.32.4...1.33.0
@@ -1015,7 +1236,9 @@ v1.32.3: 5/15/2015
 
 v1.32.2: 5/8/2015
 -----------------
- - Removed a (name+num)+num -> name+newnum optimization, which caused heavy performance regressions in Firefox when the intermediate computation wraps around the address space (#3438).
+ - Removed a (name+num)+num -> name+newnum optimization, which caused heavy
+   performance regressions in Firefox when the intermediate computation wraps
+   around the address space (#3438).
  - Improved dynamic linking support.
  - Improved emterpreter when doing dynamic linking.
  - Fixed an issue with source maps debug info containing zeroes as line numbers.
@@ -1026,7 +1249,9 @@ v1.32.2: 5/8/2015
 
 v1.32.1: 5/2/2015
 -----------------
- - Removed old deprecated options -s INIT_HEAP, MICRO_OPTS, CLOSURE_ANNOTATIONS, INLINE_LIBRARY_FUNCS, SHOW_LABELS, COMPILER_ASSERTIONS and COMPILER_FASTPATHS.
+ - Removed old deprecated options -s INIT_HEAP, MICRO_OPTS, CLOSURE_ANNOTATIONS,
+   INLINE_LIBRARY_FUNCS, SHOW_LABELS, COMPILER_ASSERTIONS and
+   COMPILER_FASTPATHS.
  - Added support for dynamic linking and dlopen().
  - Fixed a compilation issue that affected -O2 builds and higher (#3430).
  - Full list of changes:
@@ -1037,7 +1262,11 @@ v1.32.1: 5/2/2015
 v1.32.0: 4/28/2015
 ------------------
  - Compile .i files properly as C and not C++ (#3365).
- - Removed old deprecated options -s PRECISE_I32_MUL, CORRECT_ROUNDINGS, CORRECT_OVERFLOWS, CORRECT_SIGNS, CHECK_HEAP_ALIGN, SAFE_HEAP_LINES, SAFE_HEAP >= 2, ASM_HEAP_LOG, SAFE_DYNCALLS, LABEL_DEBUG, RUNTIME_TYPE_INFO and EXECUTION_TIMEOUT, since these don't apply to fastcomp, which is now the only enabled compilation mode.
+ - Removed old deprecated options -s PRECISE_I32_MUL, CORRECT_ROUNDINGS,
+   CORRECT_OVERFLOWS, CORRECT_SIGNS, CHECK_HEAP_ALIGN, SAFE_HEAP_LINES,
+   SAFE_HEAP >= 2, ASM_HEAP_LOG, SAFE_DYNCALLS, LABEL_DEBUG, RUNTIME_TYPE_INFO
+   and EXECUTION_TIMEOUT, since these don't apply to fastcomp, which is now the
+   only enabled compilation mode.
  - Preliminary work towards supporting dynamic linking and dlopen().
  - Fixed an issue where emrun stripped some characters at output (#3394).
  - Fixed alignment issues with varargs.
@@ -1049,8 +1278,10 @@ v1.32.0: 4/28/2015
 v1.31.3: 4/22/2015
 ------------------
  - Improved support for -E command line option (#3365).
- - Removed the old optimizeShifts optimization pass that was not valid for asm.js code.
- - Fixed an issue when simultaneously using EMULATE_FUNCTION_POINTER_CASTS and EMULATED_FUNCTION_POINTERS.
+ - Removed the old optimizeShifts optimization pass that was not valid for
+   asm.js code.
+ - Fixed an issue when simultaneously using EMULATE_FUNCTION_POINTER_CASTS and
+   EMULATED_FUNCTION_POINTERS.
  - Fixed an issue with -s PRECISE_I64_MATH=2 not working (#3374).
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.31.2...1.31.3
@@ -1089,14 +1320,19 @@ v1.31.0: 4/14/2015
 v1.30.6: 4/14/2015
 ------------------
  - Removed support for the deprecated jcache functionality (#3313).
- - Added support to emscripten_GetProcAddress() to fetch symbols with the ANGLE suffix (#3304, #3315).
+ - Added support to emscripten_GetProcAddress() to fetch symbols with the ANGLE
+   suffix (#3304, #3315).
  - Added immintrin.h header file to include all SSE support.
  - Added an async option to ccall (#3307).
  - Stopped from using 0 as a valid source ID for OpenAL (#3303).
- - When project has disabled exception catching, build an exceptions-disabled version of libcxx.
- - Split libcxx into two parts to optimize code size for projects that only need small amount of libcxx (#2545, #3308).
- - Avoid fprintf usage in emscripten_GetProcAddress() to allow using it with -s NO_FILESYSTEM=1 (#3327).
- - Removed old deprecated functionalities USE_TYPED_ARRAYS, FHEAP, GC emulation and non-asmjs-emscripten ABI.
+ - When project has disabled exception catching, build an exceptions-disabled
+   version of libcxx.
+ - Split libcxx into two parts to optimize code size for projects that only need
+   small amount of libcxx (#2545, #3308).
+ - Avoid fprintf usage in emscripten_GetProcAddress() to allow using it with -s
+   NO_FILESYSTEM=1 (#3327).
+ - Removed old deprecated functionalities USE_TYPED_ARRAYS, FHEAP, GC emulation
+   and non-asmjs-emscripten ABI.
  - Don't refer to prefixed GL extensions when creating a GL context (#3324).
  - Removed support code for x86_fp80 type (#3341).
  - Optimize EM_ASM() calls even more (#2596).
@@ -1107,11 +1343,15 @@ v1.30.6: 4/14/2015
 
 v1.30.5: 4/7/2015
 -----------------
- - Fixed WebIDL operation when closure is enabled after the previous EM_ASM() optimizations.
- - Optimized jsCall() to handle variadic cases of number of arguments faster (#3290, #3305).
+ - Fixed WebIDL operation when closure is enabled after the previous EM_ASM()
+   optimizations.
+ - Optimized jsCall() to handle variadic cases of number of arguments faster
+   (#3290, #3305).
  - Removed support for the getwd() function (#1115, #3309).
- - Fixed a problem with -s IGNORED_FUNCTIONS and -s DEAD_FUNCTIONS not working as expected (#3239).
- - Fixed an issue with -s EMTERPRETIFY_ASYNC=1 and emscripten_sleep() not working (#3307).
+ - Fixed a problem with -s IGNORED_FUNCTIONS and -s DEAD_FUNCTIONS not working
+   as expected (#3239).
+ - Fixed an issue with -s EMTERPRETIFY_ASYNC=1 and emscripten_sleep() not
+   working (#3307).
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.30.4...1.30.5
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.30.4...1.30.5
@@ -1119,7 +1359,8 @@ v1.30.5: 4/7/2015
 
 v1.30.4: 4/3/2015
 -----------------
- - Optimized the performance and security of EM_ASM() blocks by avoiding the use of eval() (#2596).
+ - Optimized the performance and security of EM_ASM() blocks by avoiding the use
+   of eval() (#2596).
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.30.3...1.30.4
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.30.3...1.30.4
@@ -1129,7 +1370,8 @@ v1.30.3: 4/3/2015
 -----------------
  - Improved error handling in library_idbstore.js.
  - Fixed an asm.js validation issue with EMULATE_FUNCTION_POINTER_CASTS=1 feature (#3300).
- - Fixed Clang build by adding missing nacltransforms project after latest LLVM/Clang upstream merge.
+ - Fixed Clang build by adding missing nacltransforms project after latest
+   LLVM/Clang upstream merge.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.30.2...1.30.3
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.30.2...1.30.3
@@ -1139,7 +1381,8 @@ v1.30.2: 4/1/2015
 -----------------
  - Added support to writing to mmap()ed memory by implementing msync() (#3269).
  - Updated SDL2 port to version 7.
- - Exported new singleton function Module.createContext() for creating a GL context from SDL2.
+ - Exported new singleton function Module.createContext() for creating a GL
+   context from SDL2.
  - Added support for asm.js/Emscripten arch in Clang.
  - Finished LLVM 3.6 upgrade merge.
  - Full list of changes:
@@ -1158,15 +1401,22 @@ v1.30.1: 3/24/2015
 v1.30.0: 3/24/2015
 ------------------
  - Fixed a bug where html5.h API would not remove event handlers on request.
- - Fixed a regression issue that broke building on Windows when attempting to invoke tools/gen_struct_info.py.
- - Improved memory growth feature to better handle growing to large memory sizes between 1GB and 2GB (#3253).
- - Fixed issues with emrun with terminating target browser process, managing lingering sockets and command line quote handling.
- - Fixed a bug where unsigned integer return values in embind could be returned as signed (#3249).
+ - Fixed a regression issue that broke building on Windows when attempting to
+   invoke tools/gen_struct_info.py.
+ - Improved memory growth feature to better handle growing to large memory sizes
+   between 1GB and 2GB (#3253).
+ - Fixed issues with emrun with terminating target browser process, managing
+   lingering sockets and command line quote handling.
+ - Fixed a bug where unsigned integer return values in embind could be returned
+   as signed (#3249).
  - Improved handling of lost GL contexts.
- - Changed malloc to be fallible (return null on failure) when memory growth is enabled (#3253).
+ - Changed malloc to be fallible (return null on failure) when memory growth is
+   enabled (#3253).
  - Fixed a bug with WebIDL not being able to handle enums (#3258).
- - Updated POINTER_MASKING feature to behave as a boolean rather than a mask (#3240).
- - Improved "emcmake cmake" on Windows to automatically remove from path any entries that contain sh.exe in them, which is not supported by CMake.
+ - Updated POINTER_MASKING feature to behave as a boolean rather than a mask
+   (#3240).
+ - Improved "emcmake cmake" on Windows to automatically remove from path any
+   entries that contain sh.exe in them, which is not supported by CMake.
  - Fixed an issue with symlink handling in readlink (#3277).
  - Updated SDL2 port to version 6.
  - Removed the obsolete FAST_MEMORY build option.
@@ -1189,11 +1439,14 @@ v1.29.12: 3/15/2015
 
 v1.29.11: 3/11/2015
 -------------------
- - Remove the requirement to pass -s PRECISE_F32=1 manually when building with SIMD support.
- - Fix a temp directory leak that could leave behind empty directories in the temp directory after build (#706)
+ - Remove the requirement to pass -s PRECISE_F32=1 manually when building with
+   SIMD support.
+ - Fix a temp directory leak that could leave behind empty directories in the
+   temp directory after build (#706)
  - Improve support for growable Emscripten heap in asm.js mode.
  - Added a warning message when generating huge asset bundles with file packager.
- - Fixed a bug where emscripten_get_gamepad_status might throw a JS exception if called after a gamepad was disconnected.
+ - Fixed a bug where emscripten_get_gamepad_status might throw a JS exception if
+   called after a gamepad was disconnected.
  - Improve emterpreter sleep support.
  - Optimize code generation when multiple consecutive bitshifts are present.
  - Optimize redundant stack save and restores, and memcpy/memsets.
@@ -1204,17 +1457,21 @@ v1.29.11: 3/11/2015
 
 v1.29.10: 2/19/2015
 -------------------
- - Add a warning message when generating code that has a very large number of variables, which optimization flags could remove.
+ - Add a warning message when generating code that has a very large number of
+   variables, which optimization flags could remove.
  - Improve support for SIMD casts and special loads.
  - Fix the process return code when using EMCONFIGURE_JS=1.
  - Improved the error message in abort().
  - Fix main loop handling during emterpreter sync save/load.
- - Handle emscripten_async_call and friends during sleep, by pausing all safeSet*() operations.
+ - Handle emscripten_async_call and friends during sleep, by pausing all
+   safeSet*() operations.
  - Add support for Google WTF when building with --tracing.
  - Improve emterpreter stability with fuzzing.
  - Add an option to load the memory initializer file from a typed array (#3187)
- - Remove linker warning message when linking to -lm, since Emscripten includes musl that implements the math libraries built-in.
- - Add support for SDL_WM_SetCaption(), which calls to Module['setWindowTitle'], or if not present, sets the web page title. (#3192)
+ - Remove linker warning message when linking to -lm, since Emscripten includes
+   musl that implements the math libraries built-in.
+ - Add support for SDL_WM_SetCaption(), which calls to Module['setWindowTitle'],
+   or if not present, sets the web page title. (#3192)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.29.9...1.29.10
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.29.9...1.29.10
@@ -1223,9 +1480,13 @@ v1.29.10: 2/19/2015
 v1.29.9: 2/9/2015
 -------------------
  - Documented FORCE_ALIGNED_MEMORY to be no longer supported.
- - Fixes issues with native optimizer handling of "if () else {}" statements. (#3129)
- - Improved cross-browser support for EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST. (#3165)
- - Added new linker option --profiling-funcs, which generates output that is otherwise minified, except that function names are kept intact, for use in profilers and getting descriptive call stacks.
+ - Fixes issues with native optimizer handling of "if () else {}" statements.
+   (#3129)
+ - Improved cross-browser support for EMSCRIPTEN_FULLSCREEN_FILTERING_NEAREST.
+   (#3165)
+ - Added new linker option --profiling-funcs, which generates output that is
+   otherwise minified, except that function names are kept intact, for use in
+   profilers and getting descriptive call stacks.
  - The Module object is no longer written in global scope. (#3167)
  - Added new emscripten_idb_* API. (#3169)
  - Added new function emscripten_wget_data().
@@ -1241,7 +1502,8 @@ v1.29.8: 1/31/2015
  - Fix a temp file leak with emterpreter. (#3156)
  - Fix a typo that broke glBlitFramebuffer. (#3159)
  - Added scandir() and alphasort() from musl. (#3161)
- - Add a warning if multiple .a files with same basename are being linked together. (#2619)
+ - Add a warning if multiple .a files with same basename are being linked
+   together. (#2619)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.29.7...1.29.8
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.29.7...1.29.8
@@ -1251,8 +1513,10 @@ v1.29.7: 1/28/2015
 -------------------
  - Fixed an issue with backwards compatibility in emscripten-ports. (#3144)
  - Warn on duplicate entries in archives. (#2619)
- - Removed the MAX_SETJMPS limitation to improve setjmp/longjpmp support. (#3151)
- - Improve the native optimizer to not emit empty if clauses in some cases. (#3154)
+ - Removed the MAX_SETJMPS limitation to improve setjmp/longjpmp support.
+   (#3151)
+ - Improve the native optimizer to not emit empty if clauses in some cases.
+   (#3154)
  - Optimize Math.clz32, Math.min, NaN, and inf handling in asm.js.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.29.6...1.29.7
@@ -1261,7 +1525,8 @@ v1.29.7: 1/28/2015
 
 v1.29.6: 1/23/2015
 -------------------
- - Fixed an issue where calling glGen*() when the GL context was lost might throw a JS exception, instead a GL_INVALID_OPERATION is now recorded.
+ - Fixed an issue where calling glGen*() when the GL context was lost might
+   throw a JS exception, instead a GL_INVALID_OPERATION is now recorded.
  - Improve label handling in native optimizer.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.29.5...1.29.6
@@ -1271,11 +1536,17 @@ v1.29.6: 1/23/2015
 v1.29.5: 1/23/2015
 -------------------
  - Enable compiling source files with the extension ".c++".
- - Enable versioning of the emscripten ports so that older Emscripten versions can keep using older versions of the ports (#3144)
- - Added a whitelist option to emterpreter, a linker flag of form -s EMTERPRETIFY_WHITELIST=["symbol1","symbol2"]. (#3129)
- - Improved emscripten_get_pointerlock_status() to always fill the output structure even when pointer lock is not supported.
- - Added an environment variable EMCC_NO_OPT_SORT=0/1 option to configure whether the generated output should have the functions sorted by length, useful for debugging.
- - Added new tool tools/merge_pair.py which allows bisecting differences between two output files to find discrepancies.
+ - Enable versioning of the emscripten ports so that older Emscripten versions
+   can keep using older versions of the ports (#3144)
+ - Added a whitelist option to emterpreter, a linker flag of form -s
+   EMTERPRETIFY_WHITELIST=["symbol1","symbol2"]. (#3129)
+ - Improved emscripten_get_pointerlock_status() to always fill the output
+   structure even when pointer lock is not supported.
+ - Added an environment variable EMCC_NO_OPT_SORT=0/1 option to configure
+   whether the generated output should have the functions sorted by length,
+   useful for debugging.
+ - Added new tool tools/merge_pair.py which allows bisecting differences between
+   two output files to find discrepancies.
  - Improved parsing in cashew.
  - Improved output message from emconfigure and emmake when inputs are unexpected.
  - Added built-in asm handler for LLVM fabs operation.
@@ -1286,10 +1557,15 @@ v1.29.5: 1/23/2015
 
 v1.29.4: 1/21/2015
 -------------------
- - Added new C <-> JS string marshalling functions asciiToString(), stringToAscii(), UTF8ToString(), stringToUTF8() that can be used to copy strings across the JS and C boundaries. (#2363)
- - Added new functions lengthBytesUTF8(), lengthBytesUTF16() and lengthBytesUTF32() to allow computing the byte lengths of strings in different encodings. (#2363)
+ - Added new C <-> JS string marshalling functions asciiToString(),
+   stringToAscii(), UTF8ToString(), stringToUTF8() that can be used to copy
+   strings across the JS and C boundaries. (#2363)
+ - Added new functions lengthBytesUTF8(), lengthBytesUTF16() and
+   lengthBytesUTF32() to allow computing the byte lengths of strings in
+   different encodings. (#2363)
  - Upgraded SDL2 port to version 4.
- - Add support for saving the emterpreter stack when there are functions returning a value on the stack (#3129)
+ - Add support for saving the emterpreter stack when there are functions
+   returning a value on the stack (#3129)
  - Notice async state in emterpreter trampolines (#3129)
  - Optimize SDL1 pixel copying to the screen.
  - Fixed an issue with emterpreter parsing. (#3141)
@@ -1311,9 +1587,12 @@ v1.29.3: 1/16/2015
 v1.29.2: 1/16/2015
 -------------------
  - Fixed an issue with embind compilation in LLVM 3.5.
- - Fixed an issue with SDL audio queueing stability, which would queue audio too eagerly and cause stutter in some applications (#3122, #3124)
- - Enabled native JS optimizer to be built automatically on Windows, requires VS2012 or VS2013. 
- - Improve error message to reflect the fact that DLOPEN_SUPPORT is currently not available (#2365)
+ - Fixed an issue with SDL audio queueing stability, which would queue audio too
+   eagerly and cause stutter in some applications (#3122, #3124)
+ - Enabled native JS optimizer to be built automatically on Windows, requires
+   VS2012 or VS2013. 
+ - Improve error message to reflect the fact that DLOPEN_SUPPORT is currently
+   not available (#2365)
  - Improve SIMD load and store support.
  - Upgraded SDL2 port to version 3.
  - Fix a bug with native JS optimizer and braces in nested ifs.
@@ -1343,7 +1622,8 @@ v1.28.3: 1/4/2015
 -------------------
  - embuilder.py tool
  - Many fixes for native optimizer on Windows
- - Perform LLVM LTO in a separate invocation of opt, so that it does not mix with legalization and other stuff we do at link time
+ - Perform LLVM LTO in a separate invocation of opt, so that it does not mix
+   with legalization and other stuff we do at link time
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.28.2...1.28.3
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.28.2...1.28.3
@@ -1396,11 +1676,13 @@ v1.27.1: 11/20/2014
 
 v1.27.0: 11/20/2014
 -------------------
- - Added new work in progress option -s NATIVE_OPTIMIZER=1 that migrates optimizer code from JS to C++ for better performance.
+ - Added new work in progress option -s NATIVE_OPTIMIZER=1 that migrates
+   optimizer code from JS to C++ for better performance.
  - Fixed an embind issue when compiling with closure (#2974)
  - Fixed an embind issue with unique_ptr (#2979)
  - Fixed a bug with new GL context initialization in proxy to worker mode.
- - Fixed an issue where GL context event handlers would leak after a GL context has been freed.
+ - Fixed an issue where GL context event handlers would leak after a GL context
+   has been freed.
  - Optimized embind operation in Chrome by avoiding using Function.prototype.bind().
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.26.1...1.27.0
@@ -1416,7 +1698,8 @@ v1.26.1: 11/7/2014
  - Fixed issues with llseek (#2945)
  - Enable using emscripten_get_now() in web workers (#2953)
  - Added stricter input data validation in GL code.
- - Added new HTML5 C API for managing fullscreen mode transitions to resolve cross-browser issue #2556 (#2975)
+ - Added new HTML5 C API for managing fullscreen mode transitions to resolve
+   cross-browser issue #2556 (#2975)
  - Fixed an issue with using structs in va_args (#2923)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.26.0...1.26.1
@@ -1426,12 +1709,17 @@ v1.26.1: 11/7/2014
 v1.26.0: 10/29/2014
 -------------------
  - Fixed an issue where emar would forward --em-config to llvm-ar (#2886)
- - Added a new "emterpreter" feature that allows running Emscripten compiled code in interpreted form until asm.js compilation is ready (-s EMTERPRETIFY=1).
-    - For more information, see https://groups.google.com/d/msg/emscripten-discuss/vhaPL9kULxk/_eD2G06eucwJ
- - Added new "Emscripten Ports" architecture that enables building SDL2 with -s USE_SDL=2 command line flag.
+ - Added a new "emterpreter" feature that allows running Emscripten compiled
+   code in interpreted form until asm.js compilation is ready (-s
+   EMTERPRETIFY=1).
+    - For more information, see
+      https://groups.google.com/d/msg/emscripten-discuss/vhaPL9kULxk/_eD2G06eucwJ
+ - Added new "Emscripten Ports" architecture that enables building SDL2 with -s
+   USE_SDL=2 command line flag.
  - Added support for SDL 1.2 SDL_CreateRGBSurfaceFrom() function.
  - Improved experimental SIMD support.
- - Use only minimum necessary digits to print floating point literals in generated JS code for smaller code output.
+ - Use only minimum necessary digits to print floating point literals in
+   generated JS code for smaller code output.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.25.2...1.26.0
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.25.2...1.26.0
@@ -1442,21 +1730,31 @@ v1.25.2: 10/16/2014
  - Fixed a bug in tmpfile() function not allocating the mode argument correctly.
  - Fixed a bug with handling empty files in IDBFS (#2845)
  - Added an implementation of the utimes() function (#2845)
- - Added experimental WebGL 2.0 support with the linker flag -s USE_WEBGL2=1. (#2873)
+ - Added experimental WebGL 2.0 support with the linker flag -s USE_WEBGL2=1.
+   (#2873)
  - Fixed a UnboundTypeError occurring in embind (#2875)
- - Fixed an error "IndexSizeError: Index or size is negative or greater than the allowed amount" being thrown by Emscripten SDL 1.2 surface blit code. (#2879)
+ - Fixed an error "IndexSizeError: Index or size is negative or greater than the
+   allowed amount" being thrown by Emscripten SDL 1.2 surface blit code. (#2879)
  - Fixed a JS minifier issue that generated "x--y from x - -y" (#2869)
- - Added a new emcc command line flag "--cache <dir>" to control the location of the Emscripten cache directory (#2816)
- - Implemented SDL_ConvertSurface() and added support for SDL_SRCALPHA in SDL_SetAlpha (#2871)
+ - Added a new emcc command line flag "--cache <dir>" to control the location of
+   the Emscripten cache directory (#2816)
+ - Implemented SDL_ConvertSurface() and added support for SDL_SRCALPHA in
+   SDL_SetAlpha (#2871)
  - Fixed issues with the GL library handling of invalid input values.
  - Optimized SDL copyIndexedColorData function (#2890)
- - Implemented GLES3 emulation for glMapBufferRange() for upcoming WebGL 2 support, using the -s FULL_ES3=1 linker option.
- - Fixed a bug where setting up and cancelling the main loop multiple times would stack up the main loop to be called too frequently (#2839)
- - Introduced a new API emscripten_set_main_loop_timing() for managing the Emscripten main loop calling frequency (#2839)
- - Added new optimization flags SDL.discardOnLock and SDL.opaqueFrontBuffer to Emscripten SDL 1.2 SDL_LockSurface() and SDL_UnlockSurface() (#2870)
+ - Implemented GLES3 emulation for glMapBufferRange() for upcoming WebGL 2
+   support, using the -s FULL_ES3=1 linker option.
+ - Fixed a bug where setting up and cancelling the main loop multiple times
+   would stack up the main loop to be called too frequently (#2839)
+ - Introduced a new API emscripten_set_main_loop_timing() for managing the
+   Emscripten main loop calling frequency (#2839)
+ - Added new optimization flags SDL.discardOnLock and SDL.opaqueFrontBuffer to
+   Emscripten SDL 1.2 SDL_LockSurface() and SDL_UnlockSurface() (#2870)
  - Fixed a bug with glfwGetProcAddress().
- - Added option to customize GLOBAL_BASE (the starting address of global variables in the Emscripten HEAP).
- - Added the ability to register mouseover and mouseout events from the HTML5 API.
+ - Added option to customize GLOBAL_BASE (the starting address of global
+   variables in the Emscripten HEAP).
+ - Added the ability to register mouseover and mouseout events from the HTML5
+   API.
  - Improved experimental SIMD support.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.25.1...1.25.2
@@ -1467,7 +1765,8 @@ v1.25.1: 10/1/2014
 ------------------
  - Updated heap resize support code when -s ALLOW_MEMORY_GROWTH=1 is defined.
  - Updated libc++ to new version from upstream svn revision 218372, 2014-09-24.
- - Fixed a bug where building on Windows might generate output JS files with incorrect syntax (emscripten-fastcomp #52)
+ - Fixed a bug where building on Windows might generate output JS files with
+   incorrect syntax (emscripten-fastcomp #52)
  - Improved experimental SIMD support.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.25.0...1.25.1
@@ -1486,15 +1785,25 @@ v1.25.0: 9/30/2014
 v1.24.1: 9/27/2014
 ------------------
  - Fixed issues with the tmpnam and tmpfile functions (#2797, 2798)
- - Fixed CMake package find code to not search any system directories, because Emscripten is a cross-compiler.
+ - Fixed CMake package find code to not search any system directories, because
+   Emscripten is a cross-compiler.
  - Improved support for the proposed solution for heap resizing.
- - Fixed an issue where one could not run a main loop without having first a GL context created when -s FULL_ES2 or -s LEGACY_GL_EMULATION were set.
- - For compatibility, Emscripten will no longer warn about missing library files for -lGL, -lGLU and -lglut libraries, since Emscripten provides the implementation for these without having to explicitly link to anything.
- - Added support for readonly (const) attributes and automatically call Pointer_stringify on DOMStrings in WebIDL.
+ - Fixed an issue where one could not run a main loop without having first a GL
+   context created when -s FULL_ES2 or -s LEGACY_GL_EMULATION were set.
+ - For compatibility, Emscripten will no longer warn about missing library files
+   for -lGL, -lGLU and -lglut libraries, since Emscripten provides the
+   implementation for these without having to explicitly link to anything.
+ - Added support for readonly (const) attributes and automatically call
+   Pointer_stringify on DOMStrings in WebIDL.
  - Improved SIMD support for the experimental Ecmascript SIMD spec.
  - Added support for GLFW 3.0.
- - Added new Emscripten HTML 5 functions emscripten_set_mouseenter_callback() and emscripten_set_mouseleave_callback().
- - Emscripten now recognizes an environment variable EMCC_JSOPT_BLACKLIST=a,b,c,d which can be used to force-disable Emscripten to skip running specific JS optimization passes. This is intended as a debugging aid to help zoom in on JS optimizer bugs when compiling with -O1 and greater. (#2819)
+ - Added new Emscripten HTML 5 functions emscripten_set_mouseenter_callback()
+   and emscripten_set_mouseleave_callback().
+ - Emscripten now recognizes an environment variable
+   EMCC_JSOPT_BLACKLIST=a,b,c,d which can be used to force-disable Emscripten to
+   skip running specific JS optimization passes. This is intended as a debugging
+   aid to help zoom in on JS optimizer bugs when compiling with -O1 and greater.
+   (#2819)
  - Fixed a bug where Module['TOTAL_STACK'] was ignored (#2837).
  - Improved SIMD support for the experimental Ecmascript SIMD spec. Preliminary asm.js validation.
  - Full list of changes:
@@ -1504,7 +1813,8 @@ v1.24.1: 9/27/2014
 
 v1.24.0: 9/16/2014
 ------------------
- - Renamed the earlier Module.locateFilePackage() to Module.locateFile() added in v1.22.2 to better reflect its extended usage.
+ - Renamed the earlier Module.locateFilePackage() to Module.locateFile() added
+   in v1.22.2 to better reflect its extended usage.
  - Improved exceptions support with exception_ptr.
  - Fixed a bug where restoring files from IDBFS would not preserve their file modes.
  - Fixed and issue where one could not pass a null pointer to strftime() function.
@@ -1516,12 +1826,20 @@ v1.24.0: 9/16/2014
 
 v1.23.5: 9/12/2014
 ------------------
- - Added new functions emscripten_get_device_pixel_ratio(), emscripten_set_canvas_css_size() and emscripten_get_canvas_css_size() which allow handling High DPI options from C code.
- - Fixed bugs with timzone-related functions in the JS-implemented C standard library.
- - Implemented clock_gettime(CLOCK_MONOTONIC) and added a new function emscripten_get_now_is_monotonic() to query whether the JS-provided timer is monotonic or not.
- - Fixed an issue where the user could not pass --llvm-opts=xxx when also specifying --llvm-lto=2.
- - Renamed the linker option -profiling to --profiling for consistency. The old form is still supported.
- - Formalized the set of valid characters to be used in files passed to the file_packager.py (#2765).
+ - Added new functions emscripten_get_device_pixel_ratio(),
+   emscripten_set_canvas_css_size() and emscripten_get_canvas_css_size() which
+   allow handling High DPI options from C code.
+ - Fixed bugs with timzone-related functions in the JS-implemented C standard
+   library.
+ - Implemented clock_gettime(CLOCK_MONOTONIC) and added a new function
+   emscripten_get_now_is_monotonic() to query whether the JS-provided timer is
+   monotonic or not.
+ - Fixed an issue where the user could not pass --llvm-opts=xxx when also
+   specifying --llvm-lto=2.
+ - Renamed the linker option -profiling to --profiling for consistency. The old
+   form is still supported.
+ - Formalized the set of valid characters to be used in files passed to the
+   file_packager.py (#2765).
  - Implemented SDL function SDL_BlitScaled.
  - Fixed a bug with right modifier keys in SDL.
  - Full list of changes:
@@ -1531,7 +1849,8 @@ v1.23.5: 9/12/2014
 
 v1.23.4: 9/7/2014
 ------------------
- - Implemented new targetX and targetY fields for native HTML5 mouse and touch events (#2751)
+ - Implemented new targetX and targetY fields for native HTML5 mouse and touch
+   events (#2751)
  - Improved SIMD support for the experimental Ecmascript SIMD spec.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.23.3...1.23.4
@@ -1541,12 +1860,18 @@ v1.23.4: 9/7/2014
 v1.23.3: 9/7/2014
 ------------------
  - Removed the scons-tools SCons build system as unused.
- - Fixed an issue where applications could not handle WebGL context creation failures gracefully.
- - Fixed a bug where the stringToC function in ccall/cwrap might not allocate enough space to hold unicode strings.
- - Removed CMake from attempting to link to library -ldl when building projects, by unsetting CMAKE_DL_LIBS.
- - Fixed a bug where write_sockaddr might return undefined data in its output structure.
- - Added a new _experimental_ -s POINTER_MASKING=1 linker option that might help JS VMs to optimize asm.js code.
- - Added first version of a memory tracing API to profile memory usage in Emscripten applications.
+ - Fixed an issue where applications could not handle WebGL context creation
+   failures gracefully.
+ - Fixed a bug where the stringToC function in ccall/cwrap might not allocate
+   enough space to hold unicode strings.
+ - Removed CMake from attempting to link to library -ldl when building projects,
+   by unsetting CMAKE_DL_LIBS.
+ - Fixed a bug where write_sockaddr might return undefined data in its output
+   structure.
+ - Added a new _experimental_ -s POINTER_MASKING=1 linker option that might help
+   JS VMs to optimize asm.js code.
+ - Added first version of a memory tracing API to profile memory usage in
+   Emscripten applications.
  - Added functions glob and globfree from musl regex library.
  - Improved SIMD support for the experimental Ecmascript SIMD spec.
  - Full list of changes:
@@ -1556,17 +1881,27 @@ v1.23.3: 9/7/2014
 
 v1.23.2: 9/2/2014
 ------------------
- - Adjusted the process and group ids reported by the stub library functions to be closer to native unix values.
+ - Adjusted the process and group ids reported by the stub library functions to
+   be closer to native unix values.
  - Set stack to be aligned to 16 bytes. (#2721)
- - Fixed a compiler error "unresolved symbol: __cxa_decrement_exception_refcount" (#2715)
- - Added a new warning message that instructs that building .so, .dll and .dylib files is not actually supported, and is faked for compatibility reasons for existing build chains. (#2562)
+ - Fixed a compiler error "unresolved symbol:
+   __cxa_decrement_exception_refcount" (#2715)
+ - Added a new warning message that instructs that building .so, .dll and .dylib
+   files is not actually supported, and is faked for compatibility reasons for
+   existing build chains. (#2562)
  - Fixed problems with SDL mouse scrolling (#2643)
  - Implemented OpenAL function alSourceRewind.
- - Removed several old header files from the Emscripten repository that had been included for emulation purposes (zlib.h, png.h, tiff.h, tiffio.h), but their implementation is not included.
- - Work around an issue in d8 with binary file reading that broke e.g. printf when running in d8. (#2731)
- - Rigidified the semantics of Module.preRun and Module.postRun: These must always be JS arrays, single functions are not allowed (#2729)
- - Improved compiler warning diagnostics when generating output that will not validate as asm.js (#2737)
- - Updated to latest emrun version to enable support for passing arguments with hyphens to the program. (#2742)
+ - Removed several old header files from the Emscripten repository that had been
+   included for emulation purposes (zlib.h, png.h, tiff.h, tiffio.h), but their
+   implementation is not included.
+ - Work around an issue in d8 with binary file reading that broke e.g. printf
+   when running in d8. (#2731)
+ - Rigidified the semantics of Module.preRun and Module.postRun: These must
+   always be JS arrays, single functions are not allowed (#2729)
+ - Improved compiler warning diagnostics when generating output that will not
+   validate as asm.js (#2737)
+ - Updated to latest emrun version to enable support for passing arguments with
+   hyphens to the program. (#2742)
  - Added Bessel math functions of the first kind  (j0, j1, jn) from musl.
  - Improved SIMD support for the experimental Ecmascript SIMD spec.
  - Full list of changes:
@@ -1579,12 +1914,15 @@ v1.23.1: 8/26/2014
  - Add support for the Chrome variant of the Gamepad API.
  - Updates to SIMD.js support.
  - Implemented glutSetCursor function.
- - Added new link-time options -s NO_FILESYSTEM=1 and -s NO_BROWSER=1 to enable reducing output file sizes when those functionalities are not necessary.
+ - Added new link-time options -s NO_FILESYSTEM=1 and -s NO_BROWSER=1 to enable
+   reducing output file sizes when those functionalities are not necessary.
  - Added a new option --closure 2 to allow running closure even on the asm.js output.
- - Fixed a regression bug that broke the use of emscripten_set_socket_error_callback() in emscripten.h
+ - Fixed a regression bug that broke the use of
+   emscripten_set_socket_error_callback() in emscripten.h
  - Removed the support for old discontinued Mozilla Audio Data API in src/library_sdl.js.
  - Removed the support for using Web Audio ScriptProcessorNode to stream audio.
- - Improved SDL audio streaming by using the main rAF() callback instead of a separate setTimeout() callback to schedule the audio data.
+ - Improved SDL audio streaming by using the main rAF() callback instead of a
+   separate setTimeout() callback to schedule the audio data.
  - Deprecated compiling without typed arrays support. 
  - Migrated to using musl PRNG functions. Fixes reported bugs about the quality of randomness (#2341)
  - Improved SIMD support for the experimental Ecmascript SIMD spec.
@@ -1596,7 +1934,8 @@ v1.23.1: 8/26/2014
 v1.23.0: 8/21/2014
 ------------------
  - Added support for array attributes in WebIDL bindings.
- - Allow cloning pointers that are scheduled for deletion in embind, and add support for null in embind_repr().
+ - Allow cloning pointers that are scheduled for deletion in embind, and add
+   support for null in embind_repr().
  - Fixed possible issues with rounding and flooring operations.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.22.2...1.23.0
@@ -1606,28 +1945,45 @@ v1.23.0: 8/21/2014
 v1.22.2: 8/19/2014
 ------------------
  - Adds stack overflow checks when building with the link flag -s ASSERTIONS=1.
- - Fix an issue where EM_ASM was not usable with closure when closure removed the Module object (#2639)
+ - Fix an issue where EM_ASM was not usable with closure when closure removed
+   the Module object (#2639)
  - The locale "POSIX" is now recognized (#2636)
  - Fixed a problem with embind on IE11.
- - Added OpenAL functions alSource3i, alListener3f, alGetEnumValue and alSpeedOfSound and also recognize ALC_MAX_AUXILIARY_SENDS.
- - Fixed an issue where emcc would create .o files in the current directory when compiling multiple code files simultaneously (#2644)
- - The -s PROXY_TO_WORKER1= option now looks for a GET option "?noProxy" in the page URL to select at startup time whether proxying should be on or off.
- - Added new functions emscripten_yield, emscripten_coroutine_create and emscripten_coroutine_next which implement coroutines when building with the -s ASYNCIFY=1 option.
- - Optimized the size of intermediate generated .o files by omitting LLVM debug info from them when not needed. (#2657)
- - Fixed WebSocket connection URLs to allow a port number in them, e.g. "server:port/addr" (2610)
+ - Added OpenAL functions alSource3i, alListener3f, alGetEnumValue and
+   alSpeedOfSound and also recognize ALC_MAX_AUXILIARY_SENDS.
+ - Fixed an issue where emcc would create .o files in the current directory when
+   compiling multiple code files simultaneously (#2644)
+ - The -s PROXY_TO_WORKER1= option now looks for a GET option "?noProxy" in the
+   page URL to select at startup time whether proxying should be on or off.
+ - Added new functions emscripten_yield, emscripten_coroutine_create and
+   emscripten_coroutine_next which implement coroutines when building with the
+   -s ASYNCIFY=1 option.
+ - Optimized the size of intermediate generated .o files by omitting LLVM debug
+   info from them when not needed. (#2657)
+ - Fixed WebSocket connection URLs to allow a port number in them, e.g.
+   "server:port/addr" (2610)
  - Added support for void* to the WebIDL binder, via the identifier VoidPtr.
  - Optimize emcc to not copy bitcode files around redundantly.
  - Fix stat() to correctly return ENOTDIR when expected (#2669).
  - Fixed issues with nested exception catching (#1714).
  - Increased the minimum size of the Emscripten HEAP to 64k instead of a previous 4k.
- - The {{{ cDefine('name') }}} macros now raise a compile-time error if the define name is not found, instead of hiding the error message inside the compiled output (#2672)
- - Fixed an issue where --emrun parameter was not compatible with the -s PROXY_TO_WORKER=1 option.
+ - The {{{ cDefine('name') }}} macros now raise a compile-time error if the
+   define name is not found, instead of hiding the error message inside the
+   compiled output (#2672)
+ - Fixed an issue where --emrun parameter was not compatible with the -s
+   PROXY_TO_WORKER=1 option.
  - Improved WebGL support when compiling with the PROXY_TO_WORKER=1 option.
- - Fixed a regression issue with the handling of running dtors of classes that use virtual inheritance. (#2682)
- - Added an option Module.locateFilePackage() as a means to customize where data files are found in relative to the running page (#2680). NOTE: This parameter was later renamed to Module.locateFile() instead in release 1.24.0.
+ - Fixed a regression issue with the handling of running dtors of classes that
+   use virtual inheritance. (#2682)
+ - Added an option Module.locateFilePackage() as a means to customize where data
+   files are found in relative to the running page (#2680). NOTE: This parameter
+   was later renamed to Module.locateFile() instead in release 1.24.0.
  - Fixed a bug where OpenAL sources would not properly delete.
- - Fixed a bug with upstream libc++ on std::map, std::multimap and std::unordered_map self-assignment (http://llvm.org/bugs/show_bug.cgi?id=18735)
- - Allow using __asm__ __volatile__("": : :"memory") as a compile-time reordering barrier (#2647)
+ - Fixed a bug with upstream libc++ on std::map, std::multimap and
+   std::unordered_map self-assignment
+   (http://llvm.org/bugs/show_bug.cgi?id=18735)
+ - Allow using __asm__ __volatile__("": : :"memory") as a compile-time
+   reordering barrier (#2647)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.22.1...1.22.2
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.22.1...1.22.2
@@ -1635,14 +1991,17 @@ v1.22.2: 8/19/2014
 
 v1.22.1: 8/7/2014
 ------------------
- - Added support for prefixing functions with '$' in JS libraries, in order to cause them not be prefixed with '_' when compiling.
+ - Added support for prefixing functions with '$' in JS libraries, in order to
+   cause them not be prefixed with '_' when compiling.
  - Improved WebIDL compiler to support enums.
  - Fixed a bug with emscripten_force_exit() that would throw an exception (#2629).
  - Fixed setlocale() when setting a bad locale. (#2630)
  - Fixed a compiler miscompilation bug when optimizing loops. (#2626)
  - Fixed an issue with rethrowing an exception (#2627)
- - Fixed a bug where malloc()ing from JS code would leak memory if the C/C++ side does not use malloc() (#2621)
- - Removed an unnecessary assert() in glReadPixels, and improved it to support more texture pixel types.
+ - Fixed a bug where malloc()ing from JS code would leak memory if the C/C++
+   side does not use malloc() (#2621)
+ - Removed an unnecessary assert() in glReadPixels, and improved it to support
+   more texture pixel types.
  - Fixed a bug with std::locale accepting unknown locale names (#2636)
  - Added support for WebIDL binder to work with Closure (#2620)
  - Added no-op SDL IMG_Quit() and TTF_Quit() symbols.
@@ -1654,7 +2013,8 @@ v1.22.1: 8/7/2014
 
 v1.22.0: 8/5/2014
 ------------------
- - Added support to emrun to dump files to the local filesystem for debugging purposes.
+ - Added support to emrun to dump files to the local filesystem for debugging
+   purposes.
  - Implemented emscripten_wget in ASYNCIFY mode.
  - Improved extension catching support (#2616)
  - Fixed .a link groups to also work when linking to bitcode. (#2568)
@@ -1665,7 +2025,9 @@ v1.22.0: 8/5/2014
 
 v1.21.10: 7/29/2014
 -------------------
- - Fixed a Windows-specific issue where the generated output files might contain line endings of form \r\r\n. This caused browser debuggers to get confused with line numbers. (#2133)
+ - Fixed a Windows-specific issue where the generated output files might contain
+   line endings of form \r\r\n. This caused browser debuggers to get confused
+   with line numbers. (#2133)
  - Improved the node.js workaround introduced in v1.21.8.
  - Implemented new HTML5 API for direct WebGL context creation, emscripten_webgl_*().
  - Fixed a bug when loading in node.js and loaded by another module (#2586)
@@ -1685,7 +2047,9 @@ v1.21.9: 7/28/2014
 v1.21.8: 7/28/2014
 ------------------
  - Fixed an issue when using --embed-file to embed very large files.
- - Worked around a Windows node.js bug where the compiler output might get cut off when the compilation ends in an error. (https://github.com/joyent/node/issues/1669)
+ - Worked around a Windows node.js bug where the compiler output might get cut
+   off when the compilation ends in an error.
+   (https://github.com/joyent/node/issues/1669)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.7...1.21.8
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.21.7...1.21.8
@@ -1693,18 +2057,26 @@ v1.21.8: 7/28/2014
 
 v1.21.7: 7/25/2014
 ------------------
- - Added new link option -s EMCC_ONLY_FORCED_STDLIBS which can be used to restrict to only linking to the chosen set of Emscripten-provided libraries. (See also -s EMCC_FORCE_STDLIBS)
- - Adjusted argv[0] and environment variables USER, HOME, LANG and _ to report a more convenient set of default values. (#2565)
- - Fixed an issue where the application could not use environ without also referring to getenv() (#2557)
+ - Added new link option -s EMCC_ONLY_FORCED_STDLIBS which can be used to
+   restrict to only linking to the chosen set of Emscripten-provided libraries.
+   (See also -s EMCC_FORCE_STDLIBS)
+ - Adjusted argv[0] and environment variables USER, HOME, LANG and _ to report a
+   more convenient set of default values. (#2565)
+ - Fixed an issue where the application could not use environ without also
+   referring to getenv() (#2557)
  - Fixed an issue with IDBFS running in web workers.
  - Print out an error if IDBFS is used without IDB support.
  - Fixed calling Runtime.getFuncWrapper() when -s ALIASING_FUNCTION_POINTERS=1 (#2010)
- - Fixed an issue where deleting files during directory iteration would produce incorrect iteration results (#2528)
+ - Fixed an issue where deleting files during directory iteration would produce
+   incorrect iteration results (#2528)
  - Fixed support for strftime with %z and %Z (#2570)
  - Fixed a bug with truncate() throwing an exception (#2572)
- - Improved the linker to generate warning messages if user specifies -s X=Y linker flags that do not exist (#2579)
+ - Improved the linker to generate warning messages if user specifies -s X=Y
+   linker flags that do not exist (#2579)
  - Fixed an issue with creating read-only files (#2573)
- - Added first implementation for the ASYNCIFY option, which splits up synchronous blocking loops to asynchronous execution. For more information on this approach, see https://github.com/kripken/emscripten/wiki/Asyncify
+ - Added first implementation for the ASYNCIFY option, which splits up
+   synchronous blocking loops to asynchronous execution. For more information on
+   this approach, see https://github.com/kripken/emscripten/wiki/Asyncify
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.6...1.21.7
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.21.6...1.21.7
@@ -1713,14 +2085,23 @@ v1.21.7: 7/25/2014
 v1.21.6: 7/22/2014
 ------------------
  - Separated OpenAL AL and ALC errors to properly separate fields.
- - When using EGL to initialize a GL context, initialize a stencil buffer to the context as well, since proper EGL context choosing is not yet implemented.
- - Added new linker flag -s DEMANGLE_SUPPORT to choose whether to compile the application with libcxxabi-provided demangling support ___cxa_demangle().
- - Fixed a problem where calling stat() on a nonexisting file in the runtime VFS would result in an exception being thrown. (#2552)
- - When using the -v flag, no longer retain intermediate compilation files. To preserve the intermediate files, set the EMCC_DEBUG=1 environment variable. (#2538)
- - Added a new HTML setting Module.memoryInitializerPrefixURL which specifies a prefix for where the memory initializer file .mem.js should be loaded from (#2542)
+ - When using EGL to initialize a GL context, initialize a stencil buffer to the
+   context as well, since proper EGL context choosing is not yet implemented.
+ - Added new linker flag -s DEMANGLE_SUPPORT to choose whether to compile the
+   application with libcxxabi-provided demangling support ___cxa_demangle().
+ - Fixed a problem where calling stat() on a nonexisting file in the runtime VFS
+   would result in an exception being thrown. (#2552)
+ - When using the -v flag, no longer retain intermediate compilation files. To
+   preserve the intermediate files, set the EMCC_DEBUG=1 environment variable.
+   (#2538)
+ - Added a new HTML setting Module.memoryInitializerPrefixURL which specifies a
+   prefix for where the memory initializer file .mem.js should be loaded from
+   (#2542)
  - Implemented eglReleaseThread to work according to spec.
- - Implemented a new function emscripten_force_exit() which immediately shuts down the C runtime.
- - Fixed a bug with exception handling that resulted in an error unresolved symbol: _ZTISt13bad_exception (#2560)
+ - Implemented a new function emscripten_force_exit() which immediately shuts
+   down the C runtime.
+ - Fixed a bug with exception handling that resulted in an error unresolved
+   symbol: _ZTISt13bad_exception (#2560)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.5...1.21.6
     - Emscripten-LLVM: no changes.
@@ -1730,12 +2111,16 @@ v1.21.5: 7/21/2014
 ------------------
  - Added support for glDrawBuffers with the WEBGL_draw_buffers extension.
  - Added stub implementation for eglReleaseThread.
- - Fixed a bug where passing -E to emcc used the system include headers instead of the built-in ones. (#2534)
+ - Fixed a bug where passing -E to emcc used the system include headers instead
+   of the built-in ones. (#2534)
  - Fixed the stacktrace() function to work on MSIE as well.
- - Removed the zlib.h header file from system include directory, since Emscripten does not provide an implementation of zlib built-in.
+ - Removed the zlib.h header file from system include directory, since
+   Emscripten does not provide an implementation of zlib built-in.
  - Added support for __cxa_bad_typeid (#2547)
- - Fixed an internal compiler crash with a certain pattern involving optimized builds and int64_t (#2539)
- - Fixed an issue with -s EXCEPTION_CATCHING_WHITELIST handling where an extension that was a substring of another might get erroneously handled.
+ - Fixed an internal compiler crash with a certain pattern involving optimized
+   builds and int64_t (#2539)
+ - Fixed an issue with -s EXCEPTION_CATCHING_WHITELIST handling where an
+   extension that was a substring of another might get erroneously handled.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.4...1.21.5
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.21.4...1.21.5
@@ -1744,18 +2129,29 @@ v1.21.5: 7/21/2014
 v1.21.4: 7/17/2014
 ------------------
  - Implemented the getsockopt() function.
- - Added new event callback functions emscripten_set_socket_xx_callback() that allow listening to WebSocket events in an asynchronous manner.
- - Greatly improved CMake support, now various forms of configure-time test builds are supported, and the default extension is set to ".js"
- - Prohibit the virtual filesystem from creating files with name '.' or '..' at runtime.
- - Have runtime mkdir() function call normalize the path to be created before creation.
+ - Added new event callback functions emscripten_set_socket_xx_callback() that
+   allow listening to WebSocket events in an asynchronous manner.
+ - Greatly improved CMake support, now various forms of configure-time test
+   builds are supported, and the default extension is set to ".js"
+ - Prohibit the virtual filesystem from creating files with name '.' or '..' at
+   runtime.
+ - Have runtime mkdir() function call normalize the path to be created before
+   creation.
  - Fixed an issue with omitting the third paramter in cwrap() call (#2511).
- - Fixed an issue where mouse event handling would throw an exception if the page did not contain a canvas object.
- - Fixed a GL initialization problem when user has extended Array with custom functions (#2514)
- - Added new compiler defines __EMSCRIPTEN_major__, __EMSCRIPTEN_minor__ and __EMSCRIPTEN_tiny__ which communicate the compiler version major.minor.tiny to compiled applications (#2343)
- - Fixed a bug where emrun did not properly capture the exit code when exit runtime via not calling exit().
+ - Fixed an issue where mouse event handling would throw an exception if the
+   page did not contain a canvas object.
+ - Fixed a GL initialization problem when user has extended Array with custom
+   functions (#2514)
+ - Added new compiler defines __EMSCRIPTEN_major__, __EMSCRIPTEN_minor__ and
+   __EMSCRIPTEN_tiny__ which communicate the compiler version major.minor.tiny
+   to compiled applications (#2343)
+ - Fixed a bug where emrun did not properly capture the exit code when exit
+   runtime via not calling exit().
  - Fixed an error message when symlinkin invalid filenams at runtime.
- - Fixed a bug in EGL context creation that parsed the input context creation parameters with wrong terminator.
- - Improved ffdb.py to be smarter when to attempt port forwarding to connect to a FFOS device DevTools port.
+ - Fixed a bug in EGL context creation that parsed the input context creation
+   parameters with wrong terminator.
+ - Improved ffdb.py to be smarter when to attempt port forwarding to connect to
+   a FFOS device DevTools port.
  - Implemented strsignal() function (#2532)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.3...1.21.4
@@ -1767,12 +2163,15 @@ v1.21.3: 7/10/2014
  - Added implementations for SDL function SDL_AudioQuit and SDL_VideoQuit.
  - Fix an issue with the optimizeShifts optimization enabled in previous version.
  - Fixed the -s RELOOPER command line parameter to work.
- - Fixed a bug where building the system libc migt result in a compiler deadlock on Windows.
- - Removed emcc from trying to link in .dll files as static libraries on Windows.
+ - Fixed a bug where building the system libc migt result in a compiler deadlock
+   on Windows.
+ - Removed emcc from trying to link in .dll files as static libraries on
+   Windows.
  - Added support for GL_HALF_FLOAT_OES.
  - Fixed a bug where emcmake did not work on Windows.
  - Use multithreaded compilation to build libc.
- - Fixed an issue where the GL interop library could throw an exception in an error condition, instead of raising a GL error.
+ - Fixed an issue where the GL interop library could throw an exception in an
+   error condition, instead of raising a GL error.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.2...1.21.3
     - Emscripten-LLVM: no changes.
@@ -1780,9 +2179,12 @@ v1.21.3: 7/10/2014
 
 v1.21.2: 7/5/2014
 ------------------
- - Improved the checks that detect that code is run only while the runtime is initialized.
- - The memory initializer file (.mem.js) is now emitted by default when compiling with at least -O2 optimization level.
- - Fixed a performance issue where built-in math functions (Math.sqrt, etc.) took a slightly slower path (#2484).
+ - Improved the checks that detect that code is run only while the runtime is
+   initialized.
+ - The memory initializer file (.mem.js) is now emitted by default when
+   compiling with at least -O2 optimization level.
+ - Fixed a performance issue where built-in math functions (Math.sqrt, etc.)
+   took a slightly slower path (#2484).
  - Added support for the ffs libc function.
  - Re-enabled optimizeShifts optimization when not compiling for asm.js (#2481)
  - Full list of changes:
@@ -1792,7 +2194,8 @@ v1.21.2: 7/5/2014
 
 v1.21.1: 7/3/2014
 ------------------
- - Fixed an issue where wrong python interpreter could get invoked on Windows when both native and cygwin python were installed.
+ - Fixed an issue where wrong python interpreter could get invoked on Windows
+   when both native and cygwin python were installed.
  - Updated musl from version 0.9.13 to version 1.0.3.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.21.0...1.21.1
@@ -1801,18 +2204,27 @@ v1.21.1: 7/3/2014
 
 v1.21.0: 7/2/2014
 ------------------
- - Enable memory init files (.mem) by default in optimized builds (-O2+), as if  --memory-init-file 1  is specified. This makes the default behavior on optimized builds emit smaller and faster-to-load code, but does require that you ship both a .js and a .mem file (if you prefer not to, can use  --memory-init-file 1  ).
+ - Enable memory init files (.mem) by default in optimized builds (-O2+), as if
+   --memory-init-file 1  is specified. This makes the default behavior on
+   optimized builds emit smaller and faster-to-load code, but does require that
+   you ship both a .js and a .mem file (if you prefer not to, can use
+   --memory-init-file 1  ).
  - Implemented new SDL 1.2 functions SDL_GetRGB, SDL_GetRGBA and SDL_putenv.
- - Added support for /dev/random, /dev/urandom and C++11 std::random_device, which will use cryptographically secure random api if available. (#2447)
+ - Added support for /dev/random, /dev/urandom and C++11 std::random_device,
+   which will use cryptographically secure random api if available. (#2447)
  - Added support for CMake find_path() directive.
  - Added support for std::unique_ptr in embind.
  - Improved Windows support for ffdb.py.
  - Implemented the clip_rect structure for created SDL surfaces.
  - Fixed a regression with SDL touch events (#2466)
- - Added support for C++11 std::thread::hardware_concurrency which backs to navigator.hardwareConcurrency. See http://wiki.whatwg.org/wiki/Navigator_HW_Concurrency (#2456)
+ - Added support for C++11 std::thread::hardware_concurrency which backs to
+   navigator.hardwareConcurrency. See
+   http://wiki.whatwg.org/wiki/Navigator_HW_Concurrency (#2456)
  - Optimized embind code generation with constexprs.
- - Enabled the use of Runtime.add&removeFunction when closure minification is active (#2446)
- - Implemented support for accessing WebGL when building via the proxy to worker architecture.
+ - Enabled the use of Runtime.add&removeFunction when closure minification is
+   active (#2446)
+ - Implemented support for accessing WebGL when building via the proxy to worker
+   architecture.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.20.0...1.21.0
     - Emscripten-LLVM: no changes.
@@ -1823,8 +2235,12 @@ v1.20.0: 6/13/2014
  - Optimize in-memory virtual filesystem performance when serialized to an IndexedDB.
  - Fixed memcpy regression with ta0 and ta1 modes.
  - Fixed an issue with line numbers being messed up when generating source maps (#2410)
- - Fixed an ffdb logging bug that could cause it to drop messages if they were being received too fast. Added support getting memory and system descriptions with ffdb.
- - Added a new extension to SDL "emscripten_SDL_SetEventHandler()" which enabled application to perform SDL event handling inside a JS event handler to overcome browser security restrictions. (#2417)
+ - Fixed an ffdb logging bug that could cause it to drop messages if they were
+   being received too fast. Added support getting memory and system descriptions
+   with ffdb.
+ - Added a new extension to SDL "emscripten_SDL_SetEventHandler()" which enabled
+   application to perform SDL event handling inside a JS event handler to
+   overcome browser security restrictions. (#2417)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.19.2...1.20.0
     - Emscripten-LLVM: no changes.
@@ -1835,9 +2251,12 @@ v1.19.2: 6/9/2014
  - Updated CMake support for response file handling.
  - Fixed issues with glfwGetProcAddress and glfwSetWindowSizeCallback.
  - Fixed an issue with regexes that caused issues on IE11 runtime (#2400)
- - Added a new functions emscripten_get_preloaded_image_data() and emscripten_get_preloaded_image_data_from_FILE() to obtain pixel data of preloaded images.
+ - Added a new functions emscripten_get_preloaded_image_data() and
+   emscripten_get_preloaded_image_data_from_FILE() to obtain pixel data of
+   preloaded images.
  - Greatly improved ffdb capabilities to operate a FFOS device.
- - Fixed a Windows-specific bug where the user temp directory was littered with temporary .rsp files that did not get cleaned up.
+ - Fixed a Windows-specific bug where the user temp directory was littered with
+   temporary .rsp files that did not get cleaned up.
  - Improved SIMD support.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.19.1...1.19.2
@@ -1846,9 +2265,13 @@ v1.19.2: 6/9/2014
 
 v1.19.1: 6/3/2014
 ------------------
- - Migrate to using musl sscanf and sprintf and the family that writes to memory, and not directly to the filesystem.
+ - Migrate to using musl sscanf and sprintf and the family that writes to
+   memory, and not directly to the filesystem.
  - Improve the error messages from -s SAFE_HEAP_ACCESS=1 runtime checks.
- - Added new linker flag -s NO_DYNAMIC_EXECUTION=1 which removes the use of eval() and new Function() in the generated output. For more information, see "Eval and related functions are disabled" in https://developer.chrome.com/extensions/contentSecurityPolicy .
+ - Added new linker flag -s NO_DYNAMIC_EXECUTION=1 which removes the use of
+   eval() and new Function() in the generated output. For more information, see
+   "Eval and related functions are disabled" in
+   https://developer.chrome.com/extensions/contentSecurityPolicy .
  - Fixed a compiler issue when very large double constants are present. (#2392)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.19.0...1.19.1
@@ -1858,11 +2281,16 @@ v1.19.1: 6/3/2014
 v1.19.0: 5/29/2014
 ------------------
  - Added an error message to signal that linkable modules are not supported in fastcomp.
- - Fixed a miscompilation issue that resulted in an error "SyntaxError: invalid increment operand" and a statement +(+0) being generated (#2314)
- - Make optimized compiler output smaller by running the shell code through uglify when not using closure.
+ - Fixed a miscompilation issue that resulted in an error "SyntaxError: invalid
+   increment operand" and a statement +(+0) being generated (#2314)
+ - Make optimized compiler output smaller by running the shell code through
+   uglify when not using closure.
  - Fixed a crash in SDL audio loading code introduced in v1.18.3
- - Fixed an issue where glTex(Sub)Image2D might throw an exception on error, instead of setting glGetError().
- - Added new typedefs emscripten_align1_short, emscripten_align{1/2}_int, emscripten_align{1/2}_float and emscripten_align{1/2/4}_double to ease signaling the compiler that unaligned data is present. (#2378)
+ - Fixed an issue where glTex(Sub)Image2D might throw an exception on error,
+   instead of setting glGetError().
+ - Added new typedefs emscripten_align1_short, emscripten_align{1/2}_int,
+   emscripten_align{1/2}_float and emscripten_align{1/2/4}_double to ease
+   signaling the compiler that unaligned data is present. (#2378)
  - Fixed an embind issue with refcount tracking on smart pointers.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.18.4...1.19.0
@@ -1874,7 +2302,8 @@ v1.18.4: 5/27/2014
  - Fixed error message on unsupported linking options (#2365)
  - Updated embind to latest version from IMVU upstream.
  - Fixed an issue where source maps did not load properly in Firefox.
- - Added a more descriptive error message to fastcomp when MAX_SETJMPS limit is violated. (#2379)
+ - Added a more descriptive error message to fastcomp when MAX_SETJMPS limit is
+   violated. (#2379)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.18.3...1.18.4
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.18.3...1.18.4
@@ -1882,11 +2311,13 @@ v1.18.4: 5/27/2014
 
 v1.18.3: 5/21/2014
 ------------------
- - Added support to emcc command line for "archive groups": -Wl,--start-group and -Wl,--end-group
+ - Added support to emcc command line for "archive groups": -Wl,--start-group
+   and -Wl,--end-group
  - Greatly optimized ccall and cwrap implementations.
  - Added new support for SDL_Mix backend to use WebAudio to play back audio clips.
  - Fixed a registerizeHarder issue with elimination of conditional expressions.
- - Migrated single-character standard C functions (islower, tolower, and the family) to use musl implementations.
+ - Migrated single-character standard C functions (islower, tolower, and the
+   family) to use musl implementations.
  - Updated relooper to not optimize out breaks if it causes excessive nesting.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.18.2...1.18.3
@@ -1895,12 +2326,15 @@ v1.18.3: 5/21/2014
 
 v1.18.2: 5/19/2014
 ------------------
- - Fixed a problem which blocked user applications from handling WebGL context loss events themselves.
- - Added a new HTML5 api function emscripten_is_webgl_context_lost() which allows polling for context loss in addition to receiving events.
+ - Fixed a problem which blocked user applications from handling WebGL context
+   loss events themselves.
+ - Added a new HTML5 api function emscripten_is_webgl_context_lost() which
+   allows polling for context loss in addition to receiving events.
  - Improved async wget progress events to work better across browsers.
  - Improved WebIDL binder support.
  - Added new typeof() function to emscripten::val.
- - Added support for SDL window events SDL_WINDOWEVENT_FOCUS_GAINED, SDL_WINDOWEVENT_FOCUS_LOST, SDL_WINDOWEVENT_SHOWN, SDL_WINDOWEVENT_HIDDEN.
+ - Added support for SDL window events SDL_WINDOWEVENT_FOCUS_GAINED,
+   SDL_WINDOWEVENT_FOCUS_LOST, SDL_WINDOWEVENT_SHOWN, SDL_WINDOWEVENT_HIDDEN.
  - Fixed a compiler miscompilation on unsigned i1 bitcasts (#2350)
  - Fixed a compiler bug where doubles in varargs might not get 8-byte aligned (#2358)
  - Full list of changes:
@@ -1911,8 +2345,11 @@ v1.18.2: 5/19/2014
 v1.18.1: 5/12/2014
 ------------------
  - Fixed an issue where the mouse wheel scroll did not work with SDL.
- - Fixed an issue with emscripten_async_wget, which undesirably expected that the string pointer passed to it stayed alive for the duration of the operation (#2349)
- - Emscripten now issues a warning message when the EXPORTED_FUNCTIONS list contains invalid symbol names (#2338)
+ - Fixed an issue with emscripten_async_wget, which undesirably expected that
+   the string pointer passed to it stayed alive for the duration of the
+   operation (#2349)
+ - Emscripten now issues a warning message when the EXPORTED_FUNCTIONS list
+   contains invalid symbol names (#2338)
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.18.0...1.18.1
     - Emscripten-LLVM: no changes.
@@ -1920,8 +2357,10 @@ v1.18.1: 5/12/2014
 
 v1.18.0: 5/10/2014
 ------------------
- - Enable support for low-level C<->JS interop to marshall 64 bit integers from C to JS.
- - Fixed an issue that caused some programs to immediately run out of memory "(cannot enlarge memory arrays)" at startup. (#2334)
+ - Enable support for low-level C<->JS interop to marshall 64 bit integers from
+   C to JS.
+ - Fixed an issue that caused some programs to immediately run out of memory
+   "(cannot enlarge memory arrays)" at startup. (#2334)
  - Fixed a crash issue with generated touch events that didn't correspond to a real touch.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.17.0...1.18.0
@@ -1933,21 +2372,28 @@ v1.17.0: 5/6/2014
  - Enabled asm.js compilation and -s PRECISE_F32 support when using embind.
  - Improved relooper to emit switches in many-entried blocks.
  - Fixed a GLFW bug where mouse wheel direction was reversed.
- - Fixed glfwGetKey to work even when no callback is registered with glfwGetKeyCallback (#1320)
- - Added a new tool 'webidl_binder' that generates C <-> JS interop code from WebIDL descriptions.
+ - Fixed glfwGetKey to work even when no callback is registered with
+   glfwGetKeyCallback (#1320)
+ - Added a new tool 'webidl_binder' that generates C <-> JS interop code from
+   WebIDL descriptions.
  - Fix emscripten compilation to work on pages that don't contain a HTML canvas.
  - Added a new error message to default shell when an uncaught exception is thrown.
  - Improved error diagnostics reported by -s SAFE_HEAP=1.
- - Added support for registering callbacks hook to VFS file open, write, move, close and delete.
+ - Added support for registering callbacks hook to VFS file open, write, move,
+   close and delete.
  - Added embind support to std::basic_string<unsigned char>
- - By default, the C runtime will no longer exit after returning from main() when safeSetTimeout() or safeSetInterval() is used.
+ - By default, the C runtime will no longer exit after returning from main()
+   when safeSetTimeout() or safeSetInterval() is used.
  - Fixed an issue with sscanf formatting (#2322)
  - Fixed an issue where precompiled headers were given a wrong output filename (#2320)
  - Enabled registerizeHarder optimization pass to work when outlining is enabled.
  - Fixed an issue with strptime month handling (#2324)
- - Added an initial implementation of a new tool 'ffdb' which can be used to operate a Firefox OS phone from the command line.
- - Fixed a compiler crash on assertion failure '!contains(BranchesOut, Target)' (emscripten-fastcomp #32)
- - Added a new ABI to Clang that targets Emscripten specifically. Stop aligning member functions to save some space in the function table array.
+ - Added an initial implementation of a new tool 'ffdb' which can be used to
+   operate a Firefox OS phone from the command line.
+ - Fixed a compiler crash on assertion failure '!contains(BranchesOut, Target)'
+   (emscripten-fastcomp #32)
+ - Added a new ABI to Clang that targets Emscripten specifically. Stop aligning
+   member functions to save some space in the function table array.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.16.0...1.17.0
     - Emscripten-LLVM: https://github.com/kripken/emscripten-fastcomp/compare/1.16.0...1.17.0
@@ -1964,8 +2410,11 @@ v1.16.0: 4/16/2014
 v1.15.1: 4/15/2014
 ------------------
  - Added support for SDL2 touch api.
- - Added new user-controllable emdind-related define #define EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES, which allows optimizing embind for minimal size when std::type_info is not needed. 
- - Fixed issues with CMake support where CMAKE_AR and CMAKE_RANLIB were not accessible from CMakeLists.txt files.
+ - Added new user-controllable emdind-related define #define
+   EMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES, which allows optimizing embind for minimal
+   size when std::type_info is not needed. 
+ - Fixed issues with CMake support where CMAKE_AR and CMAKE_RANLIB were not
+   accessible from CMakeLists.txt files.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.15.0...1.15.1
     - Emscripten-LLVM: no changes.
@@ -1975,7 +2424,8 @@ v1.15.0: 4/11/2014
 ------------------
  - Fix outlining feature for functions that return a double (#2278)
  - Added support for C++11 atomic constructs (#2273)
- - Adjusted stdout and stderr stream behavior in the default shell.html to always print out to both web page text log box, and the browser console.
+ - Adjusted stdout and stderr stream behavior in the default shell.html to
+   always print out to both web page text log box, and the browser console.
  - Fixed an issue with loop variable optimization.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.14.1...1.15.0
@@ -1984,12 +2434,19 @@ v1.15.0: 4/11/2014
 
 v1.14.1: 4/8/2014
 ------------------
- - Added new command line utility 'emcmake', which can be used to call emconfigure for cmake.
- - Added a new emcc command line parameter '--valid-abspath', which allows selectively suppressing warning messages that occur when using absolute path names in include and link directories.
- - Added a new emcc linker command line parameter '--emit-symbol-map', which will save a map file between minified global names and the original function names.
+ - Added new command line utility 'emcmake', which can be used to call
+   emconfigure for cmake.
+ - Added a new emcc command line parameter '--valid-abspath', which allows
+   selectively suppressing warning messages that occur when using absolute path
+   names in include and link directories.
+ - Added a new emcc linker command line parameter '--emit-symbol-map', which
+   will save a map file between minified global names and the original function
+   names.
  - Fixed an issue with --default-object-ext not always working properly.
- - Added optimizations to eliminate redundant loop variables and redundant self-assignments.
- - Migrated several libc functions to use compiled code from musl instead of handwritten JS implementations.
+ - Added optimizations to eliminate redundant loop variables and redundant
+   self-assignments.
+ - Migrated several libc functions to use compiled code from musl instead of
+   handwritten JS implementations.
  - Improved embind support.
  - Renamed the EM_ASM_() macro to the form EM_ASM_ARGS().
  - Fixed mouse button ordering issue in glfw.
@@ -2001,11 +2458,14 @@ v1.14.1: 4/8/2014
 
 v1.14.0: 3/25/2014
 ------------------
- - Added new emcc linker command line option '-profiling', which defaults JS code generation options suited for benchmarking and profiling purposes.
+ - Added new emcc linker command line option '-profiling', which defaults JS
+   code generation options suited for benchmarking and profiling purposes.
  - Implemented the EGL function eglWaitGL().
  - Fixed an issue with the HTML5 API that caused the HTML5 event listener unregistration to fail.
  - Fixed issues with numpad keys in SDL support library.
- - Added a new JS optimizer pass 'simplifyIfs', which is run when -s SIMPLIFY_IFS=1 link flag is set and -g is not specified. This pass merges multiple nested if()s together into single comparisons, where possible.
+ - Added a new JS optimizer pass 'simplifyIfs', which is run when -s
+   SIMPLIFY_IFS=1 link flag is set and -g is not specified. This pass merges
+   multiple nested if()s together into single comparisons, where possible.
  - Removed false positive messages on missing internal "emscripten_xxx" symbols at link stage.
  - Updated to latest relooper version.
  - Full list of changes:
@@ -2029,18 +2489,26 @@ v1.13.2: 3/15/2014
 
 v1.13.1: 3/10/2014
 ------------------
- - Disallow C implicit function declarations by making it an error instead of a warning by default. These will not work with Emscripten, due to strict Emscripten signature requirements when calling function pointers (#2175).
- - Allow transitioning to full screen from SDL as a response to mouse press events.
- - Fixed a bug in previous 1.13.0 release that broke fullscreen transitioning from working.
+ - Disallow C implicit function declarations by making it an error instead of a
+   warning by default. These will not work with Emscripten, due to strict
+   Emscripten signature requirements when calling function pointers (#2175).
+ - Allow transitioning to full screen from SDL as a response to mouse press
+   events.
+ - Fixed a bug in previous 1.13.0 release that broke fullscreen transitioning
+   from working.
  - Fixed emscripten/html5.h to be used in C source files.
- - Fix an issue where extraneous system libraries would get included in the generated output (#2191).
- - Added a new function emscripten_async_wget2_data() that allows reading from an XMLHTTPRequest directly into memory while supporting advanced features.
+ - Fix an issue where extraneous system libraries would get included in the
+   generated output (#2191).
+ - Added a new function emscripten_async_wget2_data() that allows reading from
+   an XMLHTTPRequest directly into memory while supporting advanced features.
  - Fixed esc key code in GLFW.
- - Added new emscripten_debugger() intrinsic function, which calls into JS "debugger;" statement to break into a JS debugger.
+ - Added new emscripten_debugger() intrinsic function, which calls into JS
+   "debugger;" statement to break into a JS debugger.
  - Fixed varargs function call alignment of doubles to 8 bytes.
  - Switched to using default function local stack alignment to 16 bytes to be SIMD-friendly.
  - Improved error messages when user code has a syntax error in em_asm() statements.
- - Switched to using a new custom LLVM datalayout format for Emscripten. See https://github.com/kripken/emscripten-fastcomp/commit/65405351ba0b32a8658c65940e0b65ceb2601ad4
+ - Switched to using a new custom LLVM datalayout format for Emscripten. See
+   https://github.com/kripken/emscripten-fastcomp/commit/65405351ba0b32a8658c65940e0b65ceb2601ad4
  - Optimized function local stack space to use fewer temporary JS variables.
  - Full list of changes:
     - Emscripten: https://github.com/kripken/emscripten/compare/1.13.0...1.13.1
@@ -2051,29 +2519,40 @@ v1.13.0: 3/3/2014
 ------------------
  - Fixed the deprecated source mapping syntax warning.
  - Fixed a buffer overflow issue in emscripten_get_callstack (#2171).
- - Added support for -Os (optimize for size) and -Oz (aggressively optimize for size) arguments to emcc.
- - Fixed a typo that broko the call signature of glCompressedTexSubImage2D() function (#2173).
- - Added new browser fullscreen resize logic that always retains aspect ratio and adds support for IE11.
- - Improve debug messaging with bad function pointer calls when -s ASSERTIONS=2 is set.
+ - Added support for -Os (optimize for size) and -Oz (aggressively optimize for
+   size) arguments to emcc.
+ - Fixed a typo that broko the call signature of glCompressedTexSubImage2D()
+   function (#2173).
+ - Added new browser fullscreen resize logic that always retains aspect ratio
+   and adds support for IE11.
+ - Improve debug messaging with bad function pointer calls when -s ASSERTIONS=2
+   is set.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.12.3...1.13.0
 
 v1.12.3: 2/27/2014
 ------------------
  - Fixed alcOpenDevice on Safari.
  - Improved the warning message on missing symbols to not show false positives (#2154).
- - Improved EmscriptenFullscreenChangeEvent HTML5 API structure to return information about HTML element and screen sizes for convenience.
+ - Improved EmscriptenFullscreenChangeEvent HTML5 API structure to return
+   information about HTML element and screen sizes for convenience.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.12.2...1.12.3
 
 v1.12.2: 2/25/2014
 ------------------
  - Added better warning message if Emscripten, LLVM and Clang versions don't match.
- - Introduced the asmjs-unknown-emscripten target triple that allows specializing LLVM codegen for Emscripten purposes.
+ - Introduced the asmjs-unknown-emscripten target triple that allows
+   specializing LLVM codegen for Emscripten purposes.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.12.1...1.12.2
 
 v1.12.1: 2/25/2014
 ------------------
- - TURNED ON FASTCOMP BY DEFAULT. This means that you will need to migrate to fastcomp-clang build. Either use an Emscripten SDK distribution, or to build manually, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html for info.
- - Migrate to requiring Clang 3.3 instead of Clang 3.2. The fastcomp-clang repository by Emscripten is based on Clang 3.3.
+ - TURNED ON FASTCOMP BY DEFAULT. This means that you will need to migrate to
+   fastcomp-clang build. Either use an Emscripten SDK distribution, or to build
+   manually, see
+   http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html
+   for info.
+ - Migrate to requiring Clang 3.3 instead of Clang 3.2. The fastcomp-clang
+   repository by Emscripten is based on Clang 3.3.
  - Deprecated old Emscripten libgc implementation.
  - asm.js will now be always enabled, even in -O0 builds in fastcomp.
  - Remove support for -s RUNTIME_TYPE_INFO, which is unsupported in fastcomp.
@@ -2087,8 +2566,13 @@ v1.12.1: 2/25/2014
 
 v1.12.0: 2/22/2014
 ------------------
- - Improved the runtime abort error message when calling an invalid function pointer if compiled with -s ASSERTIONS=1 and 2. This allows the developer to better deduce errors with bad function pointers or function pointers casted and invoked via a wrong signature.
- - Added a new api function emscripten_set_main_loop_arg, which allows passing a userData pointer that will be carried via the function call, useful for object-oriented encapsulation purposes (#2114).
+ - Improved the runtime abort error message when calling an invalid function
+   pointer if compiled with -s ASSERTIONS=1 and 2. This allows the developer to
+   better deduce errors with bad function pointers or function pointers casted
+   and invoked via a wrong signature.
+ - Added a new api function emscripten_set_main_loop_arg, which allows passing a
+   userData pointer that will be carried via the function call, useful for
+   object-oriented encapsulation purposes (#2114).
  - Fixed CMake MinSizeRel configuration type to actually optimize for minimal size with -Os.
  - Added support for GLES2 VAO extension OES_vertex_array_object for browsers that support it.
  - Fix issues with emscripten/html5.f when compiled with the SAFE_HEAP option.
@@ -2099,20 +2583,25 @@ v1.11.1: 2/19/2014
  - Improved eglSwapBuffers to be spec-conformant.
  - Fixed an issue with asm.js validation and va_args (#2120).
  - Fixed asm.js validation issues found with fuzzing.
- - Added new link-time compiler flag -s RETAIN_COMPILER_SETTINGS=1, which enables a runtime API for querying which Emscripten settings were used to compile the file.
+ - Added new link-time compiler flag -s RETAIN_COMPILER_SETTINGS=1, which
+   enables a runtime API for querying which Emscripten settings were used to
+   compile the file.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.11.0...1.11.1
 
 v1.11.0: 2/14/2014
 ------------------
  - Implemented some new SDL library functions.
- - Renamed standard file descriptors to have handles 0, 1 and 2 rather than 1, 2 and 3 to coincide with unix numbering.
+ - Renamed standard file descriptors to have handles 0, 1 and 2 rather than 1, 2
+   and 3 to coincide with unix numbering.
  - Improved embind support with smart pointers and mixins.
  - Improved the registerization -O3 optimization pass around switch-case constructs.
  - Upper-case files with suffix .C are now also recognized (#2109).
  - Fixed an issue with glGetTexParameter (#2112).
  - Improved exceptions support in fastcomp.
- - Added new linker option -s NO_EXIT_RUNTIME=1, which can be used to set a default value for the Module["noExitRuntime"] parameter at compile-time.
- - Improved SDL audio buffer queueing when the sample rate matches the native web audio graph sample rate.
+ - Added new linker option -s NO_EXIT_RUNTIME=1, which can be used to set a
+   default value for the Module["noExitRuntime"] parameter at compile-time.
+ - Improved SDL audio buffer queueing when the sample rate matches the native
+   web audio graph sample rate.
  - Added an optimization that removes redundant Math.frounds in -O3.
  - Improved the default shell.html file.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.10.4...1.11.0
@@ -2134,16 +2623,20 @@ v1.10.2: 2/7/2014
  - Added basic FS unmount support.
  - Improved screen orientation lock API to return a success code.
  - Added PRECISE_F32 support to fastcomp.
- - Fixed issues in fastcomp related to special floating point literal serialization.
+ - Fixed issues in fastcomp related to special floating point literal
+   serialization.
  - Improved SDL audio buffer queueing.
- - Added new link-time option -s WARN_UNALIGNED=1 to fastcomp to report compiler warnings about generated unaligned memory accesses, which can hurt performance.
+ - Added new link-time option -s WARN_UNALIGNED=1 to fastcomp to report compiler
+   warnings about generated unaligned memory accesses, which can hurt
+   performance.
  - Optimized libc strcmp and memcmp with the implementations from musl libc.
  - Optimized libc memcpy and memset to back to native code for large buffer sizes.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.10.1...1.10.2
 
 v1.10.1: 1/31/2014
 ------------------
- - Improve srand() and rand() to be seedable and use a Linear Congruential Generator (LCG) for the rng generation for performance.
+ - Improve srand() and rand() to be seedable and use a Linear Congruential
+   Generator (LCG) for the rng generation for performance.
  - Improved OpenAL library support.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.10.0...1.10.1
 
@@ -2151,9 +2644,11 @@ v1.10.0: 1/29/2014
 ------------------
  - Improved C++ exception handling.
  - Improved OpenAL library support.
- - Fixed an issue where loading side modules could try to allocate from sealed heap (#2060).
+ - Fixed an issue where loading side modules could try to allocate from sealed
+   heap (#2060).
  - Fixed safe heap issues (2068).
- - Added new EM_ASM variants that return a value but do not receive any inputs (#2070).
+ - Added new EM_ASM variants that return a value but do not receive any inputs
+   (#2070).
  - Add support for simultaneously using setjmp and C++ exceptions in fastcomp.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.9.5...1.10.0
 
@@ -2167,14 +2662,22 @@ v1.9.4: 1/24/2014
  - Add support for Ninja and Eclipse+Ninja builds with Emscripten+CMake.
  - Fixed regressions with GL emulation.
  - Added support for #if !X in .js library preprocessor.
- - Make the syntax EM_ASM("code"); not silently fail. Note that the proper form is EM_ASM(code); without double-quotes.
+ - Make the syntax EM_ASM("code"); not silently fail. Note that the proper form
+   is EM_ASM(code); without double-quotes.
  - Optimize generated code size by minifying loop labels as well.
- - Revised the -O3 optimization level to mean "safe, but very slow optimizations on top of -O2", instead of the old meaning "unsafe optimizations". Using -O3 will now only do safe optimizations, but can be very slow compared to -O2.
- - Implemented a new registerization optimization pass that does extra variable elimination in -O3 and later to reduce the number of local variables in functions.
- - Implemented a new emscripten/html5.h interface that exposes common HTML5 APIs directly to C code without having to handwrite JS wrappers.
- - Improved error messages reported on user-written .js libraries containing syntax errors (#2033).
+ - Revised the -O3 optimization level to mean "safe, but very slow optimizations
+   on top of -O2", instead of the old meaning "unsafe optimizations". Using -O3
+   will now only do safe optimizations, but can be very slow compared to -O2.
+ - Implemented a new registerization optimization pass that does extra variable
+   elimination in -O3 and later to reduce the number of local variables in
+   functions.
+ - Implemented a new emscripten/html5.h interface that exposes common HTML5 APIs
+   directly to C code without having to handwrite JS wrappers.
+ - Improved error messages reported on user-written .js libraries containing
+   syntax errors (#2033).
  - Fixed glBufferData() function call signature with null data pointer.
- - Added new option Module['filePackagePrefixURL'] that allows customizing the URL where the VFS package is loaded from.
+ - Added new option Module['filePackagePrefixURL'] that allows customizing the
+   URL where the VFS package is loaded from.
  - Implemented glGetTexEnviv and glGetTexEnvfv in GL emulation mode.
  - Optimized the size of large memory initializer sections.
  - Fixed issues with the safe heap compilation option.
@@ -2191,7 +2694,8 @@ v1.9.2: 1/16/2014
 
 v1.9.1: 1/16/2014
 ------------------
- - Optimize desktop GL fixed function pipeline emulation texture load instruction counts when GL_COMBINE is used.
+ - Optimize desktop GL fixed function pipeline emulation texture load
+   instruction counts when GL_COMBINE is used.
  - fix Math_floor coercion in unrecommended codegen modes
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.9.0...1.9.1
 
@@ -2212,7 +2716,8 @@ v1.8.13: 1/15/2014
 v1.8.12: 1/15/2014
 ------------------
  - Added new GLEW 1.10.0 emulation support.
- - Fixed an issue where the runtime could start more than once when run in a browser (#1992)
+ - Fixed an issue where the runtime could start more than once when run in a
+   browser (#1992)
  - Fix a regression in wprintf.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.8.11...1.8.12
 
@@ -2242,11 +2747,15 @@ v1.8.7: 1/13/2014
 ------------------
  - Added support to numpad keycodes in glut support library.
  - Fix SIMD support with fastcomp.
- - Fixed a compiler error 'ran out of names' that could occur with too many minified symbol names.
- - Work around webkit imul bug https://bugs.webkit.org/show_bug.cgi?id=126345 (#1991)
- - Optimized desktop GL fixed function pipeline emulation path for better performance.
+ - Fixed a compiler error 'ran out of names' that could occur with too many
+   minified symbol names.
+ - Work around webkit imul bug https://bugs.webkit.org/show_bug.cgi?id=126345
+   (#1991)
+ - Optimized desktop GL fixed function pipeline emulation path for better
+   performance.
  - Added support for exceptions when building with fastcomp.
- - Fix and issue where the run() function could be called multiple times at startup (#1992)
+ - Fix and issue where the run() function could be called multiple times at
+   startup (#1992)
  - Removed a relooper limitation with fixed buffer size.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.8.6...1.8.7
 
@@ -2255,7 +2764,10 @@ v1.8.6: 1/8/2014
  - Added support for the libuuid library, see http://linux.die.net/man/3/libuuid.
  - Fixed .js file preprocessor to preprocess recursively (#1984).
  - Fixed a compiler codegen issue related to overflow arithmetic (#1975)
- - Added new link-time optimization flag -s AGGRESSIVE_VARIABLE_ELIMINATION=1 that enables the aggressiveVariableElimination js optimizer pass, which tries to remove temporary variables in generated JS code at the expense of code size.
+ - Added new link-time optimization flag -s AGGRESSIVE_VARIABLE_ELIMINATION=1
+   that enables the aggressiveVariableElimination js optimizer pass, which tries
+   to remove temporary variables in generated JS code at the expense of code
+   size.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.8.5...1.8.6
 
 v1.8.5: 1/7/2014
@@ -2277,7 +2789,8 @@ v1.8.3: 1/5/2014
 
 v1.8.2: 1/4/2014
 ------------------
- - Fixed glGetFramebufferAttachmentParameteriv and an issue with glGetXXX when the returned value was null.
+ - Fixed glGetFramebufferAttachmentParameteriv and an issue with glGetXXX when
+   the returned value was null.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.8.1...1.8.2
 
 v1.8.1: 1/3/2014
@@ -2285,7 +2798,9 @@ v1.8.1: 1/3/2014
  - Added support for WebGL hardware instancing extension.
  - Improved fastcomp native LLVM backend support.
  - Added support for #include filename.js to JS libraries.
- - Deprecated --compression emcc command line parameter that manually compressed output JS files, due to performance issues. Instead, it is best to rely on the web server to serve compressed JS files.
+ - Deprecated --compression emcc command line parameter that manually compressed
+   output JS files, due to performance issues. Instead, it is best to rely on
+   the web server to serve compressed JS files.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.8.0...1.8.1
 
 v1.8.0: 12/28/2013
@@ -2295,14 +2810,25 @@ v1.8.0: 12/28/2013
 
 v1.7.9: 12/27/2013
 ------------------
- - Added new command line parameter --em-config that allows specifying a custom location for the .emscripten configuration file.
- - Reintroduced relaxed asm.js heap sizes, which no longer need to be power of 2, but a multiple of 16MB is sufficient.
- - Added emrun command line tool that allows launching .html pages from command line on desktop and Android as if they were native applications. See https://groups.google.com/forum/#!topic/emscripten-discuss/t2juu3q1H8E . Adds --emrun compiler link flag.
- - Began initial work on the "fastcomp" compiler toolchain, a rewrite of the previous JS LLVM AST parsing and codegen via a native LLVM backend.
- - Added --exclude-file command line flag to emcc and a matching --exclude command line flag to file packager, which allows specifying files and directories that should be excluded while packaging a VFS data blob.
+ - Added new command line parameter --em-config that allows specifying a custom
+   location for the .emscripten configuration file.
+ - Reintroduced relaxed asm.js heap sizes, which no longer need to be power of
+   2, but a multiple of 16MB is sufficient.
+ - Added emrun command line tool that allows launching .html pages from command
+   line on desktop and Android as if they were native applications. See
+   https://groups.google.com/forum/#!topic/emscripten-discuss/t2juu3q1H8E . Adds
+   --emrun compiler link flag.
+ - Began initial work on the "fastcomp" compiler toolchain, a rewrite of the
+   previous JS LLVM AST parsing and codegen via a native LLVM backend.
+ - Added --exclude-file command line flag to emcc and a matching --exclude
+   command line flag to file packager, which allows specifying files and
+   directories that should be excluded while packaging a VFS data blob.
  - Improved GLES2 and EGL support libraries to be more spec-conformant.
- - Optimized legacy GL emulation code path. Added new GL_FFP_ONLY optimization path to fixed function pipeline emulation.
- - Added new core functions emscripten_log() and emscripten_get_callstack() that allow printing out log messages with demangled and source-mapped callstack information.
+ - Optimized legacy GL emulation code path. Added new GL_FFP_ONLY optimization
+   path to fixed function pipeline emulation.
+ - Added new core functions emscripten_log() and emscripten_get_callstack() that
+   allow printing out log messages with demangled and source-mapped callstack
+   information.
  - Improved BSD Sockets support. Implemented getprotobyname() for BSD Sockets library.
  - Fixed issues with simd support.
  - Various bugfixes: #1573, #1846, #1886, #1908, #1918, #1930, #1931, #1942, #1948, ..
@@ -2311,7 +2837,8 @@ v1.7.9: 12/27/2013
 v1.7.8: 11/19/2013
 ------------------
  - Fixed an issue with -MMD compilation parameter.
- - Added EM_ASM_INT() and EM_ASM_DOUBLE() macros. For more information, read https://groups.google.com/forum/#!topic/emscripten-discuss/BFGTJPCgO6Y .
+ - Added EM_ASM_INT() and EM_ASM_DOUBLE() macros. For more information, read
+   https://groups.google.com/forum/#!topic/emscripten-discuss/BFGTJPCgO6Y .
  - Fixed --split parameter to also work on Windows.
  - Fixed issues with BSD sockets accept() call.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.7.7...1.7.8
@@ -2326,10 +2853,17 @@ v1.7.7: 11/16/2013
 v1.7.6: 11/15/2013
 ------------------
  - Added regex implementation from musl libc.
- - The command line parameter -s DEAD_FUNCTIONS=[] can now be used to explicitly kill functions coming from built-in library_xx.js.
+ - The command line parameter -s DEAD_FUNCTIONS=[] can now be used to explicitly
+   kill functions coming from built-in library_xx.js.
  - Improved EGL support and GLES2 spec conformance.
- - Reverted -s TOTAL_MEMORY=x to require pow2 values, instead of the relaxed 'multiples of 16MB'. This is because the relaxed rule is released only in Firefox 26 which is currently in Beta and ships on the week of December 10th (currently in Beta). As of writing, current stable Firefox 25 does not yet support these.
- - Adjusted the default linker behavior to warn about all missing symbols, instead of silently ignoring them. Use -s WARN_ON_UNDEFINED_SYMBOLS=0 to suppress these warnings if necessary.
+ - Reverted -s TOTAL_MEMORY=x to require pow2 values, instead of the relaxed
+   'multiples of 16MB'. This is because the relaxed rule is released only in
+   Firefox 26 which is currently in Beta and ships on the week of December 10th
+   (currently in Beta). As of writing, current stable Firefox 25 does not yet
+   support these.
+ - Adjusted the default linker behavior to warn about all missing symbols,
+   instead of silently ignoring them. Use -s WARN_ON_UNDEFINED_SYMBOLS=0 to
+   suppress these warnings if necessary.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.7.5...1.7.6
 
 v1.7.5: 11/13/2013
@@ -2345,22 +2879,30 @@ v1.7.4: 11/12/2013
 v1.7.3: 11/12/2013
 ------------------
  - Added support for generating single-precision floating point instructions.
-    - For more information, read https://blog.mozilla.org/javascript/2013/11/07/efficient-float32-arithmetic-in-javascript/
- - Made GLES2 support library more spec-conformant by throwing fewer exceptions on errors. Be sure to build with -s GL_ASSERTIONS=1, remember to use glGetError() and check the browser console to best detect WebGL rendering errors.
- - Converted return value of emscripten_get_now() from float to double, to not lose precision in the function call.
+    - For more information, read
+      https://blog.mozilla.org/javascript/2013/11/07/efficient-float32-arithmetic-in-javascript/
+ - Made GLES2 support library more spec-conformant by throwing fewer exceptions
+   on errors. Be sure to build with -s GL_ASSERTIONS=1, remember to use
+   glGetError() and check the browser console to best detect WebGL rendering
+   errors.
+ - Converted return value of emscripten_get_now() from float to double, to not
+   lose precision in the function call.
  - Added support for joysticks in SDL via the Gamepad API
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.7.2...1.7.3
  
 v1.7.2: 11/9/2013
 ------------------
- - The compiler now always generates a .js file that contains the generated source code even when compiling to a .html file.
+ - The compiler now always generates a .js file that contains the generated
+   source code even when compiling to a .html file.
     - Read https://groups.google.com/forum/#!topic/emscripten-discuss/EuHMwqdSsEs
  - Implemented depth+stencil buffer choosing behavior in GLUT, SDL and GLFW.
  - Fixed memory leaks generated by glGetString and eglGetString.
- - Greatly optimized startup times when virtual filesystems with a large amount of files in them.
+ - Greatly optimized startup times when virtual filesystems with a large amount
+   of files in them.
  - Added some support for SIMD generated by LLVM.
  - Fixed some mappings with SDL keyboard codes.
- - Added a new command line parameter --no-heap-copy to compiler and file packager that can be used to optimize VFS memory usage at startup.
+ - Added a new command line parameter --no-heap-copy to compiler and file
+   packager that can be used to optimize VFS memory usage at startup.
  - Updated libcxx to revision 194185, 2013-11-07.
  - Improvements to various library support. 
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.7.1...1.7.2
@@ -2374,53 +2916,77 @@ v1.7.1: 10/24/2013
 v1.7.0: 10/23/2013
 ------------------
  - Adds mouse wheel events support in GLUT library.
- - Adds support for a new link parameter -s CASE_INSENSITIVE_VFS=1 to enable Emscripten virtual filesystem to search files ignoring case.
+ - Adds support for a new link parameter -s CASE_INSENSITIVE_VFS=1 to enable
+   Emscripten virtual filesystem to search files ignoring case.
  - *Numerous* optimizations in both compilation and runtime stages.
- - Remove unnecessary whitespace, compact postSets function, and other optimizations in compilation output to save on generated file size.
+ - Remove unnecessary whitespace, compact postSets function, and other
+   optimizations in compilation output to save on generated file size.
  - Fixes float parsing from negative zero.
  - Removes the -s EMIT_GENERATED_FUNCTIONS link parameter as unneeded.
- - Fixes an issue where updating subranges of GL uniform arrays was not possible.
- - asm.js heap size (-s TOTAL_MEMORY=x) no longer needs to be a power of 2. As a relaxed rule, choosing any multiple of 16MB is now possible.
- - O1 optimization no longer runs the 'simplifyExpressions' optimization pass. This is to improve build iteration times when using -O1. Use -O2 to run that pass.
+ - Fixes an issue where updating subranges of GL uniform arrays was not
+   possible.
+ - asm.js heap size (-s TOTAL_MEMORY=x) no longer needs to be a power of 2. As a
+   relaxed rule, choosing any multiple of 16MB is now possible.
+ - O1 optimization no longer runs the 'simplifyExpressions' optimization pass.
+   This is to improve build iteration times when using -O1. Use -O2 to run that
+   pass.
  - EM_ASM() can now be used even when compiling to asm.js.
- - All currently specified non-debugging-related WebGL 1 extensions are now enabled by default on startup, no need to ctx.getExtension() manually to enable them.
- - Improve readability of uncaught JavaScript exceptions that are thrown all the way up to the web console by printing out the stack trace of where the throw occurred.
+ - All currently specified non-debugging-related WebGL 1 extensions are now
+   enabled by default on startup, no need to ctx.getExtension() manually to
+   enable them.
+ - Improve readability of uncaught JavaScript exceptions that are thrown all the
+   way up to the web console by printing out the stack trace of where the throw
+   occurred.
  - Fix an issue when renaming a directory to a subdirectory.
  - Several compiler stability fixes.
- - Adds a JavaScript implementation of cxa_demangle function for demangling call stack traces at runtime for easier debugging.
- - GL context MSAA antialising is now DISABLED by default, to make the GL behavior consistent with desktop usage.
+ - Adds a JavaScript implementation of cxa_demangle function for demangling call
+   stack traces at runtime for easier debugging.
+ - GL context MSAA antialising is now DISABLED by default, to make the GL
+   behavior consistent with desktop usage.
  - Added support to SDL, GLUT and GLFW libraries to specify MSAA on/off at startup.
  - Implemented glColor4ubv in GL emulation mode.
  - Fix an issue with LLVM keyword __attribute__ ((__constructor__)) (#1155).
  - Fix an issue with va_args and -s UNALIGNED_MEMORY=1 (#1705).
- - Add initial support code for LLVM SIMD constructs and a JavaScript SIMD polyfill implementation from https://github.com/johnmccutchan/ecmascript_simd/ .
+ - Add initial support code for LLVM SIMD constructs and a JavaScript SIMD
+   polyfill implementation from
+   https://github.com/johnmccutchan/ecmascript_simd/ .
  - Fixed support for node.js native filesystem API NODEFS on Windows.
- - Optimize application startup times of Emscripten-compiled programs by enabling the virtual filesystem XHR and asm.js compilation to proceed in parallel when opening a page.
+ - Optimize application startup times of Emscripten-compiled programs by
+   enabling the virtual filesystem XHR and asm.js compilation to proceed in
+   parallel when opening a page.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.6.4...1.7.0
 
 v1.6.4: 9/30/2013
 ------------------
- - Implements a new preprocessor tool for preparsing C struct definitions (#1554), useful for Emscripten support library implementors.
+ - Implements a new preprocessor tool for preparsing C struct definitions
+   (#1554), useful for Emscripten support library implementors.
  - Fix parsing issue with sscanf (#1668).
  - Improved the responsiveness of compiler print output on Windows.
  - Improved compilation times at link stage.
- - Added support for new "NODEFS" filesystem that directly accesses files on the native filesystem. Only usable with node.js when compiling to JS.
+ - Added support for new "NODEFS" filesystem that directly accesses files on the
+   native filesystem. Only usable with node.js when compiling to JS.
  - Added support for new IDBFS filesystem for accessing files in IndexedDB storage (#1601.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.6.3...1.6.4
 
 v1.6.3: 9/26/2013
 ------------------
- - Emscripten CMake toolchain now generates archive files with .a suffix when project target type is static library, instead of generatic .bc files (#1648).
- - Adds iconv library from the musl project to implement wide functions in C library (#1670).
- - Full list of changes: https://github.com/kripken/emscripten/compare/1.6.2...1.6.3
+ - Emscripten CMake toolchain now generates archive files with .a suffix when
+   project target type is static library, instead of generatic .bc files
+   (#1648).
+ - Adds iconv library from the musl project to implement wide functions in C
+   library (#1670).
+ - Full list of changes:
+   https://github.com/kripken/emscripten/compare/1.6.2...1.6.3
 
 v1.6.2: 9/25/2013
 ------------------
  - Added support for dprintf() function (#1250).
  - Fixes several compiler stability issues (#1637, #1166, #1661, #1651 and more).
  - Enables support for WEBGL_depth_texture.
- - Adds support for new link flag -s GL_ASSERTIONS=1 which can be used to add extra validation layer to the Emscripten GL library to catch code issues.
- - Adds support to Web Audio API in SDL audio backend so that SDL audio now works in Chrome and new Opera as well.
+ - Adds support for new link flag -s GL_ASSERTIONS=1 which can be used to add
+   extra validation layer to the Emscripten GL library to catch code issues.
+ - Adds support to Web Audio API in SDL audio backend so that SDL audio now
+   works in Chrome and new Opera as well.
  - Fixes an alpha blending issue with SDL_SetAlpha.
  - Implemented locale-related code in C library.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.6.1...1.6.2
@@ -2447,29 +3013,38 @@ v1.5.8: 9/14/2013
 ------------------
  - Add support for the GCC -E compiler flag.
  - Update Emscripten libc headers to musl-0.9.13.
- - Added new utility function emscripten_async_load_script() to asynchronously load a new .js script URL.
+ - Added new utility function emscripten_async_load_script() to asynchronously
+   load a new .js script URL.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.7...1.5.8
 
 v1.5.7: 8/30/2013
 ------------------
- - The script tag in default shell.html is now marked 'async', which enables loading the JS script code asynchronously in Firefox without making the main thread unresponsive.
- - Implemented new utility function emscripten_get_canvas_size() which returns the current Module <canvas> element size in pixels.
+ - The script tag in default shell.html is now marked 'async', which enables
+   loading the JS script code asynchronously in Firefox without making the main
+   thread unresponsive.
+ - Implemented new utility function emscripten_get_canvas_size() which returns
+   the current Module <canvas> element size in pixels.
  - Optimize code size in compiled side modules.
- - Optimize startup memory usage by avoiding unnecessary copying of VFS data at startup.
+ - Optimize startup memory usage by avoiding unnecessary copying of VFS data at
+   startup.
  - Add support for SDL_WM_ToggleFullScreen().
  - Add support for emscripten_get_now() when running in SpiderMonkey shell.
- - Added new environment variable EM_BUILD_VERBOSE=0,1,2,3 to set an extra compiler output verbosity level for debugging.
- - Added better support for dlopen() to simulate dynamic library loading in JavaScript.
+ - Added new environment variable EM_BUILD_VERBOSE=0,1,2,3 to set an extra
+   compiler output verbosity level for debugging.
+ - Added better support for dlopen() to simulate dynamic library loading in
+   JavaScript.
  - Improved support for BSD sockets and networking.
  - Added new SOCKFS filesystem, which reads files via a network connection.
- - Avoid issues with long command line limitations in CMake toolchain by using response files.
+ - Avoid issues with long command line limitations in CMake toolchain by using
+   response files.
  - Fix issues with client-side vertex data rendering in GL emulation mode.
  - Improved precision of clock_gettime().
  - Improve function outlining support.
  - Added support for using NMake generator with CMake toolchain.
  - Improved support for flexible arrays in structs (#1602).
  - Added ability to marshal UTF16 and UTF32 strings between C++ <-> JS code.
- - Added a new commandline tool validate_asms.py to help automating asm.js validation testing.
+ - Added a new commandline tool validate_asms.py to help automating asm.js
+   validation testing.
  - Improved stability with inline asm() syntax.
  - Updated libc headers to new version.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.6...1.5.7
@@ -2478,14 +3053,20 @@ v1.5.6: 8/17/2013
 ------------------
  - Improved BSD sockets support.
  - Added touch events support to GLUT library.
- - Added new --js-opts=0/1 command line option to control whether JS optimizer is run or not.
+ - Added new --js-opts=0/1 command line option to control whether JS optimizer
+   is run or not.
  - Improved OpenAL support.
- - Added new command line tool tools/find_bigvars.py which can be used on an output file to detect large functions and needs for outlining.
- - Merged link flags -s FORCE_GL_EMULATION and -s DISABLE_GL_EMULATION to a single opt-in flag -s LEGACY_GL_EMULATION=0/1 to control whether GL emulation is active.
+ - Added new command line tool tools/find_bigvars.py which can be used on an
+   output file to detect large functions and needs for outlining.
+ - Merged link flags -s FORCE_GL_EMULATION and -s DISABLE_GL_EMULATION to a
+   single opt-in flag -s LEGACY_GL_EMULATION=0/1 to control whether GL emulation
+   is active.
  - Improved SDL input support.
  - Several stability-related compiler fixes.
  - Fixed source mapping generation support on Windows.
- - Added back the EMSCRIPTEN_KEEPALIVE attribute qualifier to help prevent inlining and to retain symbols in output without dead code elimination occurring.
+ - Added back the EMSCRIPTEN_KEEPALIVE attribute qualifier to help prevent
+   inlining and to retain symbols in output without dead code elimination
+   occurring.
  - Fix issues when marshalling UTF8 strings between C<->JS.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.5...1.5.6
 
@@ -2499,23 +3080,30 @@ v1.5.4: 8/9/2013
  - Fixed multiple issues with C stdlib support.
  - Fix audio buffer queueing issues with OpenAL.
  - Improved BSD sockets support.
- - Added a new compile+link time command line option -Wno-warn-absolute-paths to hide the emscripten compiler warning when absolute paths are passed into the compiler.
- - Added new link flag -s STB_IMAGE=0/1 and integrate it to SDL image loading to enable synchronous image loading support with SDL.
+ - Added a new compile+link time command line option -Wno-warn-absolute-paths to
+   hide the emscripten compiler warning when absolute paths are passed into the
+   compiler.
+ - Added new link flag -s STB_IMAGE=0/1 and integrate it to SDL image loading to
+   enable synchronous image loading support with SDL.
  - Several improvements on function outlining support.
  - Fix issues with GLES2 interop support.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.3...1.5.4
 
 v1.5.3: 6/28/2013
 ------------------
- - Added new optimization level --llvm-lto 3 to run even more aggressive LTO optimizations.
+ - Added new optimization level --llvm-lto 3 to run even more aggressive LTO
+   optimizations.
  - Improve optimizations for libc and other libraries.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.2...1.5.3
 
 v1.5.2: 6/27/2013
 ------------------
- - Added support for generating source maps along the built application when -g is specified. This lets the browser show original .cpp sources when debugging.
+ - Added support for generating source maps along the built application when -g
+   is specified. This lets the browser show original .cpp sources when
+   debugging.
  - GLUT and SDL improvements.
- - Added new link option -g<level> where level=0-4, which allows controlling various levels of debuggability added to the output.
+ - Added new link option -g<level> where level=0-4, which allows controlling
+   various levels of debuggability added to the output.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.5.1...1.5.2
 
 v1.5.1: 6/22/2013
@@ -2560,20 +3148,23 @@ v1.4.4: 6/1/2013
 ------------------
  - Add support for symlinks in source files.
  - Fix various issues with SDL.
- - Added -s FORCE_ALIGNED_MEMORY=0/1 link time flag to control whether all loads and stores are assumed to be aligned.
+ - Added -s FORCE_ALIGNED_MEMORY=0/1 link time flag to control whether all loads
+   and stores are assumed to be aligned.
  - Fix file packager to work with closure.
  - Major improvements to embind support, and optimizations.
  - Improve GL emulation.
  - Optimize VFS usage.
  - Allow emscripten to compile .m and .mm files.
- - Added new syntax --preload-file src@dst to file packager command line to allow placing source files to custom destinations in the FS.
+ - Added new syntax --preload-file src@dst to file packager command line to
+   allow placing source files to custom destinations in the FS.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.4.3...1.4.4
 
 v1.4.3: 5/8/2013
 ------------------
  - Fix issue with strcat.
  - Major embind improvements.
- - Switch to le32-unknown-nacl LLVM target triple as default build option instead of the old i386-pc-linux-gnu target triple.
+ - Switch to le32-unknown-nacl LLVM target triple as default build option
+   instead of the old i386-pc-linux-gnu target triple.
  - Improve compiler logging behavior.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.4.2...1.4.3
 
@@ -2586,22 +3177,27 @@ v1.4.2: 5/3/2013
 v1.4.1: 4/28/2013
 ------------------
  - Implement support for le32-unknown-nacl LLVM target triple.
- - Added new cmdline option -s ERROR_ON_UNDEFINED_SYMBOLS=0/1 to give compile-time error on undefined symbols at link time. Default off.
+ - Added new cmdline option -s ERROR_ON_UNDEFINED_SYMBOLS=0/1 to give
+   compile-time error on undefined symbols at link time. Default off.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.3.8...1.4.1
 
 v1.3.8: 4/29/2013
 ------------------
  - Improved 64-bit integer ops codegen.
  - Added Indexed DB support to vfs.
- - Improve warning message on dangerous function pointer casts when compiling in asm.js mode.
- - Added --use-preload-cache command line option to emcc, to be used with the file packager.
+ - Improve warning message on dangerous function pointer casts when compiling in
+   asm.js mode.
+ - Added --use-preload-cache command line option to emcc, to be used with the
+   file packager.
  - Fixes to libcextra.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.3.7...1.3.8
 
 v1.3.7: 4/24/2013
 ------------------
- - Merge IMVU implementation of embind to emscripten trunk. Embind allows high-level C++ <-> JS types interop.
- - Enable asm.js compilation in -O1 and higher by default. Fix issues when compiling to asm.js.
+ - Merge IMVU implementation of embind to emscripten trunk. Embind allows
+   high-level C++ <-> JS types interop.
+ - Enable asm.js compilation in -O1 and higher by default. Fix issues when
+   compiling to asm.js.
  - Improve libc support with Emscripten with the musl libc headers.
  - Full list of changes: https://github.com/kripken/emscripten/compare/1.3.6...1.3.7
 

--- a/site/source/docs/introducing_emscripten/release_notes.rst
+++ b/site/source/docs/introducing_emscripten/release_notes.rst
@@ -4,19 +4,25 @@
 Release Notes
 =============
 
-Changes between tagged Emscripten versions are recorded in the :ref:`ChangeLog`. This log includes high-level information about new features, user-oriented fixes, options, command-line parameters, usage changes, deprecations, significant internal modifications, optimizations, etc. The log for each version links to a detailed diff report, which lists all the incremental changes since the previous release.
+Changes between tagged Emscripten versions are recorded in the :ref:`ChangeLog`.
+This log includes high-level information about new features, user-oriented
+fixes, options, command-line parameters, usage changes, deprecations,
+significant internal modifications, optimizations, etc. The log for each version
+links to a detailed diff report, which lists all the incremental changes since
+the previous release.
 
-In addition, the mailing list is used to announce each new :term:`SDK` release; these announcements include additional informal release notes and "highlights" information. The easiest way to find these posts is to use `this search <https://groups.google.com/forum/#!searchin/emscripten-discuss/%22Emscripten$20SDK%22$20$20AND$20(released$20OR$20out$20OR$20available)>`_.
+In addition, the mailing list is used to announce each new :term:`SDK` release;
+these announcements include additional informal release notes and "highlights"
+information. The easiest way to find these posts is to use `this search
+<https://groups.google.com/forum/#!searchin/emscripten-discuss/%22Emscripten$20SDK%22$20$20AND$20(released$20OR$20out$20OR$20available)>`_.
 
 .. _ChangeLog:
 
 ChangeLog
 =========
 
-
-The ChangeLog for Emscripten |release| (|today|) is listed below (master version `here <https://github.com/kripken/emscripten/blob/master/ChangeLog.markdown>`_).
+The ChangeLog for Emscripten |release| (|today|) is listed below (master version
+`here <https://github.com/kripken/emscripten/blob/master/ChangeLog.markdown>`_).
 
 .. include::   ../../../../ChangeLog.markdown
    :literal:
-
-


### PR DESCRIPTION
Amongst other things this makes it a lot more usable in the
web view at:
https://kripken.github.io/emscripten-site/docs/introducing_emscripten/release_notes.html