### PR TITLE
Update firefox version used in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,10 +242,10 @@ jobs:
             # --no-sandbox becasue we are running as root and chrome requires
             # this flag for now: https://crbug.com/638180
             CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader"
-            CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
+            CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer\""
             export EMTEST_BROWSER="xvfb-run /usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
             # Just run a subset of the tests for now.  To be expanded.
-            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-e]* browser.test_pthread_* skip:browser.test_aniso
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-f]* browser.test_pthread_* skip:browser.test_aniso
             # Skip browser.test_aniso - see #7117
   test-ab:
     <<: *test-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,3 +323,51 @@ workflows:
       - test-browser-firefox:
           requires:
             - build
+      - test-browser-chrome:
+          requires:
+            - build
+      - test-ab:
+          requires:
+            - build
+      - test-c:
+          requires:
+            - build
+      - test-d:
+          requires:
+            - build
+      - test-e:
+          requires:
+            - build
+      - test-f:
+          requires:
+            - build
+      - test-ghi:
+          requires:
+            - build
+      - test-jklmno:
+          requires:
+            - build
+      - test-p:
+          requires:
+            - build
+      - test-qrst:
+          requires:
+            - build
+      - test-uvwxyz:
+          requires:
+            - build
+      - test-binaryen0:
+          requires:
+            - build
+      - test-binaryen1:
+          requires:
+            - build
+      - test-binaryen2:
+          requires:
+            - build
+      - test-binaryen3:
+          requires:
+            - build
+      - test-sanity:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,30 +18,11 @@ test-defaults: &test-defaults
         name: install package dependencies
         command: |
           apt-get update -q
-          # preseed packages so that apt-get won't prompt for user input
-          echo "keyboard-configuration keyboard-configuration/layoutcode string us" | debconf-set-selections
-          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
-          apt-get install -q -y python3 cmake build-essential openjdk-9-jre-headless $TEST_DEPENDENCY
+          apt-get install -q -y python3 cmake build-essential openjdk-9-jre-headless
     - run:
         name: run tests
         command: |
-          if [ x"$DISPLAY" != x ]; then
-            # Start an X session. Openbox might be optional for now, but
-            # an ICCCM/EWMH compliant window manager is potentially needed
-            # for tests with fullscreen toggling (if we move to a headless
-            # browser, this may not be needed eventually).
-            TMPDIR=`mktemp -d`
-            mkfifo $TMPDIR/fifo
-            echo "echo -n > $TMPDIR/fifo" > $TMPDIR/autostart
-            EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
-            cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
-            rm -r $TMPDIR
-          fi
           EMCC_CORES=4 python3 emscripten/tests/runner.py $TEST_TARGET
-          if [ x"$DISPLAY" != x ]; then
-            openbox --exit
-            wait # wait for startx to shutdown cleanly
-          fi
 
 version: 2
 jobs:
@@ -77,6 +58,77 @@ jobs:
           command: |
             EMCC_CORES=4 python3 ~/emscripten/embuilder.py build ALL
             python3 ~/emscripten/tests/runner.py test_hello_world
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory
+          root: ~/
+          # Must be relative path from root
+          paths:
+            - emsdk-master/
+            - .emscripten_cache/
+            - .emscripten_ports/
+            - .emscripten
+  build-docs:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: install pip
+          command: |
+            apt-get update -q
+            apt-get install -q -y python-pip
+      - run:
+          name: install sphinx
+          command: |
+            pip install sphinx==1.7.8
+      - run: make -C site html
+  flake8:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: install pip
+          command: |
+            apt-get update -q
+            apt-get install -q -y python-pip
+      - run: pip install flake8==3.4.1
+      - run: flake8
+  test-other:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=other skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit
+      # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
+      # CircleCI actively kills memory-over-consuming process
+      # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI
+  test-browser-firefox:
+    <<: *defaults
+    environment:
+    working_directory: ~/
+    steps:
+      - checkout:
+          path: emscripten/
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/
+    steps:
+      - checkout:
+          path: emscripten/
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/
+      - run:
+          name: install package dependencies
+          command: |
+            apt-get update -q
+            apt-get install -q -y python3 cmake build-essential openjdk-9-jre-headless
+            # preseed packages so that apt-get won't prompt for user input
+            echo "keyboard-configuration keyboard-configuration/layoutcode string us" | debconf-set-selections
+            echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
+            apt-get install -q -y dbus-x11 firefox menu openbox ttf-mscorefonts-installer xinit xserver-xorg xserver-xorg-video-dummy
+      - run:
+          name: download firefox
+          command: |
+            wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.2/linux-x86_64/en-US/firefox-62.0.2.tar.bz2
+            tar xf firefox-62.0.2.tar.bz2
       - run:
           name: configure firefox
           command: |
@@ -128,71 +180,37 @@ jobs:
             Name=AT-SPI D-Bus Bus
             Hidden=true # do not auto-start AT-SPI to suppress one warning
             EOF
