### PR TITLE
Fix EXPORT_ALL with wasm backend

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1918,11 +1918,10 @@ class Building(object):
     # if Settings.DEBUG_LEVEL < 2 and not Settings.PROFILING_FUNCS:
     #   cmd.append('--strip-debug')
 
+    for export in expand_response(Settings.EXPORTED_FUNCTIONS):
+      cmd += ['--export', export[1:]] # Strip the leading underscore
     if Settings.EXPORT_ALL:
-      cmd += ['--no-gc-sections', '--export-all']
-    else:
-      for export in expand_response(Settings.EXPORTED_FUNCTIONS):
-        cmd += ['--export', export[1:]] # Strip the leading underscore
+      cmd += ['--export-all']
 
     logging.debug('emcc: lld-linking: %s to %s', args, target)
     check_call(cmd)


### PR DESCRIPTION
The semantics of EXPORT_ALL are not that we should avoid doing
any GC but rather that any symbols that survive GC should be
exported.