### PR TITLE
Fix emscripten_alcGetStringiSOFT when it calls emscripten_alcGetString

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2644,6 +2644,7 @@ var LibraryOpenAL = {
 
   emscripten_alcGetStringiSOFT__proxy: 'sync',
   emscripten_alcGetStringiSOFT__sig: 'iiii',
+  emscripten_alcGetStringiSOFT__deps: ['alcGetString'],
   emscripten_alcGetStringiSOFT: function(deviceId, param, index) {
     if (!deviceId in AL.deviceRefCounts) {
 #if OPENAL_DEBUG
@@ -2671,7 +2672,7 @@ var LibraryOpenAL = {
       }
     default:
       if (index === 0) {
-        return alcGetString(deviceId, param);
+        return _alcGetString(deviceId, param);
       } else {
 #if OPENAL_DEBUG
         console.log('alcGetStringiSOFT() with param 0x' + param.toString(16) + ' not implemented yet');


### PR DESCRIPTION
That code path was broken since the code was written, sadly.

In general we need better audio tests, right now I'm not familiar enough with the API to create one for this.

Fixes #7210