### PR TITLE
test_minified_js_function_imports

### DIFF
--- a/tests/gen_many_js_functions.py
+++ b/tests/gen_many_js_functions.py
@@ -1,0 +1,40 @@
+import sys
+
+NUM_FUNCS_TO_GENERATE = 1000
+
+def func_name(i):
+	return 'thisIsAFunctionWithVeryLongFunctionNameThatWouldBeGreatToBeMinifiedWhenImportingToAsmJsOrWasmSideCodeToCallOtherwiseCodeSizesWillBeLargeAndNetworkTransfersBecomeVerySlowThatUsersWillGoAwayAndVisitSomeOtherSiteInsteadAndThenWebAssemblyDeveloperIsSadOrEvenWorseNobodyNoticesButInternetPipesWillGetMoreCongestedWhichContributesToGlobalWarmingAndThenEveryoneElseWillBeSadAsWellEspeciallyThePolarBearsAndPenguinsJustThinkAboutThePenguins' + str(i+1)
+
+def generate_js_library_with_lots_of_functions(out_file):
+	f = open(out_file, 'w')
+
+	f.write('var FunctionsLibrary = {\n')
+
+	for i in range(NUM_FUNCS_TO_GENERATE):
+		f.write('  ' + func_name(i) + ': function() { return ' + str(i+1) + '; },\n')
+
+	f.write('}\n');
+	f.write('mergeInto(LibraryManager.library, FunctionsLibrary);\n');
+	f.close()
+
+def generate_c_program_that_calls_js_library_with_lots_of_functions(out_file):
+	f = open(out_file, 'w')
+
+	f.write('#include <stdio.h>\n\n')
+
+	for i in range(NUM_FUNCS_TO_GENERATE):
+		f.write('int ' + func_name(i) + '(void);\n')
+
+	f.write('\nint main() {\n')
+	f.write('  int sum = 0;\n')
+
+	for i in range(NUM_FUNCS_TO_GENERATE):
+		f.write('  sum += ' + func_name(i) + '();\n')
+
+	f.write('\n  printf("Sum of numbers from 1 to ' + str(NUM_FUNCS_TO_GENERATE) + ': %d (expected ' + str((NUM_FUNCS_TO_GENERATE * (NUM_FUNCS_TO_GENERATE+1))/2) + ')\\n", sum);\n');
+	f.write('}\n');
+	f.close()
+
+if __name__ == '__main__':
+	generate_js_library_with_lots_of_functions(sys.argv[1])
+	generate_c_program_that_calls_js_library_with_lots_of_functions(sys.argv[2])


### PR DESCRIPTION
Add a failing test to uncover currently missing minification opportunity in imports to asm.js and wasm modules.

There is a minification step that currently does not happen, which would help much smaller code sizes on large applications that integrate a noticeable amount of JS code in them.

This seems like something that could be always unconditionally done: when we import JS functions to asm.js/wasm side, instead of 

```javascript
Module.asmLibraryArg = {
    "_function1": _function1,
    "_function2": _function2,
    "_function3": _function3,
    "_function4": _function4,
    "_function5": _function5,
    ...
};
```

we should be able to do

```javascript
Module.asmLibraryArg = {
    "a": _function1,
    "b": _function2,
    "c": _function3,
    "d": _function4,
    "e": _function5,
    ...
};
```

and then match the corresponding minified name in asm.js/wasm module. Since both sides are generated via compiled code, i.e. "internal", this looks like something that should always be safe to do. (for profiling purposes, we may want to allow controlling this separately, and/or generate a symbol map). Checking in the test, this minification would benefit both asm.js and wasm equally. This is an optimization that Closure compiler is not currently able to pull off. (It does optimize the remaining right hand side `_functionX` bits though in the above example)