### PR TITLE
Disable lsr in the wasm backend [ci skip]

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1876,6 +1876,10 @@ class Building(object):
 
     # asm.js-style setjmp/longjmp handling
     args += ['-enable-emscripten-sjlj']
+
+    # better (smaller, sometimes faster) codegen, see binaryen#1054
+    args += ['-disable-lsr']
+
     return args
 
   @staticmethod
@@ -1901,7 +1905,6 @@ class Building(object):
         '--export',
         '__data_end',
         '--lto-O%d' % lto_level,
-        '--mllvm', '-disable-lsr', # see binaryen#1054
     ] + args
 
     if Settings.WASM_MEM_MAX != -1:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1878,6 +1878,7 @@ class Building(object):
     args += ['-enable-emscripten-sjlj']
 
     # better (smaller, sometimes faster) codegen, see binaryen#1054
+    # and https://bugs.llvm.org/show_bug.cgi?id=39488
     args += ['-disable-lsr']
 
     return args

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1901,6 +1901,7 @@ class Building(object):
         '--export',
         '__data_end',
         '--lto-O%d' % lto_level,
+        '--mllvm', '-disable-lsr', # see binaryen#1054
     ] + args
 
     if Settings.WASM_MEM_MAX != -1:


### PR DESCRIPTION
I did another round of tests now to follow up on https://github.com/WebAssembly/binaryen/issues/1054 , comparing v8 and sm, on the wasm backend with and without lsr. Disabling lsr reduces code size in all the benchmark suite, up to 1% (but usually less). It's also somewhat faster (5-10%) in a few microbenchmarks, on both VMs (so this is not a VM-specific issue). So seems worthwhile.

Verified `binaryen2` passes with the wasm backend with this.