### PR TITLE
Minify asmjs module imports

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1255,6 +1255,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           options.js_opts = True
         options.force_js_opts = True
 
+      # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
+      if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
+        shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
+
       if shared.Settings.WASM:
         # When only targeting wasm, the .asm.js file is not executable, so is treated as an intermediate build file that can be cleaned up.
         if shared.Building.is_wasm_only():

--- a/src/settings.js
+++ b/src/settings.js
@@ -1271,3 +1271,8 @@ var ENVIRONMENT_MAY_BE_WORKER = 1;
 var ENVIRONMENT_MAY_BE_NODE = 1;
 var ENVIRONMENT_MAY_BE_SHELL = 1;
 var ENVIRONMENT_MAY_BE_WEB_OR_WORKER = 1;
+
+// Internal: passes information to emscripten.py about whether to minify
+// JS -> asm.js import names. Controlled by optimization level, enabled
+// at -O1 and higher, but disabled at -g2 and higher.
+var MINIFY_ASMJS_IMPORT_NAMES = 0;

--- a/tests/gen_many_js_functions.py
+++ b/tests/gen_many_js_functions.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+import sys
+
+NUM_FUNCS_TO_GENERATE = 1000
+
+def func_name(i):
+  return 'thisIsAFunctionWithVeryLongFunctionNameThatWouldBeGreatToBeMinifiedWhenImportingToAsmJsOrWasmSideCodeToCallOtherwiseCodeSizesWillBeLargeAndNetworkTransfersBecomeVerySlowThatUsersWillGoAwayAndVisitSomeOtherSiteInsteadAndThenWebAssemblyDeveloperIsSadOrEvenWorseNobodyNoticesButInternetPipesWillGetMoreCongestedWhichContributesToGlobalWarmingAndThenEveryoneElseWillBeSadAsWellEspeciallyThePolarBearsAndPenguinsJustThinkAboutThePenguins' + str(i+1)
+
+def generate_js_library_with_lots_of_functions(out_file):
+  with open(out_file, 'w') as f:
+    f.write('var FunctionsLibrary = {\n')
+
+    for i in range(NUM_FUNCS_TO_GENERATE):
+      f.write('  ' + func_name(i) + ': function() { return ' + str(i+1) + '; },\n')
+
+    f.write('}\n');
+    f.write('mergeInto(LibraryManager.library, FunctionsLibrary);\n');
+
+def generate_c_program_that_calls_js_library_with_lots_of_functions(out_file):
+  with open(out_file, 'w') as f:
+    f.write('#include <stdio.h>\n\n')
+
+    for i in range(NUM_FUNCS_TO_GENERATE):
+      f.write('int ' + func_name(i) + '(void);\n')
+
+    f.write('\nint main() {\n')
+    f.write('  int sum = 0;\n')
+
+    for i in range(NUM_FUNCS_TO_GENERATE):
+      f.write('  sum += ' + func_name(i) + '();\n')
+
+    f.write('\n  printf("Sum of numbers from 1 to ' + str(NUM_FUNCS_TO_GENERATE) + ': %d (expected ' + str(int((NUM_FUNCS_TO_GENERATE * (NUM_FUNCS_TO_GENERATE+1))/2)) + ')\\n", sum);\n');
+    f.write('}\n');
+
+if __name__ == '__main__':
+  generate_js_library_with_lots_of_functions(sys.argv[1])
+  generate_c_program_that_calls_js_library_with_lots_of_functions(sys.argv[2])

--- a/tools/minified_js_name_generator.py
+++ b/tools/minified_js_name_generator.py
@@ -1,0 +1,49 @@
+# Copyright 2018 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+# This class can be used to produce a set of minified names to be used as JS
+# variables
+class MinifiedJsNameGenerator(object):
+  reserved_names = ['do', 'if', 'in', 'for', 'new', 'try', 'var', 'env', 'let', 'case', 'else', 'enum', 'void', 'this', 'with']
+  valid_first_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$"
+  valid_later_chars = valid_first_chars + '0123456789'
+
+  name_iterator = []
+
+  overflow_warned = False
+
+  def max_length(self, pos):
+    return len(self.valid_first_chars) if pos == 0 else len(self.valid_later_chars)
+
+  def produce_name(self):
+    name = ''
+    for i in range(len(self.name_iterator) - 1, 0, -1):
+      name += self.valid_later_chars[self.name_iterator[i]]
+    name += self.valid_first_chars[self.name_iterator[0]]
+    return name
+
+  def generate(self):
+    i = 0
+    while i < len(self.name_iterator):
+      self.name_iterator[i] += 1
+      if self.name_iterator[i] >= self.max_length(i):
+        self.name_iterator[i] = 0
+        i += 1
+      else:
+        name = self.produce_name()
+        if name not in self.reserved_names:
+          return name
+
+    self.name_iterator += [0]
+    if len(self.name_iterator) >= 5:
+      if not self.overflow_warned:
+        logging.warning('MinifiedJsNameGenerator has only been defined for symbols up to 4 characters! TODO: Add JavaScript reserved names of length 5 and more to this list')
+        self.overflow_warned = True
+
+    name = self.produce_name()
+    if name not in self.reserved_names:
+      return name
+    else:
+      return self.generate()


### PR DESCRIPTION
This minifies JS function imports to asm.js, using same minification scheme as in https://github.com/WebAssembly/binaryen/pull/1719/files#diff-402f63d949f69ca3feb553dcda0a5f26R44 .

Also this PR contains the same test from #7414, adjusted to pass for this case, so closing that PR.