### PR TITLE
Move the browser test REPORT_RESULT macro into a header file

### DIFF
--- a/tests/report_result.h
+++ b/tests/report_result.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Define REPORT_RESULT and REPORT_RESULT_SYNC for using in test code
+ */
+
+#ifndef REPORT_RESULT_H_
+#define REPORT_RESULT_H_
+
+#include <stdio.h>
+
+#ifdef __EMSCRIPTEN__
+
+#include <emscripten.h>
+
+#ifndef EMTEST_PORT_NUMBER
+#error "EMTEST_PORT_NUMBER not defined"
+#endif
+
+static void EMSCRIPTEN_KEEPALIVE _ReportResult(int result, int sync)
+{
+  printf("result: %d\n", result);
+  EM_ASM({
+    var xhr = new XMLHttpRequest();
+    var result = $0;
+    if (Module['pageThrewException']) result = 12345;
+    xhr.open('GET', 'http://localhost:' + $2 + '/report_result?' + result, !$1);
+    xhr.send();
+    if (!Module['pageThrewException'] /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000);
+  }, result, sync, EMTEST_PORT_NUMBER);
+}
+
+#if __EMSCRIPTEN_PTHREADS__
+  #include <emscripten/threading.h>
+  #define REPORT_RESULT(result) emscripten_async_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 0)
+  #define REPORT_RESULT_SYNC(result) emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, _ReportResult, (result), 1)
+#else
+  #define REPORT_RESULT(result) _ReportResult((result), 0)
+  #define REPORT_RESULT_SYNC(result) _ReportResult((result), 1)
+#endif
+
+#else
+
+#include <stdlib.h>
+#define REPORT_RESULT(result)       \
+  do {                              \
+    printf("result: %d\n", result); \
+    exit(result);                   \
+  }
+
+#define REPORT_RESULT_SYNC REPORT_RESULT
+
+#endif // __EMSCRIPTEN__
+
+#endif // REPORT_RESULT_H_

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -978,6 +978,10 @@ class BrowserCore(RunnerCore):
       time.sleep(5)
       print('(moving on..)')
 
+  def with_report_result(self, code):
+    return '#define EMTEST_PORT_NUMBER %d\n#include "%s"\n' % (self.test_port,
+            path_from_root('tests', 'report_result.h')) + code
+
   def reftest(self, expected):
     # make sure the pngs used here have no color correction, using e.g.
     #   pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB infile outfile

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -979,8 +979,7 @@ class BrowserCore(RunnerCore):
       print('(moving on..)')
 
   def with_report_result(self, code):
-    return '#define EMTEST_PORT_NUMBER %d\n#include "%s"\n' % (self.test_port,
-            path_from_root('tests', 'report_result.h')) + code
+    return '#define EMTEST_PORT_NUMBER %d\n#include "%s"\n' % (self.test_port, path_from_root('tests', 'report_result.h')) + code
 
   def reftest(self, expected):
     # make sure the pngs used here have no color correction, using e.g.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3233,7 +3233,7 @@ window.close = function() {
     assert os.path.exists('glue.js')
     for opts in [[], ['-O1'], ['-O2']]:
       print(opts)
-      self.btest(os.path.join('webidl', 'test.cpp'), '1', args=['--post-js', 'glue.js', '-I' + path_from_root('tests', 'webidl'), '-DBROWSER'] + opts)
+      self.btest(os.path.join('webidl', 'test.cpp'), '1', args=['--post-js', 'glue.js', '-I.', '-DBROWSER'] + opts)
 
   @no_chrome("required synchronous wasm compilation")
   def test_dynamic_link(self):


### PR DESCRIPTION
As a followup and plan on removing all the "ifdef" checks
for REPORT_RESULT and include the file in the normal way
in the test files.