### PR TITLE
limit scope of node_modules filter to top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.pyc
 *.bc
 
-node_modules/
+./node_modules/
 
 # Ignore generated files
 


### PR DESCRIPTION
Prevent filtering out tools/eliminator/node_modules, which is correctly in git because it predates the node_modules ignore rule.  Addresses an issue where files are incorrectly filtered when introduced to a different git repository (https://github.com/kripken/emscripten/issues/7427).