### PR TITLE
Remove explicit dependency on pthread_mutux functions from library_fe…

### DIFF
--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -23,7 +23,7 @@ var LibraryFetch = {
   $__emscripten_fetch_load_cached_data: __emscripten_fetch_load_cached_data,
   $__emscripten_fetch_cache_data: __emscripten_fetch_cache_data,
   $__emscripten_fetch_xhr: __emscripten_fetch_xhr,
-  emscripten_start_fetch__deps: ['$Fetch', '$__emscripten_fetch_xhr', '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data', '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread', 'pthread_mutex_lock', 'pthread_mutex_unlock'],
+  emscripten_start_fetch__deps: ['$Fetch', '$__emscripten_fetch_xhr', '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data', '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread'],
   emscripten_start_fetch: emscripten_start_fetch
 };
 


### PR DESCRIPTION
…tch.js

These depedencies are currently causing warning in all builds with
FETCH=1+USE_PTHTREADS=1 as far as I can tell.  This is because when
pthreads are enabled these function are implemented in native code
in musl and are named with a leading `__`.

In fact, I far can tell the fetch library doesn't actually depend
on these functions so simply removing the dependency fixes the
issue.