### PR TITLE
Observe the [Const] attribute in the webidl binder's JSImplementation functionality

### DIFF
--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -41,10 +41,21 @@ public:
   static void runVirtualFunc(Child2 *self) { self->virtualFunc(); };
   virtual void virtualFunc3(int x) { printf("*virtualf3: %d*\n", x); }
   virtual void virtualFunc4(int x) { printf("*virtualf4: %d*\n", x); }
-  static void runVirtualFunc3(Child2 *self, int x) { self->virtualFunc3(x); };
+  static void runVirtualFunc3(Child2 *self, int x) { self->virtualFunc3(x); }
 
 private:
   void doSomethingSecret() { printf("security breached!\n"); }; // we should not be able to do this
+};
+
+// We test compilation here: abstract base classes must be handled properly,
+// and in particular the const property may matter (if not overridden as
+// const, compilation will fail).
+class VirtualBase {
+public:
+  virtual ~VirtualBase() {};
+
+  virtual void func() = 0;
+  virtual void constFunc() const = 0;
 };
 
 // Part 2

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -45,6 +45,18 @@ interface Child2JS {
   void virtualFunc4(long x);
 };
 
+interface VirtualBase {
+  void func();
+  void constFunc();
+};
+
+[JSImplementation="VirtualBase"]
+interface ConcreteJS {
+  void ConcreteJS();
+  void func();
+  [Const] void constFunc();
+};
+
 // Part 2
 
 interface StringUser {

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -32,6 +32,9 @@ DEBUG = os.environ.get('IDL_VERBOSE') is '1'
 
 if DEBUG: print("Debug print ON, CHECKS=%s" % CHECKS)
 
+# We need to avoid some closure errors on the constructors we define here.
+CONSTRUCTOR_CLOSURE_SUPPRESSIONS = '/** @suppress {undefinedVars, duplicate} */'
+
 class Dummy(object):
   def __init__(self, init):
     for k, v in init.items():
@@ -473,9 +476,9 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
   body += '  %s%s(%s)%s;\n' % (call_prefix, '_' + c_names[max_args], ', '.join(pre_arg + args), call_postfix)
   if cache:
     body += '  ' + cache + '\n'
-  mid_js += [r'''/** @suppress {undefinedVars, duplicate} */function%s(%s) {
+  mid_js += [r'''%sfunction%s(%s) {
 %s
-};''' % ((' ' + func_name) if constructor else '', ', '.join(args), body[:-1])]
+};''' % (CONSTRUCTOR_CLOSURE_SUPPRESSIONS, (' ' + func_name) if constructor else '', ', '.join(args), body[:-1])]
 
   # C
 
@@ -605,7 +608,7 @@ for name in names:
 
   # Ensure a constructor even if one is not specified.
   if not any(m.identifier.name == name for m in interface.members):
-    mid_js += ['function %s() { throw "cannot construct a %s, no constructor in IDL" }\n' % (name, name)]
+    mid_js += ['%sfunction %s() { throw "cannot construct a %s, no constructor in IDL" }\n' % (CONSTRUCTOR_CLOSURE_SUPPRESSIONS, name, name)]
     mid_js += build_constructor(name)
 
   for m in interface.members:


### PR DESCRIPTION
It is necessary as we must override the pure virtual functions as const if they are defined as const in the parent class, or else we end up pure virtual.

See https://github.com/kripken/ammo.js/pull/214