### PR TITLE
fix_bad_64bit_asmjs_atomics

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -34,7 +34,7 @@ void emscripten_force_num_logical_cores(int cores);
 uint8_t emscripten_atomic_exchange_u8(void/*uint8_t*/ *addr, uint8_t newVal);
 uint16_t emscripten_atomic_exchange_u16(void/*uint16_t*/ *addr, uint16_t newVal);
 uint32_t emscripten_atomic_exchange_u32(void/*uint32_t*/ *addr, uint32_t newVal);
-uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 // CAS returns the *old* value that was in the memory location before the operation took place.
 // That is, if the return value when calling this function equals to 'oldVal', then the operation succeeded,
@@ -42,50 +42,50 @@ uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal)
 uint8_t emscripten_atomic_cas_u8(void/*uint8_t*/ *addr, uint8_t oldVal, uint8_t newVal);
 uint16_t emscripten_atomic_cas_u16(void/*uint16_t*/ *addr, uint16_t oldVal, uint16_t newVal);
 uint32_t emscripten_atomic_cas_u32(void/*uint32_t*/ *addr, uint32_t oldVal, uint32_t newVal);
-uint64_t emscripten_atomic_cas_u64(void/*uint64_t*/ *addr, uint64_t oldVal, uint64_t newVal); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_cas_u64(void/*uint64_t*/ *addr, uint64_t oldVal, uint64_t newVal); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 uint8_t emscripten_atomic_load_u8(const void/*uint8_t*/ *addr);
 uint16_t emscripten_atomic_load_u16(const void/*uint16_t*/ *addr);
 uint32_t emscripten_atomic_load_u32(const void/*uint32_t*/ *addr);
 float emscripten_atomic_load_f32(const void/*float*/ *addr);
-uint64_t emscripten_atomic_load_u64(const void/*uint64_t*/ *addr); // Emulated with locks, very slow!!
-double emscripten_atomic_load_f64(const void/*double*/ *addr); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_load_u64(const void/*uint64_t*/ *addr); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
+double emscripten_atomic_load_f64(const void/*double*/ *addr); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 // Returns the value that was stored (i.e. 'val')
 uint8_t emscripten_atomic_store_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_store_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_store_u32(void/*uint32_t*/ *addr, uint32_t val);
 float emscripten_atomic_store_f32(void/*float*/ *addr, float val);
