### PR TITLE
Add stub for pthread_sigmask

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -167,6 +167,8 @@ var LibraryPThreadStub = {
   _pthread_cleanup_push: 'pthread_cleanup_push',
   _pthread_cleanup_pop: 'pthread_cleanup_pop',
 
+  pthread_sigmask: function() { return 0; },
+
   pthread_rwlock_init: function() { return 0; },
   pthread_rwlock_destroy: function() { return 0; },
   pthread_rwlock_rdlock: function() { return 0; },


### PR DESCRIPTION
Add a no-op stub for pthread_sigmask.  Useful when building with abseil: https://github.com/abseil/abseil-cpp/tree/master/absl