### PR TITLE
No EXPORT_ALL by default in main modules

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,13 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - Breaking change: Do not automatically set EXPORT_ALL for MAIN_MODULES. This
+   means that if your side modules want to call something from the main module,
+   the main module must either export it (normally, on EXPORTED_FUNCTIONS), or
+   you can manually enable EXPORT_ALL yourself. See #7312.
+
+v1.38.13: 10/10/2018
+--------------------
  - Support `-s NO_X=1` as an alias for `-s X=0` and vice versa, which
    simplifies current settings with `NO_`-prefixed names. See #7151.
  - Various `EMULATED_FUNCTION_POINTER` improvements. See #7108, #7128.

--- a/emcc.py
+++ b/emcc.py
@@ -1162,8 +1162,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if shared.Settings.EMULATED_FUNCTION_POINTERS == 0:
           shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
         shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
-        if not shared.Settings.SIDE_MODULE:
-          shared.Settings.EXPORT_ALL = 1
 
       if shared.Settings.EMTERPRETIFY:
         shared.Settings.FINALIZE_ASM_JS = 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3796,7 +3796,7 @@ Module = {
       void call_side() {
         printf("side: jslib_x is %d.\n", jslib_x);
       }
-    ''', expected=['main: jslib_x is 148.\nside: jslib_x is 148.\n'], main_emcc_args=['--js-library', 'lib.js'])
+    ''', expected=['main: jslib_x is 148.\nside: jslib_x is 148.\n'], main_emcc_args=['--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=["_main", "_jslib_x"]'])
 
   @needs_dlfcn
   def test_dylink_many_postSets(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8234,7 +8234,7 @@ int main() {
                  0, [],                         ['tempDoublePtr', 'waka'],     8,   0,    0, 0), # noqa; totally empty!
       # but we don't metadce with linkable code! other modules may want it
       (['-O3', '-s', 'MAIN_MODULE=1'],
-              1529, ['invoke_i'],               ['waka'],                 469663, 149, 1443, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+              1529, ['invoke_i'],               ['waka'],                 469663, 149, 1105, None), # noqa; don't compare the # of functions in a main module, which changes a lot
     ]) # noqa
 
     print('test on a minimal pure computational thing')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2990,7 +2990,8 @@ myreade(){
                  '--embed-file', 'proxyfs_embed.txt', '--pre-js', 'proxyfs_pre.js',
                  '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]',
                  '-s', 'BINARYEN_ASYNC_COMPILATION=0',
-                 '-s', 'MAIN_MODULE=1'])
+                 '-s', 'MAIN_MODULE=1',
+                 '-s', 'EXPORT_ALL=1'])
     # Following shutil.copyfile just prevent 'require' of node.js from caching js-object.
     # See https://nodejs.org/api/modules.html
     shutil.copyfile('proxyfs_test.js', 'proxyfs_test1.js')
@@ -6252,12 +6253,14 @@ int main(int argc, char** argv) {
       full = test()
       # printf is not used in main, but libc was linked in, so it's there
       printf = test(library_args=['-DUSE_PRINTF'])
-      # dce in main, and side happens to be ok since it uses puts as well
-      dce = test(main_args=['-s', 'MAIN_MODULE=2'])
+      # dce in main, and it fails since puts is not exported
+      dce = test(main_args=['-s', 'MAIN_MODULE=2'], expected=('cannot', 'undefined'))
+      # with exporting, it works
+      dce = test(main_args=['-s', 'MAIN_MODULE=2', '-s', 'EXPORTED_FUNCTIONS=["_main", "_puts"]'])
       # printf is not used in main, and we dce, so we failz
       dce_fail = test(main_args=['-s', 'MAIN_MODULE=2'], library_args=['-DUSE_PRINTF'], expected=('cannot', 'undefined'))
       # exporting printf in main keeps it alive for the library
-      dce_save = test(main_args=['-s', 'MAIN_MODULE=2', '-s', 'EXPORTED_FUNCTIONS=["_main", "_printf"]'], library_args=['-DUSE_PRINTF'])
+      dce_save = test(main_args=['-s', 'MAIN_MODULE=2', '-s', 'EXPORTED_FUNCTIONS=["_main", "_printf", "_puts"]'], library_args=['-DUSE_PRINTF'])
 
       assert percent_diff(full[0], printf[0]) < 4
       assert percent_diff(dce[0], dce_fail[0]) < 4


### PR DESCRIPTION
Do not automatically set `EXPORT_ALL` for `MAIN_MODULE`s. This means that if your side modules want to call something from the main module, the main module must either export it (normally, on EXPORTED_FUNCTIONS), or you can manually enable EXPORT_ALL yourself.

This is a breaking change, and documented in the changlog, but it's hard to show a useful error message when a problem occurs in practice. Let's discuss if this is worth doing or not. My guess is that there are few users of dynamic linking currently, and a few of them have requested this change, so it might be worth doing.

Partially fixes #5586. There are still many other exports, due to how function pointers work currently, I think.
