### PR TITLE
Allow wasm-only mode with EMULATE_FUNCTION_POINTER_CASTS

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2288,9 +2288,6 @@ class Building(object):
     if Settings.RUNNING_JS_OPTS:
       # if the JS optimizer runs, it must run on valid asm.js
       return False
-    if Settings.EMULATE_FUNCTION_POINTER_CASTS:
-      # FIXME this is a current limitation
-      return False
     if Settings.RELOCATABLE and Settings.EMULATED_FUNCTION_POINTERS:
       # FIXME emulation function pointers work properly, but calling between
       #       modules as wasm-only needs more work


### PR DESCRIPTION
Thanks to other recent improvements in this area, removing this limitation just works now.