### PR TITLE
prevent exception in val::new_() after memory growth

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -174,7 +174,7 @@ var LibraryEmVal = {
 
     for(var i = 0; i < argCount; ++i) {
         functionBody +=
-            "var argType"+i+" = requireRegisteredType(HEAP32[(argTypes >> 2) + "+i+"], \"parameter "+i+"\");\n" +
+            "var argType"+i+" = requireRegisteredType(Module['HEAP32'][(argTypes >> 2) + "+i+"], \"parameter "+i+"\");\n" +
             "var arg"+i+" = argType"+i+".readValueFromPointer(args);\n" +
             "args += argType"+i+"['argPackAdvance'];\n";
     }
@@ -184,8 +184,8 @@ var LibraryEmVal = {
         "}\n";
 
     /*jshint evil:true*/
-    return (new Function("requireRegisteredType", "HEAP32", "__emval_register", functionBody))(
-        requireRegisteredType, HEAP32, __emval_register);
+    return (new Function("requireRegisteredType", "Module", "__emval_register", functionBody))(
+        requireRegisteredType, Module, __emval_register);
 #endif
   },
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -2615,6 +2615,14 @@ module({
             assert.equal(4.0, instance.b);
             assert.equal(65538, instance.c);
         });
+
+        if (cm.isMemoryGrowthEnabled) {
+            test("before and after memory growth", function() {
+                var array = cm.construct_with_arguments_before_and_after_memory_growth();
+                assert.equal(array[0].byteLength, 5);
+                assert.equal(array[0].byteLength, array[1].byteLength);
+            });
+        }
     });
 
     BaseFixture.extend("intrusive pointers", function() {

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -164,8 +164,9 @@ std::wstring get_literal_wstring() {
 }
 
 void force_memory_growth() {
-    auto heapu8 = val::global("Module")["HEAPU8"];
-    delete [] new char[heapu8["byteLength"].as<size_t>() + 1];
+    val module = val::global("Module");
+    std::size_t heap_size = module["HEAPU8"]["byteLength"].as<size_t>();
+    module.call<void>("_free", module.call<val>("_malloc", heap_size + 1));
 }
 
 std::string emval_test_take_and_return_const_char_star(const char* str) {
@@ -2726,10 +2727,21 @@ val construct_with_ints_and_float(val factory) {
     return factory.new_(65537, 4.0f, 65538);
 }
 
+val construct_with_arguments_before_and_after_memory_growth() {
+    auto out = val::array();
+    out.set(0, val::global("Uint8Array").new_(5));
+    force_memory_growth();
+    out.set(1, val::global("Uint8Array").new_(5));
+    return out;
+}
+
 EMSCRIPTEN_BINDINGS(val_new_) {
     function("construct_with_6_arguments", &construct_with_6);
     function("construct_with_memory_view", &construct_with_memory_view);
     function("construct_with_ints_and_float", &construct_with_ints_and_float);
+    function(
+            "construct_with_arguments_before_and_after_memory_growth",
+            &construct_with_arguments_before_and_after_memory_growth);
 }
 
 template <typename T>


### PR DESCRIPTION
`val::new_()` calls an allocator that closes over the value of `HEAP32` when the allocator was created. This reference becomes stale after memory growth, triggering an exception like the following:
```
BindingError {name: "BindingError", message: "parameter 0 has unknown type emsc"}
throwBindingError
requireRegisteredType
emval_allocator_1
__emval_new
```