### PR TITLE
Remove EMSCRIPTEN_ROOT from config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
             # persistent workspace and to avoid any confusion with that version
             # we are trying to test.
             rm -r ~/emsdk-master/emscripten/
-            echo EMSCRIPTEN_ROOT="'~/emscripten/'" >> ~/.emscripten
             echo BINARYEN_ROOT="''" >> ~/.emscripten
       - run:
           name: embuilder build ALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN cd /root/ \
  && ./emsdk install latest \
  && ./emsdk activate latest \
  && popd \
- && echo EMSCRIPTEN_ROOT="'/root/emscripten/'" >> .emscripten \
  && echo BINARYEN_ROOT="''" >> .emscripten
 
 ARG TEST_TARGET

--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -27,7 +27,7 @@ The settings file is created the first time a user runs :ref:`emcc <emccdoc>` (o
 	You should get a ``Welcome to Emscripten!`` message. Behind the scenes, Emscripten generates a file called ``.emscripten`` in your home folder.
 	
 	
-Emscripten makes a "best guess" at the correct locations for tools and updates the file appropriately. Where possible it will look for "system" apps (like Python and Java) and infer the location of the ``EMSCRIPTEN_ROOT`` (where :ref:`emcc <emccdoc>` is located) from the location of the command prompt. 
+Emscripten makes a "best guess" at the correct locations for tools and updates the file appropriately. Where possible it will look for "system" apps (like Python and Java).
 
 The file will probably not include the link to :term:`Fastcomp` (``LLVM_ROOT``) as a manual source build can create this anywhere.
 
@@ -49,9 +49,9 @@ Compiler configuration file-format
 
 .. note:: While the syntax is identical, the appearance of the default **.emscripten** file created by *emcc* is quite different than that created by :ref:`emsdk <compiler-configuration-file>`. This is because *emsdk* manages multiple target environments, and where possible hard codes the locations of those tools when a new environment is activated. The default file, by contrast, is managed by the user — and is designed to make that task as easy as possible.
 
-The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user cloned Emscripten to the **C:/Users/username/Documents/GitHub/emscripten** directory, then the file would have the line: ::
+The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user installed python to the **C:/Python27/** directory, then the file might have the line: ::
 
-	EMSCRIPTEN_ROOT = 'C:/Users/username/Documents/GitHub/emscripten'
+	PTYHON = 'C:\\Python27\\python2.exe'
 	
 
 The default *emcc* configuration file often gets the paths from environment variables if defined. If no variable is defined the system will also attempt to find "system executables". For example:  ::
@@ -75,13 +75,6 @@ The compiler configuration file can be edited with the text editor of your choic
 	.. note:: Use forward slashes!
 
 #. Edit the variable ``TEMP_DIR`` to point to a valid path on your local system, e.g. ``TEMP_DIR = '/tmp'`` (``TEMP_DIR = 'c:/tmp'`` on Windows), and create that folder on the local filesystem if it doesn't exist.
-
-#. You *may* need to edit the variable ``EMSCRIPTEN_ROOT`` to point to the Emscripten root folder, e.g.:
-   
-	::
-   
-		EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '/home/ubuntu/yourpath/emscripten')) # directory
- 
 
 .. comment .. The settings are now correct in the configuration file, but the paths and environment variables are not set in the command prompt/terminal. **HamishW** Follow up with Jukka on this.
  

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -97,7 +97,6 @@ Below are typical **.emscripten** files created by *emsdk*. Note the variable na
 	LLVM_ROOT='C:/Program Files/Emscripten/clang/e1.21.0_64bit'
 	NODE_JS='C:/Program Files/Emscripten/node/0.10.17_64bit/node.exe'
 	PYTHON='C:/Program Files/Emscripten/python/2.7.5.3_64bit/python.exe'
-	EMSCRIPTEN_ROOT='C:/Program Files/Emscripten/emscripten/1.21.0'
 	JAVA='C:/Program Files/Emscripten/java/7.45_64bit/bin/java.exe'
 	V8_ENGINE = ''
 	TEMP_DIR = 'c:/users/hamis_~1/appdata/local/temp'
@@ -113,7 +112,6 @@ Below are typical **.emscripten** files created by *emsdk*. Note the variable na
 	SPIDERMONKEY_ENGINE = ''
 	NODE_JS = 'nodejs'
 	LLVM_ROOT='/home/ubuntu/emsdk_portable/clang/fastcomp/build_incoming_64/bin'
-	EMSCRIPTEN_ROOT='/home/ubuntu/emsdk_portable/emscripten/incoming'
 	V8_ENGINE = ''
 	TEMP_DIR = '/tmp'
 	COMPILER_ENGINE = NODE_JS

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -108,7 +108,6 @@ class other(RunnerCore):
       run_process([PYTHON, compiler, '--generate-config', config_path])
       assert os.path.exists(config_path), 'A config file should have been created at %s' % config_path
       config_contents = open(config_path).read()
-      self.assertContained('EMSCRIPTEN_ROOT', config_contents)
       self.assertContained('LLVM_ROOT', config_contents)
       os.remove(config_path)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -169,7 +169,7 @@ class sanity(RunnerCore):
       self.assertNotContained('}}}', config_file)
       self.assertContained('{{{', template_file)
       self.assertContained('}}}', template_file)
-      for content in ['EMSCRIPTEN_ROOT', 'LLVM_ROOT', 'NODE_JS', 'TEMP_DIR', 'COMPILER_ENGINE', 'JS_ENGINES']:
+      for content in ['LLVM_ROOT', 'NODE_JS', 'TEMP_DIR', 'COMPILER_ENGINE', 'JS_ENGINES']:
         self.assertContained(content, config_file)
 
       # The guessed config should be ok
@@ -257,17 +257,6 @@ class sanity(RunnerCore):
           else:
             output = self.check_working(EMCC)
             assert LLVM_WARNING not in output, output
-
-  def test_emscripten_root(self):
-    # The correct path
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root())
-    self.check_working(EMCC)
-
-    # The correct path with extra stuff
-    restore_and_set_up()
-    add_to_config("EMSCRIPTEN_ROOT = '%s'" % (path_from_root() + os.path.sep))
-    self.check_working(EMCC)
 
   def test_llvm_fastcomp(self):
     WARNING = 'fastcomp in use, but LLVM has not been built with the JavaScript backend as a target'

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -1,22 +1,26 @@
-# This file will be edited (the {{{ }}} things), and then ~/.emscripten created with the result, if ~/.emscripten doesn't exist.
+# This file will be edited (the {{{ }}} things), and then ~/.emscripten created
+# with the result, if ~/.emscripten doesn't exist.
 
-# Note: If you put paths relative to the home directory, do not forget os.path.expanduser
+# Note: If you put paths relative to the home directory, do not forget
+# os.path.expanduser
 
-# Note: On Windows, remember to escape backslashes! I.e. EMSCRIPTEN_ROOT='c:\emscripten\' is not valid, but EMSCRIPTEN_ROOT='c:\\emscripten\\' and EMSCRIPTEN_ROOT='c:/emscripten/' are.
+# Note: On Windows, remember to escape backslashes! I.e. PYTHON='c:\Python27\'
+# is not valid, but PYTHON='c:\\Python27\\' and PYTHON='c:/Python27/'
+# are.
 
 import os
 
-# this helps projects using emscripten find it
-EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '{{{ EMSCRIPTEN_ROOT }}}')) # directory
 LLVM_ROOT = os.path.expanduser(os.getenv('LLVM', '{{{ LLVM_ROOT }}}')) # directory
 BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # if not set, we will use it from ports
 
 # If not specified, defaults to sys.executable.
 #PYTHON = 'python'
 
-# Add this if you have manually built the JS optimizer executable (in Emscripten/tools/optimizer) and want to run it from a custom location.
-# Alternatively, you can set this as the environment variable EMSCRIPTEN_NATIVE_OPTIMIZER.
-# EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
+# Add this if you have manually built the JS optimizer executable (in
+# Emscripten/tools/optimizer) and want to run it from a custom location.
+# Alternatively, you can set this as the environment variable
+# EMSCRIPTEN_NATIVE_OPTIMIZER.
+#EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
 
 # See below for notes on which JS engine(s) you need
 NODE_JS = os.path.expanduser(os.getenv('NODE', '{{{ NODE }}}')) # executable
@@ -29,7 +33,7 @@ TEMP_DIR = '{{{ TEMP }}}'
 
 #CLOSURE_COMPILER = '..' # define this to not use the bundled version
 
-########################################################################################################
+################################################################################
 
 
 # Pick the JS engine to use for running the compiler. This engine must exist, or
@@ -41,10 +45,11 @@ TEMP_DIR = '{{{ TEMP }}}'
 COMPILER_ENGINE = NODE_JS
 
 
-# All JS engines to use when running the automatic tests. Not all the engines in this list
-# must exist (if they don't, they will be skipped in the test runner).
+# All JS engines to use when running the automatic tests. Not all the engines in
+# this list must exist (if they don't, they will be skipped in the test runner).
 #
-# Recommendation: If you already have node installed, use that. If you can, also build
-#                 spidermonkey from source as well to get more test coverage.
+# Recommendation: If you already have node installed, use that. If you can, also
+#                 build spidermonkey from source as well to get more test
+#                 coverage.
 
 JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -179,7 +179,6 @@ def generate_config(path, first_time=False):
   config_file = config_file[1:] # remove "this file will be copied..."
   config_file = '\n'.join(config_file)
   # autodetect some default paths
-  config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
   llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
   config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
 
@@ -207,7 +206,6 @@ It contains our best guesses for the important paths, which are:
 
   LLVM_ROOT       = %s
   NODE_JS         = %s
-  EMSCRIPTEN_ROOT = %s
 
 Please edit the file if any of those are incorrect.
 
@@ -243,9 +241,9 @@ except:
 
 if EM_CONFIG and not os.path.isfile(EM_CONFIG):
   if EM_CONFIG.startswith('-'):
-    raise Exception('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config EMSCRIPTEN_ROOT=/path/;LLVM_ROOT=/path;...')
+    exit_with_error('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config LLVM_ROOT=/path;...')
   if '=' not in EM_CONFIG:
-    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist!')
+    exit_with_error('File ' + EM_CONFIG + ' passed to --em-config does not exist!')
   else:
     EM_CONFIG = EM_CONFIG.replace(';', '\n') + '\n'
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -175,8 +175,8 @@ def check_call(cmd, *args, **kw):
 def generate_config(path, first_time=False):
   # Note: repr is used to ensure the paths are escaped correctly on Windows.
   # The full string is replaced so that the template stays valid Python.
-  config_file = open(path_from_root('tools', 'settings_template_readonly.py')).read().split('\n')
-  config_file = config_file[1:] # remove "this file will be copied..."
+  config_file = open(path_from_root('tools', 'settings_template_readonly.py')).read().splitlines()
+  config_file = config_file[3:] # remove the initial comment
   config_file = '\n'.join(config_file)
   # autodetect some default paths
   llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
@@ -211,7 +211,7 @@ Please edit the file if any of those are incorrect.
 
 This command will now exit. When you are done editing those paths, re-run it.
 ==============================================================================
-''' % (path, abspath, llvm_root, node, __rootpath__), file=sys.stderr)
+''' % (path, abspath, llvm_root, node), file=sys.stderr)
 
 
 # Emscripten configuration is done through the --em-config command line option or


### PR DESCRIPTION
WIP: DO NOT LAND

This was previously used by external tools to find emscripten.
A better way to do that is to look for `emcc` in PATH or
check for EMSCRIPTEN_ROOT in the environment.

Hopefully once we are the only parser of our config file
we can nail it down a little and remove the `exec`.
As well as being cleaner this will also allow the config file
to know where it is via __file__ which allows for the config
to include relative paths(useful for installing toolchains
with fix local config files).