### PR TITLE
EMTEST_SAVE_DIR: do not remove the old dir if it exists

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -280,8 +280,8 @@ class RunnerCore(unittest.TestCase):
     self.use_all_engines = EMTEST_ALL_ENGINES
     if self.save_dir:
       self.working_dir = os.path.join(self.temp_dir, 'emscripten_test')
-      try_delete(self.working_dir)
-      os.makedirs(self.working_dir)
+      if not os.path.exists(self.working_dir):
+        os.makedirs(self.working_dir)
     else:
       self.working_dir = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=self.temp_dir)
     os.chdir(self.working_dir)


### PR DESCRIPTION
This makes debugging easier imo (no need to chdir each time you run, keep around files you're working with, etc.).