### PR TITLE
fix browser.test_pthread_sbrk

### DIFF
--- a/tests/pthread/test_pthread_sbrk.cpp
+++ b/tests/pthread/test_pthread_sbrk.cpp
@@ -19,31 +19,50 @@
 #define ALLOCATION_SIZE 2560 // Malloc doesn't abort, allocate a bit more memory to test graceful allocation failures
 #endif
 
+#define RESULT_OK 0
+#define RESULT_EXPECTED_FAILS 1
+#define RESULT_BAD_FAIL 2
+
 // Use barriers to make each thread synchronize their execution points, to maximize the possibility of seeing race conditions
 // if those might occur.
 static pthread_barrier_t barrierWaitToAlloc;
 static pthread_barrier_t barrierWaitToVerify;
 static pthread_barrier_t barrierWaitToFree;
 
+// Use a mutex for logging.
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
 static void *thread_start(void *arg)
 {
+#if DEBUG
+  pthread_mutex_lock( &mutex );
+  printf("thread started, will try %d allocations of size %d\n", NUM_ALLOCATIONS, ALLOCATION_SIZE);
+  pthread_mutex_unlock( &mutex );
+#endif
+
   int id = (int)(arg)+1;
-  int return_code = 0;
+  int return_code = RESULT_OK;
 
   uint8_t *allocated_buffers[NUM_ALLOCATIONS] = {};
 
   int some_allocations_failed = 0;
+  size_t allocated = 0;
 
   pthread_barrier_wait(&barrierWaitToAlloc); // Halt until all threads reach here, then proceed synchronously.
   for(int i = 0; i < NUM_ALLOCATIONS; ++i)
   {
     allocated_buffers[i] = (uint8_t*)malloc(ALLOCATION_SIZE);
-    if (allocated_buffers[i])
+    if (allocated_buffers[i]) {
       memset(allocated_buffers[i], id, ALLOCATION_SIZE);
-    else
+      allocated += ALLOCATION_SIZE;
+    } else
       some_allocations_failed = 1;
   }
-
+#if DEBUG
+  pthread_mutex_lock( &mutex );
+  printf("total allocations: %u (%d of size %d tried), some failed? %d\n", allocated, NUM_ALLOCATIONS, ALLOCATION_SIZE, some_allocations_failed);
+  pthread_mutex_unlock( &mutex );
+#endif
   pthread_barrier_wait(&barrierWaitToVerify); // Halt until all threads reach here, then proceed synchronously.
   int reported_once = 0;
   for(int i = 0; i < NUM_ALLOCATIONS; ++i)
@@ -66,10 +85,16 @@ static void *thread_start(void *arg)
 
 #if ABORTING_MALLOC
   if (some_allocations_failed)
-    return_code = 12345678; // We expect allocations not to fail (if they did, shouldn't reach here, but we should have aborted)
+    return_code = RESULT_BAD_FAIL; // We expect allocations not to fail (if they did, shouldn't reach here, but we should have aborted)
 #else
-  if (!some_allocations_failed)
-    return_code = 12345678; // We expect to be allocating so much memory that some of the allocations fail.
+  if (some_allocations_failed)
+    return_code = RESULT_EXPECTED_FAILS; // We expect to be allocating so much memory that some of the allocations fail.
+  // Otherwise, the fails might happen in another thread, that's cool.
+#endif
+#if DEBUG
+  pthread_mutex_lock( &mutex );
+  printf("the pthread return code: %d\n", return_code);
+  pthread_mutex_unlock( &mutex );
 #endif
   pthread_exit((void*)return_code);
 }
@@ -84,6 +109,8 @@ int main()
     printf("Skipped: threading support is not available!\n");
     return 0;
   }
+
+  printf("starting test, aborting? %d\n", ABORTING_MALLOC);
 
   int ret = pthread_barrier_init(&barrierWaitToAlloc, NULL, NUM_THREADS);
   assert(ret == 0);
@@ -102,13 +129,27 @@ int main()
     assert(ret == 0);
   }
 
+  int seen_expected_fails = 0;
+
   for(int i = 0; i < NUM_THREADS; ++i) {
     int res = 0;
     ret = pthread_join(thr[i], (void**)&res);
     assert(ret == 0);
-    result += res;
+    if (res == RESULT_OK) {
+    } else if (res == RESULT_EXPECTED_FAILS) {
+      seen_expected_fails = 1;
+    } else if (res == RESULT_BAD_FAIL) {
+      result = 1;
+    }
     if (res) printf("Thread %d failed with return code %d.\n", i, res);
   }
+#if !ABORTING_MALLOC
+  if (!seen_expected_fails) {
+    printf("Expected to see fails, but saw none :(\n");
+    result = 2;
+  }
+#endif
+
   printf("Test finished with result %d\n", result);
 
 #ifdef REPORT_RESULT

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3567,7 +3567,6 @@ window.close = function() {
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_proxying_in_futex_wait.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'])
 
   # Test that sbrk() operates properly in multithreaded conditions
-  @flaky
   @requires_threads
   def test_pthread_sbrk(self):
     for aborting_malloc in [0, 1]:


### PR DESCRIPTION
The test assumed each thread must see some allocation failures, but it is possible one or two will be lucky to run early enough so that their allocations all succeed. This should fix the random errors the test has been hitting recently.

Also remove `@flaky` from the test as it is no longer needed.