### PR TITLE
Increase the size limit for O1 of test_no_nuthin to 91000

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5170,7 +5170,7 @@ main(const int argc, const char * const * const argv)
       self.assertLess(sizes['no_fs_manual'], sizes['no_fs'] + 30)
 
     test(['-s', 'ASSERTIONS=0'], 120000) # we don't care about code size with assertions
-    test(['-O1'], 90000)
+    test(['-O1'], 91000)
     test(['-O2'], 46000)
     test(['-O3', '--closure', '1'], 17000)
     # asm.js too


### PR DESCRIPTION
PR #7203 added some functions used for emscripten EH and they are now
exported. They can be DCE'd if they are not used but not at -O1.