### PR TITLE
Fix or disable all `other` tests under wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1284,7 +1284,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
         shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
         shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
-        assert not shared.Settings.SPLIT_MEMORY, 'WebAssembly does not support split memory'
+        if shared.Settings.SPLIT_MEMORY:
+          exit_with_error('WebAssembly does not support split memory')
         if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
           logging.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
           shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
@@ -1297,11 +1298,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
           options.js_opts = None
           logging.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
-        assert not options.use_closure_compiler == 2, 'closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm'
+        if options.use_closure_compiler == 2:
+          exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
         # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
         #  * if we also supported js mem inits we'd have 4 modes
         #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
-        if 'MEM_INIT_METHOD' in settings_changes:
+        if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
           exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
         options.memory_init_file = True
         # async compilation requires not interpreting (the interpreter modes needs sync input)
@@ -1754,8 +1756,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
         assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
 
-    # exit block 'post-link'
-    log_time('post-link')
+      # exit block 'post-link'
+      log_time('post-link')
 
     with ToolchainProfiler.profile_block('emscript'):
       # Emscripten
@@ -2773,7 +2775,8 @@ def generate_html(target, options, js_target, target_basename,
     # Download .asm.js if --separate-asm was passed in an asm.js build, or if 'asmjs' is one
     # of the wasm run methods.
     if not options.separate_asm or (shared.Settings.WASM and 'asmjs' not in shared.Settings.BINARYEN_METHOD):
-      assert len(asm_mods) == 0, 'no --separate-asm means no client code mods are possible'
+      if len(asm_mods):
+         exit_with_error('no --separate-asm means no client code mods are possible')
     else:
       script.un_src()
       if len(asm_mods) == 0:

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -779,12 +779,9 @@ function demangle(func) {
   var __cxa_demangle_func = Module['___cxa_demangle'] || Module['__cxa_demangle'];
   assert(__cxa_demangle_func);
   try {
-    var s =
-#if WASM_BACKEND
-      func;
-#else
-      func.substr(1);
-#endif
+    var s = func;
+    if (s.startsWith('__Z'))
+      s = s.substr(1);
     var len = lengthBytesUTF8(s)+1;
     var buf = _malloc(len);
     stringToUTF8(s, buf, len);

--- a/tests/files.cpp
+++ b/tests/files.cpp
@@ -134,7 +134,7 @@ int main()
   }
 
   FILE *n = fopen("/dev/null", "w");
-  printf("5 bytes to dev/null: %d\n", fwrite(data, 1, 5, n));
+  printf("5 bytes to dev/null: %zu\n", fwrite(data, 1, 5, n));
   fclose(n);
 
   printf("ok.\n");

--- a/tests/return64bit/test.c
+++ b/tests/return64bit/test.c
@@ -1,6 +1,6 @@
 
 // This is just a trivial test function, the key bit of interest is that it returns a 64 bit long.
-long long test() {
+long long test_return64() {
     long long x = ((long long)1234 << 32) + 5678;
     return x;
 }

--- a/tests/return64bit/testbind.js
+++ b/tests/return64bit/testbind.js
@@ -8,7 +8,7 @@ var Module = {
 };
 
 Module['runtest'] = function() {
-    var low = _test();
+    var low = _test_return64();
     var high = getTempRet0();
 
     console.log("low = " + low);

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -540,7 +540,7 @@ class RunnerCore(unittest.TestCase):
       if '[' + what + ']' in line:
         ret = line.split(':')[1].strip()
         return int(ret)
-    assert False
+    raise Exception('Failed to find [%s] in wasm-opt output' % what)
 
   def get_wasm_text(self, wasm_binary):
     return run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), wasm_binary], stdout=PIPE).stdout

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,7 +18,7 @@ import tools.shared
 from tools.shared import *
 from tools.line_endings import check_line_endings
 from runner import RunnerCore, path_from_root, checked_sanity, core_test_modes, get_zlib_library, get_bullet_library
-from runner import skip_if, no_wasm_backend
+from runner import skip_if, no_wasm_backend, needs_dlfcn
 
 # decorators for limiting which modes a test can run in
 
@@ -35,14 +35,6 @@ def SIMD(f):
 
 def no_emterpreter(f):
   return skip_if(f, 'is_emterpreter')
-
-
-def needs_dlfcn(func):
-  def decorated(self):
-    self.check_dlfcn()
-    return func(self)
-
-  return decorated
 
 
 def no_wasm(note=''):
@@ -555,41 +547,41 @@ int main()
     self.do_run_in_out_file_test('tests', 'core', 'test_globaldoubles')
 
   def test_math(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_math')
+    self.do_run_in_out_file_test('tests', 'core', 'test_math')
 
   def test_erf(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_erf')
+    self.do_run_in_out_file_test('tests', 'core', 'test_erf')
 
   def test_math_hyperbolic(self):
-      src = open(path_from_root('tests', 'hyperbolic', 'src.c'), 'r').read()
-      expected = open(path_from_root('tests', 'hyperbolic', 'output.txt'), 'r').read()
-      self.do_run(src, expected)
+    src = open(path_from_root('tests', 'hyperbolic', 'src.c'), 'r').read()
+    expected = open(path_from_root('tests', 'hyperbolic', 'output.txt'), 'r').read()
+    self.do_run(src, expected)
 
   def test_math_lgamma(self):
-      test_path = path_from_root('tests', 'math', 'lgamma')
-      src, output = (test_path + s for s in ('.c', '.out'))
+    test_path = path_from_root('tests', 'math', 'lgamma')
+    src, output = (test_path + s for s in ('.c', '.out'))
 
+    self.do_run_from_file(src, output)
+
+    if self.get_setting('ALLOW_MEMORY_GROWTH') == 0 and not self.is_wasm():
+      print('main module')
+      self.set_setting('MAIN_MODULE', 1)
       self.do_run_from_file(src, output)
 
-      if self.get_setting('ALLOW_MEMORY_GROWTH') == 0 and not self.is_wasm():
-        print('main module')
-        self.set_setting('MAIN_MODULE', 1)
-        self.do_run_from_file(src, output)
-
   def test_frexp(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_frexp')
+    self.do_run_in_out_file_test('tests', 'core', 'test_frexp')
 
   def test_rounding(self):
-      # needs to flush stdio streams
-      self.set_setting('NO_EXIT_RUNTIME', 0)
-      for precise_f32 in [0, 1]:
-        print(precise_f32)
-        self.set_setting('PRECISE_F32', precise_f32)
+    # needs to flush stdio streams
+    self.set_setting('NO_EXIT_RUNTIME', 0)
+    for precise_f32 in [0, 1]:
+      print(precise_f32)
+      self.set_setting('PRECISE_F32', precise_f32)
 
-        self.do_run_in_out_file_test('tests', 'core', 'test_rounding')
+      self.do_run_in_out_file_test('tests', 'core', 'test_rounding')
 
   def test_fcvt(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_fcvt')
+    self.do_run_in_out_file_test('tests', 'core', 'test_fcvt')
 
   def test_llrint(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_llrint')
@@ -953,97 +945,99 @@ int main() {
     self.do_run(src, r'''ok.''')
 
   def test_exceptions(self):
-      self.set_setting('EXCEPTION_DEBUG', 1)
-      # needs to flush stdio streams
-      self.set_setting('NO_EXIT_RUNTIME', 0)
+    self.set_setting('EXCEPTION_DEBUG', 1)
+    # needs to flush stdio streams
+    self.set_setting('NO_EXIT_RUNTIME', 0)
 
-      self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-      self.maybe_closure()
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+    self.maybe_closure()
 
-      src = '''
-        #include <stdio.h>
-        void thrower() {
-          printf("infunc...");
-          throw(99);
+    src = '''
+      #include <stdio.h>
+      void thrower() {
+        printf("infunc...");
+        throw(99);
+        printf("FAIL");
+      }
+      int main() {
+        try {
+          printf("*throw...");
+          throw(1);
           printf("FAIL");
+        } catch(...) {
+          printf("caught!");
         }
-        int main() {
-          try {
-            printf("*throw...");
-            throw(1);
-            printf("FAIL");
-          } catch(...) {
-            printf("caught!");
-          }
-          try {
-            thrower();
-          } catch(...) {
-            printf("done!*\\n");
-          }
-          return 0;
+        try {
+          thrower();
+        } catch(...) {
+          printf("done!*\\n");
         }
-      '''
-      self.do_run(src, '*throw...caught!infunc...done!*')
-
-      self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-      self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
-
-      src = '''
-      #include <iostream>
-
-      class MyException
-      {
-      public:
-          MyException(){ std::cout << "Construct..."; }
-          MyException( const MyException & ) { std::cout << "Copy..."; }
-          ~MyException(){ std::cout << "Destruct..."; }
-      };
-
-      int function()
-      {
-          std::cout << "Throw...";
-          throw MyException();
+        return 0;
       }
+    '''
+    self.do_run(src, '*throw...caught!infunc...done!*')
 
-      int function2()
-      {
-          return function();
-      }
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
+    self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
 
-      int main()
-      {
-          try
-          {
-              function2();
-          }
-          catch (MyException & e)
-          {
-              std::cout << "Caught...";
-          }
+  def test_exceptions_custom(self):
+    #self.emcc_args.append('--profiling-funcs')
+    self.set_setting('EXCEPTION_DEBUG', 1)
+    # needs to flush stdio streams
+    self.set_setting('NO_EXIT_RUNTIME', 0)
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+    self.maybe_closure()
+    src = '''
+    #include <iostream>
 
-          try
-          {
-              function2();
-          }
-          catch (MyException e)
-          {
-              std::cout << "Caught...";
-          }
+    class MyException
+    {
+    public:
+        MyException(){ std::cout << "Construct..."; }
+        MyException( const MyException & ) { std::cout << "Copy..."; }
+        ~MyException(){ std::cout << "Destruct..."; }
+    };
 
-          return 0;
-      }
-      '''
+    int function()
+    {
+        std::cout << "Throw...";
+        throw MyException();
+    }
 
-      self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-      self.do_run(src, 'Throw...Construct...Caught...Destruct...Throw...Construct...Copy...Caught...Destruct...Destruct...')
+    int function2()
+    {
+        return function();
+    }
+
+    int main()
+    {
+        try
+        {
+            function2();
+        }
+        catch (MyException & e)
+        {
+            std::cout << "Caught...";
+        }
+
+        try
+        {
+            function2();
+        }
+        catch (MyException e)
+        {
+            std::cout << "Caught...";
+        }
+
+        return 0;
+    }
+    '''
+
+    self.do_run(src, 'Throw...Construct...Caught...Destruct...Throw...Construct...Copy...Caught...Destruct...Destruct...')
 
   def test_exceptions_2(self):
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
-
-    for safe in [0,1]:
-      # Wasm backend does not support SAFE_HEAP option
-      if self.is_wasm_backend() and safe == 1:
-        continue
+    for safe in [0, 1]:
       print(safe)
       self.set_setting('SAFE_HEAP', safe)
       self.do_run_in_out_file_test('tests', 'core', 'test_exceptions_2')
@@ -1934,12 +1928,12 @@ Success!''')
       self.do_run(src, '*4,3,4*\n*6,4,6*')
 
   def test_varargs(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_varargs')
+    self.do_run_in_out_file_test('tests', 'core', 'test_varargs')
 
   @no_wasm_backend('Calling varargs across function calls is undefined behavior in C,'
                    ' and asmjs and wasm implement it differently.')
   def test_varargs_multi(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_varargs_multi')
+    self.do_run_in_out_file_test('tests', 'core', 'test_varargs_multi')
 
   @unittest.skip('clang cannot compile this code with that target yet')
   def test_varargs_byval(self):
@@ -2016,121 +2010,121 @@ The current type of b is: 9
     self.do_run_in_out_file_test('tests', 'core', 'test_functionpointer_libfunc_varargs')
 
   def test_structbyval(self):
-      self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT', 50)
 
-      # part 1: make sure that normally, passing structs by value works
+    # part 1: make sure that normally, passing structs by value works
 
-      src = r'''
-        #include <stdio.h>
+    src = r'''
+      #include <stdio.h>
 
-        struct point
-        {
-          int x, y;
-        };
+      struct point
+      {
+        int x, y;
+      };
 
-        void dump(struct point p) {
-          p.x++; // should not modify
-          p.y++; // anything in the caller!
-          printf("dump: %d,%d\n", p.x, p.y);
-        }
+      void dump(struct point p) {
+        p.x++; // should not modify
+        p.y++; // anything in the caller!
+        printf("dump: %d,%d\n", p.x, p.y);
+      }
 
-        void dumpmod(struct point *p) {
-          p->x++; // should not modify
-          p->y++; // anything in the caller!
-          printf("dump: %d,%d\n", p->x, p->y);
-        }
+      void dumpmod(struct point *p) {
+        p->x++; // should not modify
+        p->y++; // anything in the caller!
+        printf("dump: %d,%d\n", p->x, p->y);
+      }
 
-        int main( int argc, const char *argv[] ) {
-          point p = { 54, 2 };
-          printf("pre:  %d,%d\n", p.x, p.y);
-          dump(p);
-          void (*dp)(point p) = dump; // And, as a function pointer
-          dp(p);
-          printf("post: %d,%d\n", p.x, p.y);
-          dumpmod(&p);
-          dumpmod(&p);
-          printf("last: %d,%d\n", p.x, p.y);
-          return 0;
-        }
-      '''
-      self.do_run(src, 'pre:  54,2\ndump: 55,3\ndump: 55,3\npost: 54,2\ndump: 55,3\ndump: 56,4\nlast: 56,4')
+      int main( int argc, const char *argv[] ) {
+        point p = { 54, 2 };
+        printf("pre:  %d,%d\n", p.x, p.y);
+        dump(p);
+        void (*dp)(point p) = dump; // And, as a function pointer
+        dp(p);
+        printf("post: %d,%d\n", p.x, p.y);
+        dumpmod(&p);
+        dumpmod(&p);
+        printf("last: %d,%d\n", p.x, p.y);
+        return 0;
+      }
+    '''
+    self.do_run(src, 'pre:  54,2\ndump: 55,3\ndump: 55,3\npost: 54,2\ndump: 55,3\ndump: 56,4\nlast: 56,4')
 
-      # Check for lack of warning in the generated code (they should appear in part 2)
-      generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
-      assert 'Casting a function pointer type to another with a different number of arguments.' not in generated, 'Unexpected warning'
+    # Check for lack of warning in the generated code (they should appear in part 2)
+    generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
+    assert 'Casting a function pointer type to another with a different number of arguments.' not in generated, 'Unexpected warning'
 
-      # part 2: make sure we warn about mixing c and c++ calling conventions here
+    # part 2: make sure we warn about mixing c and c++ calling conventions here
 
-      if self.emcc_args != []: return # Optimized code is missing the warning comments
+    if self.emcc_args != []: return # Optimized code is missing the warning comments
 
-      header = r'''
-        struct point
-        {
-          int x, y;
-        };
+    header = r'''
+      struct point
+      {
+        int x, y;
+      };
 
-      '''
-      open(os.path.join(self.get_dir(), 'header.h'), 'w').write(header)
+    '''
+    open(os.path.join(self.get_dir(), 'header.h'), 'w').write(header)
 
-      supp = r'''
-        #include <stdio.h>
-        #include "header.h"
+    supp = r'''
+      #include <stdio.h>
+      #include "header.h"
 
-        void dump(struct point p) {
-          p.x++; // should not modify
-          p.y++; // anything in the caller!
-          printf("dump: %d,%d\n", p.x, p.y);
-        }
-      '''
-      supp_name = os.path.join(self.get_dir(), 'supp.c')
-      open(supp_name, 'w').write(supp)
+      void dump(struct point p) {
+        p.x++; // should not modify
+        p.y++; // anything in the caller!
+        printf("dump: %d,%d\n", p.x, p.y);
+      }
+    '''
+    supp_name = os.path.join(self.get_dir(), 'supp.c')
+    open(supp_name, 'w').write(supp)
 
-      main = r'''
-        #include <stdio.h>
-        #include "header.h"
+    main = r'''
+      #include <stdio.h>
+      #include "header.h"
 
-        #ifdef __cplusplus
-        extern "C" {
-        #endif
-          void dump(struct point p);
-        #ifdef __cplusplus
-        }
-        #endif
+      #ifdef __cplusplus
+      extern "C" {
+      #endif
+        void dump(struct point p);
+      #ifdef __cplusplus
+      }
+      #endif
 
-        int main( int argc, const char *argv[] ) {
-          struct point p = { 54, 2 };
-          printf("pre:  %d,%d\n", p.x, p.y);
-          dump(p);
-          void (*dp)(struct point p) = dump; // And, as a function pointer
-          dp(p);
-          printf("post: %d,%d\n", p.x, p.y);
-          return 0;
-        }
-      '''
-      main_name = os.path.join(self.get_dir(), 'main.cpp')
-      open(main_name, 'w').write(main)
+      int main( int argc, const char *argv[] ) {
+        struct point p = { 54, 2 };
+        printf("pre:  %d,%d\n", p.x, p.y);
+        dump(p);
+        void (*dp)(struct point p) = dump; // And, as a function pointer
+        dp(p);
+        printf("post: %d,%d\n", p.x, p.y);
+        return 0;
+      }
+    '''
+    main_name = os.path.join(self.get_dir(), 'main.cpp')
+    open(main_name, 'w').write(main)
 
-      Building.emcc(supp_name)
-      Building.emcc(main_name)
-      all_name = os.path.join(self.get_dir(), 'all.bc')
-      Building.link([supp_name + '.o', main_name + '.o'], all_name)
+    Building.emcc(supp_name)
+    Building.emcc(main_name)
+    all_name = os.path.join(self.get_dir(), 'all.bc')
+    Building.link([supp_name + '.o', main_name + '.o'], all_name)
 
-      # This will fail! See explanation near the warning we check for, in the compiler source code
-      run_process([PYTHON, EMCC, all_name] + self.emcc_args, check=False, stderr=PIPE)
+    # This will fail! See explanation near the warning we check for, in the compiler source code
+    run_process([PYTHON, EMCC, all_name] + self.emcc_args, check=False, stderr=PIPE)
 
-      # Check for warning in the generated code
-      generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
-      print('skipping C/C++ conventions warning check, since not i386-pc-linux-gnu', file=sys.stderr)
+    # Check for warning in the generated code
+    generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
+    print('skipping C/C++ conventions warning check, since not i386-pc-linux-gnu', file=sys.stderr)
 
   def test_stdlibs(self):
-      # safe heap prints a warning that messes up our output.
-      self.set_setting('SAFE_HEAP', 0)
-      # needs atexit
-      self.set_setting('NO_EXIT_RUNTIME', 0)
-      self.do_run_in_out_file_test('tests', 'core', 'test_stdlibs')
+    # safe heap prints a warning that messes up our output.
+    self.set_setting('SAFE_HEAP', 0)
+    # needs atexit
+    self.set_setting('NO_EXIT_RUNTIME', 0)
+    self.do_run_in_out_file_test('tests', 'core', 'test_stdlibs')
 
   def test_stdbool(self):
-      src = r'''
+    src = r'''
         #include <stdio.h>
         #include <stdbool.h>
 
@@ -2142,7 +2136,7 @@ The current type of b is: 9
         }
       '''
 
-      self.do_run(src, '*1*', force_c=True)
+    self.do_run(src, '*1*', force_c=True)
 
   def test_strtoll_hex(self):
     # tests strtoll for hex strings (0x...)
@@ -2414,12 +2408,6 @@ The current type of b is: 9
 
     self.set_setting('RUNTIME_LINKED_LIBS', ['liblib.so'])
     self.do_run(main, 'supp: 54,2\nmain: 56\nsupp see: 543\nmain see: 76\nok.')
-
-  def check_dlfcn(self):
-    if self.get_setting('ALLOW_MEMORY_GROWTH') == 1 and not self.is_wasm():
-      self.skipTest('no dlfcn with memory growth (without wasm)')
-    if self.is_wasm_backend():
-      self.skipTest('no shared modules in wasm backend')
 
   def prep_dlfcn_lib(self):
     self.set_setting('MAIN_MODULE', 0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -981,7 +981,6 @@ int main() {
     self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
 
   def test_exceptions_custom(self):
-    #self.emcc_args.append('--profiling-funcs')
     self.set_setting('EXCEPTION_DEBUG', 1)
     # needs to flush stdio streams
     self.set_setting('NO_EXIT_RUNTIME', 0)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3687,7 +3687,7 @@ int main()
         raise Exception('cannot find llvm-lit tool')
     cmd = [PYTHON, LLVM_LIT, '-v', os.path.join(llvm_src, 'test', 'CodeGen', 'JS')]
     print(cmd)
-    p = run_process(cmd)
+    run_process(cmd)
 
   def test_bad_triple(self):
     # compile a minimal program, with as few dependencies as possible, as
@@ -7196,8 +7196,8 @@ int main() {
                    '--pre-js', path_from_root('tests', 'return64bit', 'testbindstart.js'),
                    '--pre-js', path_from_root('tests', 'return64bit', 'testbind.js'),
                    '--post-js', path_from_root('tests', 'return64bit', 'testbindend.js'),
-                   '-s', 'EXPORTED_FUNCTIONS=["_test_return64"]', '-o', 'test.js', # '-O2', '--closure', '1',
-                   '-g1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
+                   '-s', 'EXPORTED_FUNCTIONS=["_test_return64"]', '-o', 'test.js', '-O2',
+                   '--closure', '1', '-g1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
 
     # Simple test program to load the test.js binding library and call the binding to the
     # C function returning the 64 bit long.
@@ -7989,8 +7989,8 @@ int main() {
         self.assertNotContained(warning, err)
 
   def test_binaryen_invalid_method(self):
-    proc = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', "BINARYEN_METHOD='invalid'"])
-    proc.communicate()
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', "BINARYEN_METHOD='invalid'"], stderr=PIPE, check=False)
+    self.assertContained('Unrecognized BINARYEN_METHOD', proc.stderr)
     assert proc.returncode != 0
 
   @no_wasm_backend()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3692,11 +3692,11 @@ int main()
     with open('minimal.cpp', 'w') as f:
       f.write('int main() { return 0; }')
     run_process([CLANG, 'minimal.cpp', '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), env=get_clang_native_env())
-    proc = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, check=False)
+    err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, check=False).stderr
     if self.is_wasm_backend():
-      self.assertContained('machine type must be wasm32', proc.stderr)
+      self.assertContained('machine type must be wasm32', err)
     else:
-      assert 'warning' in err or 'WARNING' in proc.stderr, proc.stderr
+      assert 'warning' in err or 'WARNING' in err, err
       assert 'incorrect target triple' in err or 'different target triples' in err, err
 
   def test_valid_abspath(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1303,14 +1303,11 @@ int f() {
     open('main.cpp', 'w').write(r'''extern int side(); int main() { return side(); }''')
     run_process([CLANG, 'side.cpp', '-c', '-o', 'native.o'])
     run_process([PYTHON, EMAR, 'crs', 'foo.a', 'native.o'])
-    proc = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a'], stderr=PIPE, check=False)
-    if proc.returncode == 0:
-      print(proc.stderr)
+    proc = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a'], stderr=PIPE)
     if self.is_wasm_backend():
       self.assertIn('error: unknown file type:', proc.stderr)
     else:
       self.assertIn('is not LLVM bitcode, cannot link', proc.stderr)
-    self.assertNotEqual(proc.returncode, 0)
 
   def test_export_all(self):
     lib = r'''
@@ -3560,7 +3557,7 @@ int main() {
     assert opt_min - opt_max <= opt_max*0.1, 'opt builds are all fairly close'
     assert sizes['0'] > 1.20*opt_max, 'unopt build is quite larger'
 
-  @no_wasm_backend('relies on ctor evaluation and dtor elimiation')
+  @no_wasm_backend('relies on ctor evaluation and dtor elimination')
   def test_global_inits(self):
     open('inc.h', 'w').write(r'''
 #include <stdio.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -486,7 +486,9 @@ f.close()
 
   def test_emcc_cflags(self):
     # see we print them out
-    output = run_process([PYTHON, EMCC, '--cflags'], stdout=PIPE, stderr=PIPE)
+    # --cflags needs to set EMCC_DEBUG=1, which needs to create canonical temp directory.
+    with clean_write_access_to_canonical_temp_dir(self.canonical_temp_dir):
+      output = run_process([PYTHON, EMCC, '--cflags'], stdout=PIPE, stderr=PIPE)
     flags = output.stdout.strip()
     self.assertContained(' '.join(Building.doublequote_spaces(COMPILER_OPTS)), flags)
     # check they work

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1899,7 +1899,7 @@ class Building(object):
   @staticmethod
   def link_lld(args, target, opts=[], lto_level=0):
     # lld doesn't currently support --start-group/--end-group since the
-    # sematics are more like the windows linker where there is no need for
+    # semantics are more like the windows linker where there is no need for
     # grouping.
     args = [a for a in args if a not in ('--start-group', '--end-group')]
     cmd = [

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1321,7 +1321,7 @@ def verify_settings():
       # TODO(sbc): Make this into a hard error.  We still have a few places that
       # pass WASM=0 before we can do this (at least Platform/Emscripten.cmake and
       # generate_struct_info).
-      logging.debug('emcc: WASM_BACKEND is not compatible with asmjs (WASM=0), forcing WASM=1')
+      logging.warn('emcc: WASM_BACKEND is not compatible with asmjs (WASM=0), forcing WASM=1')
       Settings.WASM = 1
 
     if not BINARYEN_ROOT:
@@ -1897,7 +1897,11 @@ class Building(object):
     return args
 
   @staticmethod
-  def link_lld(files, target, opts=[], lto_level=0):
+  def link_lld(args, target, opts=[], lto_level=0):
+    # lld doesn't currently support --start-group/--end-group since the
+    # sematics are more like the windows linker where there is no need for
+    # grouping.
+    args = [a for a in args if a not in ('--start-group', '--end-group')]
     cmd = [
         WASM_LD,
         '-z',
@@ -1911,8 +1915,10 @@ class Building(object):
         '--import-memory',
         '--export',
         '__wasm_call_ctors',
+        '--export',
+        '__data_end',
         '--lto-O%d' % lto_level,
-    ] + files
+    ] + args
 
     if Settings.WASM_MEM_MAX != -1:
       cmd.append('--max-memory=%d' % Settings.WASM_MEM_MAX)
@@ -1935,7 +1941,7 @@ class Building(object):
       for export in expand_response(Settings.EXPORTED_FUNCTIONS):
         cmd += ['--export', export[1:]] # Strip the leading underscore
 
-    logging.debug('emcc: lld-linking: %s to %s', files, target)
+    logging.debug('emcc: lld-linking: %s to %s', args, target)
     check_call(cmd)
     return target
 


### PR DESCRIPTION
There is also some indentation fixing in test_other.py (which
I could split out if you prefer), so lookat this diff with `-w`
for easier reading.