### PR TITLE
Change EXPORT_ES6 to be compatible with ES5

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2688,7 +2688,7 @@ var %(EXPORT_NAME)s = (%(src)s)();
 
   # Export using a UMD style export, or ES6 exports if selected
   if shared.Settings.EXPORT_ES6:
-    f.write('''export default %s;''' % shared.Settings.EXPORT_NAME)
+    f.write('''module.exports.default = %s;''' % shared.Settings.EXPORT_NAME)
   else:
     f.write('''if (typeof exports === 'object' && typeof module === 'object')
     module.exports = %(EXPORT_NAME)s;


### PR DESCRIPTION
Many libraries (and depending on your support browsers) aren't ready for a pure ES6 output (Mocha, Karma for example) and require preprocessors to make imported files compatible. This is likely why [Google's own style guide](https://google.github.io/styleguide/jsguide.html#file-es6-modules) suggests to avoid direct ES6 syntax.

Instead of requiring this for all users using ES6_EXPORT, it's easier to write the ES6_EXPORT in an ES5 compatible way.