### PR TITLE
Fix filename in dlopen error message

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1701,31 +1701,31 @@ LibraryManager.library = {
   dlopen__deps: ['$DLFCN', '$FS', '$ENV'],
   dlopen__proxy: 'sync',
   dlopen__sig: 'iii',
-  dlopen: function(filename, flag) {
+  dlopen: function(filenameAddr, flag) {
 #if MAIN_MODULE == 0
     abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/kripken/emscripten/wiki/Linking");
 #endif
     // void *dlopen(const char *file, int mode);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/dlopen.html
     var searchpaths = [];
-    if (filename === 0) {
+    var filename;
+    if (filenameAddr === 0) {
       filename = '__self__';
     } else {
-      var strfilename = Pointer_stringify(filename);
+      filename = Pointer_stringify(filenameAddr);
+
       var isValidFile = function (filename) {
         var target = FS.findObject(filename);
         return target && !target.isFolder && !target.isDevice;
       };
 
-      if (isValidFile(strfilename)) {
-        filename = strfilename;
-      } else {
+      if (!isValidFile(filename)) {
         if (ENV['LD_LIBRARY_PATH']) {
           searchpaths = ENV['LD_LIBRARY_PATH'].split(':');
         }
 
         for (var ident in searchpaths) {
-          var searchfile = PATH.join2(searchpaths[ident],strfilename);
+          var searchfile = PATH.join2(searchpaths[ident], filename);
           if (isValidFile(searchfile)) {
             filename = searchfile;
             break;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2449,6 +2449,23 @@ def process(filename):
       shutil.move(filename + '.o.js', os.path.join(dirname, 'liblib.so'))
 
   @needs_dlfcn
+  def test_dlfcn_missing(self):
+    self.set_setting('MAIN_MODULE', 1)
+    src = r'''
+      #include <dlfcn.h>
+      #include <stdio.h>
+      #include <assert.h>
+
+      int main() {
+        void* lib_handle = dlopen("libfoo.so", RTLD_NOW);
+        assert(!lib_handle);
+        printf("error: %s\n", dlerror());
+        return 0;
+      }
+      '''
+    self.do_run(src, 'error: Could not find dynamic lib: libfoo.so\n')
+
+  @needs_dlfcn
   def test_dlfcn_basic(self):
     self.prep_dlfcn_lib()
     lib_src = '''


### PR DESCRIPTION
In the case that a file was not found during dlopen that
error message was including the address of the filename
string rather than the filename.

Without this change the new test will print:
`error: Could not find dynamic lib: 167662`