### PR TITLE
Copy SDL_ttf.h to SDL2/SDL_ttf.h as well

### DIFF
--- a/tools/ports/sdl_ttf.py
+++ b/tools/ports/sdl_ttf.py
@@ -12,11 +12,10 @@ def get(ports, settings, shared):
     ports.fetch_project('sdl2-ttf', 'https://github.com/emscripten-ports/SDL2_ttf/archive/' + TAG + '.zip', 'SDL2_ttf-' + TAG)
     def create():
       sdl_ttf_h = os.path.join(ports.get_dir(), 'sdl2-ttf', 'SDL2_ttf-' + TAG, 'SDL_ttf.h')
-      build_inc_path = os.path.join(ports.get_build_dir(), 'include')
-      build_inc_sdl2_path = os.path.join(ports.get_build_dir(), 'sdl2', 'include')
 
-      shutil.copy2(sdl_ttf_h, build_inc_path)
-      shutil.copy2(sdl_ttf_h, build_inc_sdl2_path)
+      shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'include'))
+      shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'sdl2', 'include'))
+      shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2'))
 
       srcs = ['SDL_ttf.c']
       commands = []


### PR DESCRIPTION
A lot of code includes SDL_ttf.h as "SDL2/SDL_ttf.h" and we put SDL_image.h in both places for that port.