### PR TITLE
Support invokes in wasm dynamic libraries even if the main file is missing that signature

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -208,6 +208,13 @@ function loadWebAssemblyModule(binary, loadAsync) {
           return Module[name];
         };
       }
+      if (prop.startsWith('invoke_')) {
+        // A missing invoke, i.e., an invoke for a function type
+        // present in the dynamic library but not in the main JS,
+        // and the dynamic library cannot provide JS for it. Use
+        // the generic "X" invoke for it.
+        return env[prop] = invoke_X;
+      }
       // if not a global, then a function - call it indirectly
       return env[prop] = function() {
 #if ASSERTIONS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3975,30 +3975,31 @@ Module = {
 
     self.dylink_test(main=r'''
       #include <stdio.h>
-      extern void side();
+      extern int side();
       int main() {
-        side();
+        printf("from side: %d.\n", side());
       }
     ''', side=r'''
       #include <stdio.h>
-      typedef void (*vfdi)(float, double, int);
-      void func_with_special_sig(float a, double b, int c) {
+      typedef int (*ifdi)(float, double, int);
+      int func_with_special_sig(float a, double b, int c) {
         printf("special %f %f %d\n", a, b, c);
+        return 1337;
       }
       struct DestructorCaller {
         ~DestructorCaller() { printf("destroy\n"); }
       };
-      void side() {
+      int side() {
         // d has a destructor that must be called on function
         // exit, which means an invoke will be used for the
         // indirect call here - and the signature of that call
         // is special and not present in the main module, so
         // it must be generated for the side module.
         DestructorCaller d;
-        volatile vfdi p = func_with_special_sig;
-        p(2.18281, 3.14159, 42);
+        volatile ifdi p = func_with_special_sig;
+        return p(2.18281, 3.14159, 42);
       }
-    ''', expected=['special 2.182810 3.141590 42\ndestroy\n'])
+    ''', expected=['special 2.182810 3.141590 42\ndestroy\nfrom side: 1337\n'])
 
   @needs_dlfcn
   def test_dylink_hyper_dupe(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3999,7 +3999,7 @@ Module = {
         volatile ifdi p = func_with_special_sig;
         return p(2.18281, 3.14159, 42);
       }
-    ''', expected=['special 2.182810 3.141590 42\ndestroy\nfrom side: 1337\n'])
+    ''', expected=['special 2.182810 3.141590 42\ndestroy\nfrom side: 1337.\n'])
 
   @needs_dlfcn
   def test_dylink_hyper_dupe(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2837,20 +2837,37 @@ class JS(object):
 
   @staticmethod
   def make_invoke(sig, named=True):
-    legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
-    args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
-    args = 'index' + (',' if args else '') + args
+    if sig == 'X' and Settings.WASM:
+      # 'X' means the generic unknown signature, used in wasm dynamic linking
+      # to indicate an invoke that the main JS may not have defined, so we
+      # go through this (which may be slower, as we don't declare the
+      # arguments explicitly). In non-wasm dynamic linking, the other modules
+      # have JS and so can define their own invokes to be linked in.
+      # This only makes sense in function pointer emulation mode, where we
+      # can do a direct table call.
+      assert Settings.EMULATED_FUNCTION_POINTERS
+      args = ''
+      body = '''
+        var args = Array.prototype.slice.call(arguments);
+        return Module['wasmTable'].get(args[0]).apply(null, args.slice(1));
+      '''
+    else:
+      legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
+      args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
+      args = 'index' + (',' if args else '') + args
+      ret = 'return ' if sig[0] != 'v' else ''
+      body = '%sModule["dynCall_%s"](%s);' % (ret, sig, args)
     # C++ exceptions are numbers, and longjmp is a string 'longjmp'
     ret = '''function%s(%s) {
   var sp = stackSave();
   try {
-    %sModule["dynCall_%s"](%s);
+    %s
   } catch(e) {
     stackRestore(sp);
     if (typeof e !== 'number' && e !== 'longjmp') throw e;
     Module["setThrew"](1, 0);
   }
-}''' % ((' invoke_' + sig) if named else '', args, 'return ' if sig[0] != 'v' else '', sig, args)
+}''' % ((' invoke_' + sig) if named else '', args, body)
     return ret
 
   @staticmethod

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2837,7 +2837,7 @@ class JS(object):
 
   @staticmethod
   def make_invoke(sig, named=True):
-    if sig == 'X' and Settings.WASM:
+    if sig == 'X':
       # 'X' means the generic unknown signature, used in wasm dynamic linking
       # to indicate an invoke that the main JS may not have defined, so we
       # go through this (which may be slower, as we don't declare the
@@ -2845,6 +2845,7 @@ class JS(object):
       # have JS and so can define their own invokes to be linked in.
       # This only makes sense in function pointer emulation mode, where we
       # can do a direct table call.
+      assert Settings.WASM
       assert Settings.EMULATED_FUNCTION_POINTERS
       args = ''
       body = '''


### PR DESCRIPTION
We use `invoke_[sig]` to call out to JS, do a try-catch, and so handle catching exceptions. There is a separate function for each signature. A potential problem is that a dynamic library may have a signature not present in the main file, so in asm.js each library adds `invoke` functions as needed. In wasm, however, a library is a pure wasm file, so it doesn't have JS that can help with loading itself.

To fix that, this PR properly implements the `invoke_X` handler (which was always present for future use, but not actually implemented). That does a generic invoke regardless of the number of arguments, using the JS `arguments` object. That's not very efficient, but it works for now until we get proper exception handling in wasm. This builds on the work in #6963 for using a JS Proxy to detect missing imports to a loaded wasm library (we detect a missing `invoke_*` import, and hook it up to `invoke_X` - in theory we could use `new Function` to create a specialized one for it).

See https://github.com/kripken/emscripten/pull/6963#issuecomment-415380555