-uint64_t emscripten_atomic_store_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
-double emscripten_atomic_store_f64(void/*double*/ *addr, double val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_store_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
+double emscripten_atomic_store_f64(void/*double*/ *addr, double val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 void emscripten_atomic_fence(void);
 
-// Each of the functions below (add, sub, and, or, xor) returns the value that was stored to memory after the operation occurred.
+// Each of the functions below (add, sub, and, or, xor) return the value that was in the memory location before the operation occurred.
 uint8_t emscripten_atomic_add_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_add_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_add_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_add_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_add_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 uint8_t emscripten_atomic_sub_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_sub_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_sub_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_sub_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_sub_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 uint8_t emscripten_atomic_and_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_and_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_and_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_and_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_and_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 uint8_t emscripten_atomic_or_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_or_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_or_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_or_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_or_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 uint8_t emscripten_atomic_xor_u8(void/*uint8_t*/ *addr, uint8_t val);
 uint16_t emscripten_atomic_xor_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_xor_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_xor_u64(void/*uint64_t*/ *addr, uint64_t val); // Emulated with locks, very slow!!
+uint64_t emscripten_atomic_xor_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
 int emscripten_futex_wait(volatile void/*uint32_t*/ *addr, uint32_t val, double maxWaitMilliseconds);
 int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -510,7 +510,7 @@ int llvm_memory_barrier()
 
 int llvm_atomic_load_add_i32_p0i32(int *ptr, int delta)
 {
-	return emscripten_atomic_add_u32(ptr, delta) - delta;
+	return emscripten_atomic_add_u32(ptr, delta);
 }
 
 typedef struct main_args

--- a/system/lib/pthread/library_pthread_asmjs.c
+++ b/system/lib/pthread/library_pthread_asmjs.c
@@ -106,11 +106,10 @@ uint64_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_add_u64(void *addr, uint64_t val
 {
 	uintptr_t m = (uintptr_t)addr >> 3;
 	SPINLOCK_ACQUIRE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	uint64_t *a = (uint64_t *)addr;
-	uint64_t newVal = *a + val;
-	*a = newVal;
+	uint64_t oldVal = *(uint64_t *)addr;
+	*(uint64_t *)addr = oldVal + val;
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	return newVal;
+	return oldVal;
 }
 
 // This variant is implemented for emulating GCC 64-bit __sync_fetch_and_add. Not to be called directly.
@@ -128,11 +127,10 @@ uint64_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_sub_u64(void *addr, uint64_t val
 {
 	uintptr_t m = (uintptr_t)addr >> 3;
 	SPINLOCK_ACQUIRE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	uint64_t *a = (uint64_t *)addr;
-	uint64_t newVal = *a - val;
-	*a = newVal;
+	uint64_t oldVal = *(uint64_t *)addr;
+	*(uint64_t *)addr = oldVal - val;
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	return newVal;
+	return oldVal;
 }
 
 // This variant is implemented for emulating GCC 64-bit __sync_fetch_and_sub. Not to be called directly.
@@ -150,11 +148,10 @@ uint64_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_and_u64(void *addr, uint64_t val
 {
 	uintptr_t m = (uintptr_t)addr >> 3;
 	SPINLOCK_ACQUIRE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	uint64_t *a = (uint64_t *)addr;
-	uint64_t newVal = *a & val;
-	*a = newVal;
+	uint64_t oldVal = *(uint64_t *)addr;
+	*(uint64_t *)addr = oldVal & val;
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	return newVal;
+	return oldVal;
 }
 
 // This variant is implemented for emulating GCC 64-bit __sync_fetch_and_and. Not to be called directly.
@@ -172,11 +169,10 @@ uint64_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_or_u64(void *addr, uint64_t val)
 {
 	uintptr_t m = (uintptr_t)addr >> 3;
 	SPINLOCK_ACQUIRE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	uint64_t *a = (uint64_t *)addr;
-	uint64_t newVal = *a | val;
-	*a = newVal;
+	uint64_t oldVal = *(uint64_t *)addr;
+	*(uint64_t *)addr = oldVal | val;
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	return newVal;
+	return oldVal;
 }
 
 // This variant is implemented for emulating GCC 64-bit __sync_fetch_and_or. Not to be called directly.
@@ -194,11 +190,10 @@ uint64_t EMSCRIPTEN_KEEPALIVE emscripten_atomic_xor_u64(void *addr, uint64_t val
 {
 	uintptr_t m = (uintptr_t)addr >> 3;
 	SPINLOCK_ACQUIRE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	uint64_t *a = (uint64_t *)addr;
-	uint64_t newVal = *a ^ val;
-	*a = newVal;
+	uint64_t oldVal = *(uint64_t *)addr;
+	*(uint64_t *)addr = oldVal ^ val;
 	SPINLOCK_RELEASE(&emulated64BitAtomicsLocks[m&(NUM_64BIT_LOCKS-1)]);
-	return newVal;
+	return oldVal;
 }
 
 // This variant is implemented for emulating GCC 64-bit __sync_fetch_and_xor. Not to be called directly.

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -136,7 +136,9 @@ void RunTest(int test)
 int main()
 {
 	globalDouble = 5.0;
-	globalU64 = 5;
+	globalU64 = 4;
+
+	uint64_t prevU64 = emscripten_atomic_add_u64((void*)&globalU64, 1); assert(prevU64 == 4);
 
 	if (!emscripten_has_threading_support())
 	{

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -22,7 +22,6 @@ volatile unsigned short globalUshort = 0;
 volatile unsigned int globalUint = 0;
 volatile float globalFloat = 0.0f;
 volatile double globalDouble = 0.0;
-volatile uint64_t globalU64 = 0;
 
 const int N = 10;
 int sharedData[N] = {};
@@ -49,7 +48,6 @@ void *ThreadMain(void *arg)
 	assert(globalUint == 5);
 	assert(globalFloat == 5.0f);
 	assert(globalDouble == 5.0);
-	assert(globalU64 == 5);
 	struct Test *t = (struct Test*)arg;
 	EM_ASM(out('Thread ' + $0 + ' for test ' + $1 + ': starting computation.'), t->threadId, t->op);
 
@@ -146,12 +144,15 @@ void RunTest(int test)
 
 int main()
 {
-	globalUchar = 5;
-	globalUshort = 5;
-	globalUint = 5;
+	globalUchar = 4;
+	globalUshort = 4;
+	globalUint = 4;
 	globalFloat = 5.0f;
 	globalDouble = 5.0;
-	globalU64 = 5;
+
+	uint8_t prevUchar = emscripten_atomic_add_u8((void*)&globalUchar, 1); assert(prevUchar == 4);
+	uint16_t prevUshort = emscripten_atomic_add_u16((void*)&globalUshort, 1); assert(prevUshort == 4);
+	uint32_t prevUint = emscripten_atomic_add_u32((void*)&globalUint, 1); assert(prevUint == 4);
 
 	emscripten_atomic_fence();
 	__sync_synchronize();


### PR DESCRIPTION
Fix bad atomics comment and 64-bit asm.js emulated implementation - the atomic operations return values *before* the operation took place.