### PR TITLE
Skip python3 tests on python3.4 and below

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -61,17 +61,17 @@ def uses_canonical_tmp(func):
   return decorated
 
 
-def check_python3_version():
-  """emscripten requires at least python3.5 since python3.4 and below do not
+def is_python3_version_supported():
+  """Retuns True if the installed python3 version is supported by emscripten.
+
+  Note: Emscripten requires python3.5 or above since python3.4 and below do not
   support circular dependencies."""
   python3 = Building.which('python3')
   if not python3:
     return False
   output = run_process([python3, '--version'], stdout=PIPE).stdout
   version = [int(x) for x in output.split(' ')[1].split('.')]
-  if version < [3, 5, 0]:
-    return False
-  return True
+  return version >= [3, 5, 0]
 
 
 class other(RunnerCore):
@@ -7175,11 +7175,11 @@ int main() {
       '''remove .py from EMCC(=emcc.py)'''
       return filename[:-3] if filename.endswith('.py') else filename
 
-    have_python3 = check_python3_version()
     for python in ('python', 'python2', 'python3'):
-      has = Building.which(python) is not None
       if python == 'python3':
-        has = have_python3
+        has = is_python3_version_supported()
+      else:
+        has = Building.which(python) is not None
       print(python, has)
       if has:
         print('  checking emcc...')
@@ -8552,7 +8552,7 @@ end
     for python in [PYTHON, 'python', 'python2', 'python3']:
       if not Building.which(python):
         continue
-      if python == 'python3' and not check_python3_version():
+      if python == 'python3' and not is_python3_version_supported():
         continue
       print(python)
       out = run_process([python, EMCC, '--help'], stdout=PIPE, env=env).stdout

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -61,6 +61,19 @@ def uses_canonical_tmp(func):
   return decorated
 
 
+def check_python3_version():
+  """emscripten requires at least python3.5 since python3.4 and below do not
+  support circular dependencies."""
+  python3 = Building.which('python3')
+  if not python3:
+    return False
+  output = run_process([python3, '--version'], stdout=PIPE).stdout
+  version = [int(x) for x in output.split(' ')[1].split('.')]
+  if version < [3, 5, 0]:
+    return False
+  return True
+
+
 class other(RunnerCore):
   # Utility to run a simple test in this suite. This receives a directory which
   # should contain a test.cpp and test.out files, compiles the cpp, and runs it
@@ -7162,8 +7175,11 @@ int main() {
       '''remove .py from EMCC(=emcc.py)'''
       return filename[:-3] if filename.endswith('.py') else filename
 
+    have_python3 = check_python3_version()
     for python in ('python', 'python2', 'python3'):
       has = Building.which(python) is not None
+      if python == 'python3':
+        has = have_python3
       print(python, has)
       if has:
         print('  checking emcc...')
@@ -8534,12 +8550,13 @@ end
     env['LC_ALL'] = 'C'
     expected = ': supported targets:.* elf'
     for python in [PYTHON, 'python', 'python2', 'python3']:
-      try:
-        out = run_process([python, EMCC, '--help'], stdout=PIPE, env=env).stdout
-        assert re.search(expected, out)
-      except OSError:
-        # Ignore missing python aliases.
-        pass
+      if not Building.which(python):
+        continue
+      if python == 'python3' and not check_python3_version():
+        continue
+      print(python)
+      out = run_process([python, EMCC, '--help'], stdout=PIPE, env=env).stdout
+      assert re.search(expected, out)
 
   def test_ioctl_window_size(self):
       self.do_other_test(os.path.join('other', 'ioctl', 'window_size'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1089,16 +1089,6 @@ try:
 except NameError:
   pass
 
-# If we have 'env', we should use that to find python, because |python| may fail while |env python| may work
-# (For example, if system python is 3.x while we need 2.x, and env gives 2.x if told to do so.)
-ENV_PREFIX = []
-if not WINDOWS:
-  try:
-    assert 'Python' in run_process(['env', 'python', '-V'], stdout=PIPE, stderr=STDOUT).stdout
-    ENV_PREFIX = ['env']
-  except:
-    pass
-
 
 # Utilities
 def make_js_command(filename, engine=None, *args):


### PR DESCRIPTION
We don't currently support python3.4 since it does support
circular dependencies in the way that we use them.  Currently
it generates:

```
Traceback (most recent call last):
  File "/b/build/slave/linux/build/src/src/work/wasm-install/emscripten/tools/cache.py", line 136, in <module>
    from . import shared
ImportError: cannot import name 'shared'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/b/build/slave/linux/build/src/src/work/wasm-install/emscripten/emcc.py", line 38, in <module>
    from tools import shared, jsrun, system_libs, client_mods, js_optimizer
  File "/b/build/slave/linux/build/src/src/work/wasm-install/emscripten/tools/shared.py", line 21, in <module>
    from . import jsrun, cache, tempfiles, colored_logger
  File "/b/build/slave/linux/build/src/src/work/wasm-install/emscripten/tools/cache.py", line 139, in <module>
    import shared
ImportError: No module named 'shared'
```