### PR TITLE
Always implement getTempRet0/setTempRet0 in JS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1150,10 +1150,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # Always need malloc and free to be kept alive and exported, for internal use and other modules
         shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
         if shared.Settings.WASM_BACKEND:
-          # llvm wasm backend will generate calls to these when using setjmp
-          # and/or C++ exceptions, so we pretty much alwasy need them.  They are
-          # also tiny, and should be elimitated by meta-DCE when not used.
-          shared.Settings.EXPORTED_FUNCTIONS += ['_setTempRet0', '_setThrew']
+          # setjmp/longjmp and exception handling JS code depends on this so we
+          # include it by default.  Should be elimiated by meta-DCE if unused.
+          shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
 
       assert not (not shared.Settings.DYNAMIC_EXECUTION and shared.Settings.RELOCATABLE), 'cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()'
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -659,8 +659,6 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
       funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace']
     if shared.Settings.SAFE_HEAP:
       funcs += ['setDynamicTop']
-    if not shared.Settings.RELOCATABLE:
-      funcs += ['setTempRet0', 'getTempRet0']
     if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
       funcs += ['setThrew']
     if shared.Settings.EMTERPRETIFY:
@@ -1317,7 +1315,7 @@ function ftCall_%s(%s) {%s
 
 
 def create_basic_funcs(function_table_sigs):
-  basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
+  basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory', 'setTempRet0', 'getTempRet0']
   if shared.Settings.ABORTING_MALLOC:
     basic_funcs += ['abortOnCannotGrowMemory']
   if shared.Settings.STACK_OVERFLOW_CHECK:
@@ -1332,8 +1330,6 @@ def create_basic_funcs(function_table_sigs):
   if shared.Settings.ASSERTIONS:
     for sig in function_table_sigs:
       basic_funcs += ['nullFunc_' + sig]
-  if shared.Settings.RELOCATABLE:
-    basic_funcs += ['setTempRet0', 'getTempRet0']
 
   for sig in function_table_sigs:
     basic_funcs.append('invoke_%s' % sig)
@@ -1395,8 +1391,6 @@ def create_asm_runtime_funcs():
   funcs = []
   if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
     funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
-  if not shared.Settings.RELOCATABLE:
-    funcs += ['setTempRet0', 'getTempRet0']
   if shared.Settings.SAFE_HEAP:
     funcs += ['setDynamicTop']
   if shared.Settings.ONLY_MY_CODE:
@@ -1650,17 +1644,6 @@ function SAFE_FT_MASK(value, mask) {
 }
 ''')
 
-  if not shared.Settings.RELOCATABLE:
-    funcs.append('''
-function setTempRet0(value) {
-  value = value|0;
-  tempRet0 = value;
-}
-function getTempRet0() {
-  return tempRet0|0;
-}
-''')
-
   return funcs
 
 
@@ -1706,9 +1689,6 @@ def create_asm_temp_vars():
   var nan = global%s, inf = global%s;
   var tempInt = 0, tempBigInt = 0, tempBigIntS = 0, tempValue = 0, tempDouble = 0.0;
 ''' % (access_quote('NaN'), access_quote('Infinity'))
-
-  if not shared.Settings.RELOCATABLE:
-    rtn += 'var tempRet0 = 0;\n'
 
   return rtn
 
@@ -2091,7 +2071,7 @@ def create_em_js(forwarded_json, metadata):
 
 
 def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
-  basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
+  basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory', 'setTempRet0', 'getTempRet0']
   if shared.Settings.ABORTING_MALLOC:
     basic_funcs += ['abortOnCannotGrowMemory']
   if shared.Settings.SAFE_HEAP:
@@ -2167,12 +2147,6 @@ var stackRestore = Module['_stackRestore'];
 var establishStackSpace = Module['establishStackSpace'];
 ''')
 
-  # some runtime functionality may not have been generated in
-  # the wasm; provide a JS shim for it
-  for name in ['setTempRet0', 'getTempRet0', 'stackSave', 'stackRestore', 'stackAlloc']:
-    if name not in exported_implemented_functions:
-      module.append('var %s;\n' % name)
-
   module.append(invoke_wrappers)
   module.append(jscall_funcs)
   return module
@@ -2239,7 +2213,7 @@ def asmjs_mangle(name):
   Prepends '_' and replaces non-alphanumerics with '_'.
   Used by wasm backend for JS library consistency with asm.js.
   """
-  library_functions_in_module = ('setThrew', 'setTempRet0', 'getTempRet0')
+  library_functions_in_module = ('setThrew',)
   if name.startswith('dynCall_'):
     return name
   if name in library_functions_in_module:

--- a/src/library.js
+++ b/src/library.js
@@ -57,6 +57,20 @@ LibraryManager.library = {
   },
 
   // ==========================================================================
+  // getTempRet0/setTempRet0: scratch space handling i64 return
+  // ==========================================================================
+
+  getTempRet0__sig: 'i',
+  getTempRet0: function() {
+    return {{{ makeGetTempRet0() }}};
+  },
+
+  setTempRet0__sig: 'vi',
+  setTempRet0: function($i) {
+    {{{ makeSetTempRet0('$i') }}};
+  },
+
+  // ==========================================================================
   // utime.h
   // ==========================================================================
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1312,15 +1312,11 @@ function makeGetSlabs(ptr, type, allowMultiple, unsigned) {
 }
 
 function makeGetTempRet0() {
-  return RELOCATABLE ? "(getTempRet0() | 0)" : "tempRet0";
+  return "(getTempRet0() | 0)";
 }
 
 function makeSetTempRet0(value) {
-  if (WASM_BACKEND == 1) {
-    return 'Module["asm"]["setTempRet0"](' + value + ')';
-  } else {
-    return RELOCATABLE ? "setTempRet0((" + value + ") | 0)" : ("tempRet0 = " + value);
-  }
+  return "setTempRet0((" + value + ") | 0)";
 }
 
 function makeStructuralReturn(values, inAsm) {

--- a/src/support.js
+++ b/src/support.js
@@ -10,7 +10,7 @@ var STACK_ALIGN = {{{ STACK_ALIGN }}};
 #if ASSERTIONS
 // stack management, and other functionality that is provided by the compiled code,
 // should not be used before it is ready
-stackSave = stackRestore = stackAlloc = setTempRet0 = getTempRet0 = function() {
+stackSave = stackRestore = stackAlloc = function() {
   abort('cannot use the stack before compiled code is ready to run, and has provided stack access');
 };
 #endif
@@ -544,10 +544,6 @@ function dynCall(sig, ptr, args) {
   }
 }
 
-#if RELOCATABLE
-// tempRet0 is normally handled in the module. but in relocatable code,
-// we need to share a single one among all the modules, so they all call
-// out.
 var tempRet0 = 0;
 
 var setTempRet0 = function(value) {
@@ -557,7 +553,6 @@ var setTempRet0 = function(value) {
 var getTempRet0 = function() {
   return tempRet0;
 }
-#endif // RELOCATABLE
 
 #if RETAIN_COMPILER_SETTINGS
 var compilerSettings = {{{ JSON.stringify(makeRetainedCompilerSettings()) }}} ;

--- a/system/lib/compiler-rt/extras.c
+++ b/system/lib/compiler-rt/extras.c
@@ -13,19 +13,10 @@
  * cannot be static */
 int __THREW__ = 0;
 int __threwValue = 0;
-int __tempRet0 = 0;
 
 void setThrew(int threw, int value) {
   if (__THREW__ == 0) {
     __THREW__ = threw;
     __threwValue = value;
   }
-}
-
-void setTempRet0(int value) {
-  __tempRet0 = value;
-}
-
-int getTempRet0() {
-  return __tempRet0;
 }


### PR DESCRIPTION
Export them as library functions so compiled code can access them.
Remove them from system/lib/compiler-rt/extras.c.

Fixes: #7273