### PR TITLE
Add a workaround for Safari 9 ARM iOS right shift by non-immediate zero JIT bug

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1097,6 +1097,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.LEGACY_VM_SUPPORT:
         # legacy vms don't have wasm
         assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
+        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
+        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
 
       if shared.Settings.SPLIT_MEMORY:
         if shared.Settings.WASM:

--- a/emscripten.py
+++ b/emscripten.py
@@ -461,6 +461,8 @@ def create_backend_args(infile, temp_js):
     args += ['-emscripten-asyncify-whitelist=' + ','.join(shared.Settings.ASYNCIFY_WHITELIST)]
   if not shared.Settings.EXIT_RUNTIME:
     args += ['-emscripten-no-exit-runtime']
+  if shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG:
+    args += ['-emscripten-asmjs-work-around-ios-9-right-shift-bug']
   if shared.Settings.WASM:
     args += ['-emscripten-wasm']
     if shared.Building.is_wasm_only():

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1703,7 +1703,7 @@ function writeAsciiToMemory(str, buffer, dontAddNull) {
 {{{ unSign }}}
 {{{ reSign }}}
 
-#if LEGACY_VM_SUPPORT
+#if POLYFILL_OLD_MATH_FUNCTIONS
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
 if (!Math['imul'] || Math['imul'](0xffffffff, 5) !== -5) Math['imul'] = function imul(a, b) {
   var ah  = a >>> 16;
@@ -1745,9 +1745,12 @@ if (!Math['trunc']) Math['trunc'] = function(x) {
   return x < 0 ? Math.ceil(x) : Math.floor(x);
 };
 Math.trunc = Math['trunc'];
-#else // LEGACY_VM_SUPPORT
+#else // POLYFILL_OLD_MATH_FUNCTIONS
 #if ASSERTIONS
-assert(Math['imul'] && Math['fround'] && Math['clz32'] && Math['trunc'], 'this is a legacy browser, build with LEGACY_VM_SUPPORT');
+assert(Math['imul'], 'This browser does not support Math.imul(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
+assert(Math['fround'], 'This browser does not support Math.fround(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
+assert(Math['clz32'], 'This browser does not support Math.clz32(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
+assert(Math['trunc'], 'This browser does not support Math.trunc(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 #endif
 #endif // LEGACY_VM_SUPPORT
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -430,11 +430,26 @@ var GL_PREINITIALIZED_CONTEXT = 0;
 // stbi_* functions directly yourself.
 var STB_IMAGE = 0;
 
-// Enable this to get support for non-modern browsers, node.js, etc. This gives you
+// If WORKAROUND_IOS_9_RIGHT_SHIFT_BUG==1, work around Safari/WebKit bug in iOS 9.3.5: https://bugs.webkit.org/show_bug.cgi?id=151514 where computing "a >> b" or "a >>> b" in
+// JavaScript would erroneously output 0 when a!=0 and b==0, after suitable JIT compiler optimizations have been applied to a function at runtime (bug does not
+// occur in debug builds). Fix was landed in https://trac.webkit.org/changeset/196591/webkit on Feb 15th 2016. iOS 9.3.5 was released on August 25 2016, but
+// oddly did not have the fix. iOS Safari 10.3.3 was released on July 19 2017, that no longer has the issue. Unknown which released version between these was the
+// first to contain the fix, though notable is that iOS 9.3.5 and iOS 10.3.3 are the two consecutive "end-of-life" versions of iOS that users are likely
+// to be on, e.g. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 all had end-of-life at iOS 9.3.5 (tested to be affected),
+// and iPad 4, iPhone 5 and iPhone 5c all had end-of-life at iOS 10.3.3 (confirmed not affected).
+// If you do not care about old iOS 9 support, keep this disabled.
+var WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0;
+
+// If set, enables polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
+var POLYFILL_OLD_MATH_FUNCTIONS = 0;
+
+// Set this to enable compatibility emulations for old JavaScript engines. This gives you
 // the highest possible probability of the code working everywhere, even in rare old
 // browsers and shell environments. Specifically:
-//  * Add polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
-//  * Disable WebAssembly.
+//  * Add polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround. (-s POLYFILL_OLD_MATH_FUNCTIONS=1)
+//  * Work around iOS 9 right shift bug (-s WORKAROUND_IOS_9_RIGHT_SHIFT_BUG=1)
+//  * Disable WebAssembly. (Must be paired with -s WASM=0)
+// You can also configure the above options individually.
 var LEGACY_VM_SUPPORT = 0;
 
 // By default, emscripten output will run on the web, in a web worker,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3316,7 +3316,7 @@ int main() {
         self.assertContained(expected, result.stderr)
 
     # when legacy is needed, we show an error indicating so
-    test('this is a legacy browser, build with LEGACY_VM_SUPPORT')
+    test('build with LEGACY_VM_SUPPORT')
     # wasm is on by default, and does not mix with legacy, so we show an error
     test('LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0', ['-s', 'LEGACY_VM_SUPPORT=1'])
     # legacy + disabling wasm works


### PR DESCRIPTION
Needs https://github.com/kripken/emscripten-fastcomp/pull/231 to land first.