### PR TITLE
Handle lack of streaming fetch support on chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
             CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer\""
             export EMTEST_BROWSER="xvfb-run /usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
             # Just run a subset of the tests for now.  To be expanded.
-            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-e]* browser.test_pthread_*
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-f]* browser.test_pthread_*
   test-ab:
     <<: *test-defaults
     environment:

--- a/tests/fetch/stream_file.cpp
+++ b/tests/fetch/stream_file.cpp
@@ -28,13 +28,15 @@ int main()
 #endif
   };
   attr.onprogress = [](emscripten_fetch_t *fetch) {
-    printf("Downloading.. %.2f%s complete. Received chunk [%llu, %llu[\n", 
+    printf("Downloading.. %.2f%s complete. Received chunk [%llu, %llu]\n", 
       (fetch->totalBytes > 0) ? ((fetch->dataOffset + fetch->numBytes) * 100.0 / fetch->totalBytes) : (double)(fetch->dataOffset + fetch->numBytes),
       (fetch->totalBytes > 0) ? "%" : " bytes",
       fetch->dataOffset,
       fetch->dataOffset + fetch->numBytes);
-    assert(fetch->data != 0);
-    assert(fetch->numBytes > 0);
+    // On browsers that don't support `moz-chunked-arraybuffer` (e.g. chrome)
+    // both data and numBytes will be null until the final progesss callback.
+    if (fetch->numBytes > 0)
+      assert(fetch->data != 0);
     assert(fetch->dataOffset + fetch->numBytes <= fetch->totalBytes);
     assert(fetch->totalBytes <= 134217728);
 


### PR DESCRIPTION
This fixes test_fetch_stream_file when running on non-firefox
browsers, but I'm not totally sure its the best solution.

Also, enable all browser.test_f* tests under chrome on circleci.

Fixes #7090