### PR TITLE
Fix for missing tools like `eliminator` - limit the scope of `node_mo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 *.pyc
 *.bc
 
-node_modules/
+# Ignore only the root node_modules, but not any further down the path
+/node_modules/
 
 # Ignore generated files
 


### PR DESCRIPTION
…dules .gitignore` filter to top level

Fixes: https://github.com/kripken/emscripten/issues/7427
Supersedes: https://github.com/kripken/emscripten/pull/7443

Signed-off-by: Layla <layla@insightfulvr.com>