### PR TITLE
Fix error handling for instantiateStreaming

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2286,7 +2286,7 @@ function integrateWasmJS() {
     function instantiateArrayBuffer(receiver) {
       getBinaryPromise().then(function(binary) {
         return WebAssembly.instantiate(binary, info);
-      }).then(receiver).catch(function(reason) {
+      }).then(receiver, function(reason) {
         err('failed to asynchronously prepare wasm: ' + reason);
         abort(reason);
       });
@@ -2297,8 +2297,7 @@ function integrateWasmJS() {
         !isDataURI(wasmBinaryFile) &&
         typeof fetch === 'function') {
       WebAssembly.instantiateStreaming(fetch(wasmBinaryFile, { credentials: 'same-origin' }), info)
-        .then(receiveInstantiatedSource)
-        .catch(function(reason) {
+        .then(receiveInstantiatedSource, function(reason) {
           // We expect the most common failure cause to be a bad MIME type for the binary,
           // in which case falling back to ArrayBuffer instantiation should work.
           err('wasm streaming compile failed: ' + reason);

--- a/src/shell.js
+++ b/src/shell.js
@@ -165,6 +165,7 @@ if (ENVIRONMENT_IS_NODE) {
   // Currently node will swallow unhandled rejections, but this behavior is
   // deprecated, and in the future it will exit with error status.
   process['on']('unhandledRejection', function(reason, p) {
+    err(reason);
 #if ASSERTIONS
     err('node.js exiting due to unhandled promise rejection');
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -166,9 +166,7 @@ if (ENVIRONMENT_IS_NODE) {
   // deprecated, and in the future it will exit with error status.
   process['on']('unhandledRejection', function(reason, p) {
     err(reason);
-#if ASSERTIONS
     err('node.js exiting due to unhandled promise rejection');
-#endif
     process['exit'](1);
   });
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4666,6 +4666,11 @@ name: .
       f.write('Module.preRun = function() { %s }' % code)
     self.emcc_args = ['--pre-js', 'pre.js']
 
+  def add_post_run(self, code):
+    with open('post.js', 'w') as f:
+      f.write('Module.postRun = function() { %s }' % code)
+    self.emcc_args = ['--post-js', 'post.js']
+
   def test_fcntl(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     src = open(path_from_root('tests', 'fcntl', 'src.c'), 'r').read()
@@ -7117,7 +7122,6 @@ err = err = function(){};
     Building.COMPILER_TEST_OPTS.append('-g4')
 
     def build_and_check():
-      import json
       Building.emcc(src_filename, self.serialize_settings() + self.emcc_args +
           Building.COMPILER_TEST_OPTS, out_filename, stderr=PIPE)
       map_referent = out_filename if not self.get_setting('WASM') else wasm_filename
@@ -7821,6 +7825,18 @@ extern "C" {
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
     self.emcc_args += ['-g2'] # test for issue #6331
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+
+  def test_postrun_exception(self):
+    # verify that an exception thrown in postRun() will not trigger the
+    # compilation failed handler, and will be printed to stderr.
+    self.add_post_run('ThisFunctionDoesNotExist()')
+    src = open(path_from_root('tests', 'core', 'test_hello_world.c')).read()
+    self.build(src, self.get_dir(), 'src.c')
+    output = run_js('src.c.o.js', assert_returncode=None, stderr=STDOUT)
+    self.assertNotContained('failed to asynchronously prepare wasm', output)
+    self.assertContained('hello, world!', output)
+    self.assertContained('ThisFunctionDoesNotExist is not defined', output)
+
 
 # Generate tests for everything
 def make_run(name, emcc_args=None, env=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4664,12 +4664,12 @@ name: .
   def add_pre_run(self, code):
     with open('pre.js', 'w') as f:
       f.write('Module.preRun = function() { %s }' % code)
-    self.emcc_args = ['--pre-js', 'pre.js']
+    self.emcc_args += ['--pre-js', 'pre.js']
 
   def add_post_run(self, code):
-    with open('post.js', 'w') as f:
+    with open('pre.js', 'w') as f:
       f.write('Module.postRun = function() { %s }' % code)
-    self.emcc_args = ['--post-js', 'post.js']
+    self.emcc_args += ['--pre-js', 'pre.js']
 
   def test_fcntl(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")


### PR DESCRIPTION
We were incorrectly attributing exceptions receiveInstantiatedSource
as instantiation errors.  This was leading to the wasm module being
created twice in the case when receiveInstantiatedSource throws
(i.e. an exception in postRun()).