### PR TITLE
honor WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION when constructing GL version info

### DIFF
--- a/tests/webgl2_backwards_compatibility_emulation.cpp
+++ b/tests/webgl2_backwards_compatibility_emulation.cpp
@@ -28,6 +28,13 @@ int main()
   EMSCRIPTEN_RESULT res = emscripten_webgl_make_context_current(context);
   assert(res == EMSCRIPTEN_RESULT_SUCCESS);
   assert(emscripten_webgl_get_current_context() == context);
+  const char *gles20 = "OpenGL ES 2.0 ";
+  const char *glsles100 = "OpenGL ES GLSL ES 1.00 ";
+  const char *ver;
+  ver = (const char *)glGetString(GL_VERSION);
+  assert(strncmp(ver, gles20, strlen(gles20)) == 0);
+  ver = (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION);
+  assert(strncmp(ver, glsles100, strlen(glsles100)) == 0);
   GLuint tex;
   glGenTextures(1, &tex);
   glBindTexture(GL_TEXTURE_2D, tex);


### PR DESCRIPTION
In compatibility mode, OpenGL ES 2 APIs are implemented on top of WebGL 2, and shaders are automatically upgraded to WebGL 2 with best effort. It looks reasonable to ensure the reported version numbers are aligned with the exposed APIs, since improper code paths or shaders might be chosen by applications at runtime if the info is inaccurate.