-      - persist_to_workspace:
-          # Must be an absolute path, or relative path from working_directory
-          root: ~/
-          # Must be relative path from root
-          paths:
-            - emsdk-master/
-            - .emscripten_cache/
-            - .emscripten_ports/
-            - .emscripten
-            - tmp-firefox-profile/
-            - .config/X11/xorg.conf
-            - .config/openbox/autostart
-            - .config/autostart/at-spi-dbus-bus.desktop
-  build-docs:
-    <<: *defaults
-    steps:
-      - checkout
       - run:
-          name: install pip
+          # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
+          # to be failing here, and the root cause might be related with the
+          # initial position of the mouse pointer relative to the canvas.
+          # browser.test_html5_webgl_create_context is skipped because
+          # anti-aliasing is not well supported.
+          # browser.test_webgl_offscreen_canvas_in_pthread and
+          # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
+          # are crashing Firefox (bugzil.la/1281796). The former case is
+          # further blocked by issue #6897.
+          # TODO: use Firefox headless mode when https://bugzil.la/1375585 resolves
+          name: run tests
           command: |
-            apt-get update -q
-            apt-get install -q -y python-pip
-      - run:
-          name: install sphinx
-          command: |
-            pip install sphinx==1.7.8
-      - run: make -C site html
-  flake8:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: install pip
-          command: |
-            apt-get update -q
-            apt-get install -q -y python-pip
-      - run: pip install flake8==3.4.1
-      - run: flake8
-  test-other:
-    <<: *test-defaults
-    environment:
-      - TEST_TARGET=other skip:other.test_native_link_error_message skip:other.test_emcc_v skip:other.test_llvm_lit
-      # some native-dependent tests fail because of the lack of native headers on emsdk-bundled clang
-      # CircleCI actively kills memory-over-consuming process
-      # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI
-  test-browser-firefox:
-    <<: *test-defaults
-    environment:
-      # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
-      # to be failing here, and the root cause might be related with the
-      # initial position of the mouse pointer relative to the canvas.
-      # browser.test_html5_webgl_create_context is skipped because
-      # anti-aliasing is not well supported.
-      # browser.test_webgl_offscreen_canvas_in_pthread and
-      # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-      # are crashing Firefox (bugzil.la/1281796). The former case is
-      # further blocked by issue #6897.
-      - TEST_TARGET=browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-      # TODO: use Firefox headless mode when https://bugzil.la/1375585 resolves
-      - TEST_DEPENDENCY=dbus-x11 firefox menu openbox ttf-mscorefonts-installer xinit xserver-xorg xserver-xorg-video-dummy
-      - EMTEST_BROWSER=firefox -profile tmp-firefox-profile/
-      - EMTEST_LACKS_SOUND_HARDWARE=1
-      - EMTEST_DETECT_TEMPFILE_LEAKS=0
-      - DISPLAY=:0
-      - GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
+            export EMTEST_BROWSER="$HOME/firefox/firefox -profile tmp-firefox-profile/"
+            export GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
+            export EMTEST_LACKS_SOUND_HARDWARE=1
+            export EMTEST_DETECT_TEMPFILE_LEAKS=0
+            export DISPLAY=:0
+            # Start an X session. Openbox might be optional for now, but
+            # an ICCCM/EWMH compliant window manager is potentially needed
+            # for tests with fullscreen toggling (if we move to a headless
+            # browser, this may not be needed eventually).
+            TMPDIR=`mktemp -d`
+            mkfifo $TMPDIR/fifo
+            echo "echo -n > $TMPDIR/fifo" > $TMPDIR/autostart
+            EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
+            cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
+            rm -r $TMPDIR
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
+            openbox --exit
+            wait # wait for startx to shutdown cleanly
   test-browser-chrome:
     <<: *defaults
     environment:
@@ -224,10 +242,10 @@ jobs:
             # --no-sandbox becasue we are running as root and chrome requires
             # this flag for now: https://crbug.com/638180
             CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader"
-            CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer\""
+            CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
             export EMTEST_BROWSER="xvfb-run /usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
             # Just run a subset of the tests for now.  To be expanded.
-            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-f]* browser.test_pthread_* skip:browser.test_aniso
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser.test_[a-e]* browser.test_pthread_* skip:browser.test_aniso
             # Skip browser.test_aniso - see #7117
   test-ab:
     <<: *test-defaults
@@ -303,53 +321,5 @@ workflows:
           requires:
             - build
       - test-browser-firefox:
-          requires:
-            - build
-      - test-browser-chrome:
-          requires:
-            - build
-      - test-ab:
-          requires:
-            - build
-      - test-c:
-          requires:
-            - build
-      - test-d:
-          requires:
-            - build
-      - test-e:
-          requires:
-            - build
-      - test-f:
-          requires:
-            - build
-      - test-ghi:
-          requires:
-            - build
-      - test-jklmno:
-          requires:
-            - build
-      - test-p:
-          requires:
-            - build
-      - test-qrst:
-          requires:
-            - build
-      - test-uvwxyz:
-          requires:
-            - build
-      - test-binaryen0:
-          requires:
-            - build
-      - test-binaryen1:
-          requires:
-            - build
-      - test-binaryen2:
-          requires:
-            - build
-      - test-binaryen3:
-          requires:
-            - build
-      - test-sanity:
           requires:
             - build


### PR DESCRIPTION
This is in preparation for running wasm thread tests (which
requires a more recent version of firefox).