### PR TITLE
Fix runner.py fails with benchmark command

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 
 from __future__ import print_function
-import math, os, shutil, subprocess, zlib
+import math, os, shutil, subprocess, zlib, time
 import runner
 from runner import RunnerCore, path_from_root
 from tools.shared import *


### PR DESCRIPTION
There was a missing `import time` missing in `test_becnhmark.py`

Fix issue #7130
https://github.com/kripken/emscripten/issues/7130