### PR TITLE
Fix test_only_force_stdlibs_2 with wasm backend

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4632,7 +4632,7 @@ int main()
   }
 }
 ''')
-    with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libcxxabi,libcxx', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
+    with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libcxxabi,libcxx,dlmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
       run_process([PYTHON, EMXX, 'src.cpp', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Caught exception: std::exception', run_js('a.out.js', stderr=PIPE))
 


### PR DESCRIPTION
The wasm backend currently exports more than it needs to
so ends up depending on calloc and posix_memalign from dlmalloc
in this case.

There is a plan to have it export less:
https://github.com/WebAssembly/tool-conventions/issues/64

This should fix the current wasm waterfall failure.