### PR TITLE
Increase the O2 size limit for test_no_nuthin

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5153,7 +5153,7 @@ main(const int argc, const char * const * const argv)
 
     test(['-s', 'ASSERTIONS=0'], 120000) # we don't care about code size with assertions
     test(['-O1'], 90000)
-    test(['-O2'], 45000)
+    test(['-O2'], 46000)
     test(['-O3', '--closure', '1'], 17000)
     # asm.js too
     if not self.is_wasm_backend():


### PR DESCRIPTION
The current size limit for `-O2` is set to 45000 and the size for
`no_fs` configuration before was 44973, but #7127 seemed to increase the
the size of .js file a little and now it is 45029, making
`test_no_nuthin` fail. This increases the limit a bit.

Waterfall failure log: https://logs.chromium.org/v/?s=chromium%2Fbb%2Fclient.wasm.llvm%2Flinux%2F35668%2F%2B%2Frecipes%2Fsteps%2FExecute_emscripten_testsuite__emwasm_%2F0%2Fstdout