### PR TITLE
Improve detection in benchmark script

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -347,17 +347,17 @@ try:
     NativeBenchmarker('clang', CLANG_CC, CLANG),
     # NativeBenchmarker('gcc',   'gcc',    'g++')
   ]
-  if SPIDERMONKEY_ENGINE and Building.which(SPIDERMONKEY_ENGINE[0]):
+  if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:
     benchmarkers += [
       EmscriptenBenchmarker('sm-asmjs', SPIDERMONKEY_ENGINE, ['-s', 'PRECISE_F32=2', '-s', 'WASM=0']),
       EmscriptenBenchmarker('sm-asm2wasm',  SPIDERMONKEY_ENGINE + ['--no-wasm-baseline'], []),
       # EmscriptenBenchmarker('sm-asm2wasm-lto',  SPIDERMONKEY_ENGINE + ['--no-wasm-baseline'], ['--llvm-lto', '1']),
-      # EmscriptenBenchmarker('sm-wasmbackend',  SPIDERMONKEY_ENGINE + ['--no-wasm-baseline'], [env={
+      # EmscriptenBenchmarker('sm-wasmbackend',  SPIDERMONKEY_ENGINE + ['--no-wasm-baseline'], env={
       #   'LLVM': '/home/alon/Dev/llvm/build/bin',
       #   'EMCC_WASM_BACKEND': '1',
       # }),
     ]
-  if V8_ENGINE and Building.which(V8_ENGINE[0]):
+  if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
     benchmarkers += [
       EmscriptenBenchmarker('v8-wasm',  V8_ENGINE),
     ]


### PR DESCRIPTION
Using `which` is somewhat fragile. Instead, check if the engine is defined in the config file, and if it is in the list of engines to test on there. That's the same logic we use to decide which engines to use in the rest of the test suite.

Also fixes a typo in a commented-out piece of code.