### PR TITLE
fix_full_es2_without_enable_extensions_by_default

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -724,6 +724,16 @@ var LibraryGL = {
         GL.initExtensions(context);
       }
 
+#if FULL_ES2
+      context.maxVertexAttribs = context.GLctx.getParameter(context.GLctx.MAX_VERTEX_ATTRIBS);
+      context.clientBuffers = [];
+      for (var i = 0; i < context.maxVertexAttribs; i++) {
+        context.clientBuffers[i] = { enabled: false, clientside: false, size: 0, type: 0, normalized: 0, stride: 0, ptr: 0, vertexAttribPointerAdaptor: null };
+      }
+
+      GL.generateTempBuffers(false, context);
+#endif
+
 #if OFFSCREEN_FRAMEBUFFER
       if (webGLContextAttributes['renderViaOffscreenBackBuffer']) GL.createOffscreenFramebuffer(context);
 #else
@@ -766,16 +776,6 @@ var LibraryGL = {
       context.initExtensionsDone = true;
 
       var GLctx = context.GLctx;
-
-      context.maxVertexAttribs = GLctx.getParameter(GLctx.MAX_VERTEX_ATTRIBS);
-#if FULL_ES2
-      context.clientBuffers = [];
-      for (var i = 0; i < context.maxVertexAttribs; i++) {
-        context.clientBuffers[i] = { enabled: false, clientside: false, size: 0, type: 0, normalized: 0, stride: 0, ptr: 0, vertexAttribPointerAdaptor: null };
-      }
-
-      GL.generateTempBuffers(false, context);
-#endif
 
       // Detect the presence of a few extensions manually, this GL interop layer itself will need to know if they exist.
 #if LEGACY_GL_EMULATION

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3804,6 +3804,11 @@ window.close = function() {
   def test_webgl_offscreen_canvas_only_in_pthread(self):
     self.btest('gl_only_in_pthread.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL'])
 
+  # Tests that rendering from client side memory without default-enabling extensions works.
+  @requires_graphics_hardware
+  def test_webgl_from_client_side_memory_without_default_enabled_extensions(self):
+    self.btest('webgl_draw_triangle.c', '0', args=['-lGL', '-s', 'OFFSCREEN_FRAMEBUFFER=1', '-DEXPLICIT_SWAP=1', '-DDRAW_FROM_CLIENT_MEMORY=1', '-s', 'FULL_ES2=1'])
+
   # Tests that -s OFFSCREEN_FRAMEBUFFER=1 rendering works.
   @requires_graphics_hardware
   def test_webgl_offscreen_framebuffer(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4948,7 +4948,7 @@ def process(filename):
       self.do_run(src, expected, js_engines=[NODE_JS])
 
   @no_windows("Windows throws EPERM rather than EACCES or EINVAL")
-  @unittest.skipIf(os.geteuid() == 0, "Root access invalidates this test by being able to write on readonly files")
+  @unittest.skipIf(WINDOWS or os.geteuid() == 0, "Root access invalidates this test by being able to write on readonly files")
   def test_unistd_truncate_noderawfs(self):
     self.emcc_args += ['-s', 'NODERAWFS=1']
     test_path = path_from_root('tests', 'unistd', 'truncate')

--- a/tests/webgl_draw_triangle.c
+++ b/tests/webgl_draw_triangle.c
@@ -51,6 +51,10 @@ int main()
 #ifdef EXPLICIT_SWAP
   attr.explicitSwapControl = 1;
 #endif
+#ifdef DRAW_FROM_CLIENT_MEMORY
+  // This test verifies that drawing from client-side memory when enableExtensionsByDefault==false works.
+  attr.enableExtensionsByDefault = 0;
+#endif
 
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
   emscripten_webgl_make_context_current(ctx);
@@ -76,18 +80,24 @@ int main()
   GLuint program = create_program(vs, fs);
   glUseProgram(program);
 
-  GLuint vbo;
-  glGenBuffers(1, &vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, vbo);
-  const float pos_and_color[] = {
+  static const float pos_and_color[] = {
   //     x,     y, r, g, b
      -0.6f, -0.6f, 1, 0, 0,
       0.6f, -0.6f, 0, 1, 0,
       0.f,   0.6f, 0, 0, 1,
   };
+
+#ifdef DRAW_FROM_CLIENT_MEMORY
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 20, pos_and_color);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 20, (void*)(pos_and_color+2));
+#else
+  GLuint vbo;
+  glGenBuffers(1, &vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
   glBufferData(GL_ARRAY_BUFFER, sizeof(pos_and_color), pos_and_color, GL_STATIC_DRAW);
   glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 20, 0);
   glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 20, (void*)8);
+#endif
   glEnableVertexAttribArray(0);
   glEnableVertexAttribArray(1);
 


### PR DESCRIPTION
Fix FULL_ES2=1 rendering to work on contexts created without enableExtensionsByDefault attribute