### PR TITLE
EMULATED_FUNCTION_POINTERS: Don't export the entire table unless we are in a shared module

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1215,7 +1215,9 @@ function ftCall_%s(%s) {
         if shared.Settings.SIDE_MODULE:
           table_access = 'parentModule["' + table_access + '"]' # side module tables were merged into the parent, we need to access the global one
         table_read = table_access + '[x]'
-      prelude = '''
+      prelude = ''
+      if shared.Settings.ASSERTIONS:
+        prelude = '''
   if (x < 0 || x >= %s.length) { err("Function table mask error (out of range)"); %s ; abort(x) }''' % (table_access, get_function_pointer_error(sig, function_table_sigs))
       asm_setup += '''
 function ftCall_%s(%s) {%s

--- a/emscripten.py
+++ b/emscripten.py
@@ -1275,7 +1275,9 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   quote = quoter()
   asm_runtime_funcs = create_asm_runtime_funcs()
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
-  if shared.Settings.EMULATED_FUNCTION_POINTERS:
+  # in a shared library + emulated function pointers, export all the table so that
+  # we can easily find the function pointer for each function
+  if shared.Settings.RELOCATABLE and shared.Settings.EMULATED_FUNCTION_POINTERS:
     all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1275,9 +1275,10 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   quote = quoter()
   asm_runtime_funcs = create_asm_runtime_funcs()
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
-  # in a shared library + emulated function pointers, export all the table so that
+  # in a wasm shared library + emulated function pointers, export all the table so that
   # we can easily find the function pointer for each function
-  if shared.Settings.RELOCATABLE and shared.Settings.EMULATED_FUNCTION_POINTERS:
+  if (shared.Settings.RELOCATABLE or not shared.Settings.WASM) and \
+     shared.Settings.EMULATED_FUNCTION_POINTERS:
     all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):

--- a/src/support.js
+++ b/src/support.js
@@ -308,6 +308,7 @@ Module['loadWebAssemblyModule'] = loadWebAssemblyModule;
 #endif // RELOCATABLE
 
 #if EMULATED_FUNCTION_POINTERS
+#if WASM == 0
 function getFunctionTables(module) {
   if (!module) module = Module;
   var tables = {};
@@ -333,6 +334,7 @@ function alignFunctionTables(module) {
   }
   return maxx;
 }
+#endif // WASM == 0
 
 #if RELOCATABLE
 // register functions from a new module being loaded

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3869,8 +3869,8 @@ int main() {
                     # informative error message (assertions are enabled in -O0)
                     self.assertContained('Invalid function pointer called', output)
                   else:
-                    # non-informative abort()
-                    self.assertContained('abort(', output)
+                    # non-informative error
+                    self.assertContained(('abort(', 'exception'), output)
 
   @no_wasm_backend()
   def test_aliased_func_pointers(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8156,10 +8156,15 @@ int main() {
         self.assertEqual(imports, expected_wasm_imports)
         self.assertEqual(exports, expected_wasm_exports)
 
+    print('test on libc++: see effects of emulated function pointers')
+    test(path_from_root('tests', 'hello_libcxx.cpp'), [
+      (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+                53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  31,   31), # noqa
+      (['-O2'], 53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   44), # noqa
+    ]) # noqa
+
     print('test on hello world')
     test(path_from_root('tests', 'hello_world.cpp'), [
-      (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                19, ['abort', 'tempDoublePtr'], ['waka'],                  12598,  16,   15), # noqa; for comparison to without emulated fps
       ([],      23, ['abort', 'tempDoublePtr'], ['waka'],                  46505,  24,   19), # noqa
       (['-O1'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12630,  16,   17), # noqa
       (['-O2'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12616,  16,   17), # noqa

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -820,14 +820,14 @@ f.close()
       self.assertContained(expected, run_js(self.in_dir('a.out.js'), stderr=PIPE, full_output=True, assert_returncode=None))
       # TODO: emulation function support in wasm is imperfect
       print('with emulated function pointers in asm.js')
-      run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-s', 'BINARYEN_ASYNC_COMPILATION=0'] + args + ['-s', 'EMULATED_FUNCTION_POINTERS=1'], stderr=PIPE)
+      run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-s', 'ASSERTIONS=1'] + args + ['-s', 'EMULATED_FUNCTION_POINTERS=1'], stderr=PIPE)
       out = run_js(self.in_dir('a.out.js'), stderr=PIPE, full_output=True, assert_returncode=None)
       self.assertContained(expected, out)
 
     # fastcomp. all asm, so it can't just work with wrong sigs. but,
     # ASSERTIONS=2 gives much better info to debug
     # Case 1: No useful info, but does mention ASSERTIONS
-    test(['-O1'], 'Build with -s ASSERTIONS=1 for more info.')
+    test(['-O1'], 'ASSERTIONS')
     # Case 2: Some useful text
     test(['-O1', '-s', 'ASSERTIONS=1'], [
         "Invalid function pointer called with signature 'v'. Perhaps this is an invalid value",

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8156,13 +8156,6 @@ int main() {
         self.assertEqual(imports, expected_wasm_imports)
         self.assertEqual(exports, expected_wasm_exports)
 
-    print('test on libc++: see effects of emulated function pointers')
-    test(path_from_root('tests', 'hello_libcxx.cpp'), [
-      (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  31,   31), # noqa
-      (['-O2'], 53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   44), # noqa
-    ]) # noqa
-
     print('test on hello world')
     test(path_from_root('tests', 'hello_world.cpp'), [
       ([],      23, ['abort', 'tempDoublePtr'], ['waka'],                  46505,  24,   19), # noqa
@@ -8197,6 +8190,13 @@ int main() {
       (['-Os'],  0, [],                         ['tempDoublePtr', 'waka'],    58,  0,  1), # noqa
       (['-Oz'],  0, [],                         ['tempDoublePtr', 'waka'],    58,  0,  1), # noqa
     ])
+
+    print('test on libc++: see effects of emulated function pointers')
+    test(path_from_root('tests', 'hello_libcxx.cpp'), [
+      (['-O2'], 53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   44), # noqa
+      (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+                53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  31,   31), # noqa
+    ]) # noqa
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8158,6 +8158,8 @@ int main() {
 
     print('test on hello world')
     test(path_from_root('tests', 'hello_world.cpp'), [
+      (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+                19, ['abort', 'tempDoublePtr'], ['waka'],                  12598,  16,   15), # noqa; for comparison to without emulated fps
       ([],      23, ['abort', 'tempDoublePtr'], ['waka'],                  46505,  24,   19), # noqa
       (['-O1'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12630,  16,   17), # noqa
       (['-O2'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12616,  16,   17), # noqa

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3862,7 +3862,7 @@ int main() {
                   if self.is_wasm_backend() or (wasm and (relocate or emulate_fps)):
                     # wasm trap raised by the vm
                     self.assertContained('function signature mismatch', output)
-                  elif safe and not wasm:
+                  elif opts == 0 and safe and not wasm:
                     # non-wasm safe mode checks asm.js function table masks
                     self.assertContained('Function table mask error', output)
                   elif opts == 0:


### PR DESCRIPTION
See https://github.com/WebAssembly/binaryen/pull/1675#issuecomment-419678526