### PR TITLE
Do not export internal functions for dylinking

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1284,9 +1284,9 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
   # in a wasm shared library + emulated function pointers, export all the table so that
   # we can easily find the function pointer for each function
-  if (shared.Settings.RELOCATABLE or not shared.Settings.WASM) and \
-     shared.Settings.EMULATED_FUNCTION_POINTERS:
-    all_exported += in_table
+  # if (shared.Settings.RELOCATABLE or not shared.Settings.WASM) and \
+  #    shared.Settings.EMULATED_FUNCTION_POINTERS:
+  #   all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):
     exports.append(quote(export) + ": " + export)

--- a/emscripten.py
+++ b/emscripten.py
@@ -1282,7 +1282,13 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   quote = quoter()
   asm_runtime_funcs = create_asm_runtime_funcs()
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
-  
+  # In an asm shared library + emulated function pointers, export all the table so that
+  # we can easily find the function pointer for each function. The reason is that for asm, we use 
+  # JS to add the side module's functions to the shared table with the parent, so they must 
+  # be exported for that JS to access them. In wasm we don't need that, as the wasm can 
+  # directly add its functions to the Table. 
+  if (not shared.Settings.WASM and shared.Settings.EMULATED_FUNCTION_POINTERS):
+    all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):
     exports.append(quote(export) + ": " + export)

--- a/emscripten.py
+++ b/emscripten.py
@@ -1287,7 +1287,7 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   # JS to add the side module's functions to the shared table with the parent, so they must 
   # be exported for that JS to access them. In wasm we don't need that, as the wasm can 
   # directly add its functions to the Table. 
-  if (not shared.Settings.WASM and shared.Settings.EMULATED_FUNCTION_POINTERS):
+  if not shared.Settings.WASM and shared.Settings.EMULATED_FUNCTION_POINTERS:
     all_exported += in_table
   exports = []
   for export in sorted(set(all_exported)):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1282,11 +1282,7 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
   quote = quoter()
   asm_runtime_funcs = create_asm_runtime_funcs()
   all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
-  # in a wasm shared library + emulated function pointers, export all the table so that
-  # we can easily find the function pointer for each function
-  # if (shared.Settings.RELOCATABLE or not shared.Settings.WASM) and \
-  #    shared.Settings.EMULATED_FUNCTION_POINTERS:
-  #   all_exported += in_table
+  
   exports = []
   for export in sorted(set(all_exported)):
     exports.append(quote(export) + ": " + export)


### PR DESCRIPTION
@kripken , I was thinking that there should be no need to export internal functions either for asm or wasm. I ran the test suite for test_dylinking* and did not find any errors.

I subsequently ran the test suite for asm* and binaryen* and saw some errors with not being able to find zlib.a and some other archive libs so I presume the errors are not related to this change.

Can you take a look and see if we can avoid exporting all internal functions that are not DCE'ed? This will help us stay within the export limit as well as reduce the Wasm binary size substantially.

If it turns out that we still need to do this for asm, perhaps we can turn this off for Wasm? Thanks.