### PR TITLE
Cleaner handling of clusure compiler errors

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8594,16 +8594,17 @@ end
       }
     ''')
 
-    def test(extra=[]):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--pre-js', 'pre.js'] + extra)
+    def test(check, extra=[]):
+      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--pre-js', 'pre.js'] + extra
+      proc = run_process(cmd, check=check, stderr=PIPE)
+      if not check:
+        self.assertNotEqual(proc.returncode, 0)
+      return proc
 
-    failed = False
-    try:
-      test()
-    except:
-      failed = True
-    assert failed
-    test(['-s', 'IGNORE_CLOSURE_COMPILER_ERRORS=1'])
+    proc = test(check=False)
+    self.assertContained('ERROR - Variable dupe declared more than once', proc.stderr)
+    proc = test(check=True, extra=['-s', 'IGNORE_CLOSURE_COMPILER_ERRORS=1'])
+    self.assertEqual(proc.stderr, '')
 
   def test_toolchain_profiler(self):
     environ = os.environ.copy()


### PR DESCRIPTION
Previously you would see an emscripten internal backtrace
if closure compiler failed.

Sadly we have a lot of existing warnings so we don't display
the process stderr unless we the subprcess returns non-zero.

I guess we should try to address the closure warnings, at least
the ones in emscripten proper.