### PR TITLE
Show a clear error when tests/test_*.py is run directly, which is wrong

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -14,6 +14,9 @@ import time
 import unittest
 import zlib
 
+if __name__ == '__main__':
+  raise Exception('do not run this file directly; do something like: tests/runner.py benchmark')
+
 from runner import RunnerCore, chdir
 from tools.shared import run_process, path_from_root, CLANG, Building, SPIDERMONKEY_ENGINE, LLVM_ROOT, CLOSURE_COMPILER, CLANG_CC, V8_ENGINE, PIPE, try_delete, PYTHON, EMCC
 from tools import shared, jsrun

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,9 @@ import time
 import unittest
 from textwrap import dedent
 
+if __name__ == '__main__':
+  raise Exception('do not run this file directly; do something like: tests/runner.py')
+
 from tools.shared import Building, STDOUT, PIPE, run_js, run_process, Settings, try_delete
 from tools.shared import NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, PYTHON, EMCC, EMAR, CLANG, WINDOWS, AUTODEBUGGER
 from tools import jsrun, shared

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -6,6 +6,10 @@
 from __future__ import print_function
 import os
 import shutil
+
+if __name__ == '__main__':
+  raise Exception('do not run this file directly; do something like: tests/runner.py interactive')
+
 from runner import BrowserCore, path_from_root
 from tools.shared import Popen, EMCC, PYTHON, WINDOWS, Building
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -24,6 +24,9 @@ import tempfile
 import unittest
 import uuid
 
+if __name__ == '__main__':
+  raise Exception('do not run this file directly; do something like: tests/runner.py other')
+
 from tools.shared import Building, PIPE, run_js, run_process, STDOUT, try_delete, listify
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, MACOS, LLVM_ROOT, EMCONFIG, TEMP_DIR, EM_BUILD_VERBOSE
 from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -11,6 +11,9 @@ import shutil
 import sys
 import time
 
+if __name__ == '__main__':
+  raise Exception('do not run this file directly; do something like: tests/runner.py sockets')
+
 import websockify
 from runner import BrowserCore, no_windows, chdir, flaky
 from tools import shared


### PR DESCRIPTION
Point people to the runner.py script. Right now, it hits an exception when it tries to do the tools.shared imports etc.

@sbc100 is there a nicer way to do this in python?