### PR TITLE
Remove BUILD_AS_SHARED_LIBRARY settings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ Current Trunk
    dynamic linking, and will match what the LLVM wasm backend will have.
    See #7312.
  - Invalid -s flags on the command line are now treated as errors.
- - Remove BUILD_AS_SHARED_LIBRRARY setting
+ - Remove BUILD_AS_SHARED_LIBRARY setting.
 
 v1.38.14: 10/22/2018
 --------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Current Trunk
    dynamic linking, and will match what the LLVM wasm backend will have.
    See #7312.
  - Invalid -s flags on the command line are now treated as errors.
+ - Remove BUILD_AS_SHARED_LIBRRARY setting
 
 v1.38.14: 10/22/2018
 --------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1650,7 +1650,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # link in ports and system libraries, if necessary
       if not LEAVE_INPUTS_RAW and \
-         not shared.Settings.BUILD_AS_SHARED_LIB and \
          not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
          not shared.Settings.ONLY_MY_CODE and \
          not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
@@ -1696,7 +1695,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if perform_link:
         logging.debug('linking: ' + str(linker_inputs))
         # force archive contents to all be included, if just archives, or if linking shared modules
-        force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or not shared.Building.can_build_standalone()
+        force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
 
         # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
         # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
@@ -1754,7 +1753,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             save_intermediate('opt', 'bc')
 
           # If we can LTO, do it before dce, since it opens up dce opportunities
-          if shared.Building.can_build_standalone() and options.llvm_lto and options.llvm_lto != 2:
+          if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
             if not shared.Building.can_inline():
               link_opts.append('-disable-inlining')
             # add a manual internalize with the proper things we need to be kept alive during lto

--- a/src/settings.js
+++ b/src/settings.js
@@ -662,6 +662,7 @@ var SHELL_FILE = 0;
 
 // If set to 1, we emit relocatable code from the LLVM backend; both
 // globals and function pointers are all offset (by gb and fp, respectively)
+// Automatically set for SIDE_MODULE or MAIN_MODULE.
 var RELOCATABLE = 0;
 
 // A main module is a file compiled in a way that allows us to link it to
@@ -679,9 +680,6 @@ var SIDE_MODULE = 0;
 // we will link these at runtime. They must have been built with
 // SIDE_MODULE == 1.
 var RUNTIME_LINKED_LIBS = [];
-
-// (deprecated option TODO: remove)
-var BUILD_AS_SHARED_LIB = 0;
 
 // If set to 1, this is a worker library, a special kind of library that is run
 // in a worker. See emscripten.h
@@ -708,11 +706,8 @@ var PROXY_TO_PTHREAD = 0;
 // remove unused functions and globals, which might be used by another module we
 // are linked with.
 //
-// BUILD_AS_SHARED_LIB > 0 implies this, so it is only important to set this to
-// 1 when building the main file, and *if* that main file has symbols that the
-// library it will open will then access through an extern.  LINKABLE of 0 is
-// very useful in that we can reduce the size of the generated code very
-// significantly, by removing everything not actually used.
+// MAIN_MODULE and SIDE_MODULE both imply this, so it not normally necessary
+// to set this explicitly.
 var LINKABLE = 0;
 
 // Emscripten 'strict' build mode: Drop supporting any deprecated build options.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2396,26 +2396,6 @@ The current type of b is: 9
       # Bloated memory; same layout as C/C++
       self.do_run(src, '*16,0,4,8,8,12|20,0,4,4,8,12,12,16|24,0,20,0,4,4,8,12,12,16*\n*0,0,0,1,2,64,68,69,72*\n*2*')
 
-  @unittest.skip('BUILD_AS_SHARED_LIB=2 is deprecated')
-  def test_runtimelink(self):
-    if Building.LLVM_OPTS:
-      self.skipTest('LLVM opts will optimize printf into puts in the parent, and the child will still look for puts')
-    if self.get_setting('ASM_JS'):
-      self.skipTest('asm does not support runtime linking')
-
-    main, supp = self.setup_runtimelink_test()
-
-    self.banned_js_engines = [NODE_JS] # node's global scope behaves differently than everything else, needs investigation FIXME
-    self.set_setting('LINKABLE', 1)
-    self.set_setting('BUILD_AS_SHARED_LIB', 2)
-
-    self.build(supp, self.get_dir(), self.in_dir('supp.cpp'))
-    shutil.move(self.in_dir('supp.cpp.o.js'), self.in_dir('liblib.so'))
-    self.set_setting('BUILD_AS_SHARED_LIB', 0)
-
-    self.set_setting('RUNTIME_LINKED_LIBS', ['liblib.so'])
-    self.do_run(main, 'supp: 54,2\nmain: 56\nsupp see: 543\nmain see: 76\nok.')
-
   def prep_dlfcn_lib(self):
     self.set_setting('MAIN_MODULE', 0)
     self.set_setting('SIDE_MODULE', 1)
@@ -2699,7 +2679,6 @@ The current type of b is: 9
     self.build_dlfcn_lib(lib_src, dirname, filename)
 
     self.prep_dlfcn_main()
-    self.set_setting('LINKABLE', 1)
     src = '''
       #include <stdio.h>
       #include <dlfcn.h>
@@ -2759,8 +2738,8 @@ The current type of b is: 9
 
   @needs_dlfcn
   def test_dlfcn_varargs(self):
-    # this test is not actually valid - it fails natively. the child should fail to be loaded, not load and successfully see the parent print_ints func
-    self.set_setting('LINKABLE', 1)
+    # this test is not actually valid - it fails natively. the child should fail
+    # to be loaded, not load and successfully see the parent print_ints func
 
     self.prep_dlfcn_lib()
     lib_src = r'''

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2293,11 +2293,6 @@ class Building(object):
 
     return filename + '.o.js'
 
-  # TODO: deprecate this method, we should just need Settings.LINKABLE anyhow
-  @staticmethod
-  def can_build_standalone():
-    return not Settings.BUILD_AS_SHARED_LIB and not Settings.LINKABLE
-
   @staticmethod
   def can_inline():
     return Settings.INLINING_LIMIT == 0
@@ -2332,7 +2327,7 @@ class Building(object):
 
   @staticmethod
   def get_safe_internalize():
-    if not Building.can_build_standalone():
+    if Settings.LINKABLE:
       return [] # do not internalize anything
 
     exps = expand_response(Settings.EXPORTED_FUNCTIONS)


### PR DESCRIPTION
This settings is apparently deprecated and has been replaced
by SIDE_MODULE.