### PR TITLE
Fix a crash if the worker has the 'window' object defined

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -363,3 +363,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Elmo Todurov <elmo.todurov@eesti.ee>
 * Zoltán Žarkov <zeko@freecivweb.org>
 * Roman Yurchak <rth.yurchak@pm.me>
+* Hampton Maxwell <me@hamptonmaxwell.com>

--- a/src/shell.js
+++ b/src/shell.js
@@ -230,12 +230,10 @@ if (ENVIRONMENT_IS_SHELL) {
 #endif // ENVIRONMENT_MAY_BE_SHELL
 #if ENVIRONMENT_MAY_BE_WEB_OR_WORKER
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
-  if (ENVIRONMENT_IS_WEB) {
-    if (document.currentScript) {
-      scriptDirectory = document.currentScript.src;
-    }
-  } else { // worker
+  if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
     scriptDirectory = self.location.href;
+  } else if (document.currentScript) { // web
+    scriptDirectory = document.currentScript.src;
   }
 #if MODULARIZE
 #if MODULARIZE_INSTANCE == 0


### PR DESCRIPTION
Fixes #7222 

In some situations, the window object may be defined in a worker context, for example if window is defined for a polyfill. In these cases, the worker would report ENVIRONMENT_IS_WEB true and attempt to access document.currentScript. This would cause the worker to crash.

This PR inverts that check so that we check if we're a worker rather than web. This shouldn't cause any changes to functionality.