### PR TITLE
GLUT: support more glutGet() attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
             EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
             cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
             rm -r $TMPDIR
-            EMCC_CORES=4 ./emscripten/tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
+            EMCC_CORES=4 ./emscripten/tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread skip:browser.test_glut_glutget
             openbox --exit
             wait # wait for startx to shutdown cleanly
   test-browser-chrome:

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -427,6 +427,14 @@ var LibraryGLUT = {
       case 700: /* GLUT_ELAPSED_TIME */
         var now = Date.now();
         return now - GLUT.initTime;
+      case 0x0069: /* GLUT_WINDOW_STENCIL_SIZE */
+	return Module.ctx.getContextAttributes().stencil ? 8 : 0;
+      case 0x006A: /* GLUT_WINDOW_DEPTH_SIZE */
+	return Module.ctx.getContextAttributes().depth ? 8 : 0;
+      case 0x006E: /* GLUT_WINDOW_ALPHA_SIZE */
+	return Module.ctx.getContextAttributes().alpha ? 8 : 0;
+      case 0x0078: /* GLUT_WINDOW_NUM_SAMPLES */
+	return Module.ctx.getContextAttributes().antialias ? 1 : 0;
 
       default:
         throw "glutGet(" + type + ") not implemented yet";

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -428,13 +428,13 @@ var LibraryGLUT = {
         var now = Date.now();
         return now - GLUT.initTime;
       case 0x0069: /* GLUT_WINDOW_STENCIL_SIZE */
-	return Module.ctx.getContextAttributes().stencil ? 8 : 0;
+        return Module.ctx.getContextAttributes().stencil ? 8 : 0;
       case 0x006A: /* GLUT_WINDOW_DEPTH_SIZE */
-	return Module.ctx.getContextAttributes().depth ? 8 : 0;
+        return Module.ctx.getContextAttributes().depth ? 8 : 0;
       case 0x006E: /* GLUT_WINDOW_ALPHA_SIZE */
-	return Module.ctx.getContextAttributes().alpha ? 8 : 0;
+        return Module.ctx.getContextAttributes().alpha ? 8 : 0;
       case 0x0078: /* GLUT_WINDOW_NUM_SAMPLES */
-	return Module.ctx.getContextAttributes().antialias ? 1 : 0;
+        return Module.ctx.getContextAttributes().antialias ? 1 : 0;
 
       default:
         throw "glutGet(" + type + ") not implemented yet";

--- a/tests/glut_glutget.c
+++ b/tests/glut_glutget.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <GL/gl.h>
+#include <GL/glut.h>
+
+#ifndef REPORT_RESULT
+#define REPORT_RESULT(x) printf("%d\n", result)
+#endif
+
+int main(int argc, char* argv[]) {
+  bool stencilActivated = false;
+  bool depthActivated = false;
+  bool alphaActivated = false;
+  bool antiAliasingActivated = false;
+
+  unsigned int mode = GLUT_RGBA | GLUT_DOUBLE;
+
+#ifdef STENCIL_ACTIVATED
+    stencilActivated = true;
+    mode |= GLUT_STENCIL;
+#endif
+#ifdef DEPTH_ACTIVATED
+    depthActivated = true;
+    mode |= GLUT_DEPTH;
+#endif
+#ifdef ALPHA_ACTIVATED
+    alphaActivated = true;
+    mode |= GLUT_ALPHA;
+#endif
+#ifdef AA_ACTIVATED
+    antiAliasingActivated = true;
+    mode |= GLUT_MULTISAMPLE;
+#endif
+
+  glutInit(&argc, argv);
+  glutInitWindowSize(640, 480);
+  glutInitDisplayMode(mode);
+  glutCreateWindow(__FILE__);
+
+  printf("stencil:   %d\n", glutGet(GLUT_WINDOW_STENCIL_SIZE));
+  printf("depth:     %d\n", glutGet(GLUT_WINDOW_DEPTH_SIZE));
+  printf("alpha:     %d\n", glutGet(GLUT_WINDOW_ALPHA_SIZE));
+  printf("antialias: %d\n", glutGet(GLUT_WINDOW_NUM_SAMPLES));
+  int result = (
+    (!stencilActivated      || glutGet(GLUT_WINDOW_STENCIL_SIZE) > 0) &&
+    (!depthActivated        || glutGet(GLUT_WINDOW_DEPTH_SIZE)   > 0) &&
+    (!alphaActivated        || glutGet(GLUT_WINDOW_ALPHA_SIZE)   > 0) &&
+    (!antiAliasingActivated || glutGet(GLUT_WINDOW_NUM_SAMPLES)  > 0)
+    );
+
+  // fix-up "ReferenceError: GL is not defined,createContext" due to
+  // overzealous JS stripping
+  glClear(0);
+
+  REPORT_RESULT(result);
+}

--- a/tests/glut_glutget.c
+++ b/tests/glut_glutget.c
@@ -1,3 +1,8 @@
+// Copyright 2018 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
 #include <stdio.h>
 #include <stdbool.h>
 #include <GL/gl.h>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1082,6 +1082,10 @@ keydown(100);keyup(100); // trigger the end
   def test_glut_wheelevents(self):
     self.btest('glut_wheelevents.c', '1', args=['-lglut'])
 
+  def test_glut_glutget(self):
+    self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL'])
+    self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
+
   def test_sdl_joystick_1(self):
     # Generates events corresponding to the Working Draft of the HTML5 Gamepad API.
     # http://www.w3.org/TR/2012/WD-gamepad-20120529/#gamepad-interface

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1082,6 +1082,7 @@ keydown(100);keyup(100); // trigger the end
   def test_glut_wheelevents(self):
     self.btest('glut_wheelevents.c', '1', args=['-lglut'])
 
+  @requires_graphics_hardware
   def test_glut_glutget(self):
     self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL'])
     self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1083,6 +1083,12 @@ keydown(100);keyup(100); // trigger the end
     self.btest('glut_wheelevents.c', '1', args=['-lglut'])
 
   @requires_graphics_hardware
+  def test_glut_glutget_no_antialias(self):
+    self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL'])
+    self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])
+
+  # This test supersedes the one above, but it's skipped in the CI because anti-aliasing is not well supported by the Mesa software renderer.
+  @requires_graphics_hardware
   def test_glut_glutget(self):
     self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL'])
     self.btest('glut_glutget.c', '1', args=['-lglut', '-lGL', '-DAA_ACTIVATED', '-DDEPTH_ACTIVATED', '-DSTENCIL_ACTIVATED', '-DALPHA_ACTIVATED'])


### PR DESCRIPTION
Adding support for more glutGet() queries for webgl attributes i.e. antialias/alpha/depth/stencil.