### PR TITLE
fix an FS trackingDelegate usage of err

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1062,7 +1062,7 @@ mergeInto(LibraryManager.library, {
         if (!FS.readFiles) FS.readFiles = {};
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
-          err('read file: ' + path);
+          console.log("FS.trackingDelegate error on read file: " + path);
         }
       }
       try {
@@ -1379,7 +1379,6 @@ mergeInto(LibraryManager.library, {
     ensureErrnoError: function() {
       if (FS.ErrnoError) return;
       FS.ErrnoError = function ErrnoError(errno, node) {
-        //err(stackTrace()); // useful for debugging
         this.node = node;
         this.setErrno = function(errno) {
           this.errno = errno;


### PR DESCRIPTION
Which was also a local var, and so invalidly used. Instead, use console.log, consistently with the rest of the trackingDelegate code.