### PR TITLE
Update EM_QUEUED_CALL_MAX_ARGS

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -100,7 +100,7 @@ typedef union em_variant_val
   char *cp;
 } em_variant_val;
 
-#define EM_QUEUED_CALL_MAX_ARGS 8
+#define EM_QUEUED_CALL_MAX_ARGS 9
 typedef struct em_queued_call
 {
   int functionEnum;


### PR DESCRIPTION
When EM_FUNC_SIG_VIIIIIIIII was added it overflowed the args array in
em_queued_call. (Found by clang's -Warray-bounds warning which is on by default
for the wasm backend)