### PR TITLE
Robustness fixes to memoryprofiler

### DIFF
--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -150,9 +150,10 @@ var emscriptenMemoryProfiler = {
     Module['onFree'] = function onFree(ptr) { emscriptenMemoryProfiler.onFree(ptr); };
 
     // Add a tracking mechanism to detect when VFS loading is complete.
+    if (!Module['preRun']) Module['preRun'] = [];
     Module['preRun'].push(function() { emscriptenMemoryProfiler.onPreloadComplete(); });
 
-    if (this.hookStackAlloc) {
+    if (this.hookStackAlloc && typeof stackAlloc === 'function') {
       // Inject stack allocator.
       var prevStackAlloc = stackAlloc;
       function hookedStackAlloc(size) {


### PR DESCRIPTION
Robustness fixes to memoryprofiler: add Module.prerun if it does not exist, and do not assume stackAlloc to exist (customizations to preamble may have nuked this)