### PR TITLE
Restrict the environment in which emscripten config file is parsed

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -148,9 +148,9 @@ def main():
       tasks = [x for x in tasks if x not in skip_tasks]
     else:
       if os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER'):
-        print('Skipping building of native-optimizer since environment variable EMSCRIPTEN_NATIVE_OPTIMIZER is present and set to point to a prebuilt native optimizer path.')
-      elif hasattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER'):
-        print('Skipping building of native-optimizer since .emscripten config file has set EMSCRIPTEN_NATIVE_OPTIMIZER to point to a prebuilt native optimizer path.')
+        print('Skipping building of native-optimizer; EMSCRIPTEN_NATIVE_OPTIMIZER is environment.')
+      elif shared.EMSCRIPTEN_NATIVE_OPTIMIZER:
+        print('Skipping building of native-optimizer; EMSCRIPTEN_NATIVE_OPTIMIZER set in .emscripten config.')
       else:
         tasks += ['native_optimizer']
     print('Building targets: %s' % ' '.join(tasks))

--- a/emcc.py
+++ b/emcc.py
@@ -222,7 +222,7 @@ class JSOptimizer(object):
     self.queue = []
     self.extra_info = {}
     self.queue_history = []
-    self.blacklist = (os.environ.get('EMCC_JSOPT_BLACKLIST') or '').split(',')
+    self.blacklist = os.environ.get('EMCC_JSOPT_BLACKLIST', '').split(',')
     self.minify_whitespace = False
     self.cleanup_shell = False
 

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -72,14 +72,16 @@ def get_native_optimizer():
     logging.critical('Non-fastcomp compiler is no longer available, please use fastcomp or an older version of emscripten')
     sys.exit(1)
 
-  # Allow users to override the location of the optimizer executable by setting an environment variable EMSCRIPTEN_NATIVE_OPTIMIZER=/path/to/optimizer(.exe)
-  opt = os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER', '')
-  if len(opt):
+  # Allow users to override the location of the optimizer executable by setting
+  # an environment variable EMSCRIPTEN_NATIVE_OPTIMIZER=/path/to/optimizer(.exe)
+  opt = os.environ.get('EMSCRIPTEN_NATIVE_OPTIMIZER')
+  if opt:
     logging.debug('env forcing native optimizer at ' + opt)
     return opt
-  # Also, allow specifying the location of the optimizer in .emscripten configuration file under EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/optimizer'
-  opt = getattr(shared, 'EMSCRIPTEN_NATIVE_OPTIMIZER', '')
-  if len(opt):
+  # Also, allow specifying the location of the optimizer in .emscripten
+  # configuration file under EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/optimizer'
+  opt = shared.EMSCRIPTEN_NATIVE_OPTIMIZER
+  if opt:
     logging.debug('config forcing native optimizer at ' + opt)
     return opt
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -260,6 +260,7 @@ else:
     sys.exit(0)
 
 # The following globals can be overridden by the config file.
+# See parse_config_file below.
 NODE_JS = None
 BINARYEN_ROOT = None
 EM_POPEN_WORKAROUND = None
@@ -273,14 +274,42 @@ CLOSURE_COMPILER = None
 JAVA = None
 PYTHON = None
 JS_ENGINE = None
+JS_ENGINES = []
 COMPILER_OPTS = []
 
-try:
+
+def parse_config_file():
+  """Parse the emscripten config file using python's exec"""
+  config = {}
   config_text = open(CONFIG_FILE, 'r').read() if CONFIG_FILE else EM_CONFIG
-  exec(config_text)
-except Exception as e:
-  logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
-  sys.exit(1)
+  try:
+    exec(config_text, config)
+  except Exception as e:
+    logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
+    sys.exit(1)
+
+  CONFIG_KEYS = (
+    'NODE_JS',
+    'BINARYEN_ROOT',
+    'EM_POPEN_WORKAROUND',
+    'SPIDERMONKEY_ENGINE',
+    'V8_ENGINE',
+    'LLVM_ROOT',
+    'COMPILER_ENGINE',
+    'LLVM_ADD_VERSION',
+    'CLANG_ADD_VERSION',
+    'CLOSURE_COMPILER',
+    'JAVA',
+    'PYTHON',
+    'JS_ENGINE',
+    'JS_ENGINES',
+    'COMPILER_OPTS',
+  )
+
+  # Only popogate certain settings from the config file.
+  for key in CONFIG_KEYS:
+    if key in config:
+      globals()[key] = config[key]
 
 
 # Returns a suggestion where current .emscripten config file might be located
@@ -307,6 +336,7 @@ def fix_js_engine(old, new):
   return new
 
 
+parse_config_file()
 SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, listify(SPIDERMONKEY_ENGINE))
 NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
 V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -250,7 +250,7 @@ if EM_CONFIG and not os.path.isfile(EM_CONFIG):
 if not EM_CONFIG:
   EM_CONFIG = '~/.emscripten'
 if '\n' in EM_CONFIG:
-  ONFIG_FILE = None
+  CONFIG_FILE = None
   logging.debug('EM_CONFIG is specified inline without a file')
 else:
   CONFIG_FILE = os.path.expanduser(EM_CONFIG)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -250,7 +250,7 @@ if EM_CONFIG and not os.path.isfile(EM_CONFIG):
 if not EM_CONFIG:
   EM_CONFIG = '~/.emscripten'
 if '\n' in EM_CONFIG:
-  CONFIG_FILE = None
+  ONFIG_FILE = None
   logging.debug('EM_CONFIG is specified inline without a file')
 else:
   CONFIG_FILE = os.path.expanduser(EM_CONFIG)
@@ -271,6 +271,7 @@ COMPILER_ENGINE = None
 LLVM_ADD_VERSION = None
 CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
+EMSCRIPTEN_NATIVE_OPTIMIZER = None
 JAVA = None
 PYTHON = None
 JS_ENGINE = None
@@ -285,14 +286,14 @@ def parse_config_file():
   try:
     exec(config_text, config)
   except Exception as e:
-    logging.error('Error in evaluating %s (at %s): %s, text: %s' % (EM_CONFIG, CONFIG_FILE, str(e), config_text))
-    sys.exit(1)
+    exit_with_error('Error in evaluating %s (at %s): %s, text: %s', EM_CONFIG, CONFIG_FILE, str(e), config_text)
 
   CONFIG_KEYS = (
     'NODE_JS',
     'BINARYEN_ROOT',
     'EM_POPEN_WORKAROUND',
     'SPIDERMONKEY_ENGINE',
+    'EMSCRIPTEN_NATIVE_OPTIMIZER',
     'V8_ENGINE',
     'LLVM_ROOT',
     'COMPILER_ENGINE',


### PR DESCRIPTION
This change means that only certain keys are pulled out of the
config file and limits its ability to do arbitrary things to the
running python environment.

It also allows us to validate the types of the various settings.