### PR TITLE
Report missing EXPORTED_FUNCTIONS by default

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -698,13 +698,15 @@ var STRICT = 0;
 // (and don't want to mess with the existing buildsystem), and functions might
 // be implemented later on, say in --pre-js, so you may want to build with -s
 // WARN_ON_UNDEFINED_SYMBOLS=0 to disable the warnings if they annoy you.  See
-// also ERROR_ON_UNDEFINED_SYMBOLS
+// also ERROR_ON_UNDEFINED_SYMBOLS.  Any undefined symbols that are listed in-
+// EXPORTED_FUNCTIONS will also be reported.
 var WARN_ON_UNDEFINED_SYMBOLS = 1;
 
 // If set to 1, we will give a link-time error on any undefined symbols (see
-// WARN_ON_UNDEFINED_SYMBOLS). The default value is 1. To allow undefined symbols
-// at link time set this to 0, in which case if an undefined function is called
-// a runtime error will occur.
+// WARN_ON_UNDEFINED_SYMBOLS). The default value is 1. To allow undefined
+// symbols at link time set this to 0, in which case if an undefined function is
+// called a runtime error will occur.  Any undefined symbols that are listed in
+// EXPORTED_FUNCTIONS will also be reported.
 var ERROR_ON_UNDEFINED_SYMBOLS = 1;
 
 // If set to 1, any -lfoo directives pointing to nonexisting library files will

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6342,7 +6342,7 @@ def process(filename):
   open(filename, 'w').write(src)
 '''
 
-    self.set_setting('EXPORTED_FUNCTIONS', self.get_setting('EXPORTED_FUNCTIONS') + ['_get_int', '_get_float', '_get_bool', '_get_string', '_print_int', '_print_float', '_print_bool', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc'])
+    self.set_setting('EXPORTED_FUNCTIONS', ['_get_int', '_get_float', '_get_bool', '_get_string', '_print_int', '_print_float', '_print_bool', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc'])
     self.do_run_in_out_file_test('tests', 'core', 'test_ccall', js_transform=post)
 
     if '-O2' in self.emcc_args or self.is_emterpreter():


### PR DESCRIPTION
Remove duplication by calling `check_all_implemented` in both asm and wasm paths.
