### PR TITLE
Fix timedwait cp

### DIFF
--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -42,8 +42,10 @@ int __timedwait_cp(volatile int *addr, int val,
 	}
 
 #ifdef __EMSCRIPTEN__
-	if (1 || pthread_self()->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS) {
-		int is_main_thread = emscripten_is_main_runtime_thread();
+	double msecsToSleep = top ? (top->tv_sec * 1000 + top->tv_nsec / 1000000.0) : INFINITY;
+	int is_main_thread = emscripten_is_main_browser_thread();
+	if (is_main_thread || pthread_self()->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS) {
+		double sleepUntilTime = emscripten_get_now() + msecsToSleep;
 		do {
 			if (_pthread_isduecanceled(pthread_self())) {
 				// Emscripten-specific return value: The wait was canceled by user calling
@@ -54,7 +56,7 @@ int __timedwait_cp(volatile int *addr, int val,
 			// Assist other threads by executing proxied operations that are effectively singlethreaded.
 			if (is_main_thread) emscripten_main_thread_process_queued_calls();
 			// Must wait in slices in case this thread is cancelled in between.
-			double waitMsecs = at ? _pthread_msecs_until(at) : INFINITY;
+			double waitMsecs = sleepUntilTime - emscripten_get_now();
 			if (waitMsecs <= 0) {
 				r = ETIMEDOUT;
 				break;
@@ -65,8 +67,7 @@ int __timedwait_cp(volatile int *addr, int val,
 		} while(r == ETIMEDOUT);
 	} else {
 		// Can wait in one go.
-		double waitMsecs = at ? _pthread_msecs_until(at) : INFINITY;
-		r = -emscripten_futex_wait((void*)addr, val, waitMsecs);
+		r = -emscripten_futex_wait((void*)addr, val, msecsToSleep);
 	}
 #else
 	r = -__syscall_cp(SYS_futex, addr, FUTEX_WAIT|priv, val, top);

--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -15,9 +15,7 @@
 int __pthread_setcancelstate(int, int *);
 int __clock_gettime(clockid_t, struct timespec *);
 
-
 #ifdef __EMSCRIPTEN__
-double _pthread_msecs_until(const struct timespec *restrict at);
 int _pthread_isduecanceled(struct pthread *pthread_ptr);
 #endif
 

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -67,16 +67,6 @@ static void inline __pthread_mutex_locked(pthread_mutex_t *mutex)
 	if (_pthread_getcanceltype() == PTHREAD_CANCEL_ASYNCHRONOUS) __pthread_testcancel();
 }
 
-double _pthread_msecs_until(const struct timespec *restrict at)
-{
-	struct timeval t;
-	gettimeofday(&t, NULL);
-	double cur_t = t.tv_sec * 1e3 + t.tv_usec * 1e-3;
-	double at_t = at->tv_sec * 1e3 + at->tv_nsec * 1e-6;
-	double msecs = at_t - cur_t;
-	return msecs;
-}
-
 int sched_get_priority_max(int policy)
 {
 	// Web workers do not actually support prioritizing threads,

--- a/system/lib/pthreads.symbols
+++ b/system/lib/pthreads.symbols
@@ -15,7 +15,6 @@
          T __wait
          T _pthread_getcanceltype
          T _pthread_isduecanceled
-         T _pthread_msecs_until
          T ___atomic_is_lock_free
          T _llvm_atomic_load_add_i32_p0i32
          T _llvm_memory_barrier


### PR DESCRIPTION
pthread_msecs_until unconditionally calling to gettimeofday was wrong, depending on whether the clock type used for the wait was based on Date.now() or performance.now().