### PR TITLE
Add prototypes for MAIN_THREAD_EM_ASM functions to wasm backend

### DIFF
--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -131,6 +131,17 @@ int emscripten_asm_const_int(const char* code, const char* arg_sigs, ...);
 __attribute__((nothrow))
 double emscripten_asm_const_double(const char* code, const char* arg_sigs, ...);
 
+__attribute__((nothrow))
+int emscripten_asm_const_int_sync_on_main_thread(
+  const char* code, const char* arg_sigs, ...);
+__attribute__((nothrow))
+double emscripten_asm_const_double_sync_on_main_thread(
+  const char* code, const char* arg_sigs, ...);
+
+__attribute__((nothrow))
+void emscripten_asm_const_async_on_main_thread(
+  const char* code, const char* arg_sigs, ...);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1706,7 +1706,6 @@ int main(int argc, char **argv) {
   # Tests various different ways to invoke the MAIN_THREAD_EM_ASM(), MAIN_THREAD_EM_ASM_INT() and MAIN_THREAD_EM_ASM_DOUBLE() macros.
   # This test is identical to test_em_asm_2, just search-replaces EM_ASM to MAIN_THREAD_EM_ASM on the test file. That way if new
   # test cases are added to test_em_asm_2.cpp for EM_ASM, they will also get tested in MAIN_THREAD_EM_ASM form.
-  @no_wasm_backend('Proxying EM_ASM calls is not yet implemented in Wasm backend')
   def test_main_thread_em_asm(self):
     src = open(path_from_root('tests', 'core', 'test_em_asm_2.cpp'), 'r').read()
     test_file = 'src.cpp'
@@ -1719,13 +1718,11 @@ int main(int argc, char **argv) {
     self.do_run_from_file(test_file, expected_result_file)
     self.do_run_from_file(test_file, expected_result_file, force_c=True)
 
-  @no_wasm_backend('Proxying EM_ASM calls is not yet implemented in Wasm backend')
   def test_main_thread_async_em_asm(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_main_thread_async_em_asm')
     self.do_run_in_out_file_test('tests', 'core', 'test_main_thread_async_em_asm', force_c=True)
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call with different signatures.
-  @no_wasm_backend('Proxying EM_ASM calls is not yet implemented in Wasm backend')
   def test_main_thread_em_asm_signatures(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_signatures')
 


### PR DESCRIPTION
This works for the single-threaded case because wasm-emscripten-finalize
checks for functions with 'emscripten_asm_const' as a prefix, and
rewrites these to normal EM_ASM calls.

This passes the core tests, but does not pass in the browser test that
actually checks threadedness.