### PR TITLE
Always include compiler-rt on link line

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -599,7 +599,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   system_libs += [('libc-extras', ext, create_libc_extras, libc_extras_symbols, [], False)]
 
   force.add(malloc_name())
-  force.add('compiler-rt')
+  if shared.Settings.WASM_BACKEND:
+    force.add('compiler-rt')
 
   # Go over libraries to figure out which we must include
   def maybe_noexcept(name):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -599,6 +599,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   system_libs += [('libc-extras', ext, create_libc_extras, libc_extras_symbols, [], False)]
 
   force.add(malloc_name())
+  force.add('compiler-rt')
 
   # Go over libraries to figure out which we must include
   def maybe_noexcept(name):


### PR DESCRIPTION
We need this under wasm since we are already force including
wasm_compiler-rt which can depend on compiler-rt.

compiler-rt is tiny (most of the code from upstream compiler-rt
is only included in wasm_compiler-rt) and won't actually end up in
binary anyway unless referenced.

This fixed the current wasm wasterfall failure of test_constglobalunion.