### PR TITLE
Move setjmp/longjmp helper functions and globals to compiler_rt_wasm …

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -65,7 +65,7 @@ def run():
         i += 1
 
   if DEBUG:
-    print('Invoking ' + str(newargs))
+    print('Invoking ' + str(newargs), file=sys.stderr)
   try:
     return subprocess.call(newargs, stdin=sys.stdin)
   finally:

--- a/emcc.py
+++ b/emcc.py
@@ -1146,8 +1146,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not shared.Settings.ONLY_MY_CODE:
         # Always need malloc and free to be kept alive and exported, for internal use and other modules
         shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
-        # Needed by setjmp as well as C++ exceptions.
-        shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
+        if shared.Settings.WASM_BACKEND:
+          # llvm wasm backend will generate calls to these when using setjmp
+          # and/or C++ exceptions, so we pretty much alwasy need them.  They are
+          # also tiny, and should be elimitated by meta-DCE when not used.
+          shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
 

--- a/emcc.py
+++ b/emcc.py
@@ -1144,8 +1144,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         forced_stdlibs += ['libcxxabi']
 
       if not shared.Settings.ONLY_MY_CODE:
-        # always need malloc and free to be kept alive and exported, for internal use and other modules
+        # Always need malloc and free to be kept alive and exported, for internal use and other modules
         shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
+        # Needed by setjmp as well as C++ exceptions.
+        shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
 

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -24,6 +24,6 @@ void setTempRet0(int value) {
   __tempRet0 = value;
 }
 
-void getTempRet0(int value) {
-  __tempRet0 = value;
+int getTempRet0() {
+  return __tempRet0;
 }

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Support functions for emscripten setjmp/longjmp and exception handling
+ * support.
+ * See: https://llvm.org/doxygen/WebAssemblyLowerEmscriptenEHSjLj_8cpp.html
+ */
+
+int __THREW__;
+int __threwValue;
+int __tempRet0;
+
+void setThrew(int threw, int value) {
+  if (__THREW__ == 0) {
+    __THREW__ = threw;
+    __threwValue = value;
+  }
+}
+
+void setTempRet0(int value) {
+  __tempRet0 = value;
+}
+
+void getTempRet0(int value) {
+  __tempRet0 = value;
+}

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -467,6 +467,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
                  'ashldi3.c', 'fixdfdi.c', 'floatdidf.c', 'lshrdi3.c', 'moddi3.c',
                  'trunctfdf2.c', 'trunctfsf2.c', 'umoddi3.c', 'fixunsdfdi.c', 'muldi3.c',
                  'divdi3.c', 'divmoddi4.c', 'udivdi3.c', 'udivmoddi4.c'])
+    files += files_in_path(path_components=['system', 'lib', 'compiler-rt'],
+                           filenames=['extras.c'])
     return create_wasm_rt_lib(libname, files)
 
   def create_wasm_libc_rt(libname):


### PR DESCRIPTION
…library

Previously these have been generated by LLVM during codegen
but this doesn't work once we have separate compilation.

See LLVM change: https://reviews.llvm.org/D49208