### PR TITLE
DOC remove outdated comment about unlinkat not being tested

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1182,9 +1182,6 @@ var SyscallsLibrary = {
     return SYSCALLS.doStat(nofollow ? FS.lstat : FS.stat, path, buf);
   },
   __syscall301: function(which, varargs) { // unlinkat
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), flags = SYSCALLS.get();
     path = SYSCALLS.calculateAt(dirfd, path);
     if (flags === 0) {


### PR DESCRIPTION
Following https://github.com/kripken/emscripten/issues/7194, I have analysed syscalls that are marked as untested in `src/library_syscall.js` -- most comments are still valid, except for `unlinkat` for which tests exist in [`tests/other/unlink/test.cpp`](https://github.com/kripken/emscripten/blob/5187ea263120ff57424a184c1bc73259e24dc9a9/tests/other/unlink/test.cpp#L41) (added in https://github.com/kripken/emscripten/pull/6466).

I'm not sure if I should also remove the following comment in **emscripten/system/lib/fetch/asmfs.cpp**,
```cpp
 // TODO: syscall301: unlinkat
```

A more detailed report of this analysis can be found in https://github.com/iodide-project/pyodide/issues/196

Closes #7184