### PR TITLE
Add an assertion for OFFSCREENCANVAS_SUPPORT without GL

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -563,6 +563,9 @@ var LibraryPThread = {
           }
           name = Module['canvas'].id;
         }
+#if ASSERTIONS
+        assert(typeof GL === 'object', 'OFFSCREENCANVAS_SUPPORT assumes GL is in use (you can force-include it with -s \'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["$GL"]\')');
+#endif
         if (GL.offscreenCanvases[name]) {
           offscreenCanvas = GL.offscreenCanvases[name];
           GL.offscreenCanvases[name] = null; // This thread no longer owns this canvas.


### PR DESCRIPTION
Without this, a simple hello world (with no GL) hits a confusing error on startup (on the next line after the addition).