### PR TITLE
Output emscripten version info to stderr

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -127,7 +127,7 @@ if (EMSCRIPTEN_FORCE_COMPILERS)
 
 	# Capture the Emscripten version to EMSCRIPTEN_VERSION variable.
 	if (NOT EMSCRIPTEN_VERSION)
-		execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result OUTPUT_VARIABLE _cmake_compiler_output ERROR_QUIET)
+		execute_process(COMMAND "${CMAKE_C_COMPILER}" "-v" RESULT_VARIABLE _cmake_compiler_result ERROR_VARIABLE _cmake_compiler_output OUTPUT_QUIET)
 		if (NOT _cmake_compiler_result EQUAL 0)
 			message(FATAL_ERROR "Failed to fetch Emscripten version information with command \"'${CMAKE_C_COMPILER}' -v\"! Process returned with error code ${_cmake_compiler_result}.")
 		endif()

--- a/emcc.py
+++ b/emcc.py
@@ -431,7 +431,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   elif len(sys.argv) == 2 and sys.argv[1] == '-v': # -v with no inputs
     # autoconf likes to see 'GNU' in the output to enable shared object support
-    print('emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) %s' % shared.EMSCRIPTEN_VERSION)
+    print('emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) %s' % shared.EMSCRIPTEN_VERSION, file=sys.stderr)
     code = run_process([shared.CLANG, '-v'], check=False).returncode
     shared.check_sanity(force=True)
     return code

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -74,11 +74,11 @@ class other(RunnerCore):
   def test_emcc_v(self):
     for compiler in [EMCC, EMXX]:
       # -v, without input files
-      output = run_process([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE)
-      self.assertContained('''clang version %s''' % expected_llvm_version(), output.stderr.replace('\r', ''), output.stderr.replace('\r', ''))
-      self.assertContained('''GNU''', output.stdout)
-      self.assertNotContained('this is dangerous', output.stdout)
-      self.assertNotContained('this is dangerous', output.stderr)
+      proc = run_process([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE)
+      self.assertContained('clang version %s' % expected_llvm_version(), proc.stderr)
+      self.assertContained('GNU', proc.stderr)
+      self.assertNotContained('this is dangerous', proc.stdout)
+      self.assertNotContained('this is dangerous', proc.stderr)
 
   def test_emcc_generate_config(self):
     for compiler in [EMCC, EMXX]:


### PR DESCRIPTION
This matches what clang and gcc do.  This change specifically
fixes `other.test_cmake` with the llvm backend, because the cmake
code that checks for emscripten was checking for the word
emscripten in stderr and not stdout.

For the fastcomp this is fine because the word emscripten appears
in the stderr of `clang -v`, but for the llvm backend we rely on
the first line of `emcc -v` output which contains the word emscripten.

For reference once the output `emcc -v` is something like like this:

```
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 1.38.11
clang version 8.0.0 (trunk 340421) (llvm/trunk 340423)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/local/google/home/sbc/dev/wasm/llvm-build/bin
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/6
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/6.4.0
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/7
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/7.3.0
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/8
Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/8.0.1
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.4.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.3.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/8
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/8.0.1
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.3.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
```

Prior to this change the first line went to stdout and the rest
to stderr.