### PR TITLE
Remove getTemp0/setTemp0 from system/lib/compiler-rt/extras.c

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1152,10 +1152,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # Always need malloc and free to be kept alive and exported, for internal use and other modules
         shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
         if shared.Settings.WASM_BACKEND:
-          # llvm wasm backend will generate calls to these when using setjmp
-          # and/or C++ exceptions, so we pretty much alwasy need them.  They are
-          # also tiny, and should be elimitated by meta-DCE when not used.
-          shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
+          # llvm wasm backend will generate setThrew using setjmp and/or
+          # C++ exceptions, so we pretty much always need it.  Should be
+          # elimiated by meta-DCE if unused.
+          shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
 

--- a/emcc.py
+++ b/emcc.py
@@ -1152,9 +1152,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # Always need malloc and free to be kept alive and exported, for internal use and other modules
         shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
         if shared.Settings.WASM_BACKEND:
-          # llvm wasm backend will generate setThrew using setjmp and/or
-          # C++ exceptions, so we pretty much always need it.  Should be
-          # elimiated by meta-DCE if unused.
+          # setjmp/longjmp and exception handling JS code depends on this so we
+          # include it by default.  Should be elimiated by meta-DCE if unused.
           shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -13,19 +13,10 @@
  * cannot be static */
 int __THREW__ = 0;
 int __threwValue = 0;
-int __tempRet0 = 0;
 
 void setThrew(int threw, int value) {
   if (__THREW__ == 0) {
     __THREW__ = threw;
     __threwValue = value;
   }
-}
-
-void setTempRet0(int value) {
-  __tempRet0 = value;
-}
-
-int getTempRet0() {
-  return __tempRet0;
 }


### PR DESCRIPTION
These are now always generated by emscripten-wasm-finalize
See: https://github.com/WebAssembly/binaryen/pull/1703

Partial fix for #7273