### PR TITLE
Add --export-dynamic to lld args

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1900,6 +1900,8 @@ class Building(object):
         '--import-memory',
         '--export',
         '__wasm_call_ctors',
+        '--export',
+        '__data_end',
         '--lto-O%d' % lto_level,
     ] + args
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1888,6 +1888,7 @@ class Building(object):
     args = [a for a in args if a not in ('--start-group', '--end-group')]
     cmd = [
         WASM_LD,
+        '--export-dynamic',
         '-z',
         'stack-size=%s' % Settings.TOTAL_STACK,
         '--global-base=%s' % Settings.GLOBAL_BASE,
@@ -1899,8 +1900,6 @@ class Building(object):
         '--import-memory',
         '--export',
         '__wasm_call_ctors',
-        '--export',
-        '__data_end',
         '--lto-O%d' % lto_level,
     ] + args
 


### PR DESCRIPTION
I recently made a change to lld to disables this behaviour
by default: https://reviews.llvm.org/D52587

Sadly this broke a few things for emscripten. For example, it
meant that EMSCRIPTEN_KEEPALIVE was not longer enough to save
a native code symbol from GC.

For now add --export-dynamic to the lld args to restore the
previous behavior.