### PR TITLE
Actually fix fix_test_binaryen_metadce

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8194,7 +8194,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0), # noqa; totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1526, ['invoke_i'],               ['waka'],                 469663, 149, 1449),
+              1526, ['invoke_i'],               ['waka'],                 469663, 149, 1439),
     ]) # noqa
 
     print('test on a minimal pure computational thing')


### PR DESCRIPTION
My appologies #7233 was supposed to fix breakage that was
introduced by #7250.  This time I ran the full test after
fixing.

[ci skip]