### PR TITLE
Honor EXPORT_ALL in get_safe_internalize

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1604,7 +1604,6 @@ def process(filename):
       # test EXPORT_ALL
       self.set_setting('EXPORTED_FUNCTIONS', [])
       self.set_setting('EXPORT_ALL', 1)
-      self.set_setting('LINKABLE', 1)
       self.do_run_in_out_file_test('tests', 'core', 'test_emscripten_api',
                                    js_transform=check)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2290,7 +2290,7 @@ class Building(object):
 
   @staticmethod
   def get_safe_internalize():
-    if not Building.can_build_standalone():
+    if Settings.EXPORT_ALL or not Building.can_build_standalone():
       return [] # do not internalize anything
 
     exps = expand_response(Settings.EXPORTED_FUNCTIONS)


### PR DESCRIPTION
This allows LINKABLE to be removed from one of the tests
that already has EXPORTA_ALL.