### PR TITLE
Fix function dependecy handling in library_gl.js

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7971,8 +7971,10 @@ keys(LibraryGL).forEach(function(x) {
       var orig = dep;
       dep = 'emscripten_' + dep;
       var fixed = LibraryGL[x].toString().replace(new RegExp('_' + orig + '\\(', 'g'), '_' + dep + '(');
-      // `function` is 8 characters, add space and an explicit name after
-      fixed = fixed.substr(0, 8) + ' _' + y + fixed.substr(8);
+      // `function` is 8 characters, add space and an explicit name after if there isn't one already
+      if (fixed.startsWith('function(') || fixed.startsWith('function (')) {
+        fixed = fixed.substr(0, 8) + ' _' + y + fixed.substr(8);
+      }
       LibraryGL[x] = eval('(function() { return ' + fixed + ' })()');
     }
     return dep;

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7971,7 +7971,8 @@ keys(LibraryGL).forEach(function(x) {
       var orig = dep;
       dep = 'emscripten_' + dep;
       var fixed = LibraryGL[x].toString().replace(new RegExp('_' + orig + '\\(', 'g'), '_' + dep + '(');
-      fixed = fixed.substr(0, 9) + '_' + y + fixed.substr(9);
+      // `function` is 8 characters, add space and an explicit name after
+      fixed = fixed.substr(0, 8) + ' _' + y + fixed.substr(8);
       LibraryGL[x] = eval('(function() { return ' + fixed + ' })()');
     }
     return dep;


### PR DESCRIPTION
I tried to use the `glDrawRangeElements()` function that's available on WebGL 2 but the generated code looks like this:

```js
function _glDrawElements(mode, count, type, indices) {
    GLctx.drawElements(mode, count, type, indices)
}
function _glDrawElementsInstanced(mode, count, type, indices, primcount) {
    GLctx["drawElementsInstanced"](mode, count, type, indices, primcount)
}
function _emscripten_glDrawElements(mode, count, type, indices) {
    GLctx.drawElements(mode, count, type, indices)
}
function _glDrawRangeElements(_emscripten_glDrawRangeElementsmode, start, end, count, type, indices) {
    _emscripten_glDrawElements(mode, count, type, indices)
}
```

Note the `_emscripten_glDrawRangeElements` prepended before `mode`. That obviously fails at runtime with

> ReferenceError: mode is not defined

This seems to be because `glDrawRangeElements()` is one of the very few functions that [depend on other GL functions](https://github.com/kripken/emscripten/blob/a67105b4953e86058b19cdebdd485e5525d9db7e/src/library_gl.js#L7723-L7731) and the code that handles the dependencies is broken. Since `glDrawRangeElements()` is a WebGL2-only function that [caused a crash on Firefox until relatively recently](https://bugzilla.mozilla.org/show_bug.cgi?id=1202427) and all the other functions with dependencies are either emulating legacy GL or non-standard and (so I assume) very seldom used, I think the dependency handling code never really worked to begin with. The code originates in 72c0b9e5c7682413398e31688999d3dc0e5384d8 back from February 2014 and was not changed since. To me at least, the line I removed doesn't seem to serve any purpose other than breaking the code.

**Note:** I don't have any means to test the legacy GL emulation, so I can't verify it *really* didn't break anything there. Nevertheless, I can't find any purpose that the removed line could have in the legacy emulation code either.