### PR TITLE
Use jdk-8 on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ test-defaults: &test-defaults
         name: install package dependencies
         command: |
           apt-get update -q
-          apt-get install -q -y python3 cmake build-essential openjdk-9-jre-headless
+          apt-get install -q -y python3 cmake build-essential openjdk-8-jre-headless
     - run:
         name: run tests
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ test-defaults: &test-defaults
         name: install package dependencies
         command: |
           apt-get update -q
+          # openjdk-9 is also available, but hits #7232
           apt-get install -q -y python3 cmake build-essential openjdk-8-jre-headless
     - run:
         name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           name: install package dependencies
           command: |
             apt-get update -q
-            apt-get install -q -y python3 cmake build-essential openjdk-9-jre-headless
+            apt-get install -q -y python3 cmake build-essential openjdk-8-jre-headless
             # preseed packages so that apt-get won't prompt for user input
             echo "keyboard-configuration keyboard-configuration/layoutcode string us" | debconf-set-selections
             echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
@@ -233,7 +233,7 @@ jobs:
             # install chromium-browser in order to ensure we have most of the
             # dependecies for chrome.
             EXTRA_CHROME_DEPS="lsb-release fonts-liberation libappindicator3-1"
-            apt-get install -q -y unzip xvfb chromium-browser openjdk-9-jre-headless $EXTRA_CHROME_DEPS
+            apt-get install -q -y unzip xvfb chromium-browser openjdk-8-jre-headless $EXTRA_CHROME_DEPS
       - run:
           name: download chrome
           command: |


### PR DESCRIPTION
This seems to fix the recent java crashes that have gotten quite frequent, #7232. 8 is the default on xenial, and we were using 9, so this just changes us to use the standard one.

This passes 2 full runs of the test suite with no java errors, so either it fixed it or it was quite lucky, as otherwise practically every recent run has had at least one failure...