### PR TITLE
Partial revet of #7254: Remove EMSCRIPTEN_ROOT from config file

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -108,6 +108,7 @@ class other(RunnerCore):
       run_process([PYTHON, compiler, '--generate-config', config_path])
       assert os.path.exists(config_path), 'A config file should have been created at %s' % config_path
       config_contents = open(config_path).read()
+      self.assertContained('EMSCRIPTEN_ROOT', config_contents)
       self.assertContained('LLVM_ROOT', config_contents)
       os.remove(config_path)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -169,7 +169,7 @@ class sanity(RunnerCore):
       self.assertNotContained('}}}', config_file)
       self.assertContained('{{{', template_file)
       self.assertContained('}}}', template_file)
-      for content in ['LLVM_ROOT', 'NODE_JS', 'TEMP_DIR', 'COMPILER_ENGINE', 'JS_ENGINES']:
+      for content in ['EMSCRIPTEN_ROOT', 'LLVM_ROOT', 'NODE_JS', 'TEMP_DIR', 'COMPILER_ENGINE', 'JS_ENGINES']:
         self.assertContained(content, config_file)
 
       # The guessed config should be ok
@@ -257,6 +257,17 @@ class sanity(RunnerCore):
           else:
             output = self.check_working(EMCC)
             assert LLVM_WARNING not in output, output
+
+  def test_emscripten_root(self):
+    # The correct path
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '%s'" % path_from_root())
+    self.check_working(EMCC)
+
+    # The correct path with extra stuff
+    restore_and_set_up()
+    add_to_config("EMSCRIPTEN_ROOT = '%s'" % (path_from_root() + os.path.sep))
+    self.check_working(EMCC)
 
   def test_llvm_fastcomp(self):
     WARNING = 'fastcomp in use, but LLVM has not been built with the JavaScript backend as a target'

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -10,6 +10,10 @@
 
 import os
 
+# This is used by external projects in order to find emscripten.  It is not used
+# by emscripten itself.
+EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '{{{ EMSCRIPTEN_ROOT }}}')) # directory
+
 LLVM_ROOT = os.path.expanduser(os.getenv('LLVM', '{{{ LLVM_ROOT }}}')) # directory
 BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # if not set, we will use it from ports
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -179,6 +179,7 @@ def generate_config(path, first_time=False):
   config_file = config_file[3:] # remove the initial comment
   config_file = '\n'.join(config_file)
   # autodetect some default paths
+  config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
   llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
   config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
 
@@ -206,12 +207,13 @@ It contains our best guesses for the important paths, which are:
 
   LLVM_ROOT       = %s
   NODE_JS         = %s
+  EMSCRIPTEN_ROOT = %s
 
 Please edit the file if any of those are incorrect.
 
 This command will now exit. When you are done editing those paths, re-run it.
 ==============================================================================
-''' % (path, abspath, llvm_root, node), file=sys.stderr)
+''' % (path, abspath, llvm_root, node, __rootpath__), file=sys.stderr)
 
 
 # Emscripten configuration is done through the --em-config command line option or


### PR DESCRIPTION
Turns out there are more third party project using the 'exec'
of ~/.emscripten_config to locate EMSCRIPTEN_ROOT (e.g.
https://github.com/godotengine/godot) so for now reinstate it.