### PR TITLE
manual_html5_event_unloading

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -40,10 +40,13 @@ var LibraryJSEvents = {
     // Track in this field whether we have yet registered that __ATEXIT__ handler.
     removeEventListenersRegistered: false, 
 
+    _onGamepadConnected: function() { ++JSEvents.numGamepadsConnected; },
+    _onGamepadDisconnected: function() { --JSEvents.numGamepadsConnected; },
+
     staticInit: function() {
       if (typeof window !== 'undefined') {
-        window.addEventListener("gamepadconnected", function() { ++JSEvents.numGamepadsConnected; });
-        window.addEventListener("gamepaddisconnected", function() { --JSEvents.numGamepadsConnected; });
+        window.addEventListener("gamepadconnected", JSEvents._onGamepadConnected);
+        window.addEventListener("gamepaddisconnected", JSEvents._onGamepadDisconnected);
         
         // Chromium does not fire the gamepadconnected event on reload, so we need to get the number of gamepads here as a workaround.
         // See https://bugs.chromium.org/p/chromium/issues/detail?id=502824
@@ -54,13 +57,19 @@ var LibraryJSEvents = {
       }
     },
 
+    removeAllEventListeners: function() {
+      for(var i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
+        JSEvents._removeHandler(i);
+      }
+      JSEvents.eventHandlers = [];
+      JSEvents.deferredCalls = [];
+      window.removeEventListener("gamepadconnected", JSEvents._onGamepadConnected);
+      window.removeEventListener("gamepaddisconnected", JSEvents._onGamepadDisconnected);
+    },
+
     registerRemoveEventListeners: function() {
       if (!JSEvents.removeEventListenersRegistered) {
-      __ATEXIT__.push(function() {
-          for(var i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
-            JSEvents._removeHandler(i);
-          }
-         });
+        __ATEXIT__.push(JSEvents.removeAllEventListeners);
         JSEvents.removeEventListenersRegistered = true;
       }
     },
@@ -2022,6 +2031,10 @@ var LibraryJSEvents = {
     }
 
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_html5_remove_all_event_listeners: function() {
+    JSEvents.removeAllEventListeners();
   }
 };
 

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -464,6 +464,8 @@ extern EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, 
 extern EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
 extern EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
 
+extern void emscripten_html5_remove_all_event_listeners(void);
+
 #define EM_CALLBACK_THREAD_CONTEXT_MAIN_BROWSER_THREAD ((pthread_t)0x1)
 #define EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD ((pthread_t)0x2)
 

--- a/tests/test_html5.c
+++ b/tests/test_html5.c
@@ -295,6 +295,7 @@ void mainloop()
 #ifdef REPORT_RESULT
 void report_result(void *arg)
 {
+  emscripten_html5_remove_all_event_listeners();
   REPORT_RESULT(0);
 }
 #endif
@@ -479,7 +480,7 @@ int main()
   /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means. 
      Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
   EM_ASM(Module['noExitRuntime'] = true);
-  
+
 #ifdef REPORT_RESULT
   // Keep the page running for a moment.
   emscripten_async_call(report_result, 0, 5000);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8261,7 +8261,7 @@ int main() {
                  0, [],                         [],     8,   0,    0, 0), # noqa; totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1493, [],                         [], 226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+              1494, [],                         [], 226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
     ]) # noqa
 
     print('test on a minimal pure computational thing')


### PR DESCRIPTION
Add `emscripten_html5_remove_all_event_listeners()` to allow unregistering all registered event handlers.