### PR TITLE
[wasm-backend] Fix crash in read_proxied_function_signatures

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -535,19 +535,22 @@ def update_settings_glue(metadata):
     shared.Settings.JSCALL_START_INDEX = start_index
     shared.Settings.JSCALL_SIG_ORDER = sig2order
 
-  # Extract the list of function signatures that MAIN_THREAD_EM_ASM blocks in the compiled code have, each signature
-  # will need a proxy function invoker generated for it.
+  # Extract the list of function signatures that MAIN_THREAD_EM_ASM blocks in
+  # the compiled code have, each signature will need a proxy function invoker
+  # generated for it.
   def read_proxied_function_signatures(asmConsts):
     proxied_function_signatures = set()
-    for i in asmConsts.values():
-      _, sigs, proxying_types = i
-      for j in range(len(proxying_types)):
-        if proxying_types[j] == 'sync_on_main_thread_':
-          proxied_function_signatures.add(sigs[j] + '_sync')
-        elif proxying_types[j] == 'async_on_main_thread_':
-          proxied_function_signatures.add(sigs[j] + '_async')
+    for _, sigs, proxying_types in asmConsts.values():
+      for sig, proxying_type in zip(sigs, proxying_types):
+        if proxying_type == 'sync_on_main_thread_':
+          proxied_function_signatures.add(sig + '_sync')
+        elif proxying_type == 'async_on_main_thread_':
+          proxied_function_signatures.add(sig + '_async')
     return list(proxied_function_signatures)
-  shared.Settings.PROXIED_FUNCTION_SIGNATURES = read_proxied_function_signatures(metadata['asmConsts'])
+
+  # Proxying EM_ASM calls is not yet implemented in Wasm backend
+  if not shared.Settings.WASM_BACKEND:
+    shared.Settings.PROXIED_FUNCTION_SIGNATURES = read_proxied_function_signatures(metadata['asmConsts'])
 
 
 def compile_settings(compiler_engine, libraries, temp_files):
@@ -790,7 +793,7 @@ def all_asm_consts(metadata):
   for k, v in metadata['asmConsts'].items():
     const = asstr(v[0])
     sigs = v[1]
-    call_types = v[2] if len(v) >= 3 else None
+    call_types = v[2]
     const = trim_asm_const_body(const)
     const = '{ ' + const + ' }'
     args = []


### PR DESCRIPTION
The asmConsts structure only has two elements under the wasm
backend right now.  We should probably fix that and enable
proxied EM_ASM too, but for now this fixes the currently failure
on the wasm waterfall.