### PR TITLE
Simplify the node rejection handling code

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -164,11 +164,7 @@ if (ENVIRONMENT_IS_NODE) {
 #endif
   // Currently node will swallow unhandled rejections, but this behavior is
   // deprecated, and in the future it will exit with error status.
-  process['on']('unhandledRejection', function(reason, p) {
-    err(reason);
-    err('node.js exiting due to unhandled promise rejection');
-    process['exit'](1);
-  });
+  process['on']('unhandledRejection', abort);
 
   Module['quit'] = function(status) {
     process['exit'](status);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4558,7 +4558,8 @@ main()
       print(name)
       run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE)
       if fail:
-        run_js('a.out.js', stderr=PIPE, assert_returncode=1)
+        proc = run_process(NODE_JS + ['a.out.js'], stdout=PIPE, stderr=PIPE, check=False)
+        self.assertNotEqual(proc.returncode, 0)
       else:
         self.assertContained('hello, world!', run_js('a.out.js', stderr=PIPE))
 


### PR DESCRIPTION
If a promise is rejected, we should halt the entire application, which we can do by just calling `abort()`, which is more concise.

This changed the return code from 1 to 7 in that case, which required updating a test.