### PR TITLE
Fix for file packager + memory growth

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -284,12 +284,18 @@ mergeInto(LibraryManager.library, {
         // If memory can grow, we don't want to hold on to references of
         // the memory Buffer, as they may get invalidated. That means
         // we need to do a copy here.
+#if ASSERTIONS
         // FIXME: this is inefficient as the file packager may have
         //        copied the data into memory already - we may want to
         //        integrate more there and let the file packager loading
         //        code be able to query if memory growth is on or off.
+        if (canOwn) {
+          warnOnce('file packager has copied file data into memory, but in memory growth we are forced to copy it again (see --no-heap-copy)');
+        }
+#endif // ASSERTIONS
         canOwn = false;
-#endif
+#endif // ALLOW_MEMORY_GROWTH
+
         if (!length) return 0;
         var node = stream.node;
         node.timestamp = Date.now();

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -284,6 +284,10 @@ mergeInto(LibraryManager.library, {
         // If memory can grow, we don't want to hold on to references of
         // the memory Buffer, as they may get invalidated. That means
         // we need to do a copy here.
+        // FIXME: this is inefficient as the file packager may have
+        //        copied the data into memory already - we may want to
+        //        integrate more there and let the file packager loading
+        //        code be able to query if memory growth is on or off.
         canOwn = false;
 #endif
         if (!length) return 0;

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -280,6 +280,12 @@ mergeInto(LibraryManager.library, {
       //         with canOwn=true, creating a copy of the bytes is avoided, but the caller shouldn't touch the passed in range
       //         of bytes anymore since their contents now represent file data inside the filesystem.
       write: function(stream, buffer, offset, length, position, canOwn) {
+#if ALLOW_MEMORY_GROWTH
+        // If memory can grow, we don't want to hold on to references of
+        // the memory Buffer, as they may get invalidated. That means
+        // we need to do a copy here.
+        canOwn = false;
+#endif
         if (!length) return 0;
         var node = stream.node;
         node.timestamp = Date.now();
@@ -288,9 +294,6 @@ mergeInto(LibraryManager.library, {
           if (canOwn) {
 #if ASSERTIONS
             assert(position === 0, 'canOwn must imply no weird position inside the file');
-#endif
-#if ALLOW_MEMORY_GROWTH
-            abort('WAKA WAKA');
 #endif
             node.contents = buffer.subarray(offset, offset + length);
             node.usedBytes = length;

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -289,6 +289,9 @@ mergeInto(LibraryManager.library, {
 #if ASSERTIONS
             assert(position === 0, 'canOwn must imply no weird position inside the file');
 #endif
+#if ALLOW_MEMORY_GROWTH
+            abort('WAKA WAKA');
+#endif
             node.contents = buffer.subarray(offset, offset + length);
             node.usedBytes = length;
             return length;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4006,6 +4006,14 @@ window.close = function() {
     run_process([PYTHON, EMCC, 'page.c', '-s', 'WASM=1', '-s', 'ALLOW_MEMORY_GROWTH=1', '--preload-file', 'test.txt', '-o', 'page.html'])
     self.run_browser('page.html', 'hello from file', '/report_result?15')
 
+    # with separate file packager invocation, letting us affect heap copying
+    # or lack thereof
+    for file_packager_args in [[], ['--no-heap-copy']]:
+      print(file_packager_args)
+      run_process([PYTHON, FILE_PACKAGER, 'data.js', '--preload', 'test.txt', '--js-output=' + 'data.js'] + file_packager_args)
+      run_process([PYTHON, EMCC, 'page.c', '-s', 'WASM=1', '-s', 'ALLOW_MEMORY_GROWTH=1', '--pre-js', 'data.js', '-o', 'page.html', '-s', 'FORCE_FILESYSTEM=1'])
+      self.run_browser('page.html', 'hello from file', '/report_result?15')
+
   def test_unicode_html_shell(self):
     open(self.in_dir('main.cpp'), 'w').write(self.with_report_result(r'''
       int main() {


### PR DESCRIPTION
When memory can grow, do not hold on to references to the buffer in filesystem code, specifically when we do a heap copy.

Warn at runtime (in ASSERTIONS mode) when we do this, as it means we are doing an extra copy after the filesystem loading code already did (which can be avoided, see the `no-heap-copy` flag).

Fixes #5179