### PR TITLE
[wasm-backend] Move fixImports from runtime to compile time

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2127,10 +2127,9 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
     return g
 
   send_items_map = OrderedDict()
-  seen = set()
   for name in send_items:
     internal_name = fixImportName(name)
-    if internal_name in seen:
+    if internal_name in send_items_map:
       exit_with_error('duplicate symbol in exports to wasm: %s', name)
     send_items_map[internal_name] = name
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -366,7 +366,7 @@ def create_module_asmjs(function_table_sigs, metadata,
                         funcs_js, asm_setup, the_global, sending, receiving, asm_global_vars,
                         asm_global_funcs, pre_tables, final_function_tables, exports):
   receiving += create_named_globals(metadata)
-  runtime_funcs = create_runtime_funcs(exports)
+  runtime_funcs = create_runtime_funcs_asmjs(exports)
 
   asm_start_pre = create_asm_start_pre(asm_setup, the_global, sending, metadata)
   asm_temp_vars = create_asm_temp_vars()
@@ -1492,7 +1492,7 @@ for (var named in NAMED_GLOBALS) {
   return named_globals
 
 
-def create_runtime_funcs(exports):
+def create_runtime_funcs_asmjs(exports):
   if shared.Settings.ONLY_MY_CODE:
     return []
 
@@ -2093,7 +2093,7 @@ def create_em_js(forwarded_json, metadata):
 
 
 def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
-  basic_funcs = ['abort', 'assert', 'enlargeMemory', 'getTotalMemory']
+  basic_funcs = ['assert', 'enlargeMemory', 'getTotalMemory']
   if shared.Settings.ABORTING_MALLOC:
     basic_funcs += ['abortOnCannotGrowMemory']
   if shared.Settings.SAFE_HEAP:
@@ -2107,17 +2107,34 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
     global_vars = [] # linkable code accesses globals through function calls
 
   implemented_functions = set(metadata['implementedFunctions'])
-  global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].items() if value != 2]).difference(set(global_vars)).difference(implemented_functions))
+  library_funcs = set(k for k, v in forwarded_json['Functions']['libraryFunctions'].items() if v != 2)
+  global_funcs = list(library_funcs.difference(set(global_vars)).difference(implemented_functions))
 
   jscall_funcs = ['jsCall_' + sig for sig in jscall_sigs]
 
   send_items = (basic_funcs + invoke_funcs + jscall_funcs + global_funcs +
                 basic_vars + global_vars)
 
-  def math_fix(g):
-    return g if not g.startswith('Math_') else g.split('_')[1]
+  def fixImportName(g):
+    if g.startswith('Math_'):
+      return g.split('_')[1]
+    # Unlike wasm backend doesn't use the '_' prefix for native symbols.
+    # Emscripten currnetly expects symbols to start with '_' so artificially
+    # add them to the output of emscripten-wasm-finalize and them strip them
+    # again here.
+    if g.startswith('_'):
+      return g[1:]
+    return g
 
-  return '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in send_items]) + ' }'
+  send_items_map = OrderedDict()
+  seen = set()
+  for name in send_items:
+    internal_name = fixImportName(name)
+    if internal_name in seen:
+      exit_with_error('duplicate symbol in exports to wasm: %s', name)
+    send_items_map[internal_name] = name
+
+  return '{ ' + ', '.join('"' + k + '": ' + v for k, v in send_items_map.items()) + ' }'
 
 
 def create_receiving_wasm(exported_implemented_functions):
@@ -2146,18 +2163,16 @@ def create_module_wasm(sending, receiving, invoke_funcs, jscall_sigs,
   invoke_wrappers = create_invoke_wrappers(invoke_funcs)
   jscall_funcs = create_jscall_funcs(jscall_sigs)
 
-  the_global = '{}'
-
   if shared.Settings.USE_PTHREADS and not shared.Settings.WASM:
     shared_array_buffer = "if (typeof SharedArrayBuffer !== 'undefined') Module.asmGlobalArg['Atomics'] = Atomics;"
   else:
     shared_array_buffer = ''
 
   module = ['''
-Module%s = %s;
+Module%s = {};
 %s
 Module%s = %s;
-''' % (access_quote('asmGlobalArg'), the_global, shared_array_buffer, access_quote('asmLibraryArg'), sending) + '''
+''' % (access_quote('asmGlobalArg'), shared_array_buffer, access_quote('asmLibraryArg'), sending) + '''
 var asm = Module['asm'](Module%s, Module%s, buffer);
 %s;
 ''' % (access_quote('asmGlobalArg'), access_quote('asmLibraryArg'), receiving)]

--- a/emscripten.py
+++ b/emscripten.py
@@ -2115,7 +2115,7 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
   send_items = (basic_funcs + invoke_funcs + jscall_funcs + global_funcs +
                 basic_vars + global_vars)
 
-  def fixImportName(g):
+  def fix_import_name(g):
     if g.startswith('Math_'):
       return g.split('_')[1]
     # Unlike fastcomp the wasm backend doesn't use the '_' prefix for native
@@ -2128,7 +2128,7 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
 
   send_items_map = OrderedDict()
   for name in send_items:
-    internal_name = fixImportName(name)
+    internal_name = fix_import_name(name)
     if internal_name in send_items_map:
       exit_with_error('duplicate symbol in exports to wasm: %s', name)
     send_items_map[internal_name] = name

--- a/emscripten.py
+++ b/emscripten.py
@@ -2118,10 +2118,10 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
   def fixImportName(g):
     if g.startswith('Math_'):
       return g.split('_')[1]
-    # Unlike wasm backend doesn't use the '_' prefix for native symbols.
-    # Emscripten currnetly expects symbols to start with '_' so artificially
-    # add them to the output of emscripten-wasm-finalize and them strip them
-    # again here.
+    # Unlike fastcomp the wasm backend doesn't use the '_' prefix for native
+    # symbols.  Emscripten currently expects symbols to start with '_' so we
+    # artificially add them to the output of emscripten-wasm-finalize and them
+    # strip them again here.
     if g.startswith('_'):
       return g[1:]
     return g

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2115,20 +2115,6 @@ function integrateWasmJS() {
     updateGlobalBufferViews();
   }
 
-  function fixImports(imports) {
-#if WASM_BACKEND
-    var ret = {};
-    for (var i in imports) {
-      var fixed = i;
-      if (fixed[0] == '_') fixed = fixed.substr(1);
-      ret[fixed] = imports[i];
-    }
-    return ret;
-#else
-    return imports;
-#endif // WASM_BACKEND
-  }
-
   function getBinary() {
     try {
       if (Module['wasmBinary']) {
@@ -2447,11 +2433,6 @@ function integrateWasmJS() {
   // doesn't need to care that it is wasm or olyfilled wasm or asm.js.
 
   Module['asm'] = function(global, env, providedBuffer) {
-#if BINARYEN_METHOD != 'native-wasm'
-    global = fixImports(global);
-#endif
-    env = fixImports(env);
-
     // import table
     if (!env['table']) {
       var TABLE_SIZE = Module['wasmTableSize'];


### PR DESCRIPTION
With the wasm backend with don't have leading "_" on symbol
names but to fit in with the current codebase we pretend that
we do right up until the end.

This change moves the stripping on the '_' from runtime, right
before instantiate to compile time.  This also allows us to
add error checking to avoid duplicate dictionary keys that
could result.