### PR TITLE
Export getTempRet0 like other EH library functions

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1155,7 +1155,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # llvm wasm backend will generate calls to these when using setjmp
           # and/or C++ exceptions, so we pretty much alwasy need them.  They are
           # also tiny, and should be elimitated by meta-DCE when not used.
-          shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
+          shared.Settings.EXPORTED_FUNCTIONS += \
+            ['_setTempRet0', '_getTempRet0', '_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
 

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -25,7 +25,3 @@ void setThrew(int threw, int value) {
 void setTempRet0(int value) {
   __tempRet0 = value;
 }
-
-int getTempRet0() {
-  return __tempRet0;
-}

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -25,3 +25,7 @@ void setThrew(int threw, int value) {
 void setTempRet0(int value) {
   __tempRet0 = value;
 }
+
+int getTempRet0() {
+  return __tempRet0;
+}


### PR DESCRIPTION
In the current emscripten EH with the LLVM wasm backend, `__tempRet0`
variable is in the wasm side and set by JS code and read by wasm code.
So we need `setTempRet0` but not `getTempRet0`. [This does not seem to be
currently exported](https://github.com/kripken/emscripten/blob/f93f40d1bc5b2a2a136b453a687151f279cdad51/emcc.py#L1158) so it's not used anyway.