### PR TITLE
Show demangled names as "demangled [mangled]", fixes #7104

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -827,7 +827,7 @@ function demangleAll(text) {
   return text.replace(regex,
     function(x) {
       var y = demangle(x);
-      return x === y ? x : (x + ' [' + y + ']');
+      return x === y ? x : (y + ' [' + x + ']');
     });
 }
 


### PR DESCRIPTION
This puts the demangled and clearer name in a more prominent position, as suggested in that issue.