### PR TITLE
Improve ubsan support and testing

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4376,8 +4376,21 @@ LibraryManager.library = {
   __unlockfile: function(){},
 
   // ubsan (undefined behavior sanitizer) support
+  // TODO(sbc): Use the actual implementations from clang's compiler-rt
   __ubsan_handle_float_cast_overflow: function(id, post) {
     abort('Undefined behavior! ubsan_handle_float_cast_overflow: ' + [id, post]);
+  },
+
+  __ubsan_handle_pointer_overflow: function(id, post) {
+    abort('Undefined behavior! ubsan_handle_pointer_overflow: ' + [id, post]);
+  },
+
+  __ubsan_handle_type_mismatch_v1: function(id, post) {
+    abort('Undefined behavior! ubsan_handle_type_mismatch_v1: ' + [id, post]);
+  },
+
+  __ubsan_handle_add_overflow: function(id, post) {
+    abort('Undefined behavior! ubsan_handle_add_overflow: ' + [id, post]);
   },
 
   // USE_FULL_LIBRARY hacks

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -747,8 +747,9 @@ f.close()
       run_process([PYTHON, EMCC, 'binary.' + suffix])
       self.assertContained('hello, world!', run_js(os.path.join(self.get_dir(), 'a.out.js')))
 
-  def test_catch_undef(self):
-    open(os.path.join(self.get_dir(), 'test.cpp'), 'w').write(r'''
+  def test_ubsan(self):
+    with open('test.cpp', 'w') as f:
+      f.write(r'''
       #include <vector>
       #include <stdio.h>
 
@@ -764,8 +765,28 @@ f.close()
         return 0;
       }
     ''')
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'test.cpp'), '-fsanitize=undefined'])
-    self.assertContained('hello, world!', run_js(os.path.join(self.get_dir(), 'a.out.js')))
+
+    run_process([PYTHON, EMCC, 'test.cpp', '-fsanitize=undefined'])
+    self.assertContained('hello, world!', run_js('a.out.js'))
+
+  def test_ubsan_add_overflow(self):
+    with open('test.cpp', 'w') as f:
+      f.write(r'''
+      #include <stdio.h>
+
+      int main(int argc, char **argv) {
+        printf("hello, world!\n");
+        fflush(stdout);
+        int k = 0x7fffffff;
+        k += argc;
+        return k;
+      }
+    ''')
+
+    run_process([PYTHON, EMCC, 'test.cpp', '-fsanitize=undefined'])
+    output = run_js('a.out.js', assert_returncode=1, stderr=STDOUT)
+    self.assertContained('hello, world!', output)
+    self.assertContained('Undefined behavior! ubsan_handle_add_overflow:', output)
 
   @no_wasm_backend()
   def test_asm_minify(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8228,7 +8228,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0), # noqa; totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1526, ['invoke_i'],               ['waka'],                 469663, 149, 1439),
+              1529, ['invoke_i'],               ['waka'],                 469663, 149, 1439),
     ]) # noqa
 
     print('test on a minimal pure computational thing')


### PR DESCRIPTION
This support is still partial.  Ideally we would use the
implements from these functions from compiler-rt.