### PR TITLE
Add validation for 10_10_10 packed vertices.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -391,16 +391,20 @@ var LibraryGL = {
         case 0x1404 /* GL_INT */:
         case 0x1405 /* GL_UNSIGNED_INT */:
         case 0x1406 /* GL_FLOAT */:
-#if USE_WEBGL2
-        case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
-        case 0x8D9F /* GL_INT_2_10_10_10_REV */:
-#endif
           sizeBytes = 4;
           break;
         case 0x140A /* GL_DOUBLE */:
           sizeBytes = 8;
           break;
         default:
+#if USE_WEBGL2
+          if (GL.currentContext.version >= 2 && (dataType == 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */ || dataType == 0x8D9F /* GL_INT_2_10_10_10_REV */)) {
+            sizeBytes = 4;
+            break;
+          } else {
+            // else fall through
+          }
+#endif
           console.error('Invalid vertex attribute data type GLenum ' + dataType + ' passed to GL function!');
       }
       if (dimension == 0x80E1 /* GL_BGRA */) {

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -391,6 +391,10 @@ var LibraryGL = {
         case 0x1404 /* GL_INT */:
         case 0x1405 /* GL_UNSIGNED_INT */:
         case 0x1406 /* GL_FLOAT */:
+#if USE_WEBGL2
+		case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
+		case 0x8D9F /* GL_INT_2_10_10_10_REV */:
+#endif
           sizeBytes = 4;
           break;
         case 0x140A /* GL_DOUBLE */:

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -392,8 +392,8 @@ var LibraryGL = {
         case 0x1405 /* GL_UNSIGNED_INT */:
         case 0x1406 /* GL_FLOAT */:
 #if USE_WEBGL2
-		case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
-		case 0x8D9F /* GL_INT_2_10_10_10_REV */:
+        case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
+        case 0x8D9F /* GL_INT_2_10_10_10_REV */:
 #endif
           sizeBytes = 4;
           break;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2519,6 +2519,11 @@ Module["preRun"].push(function () {
   def test_webgl_with_closure(self):
     self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
 
+  # Tests that -s GL_ASSERTIONS=1 and glVertexAttribPointer with packed types works
+  @requires_graphics_hardware
+  def test_webgl2_packed_types(self):
+    self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'USE_WEBGL2=1', '-s', 'GL_ASSERTIONS=1'], expected='0')
+
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1']]:
       print(opts)

--- a/tests/webgl2_draw_packed_triangle.c
+++ b/tests/webgl2_draw_packed_triangle.c
@@ -10,16 +10,7 @@
 #include <assert.h>
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
-#include <GLES2/gl2.h>
-
-/**
- * \def GL_INT_2_10_10_10_REV
- * Packed signed 2.10.10.10 data format (present in ES3, missing in ES2 but
- * may still work, depending on the browser).
- */
-#ifndef GL_INT_2_10_10_10_REV
-#define GL_INT_2_10_10_10_REV 0x8D9F
-#endif
+#include <GLES3/gl3.h>
 
 GLuint compile_shader(GLenum shaderType, const char *src)
 {
@@ -62,12 +53,12 @@ int main()
   attr.explicitSwapControl = 1;
 #endif
   attr.majorVersion = 2;
-  int result = 0;
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
   assert(ctx && "Failed to create WebGL2 context");
   emscripten_webgl_make_context_current(ctx);
 
   static const char vertex_shader[] =
+    "#version 100\n"
     "attribute vec4 apos;"
     "attribute vec4 acolor;"
     "varying vec4 color;"
@@ -78,6 +69,7 @@ int main()
   GLuint vs = compile_shader(GL_VERTEX_SHADER, vertex_shader);
 
   static const char fragment_shader[] =
+    "#version 100\n"
     "precision lowp float;"
     "varying vec4 color;"
     "void main() {"
@@ -90,9 +82,9 @@ int main()
 
   static const uint32_t pos_and_color[] = {
   //  1,0,y,x,    a,b,g,r
-    0x400b36cd, 0xffff0000,
-    0x400b3533, 0xff00ff00,
-    0x4004cc00, 0xff0000ff,
+    0x400b36cd, 0xc00003ff,
+    0x400b3533, 0xc00ffc00,
+    0x4004cc00, 0xfff00000,
   };
 
   GLuint vbo;
@@ -100,8 +92,9 @@ int main()
   glBindBuffer(GL_ARRAY_BUFFER, vbo);
   glBufferData(GL_ARRAY_BUFFER, sizeof(pos_and_color), pos_and_color, GL_STATIC_DRAW);
   glVertexAttribPointer(0, 4, GL_INT_2_10_10_10_REV, GL_TRUE, 8, 0);
-  assert(glGetError() == GL_NO_ERROR && "GL_INT_2_10_10_10_REV failed");
-  glVertexAttribPointer(1, 3, GL_UNSIGNED_BYTE, GL_TRUE, 8, (void*)4);
+  assert(glGetError() == GL_NO_ERROR && "glVertexAttribPointer with GL_INT_2_10_10_10_REV failed");
+  glVertexAttribPointer(1, 4, GL_UNSIGNED_INT_2_10_10_10_REV, GL_TRUE, 8, (void*)4);
+  assert(glGetError() == GL_NO_ERROR && "glVertexAttribPointer with GL_UNSIGNED_INT_2_10_10_10_REV failed");
 
   glEnableVertexAttribArray(0);
   glEnableVertexAttribArray(1);

--- a/tests/webgl2_draw_packed_triangle.c
+++ b/tests/webgl2_draw_packed_triangle.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+#include <GLES2/gl2.h>
+
+/**
+ * \def GL_INT_2_10_10_10_REV
+ * Packed signed 2.10.10.10 data format (present in ES3, missing in ES2 but
+ * may still work, depending on the browser).
+ */
+#ifndef GL_INT_2_10_10_10_REV
+#define GL_INT_2_10_10_10_REV 0x8D9F
+#endif
+
+GLuint compile_shader(GLenum shaderType, const char *src)
+{
+  GLuint shader = glCreateShader(shaderType);
+  glShaderSource(shader, 1, &src, NULL);
+  glCompileShader(shader);
+
+  GLint isCompiled = 0;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &isCompiled);
+  if (!isCompiled)
+  {
+    GLint maxLength = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    char *buf = (char*)malloc(maxLength+1);
+    glGetShaderInfoLog(shader, maxLength, &maxLength, buf);
+    printf("%s\n", buf);
+    free(buf);
+    return 0;
+  }
+
+   return shader;
+}
+
+GLuint create_program(GLuint vertexShader, GLuint fragmentShader)
+{
+   GLuint program = glCreateProgram();
+   glAttachShader(program, vertexShader);
+   glAttachShader(program, fragmentShader);
+   glBindAttribLocation(program, 0, "apos");
+   glBindAttribLocation(program, 1, "acolor");
+   glLinkProgram(program);
+   return program;
+}
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+#ifdef EXPLICIT_SWAP
+  attr.explicitSwapControl = 1;
+#endif
+  attr.majorVersion = 2;
+  int result = 0;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  assert(ctx && "Failed to create WebGL2 context");
+  emscripten_webgl_make_context_current(ctx);
+
+  static const char vertex_shader[] =
+    "attribute vec4 apos;"
+    "attribute vec4 acolor;"
+    "varying vec4 color;"
+    "void main() {"
+      "color = acolor;"
+      "gl_Position = apos;"
+    "}";
+  GLuint vs = compile_shader(GL_VERTEX_SHADER, vertex_shader);
+
+  static const char fragment_shader[] =
+    "precision lowp float;"
+    "varying vec4 color;"
+    "void main() {"
+      "gl_FragColor = color;"
+    "}";
+  GLuint fs = compile_shader(GL_FRAGMENT_SHADER, fragment_shader);
+
+  GLuint program = create_program(vs, fs);
+  glUseProgram(program);
+
+  static const uint32_t pos_and_color[] = {
+  //  1,0,y,x,    a,b,g,r
+    0x400b36cd, 0xffff0000,
+    0x400b3533, 0xff00ff00,
+    0x4004cc00, 0xff0000ff,
+  };
+
+  GLuint vbo;
+  glGenBuffers(1, &vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(pos_and_color), pos_and_color, GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 4, GL_INT_2_10_10_10_REV, GL_TRUE, 8, 0);
+  assert(glGetError() == GL_NO_ERROR && "GL_INT_2_10_10_10_REV failed");
+  glVertexAttribPointer(1, 3, GL_UNSIGNED_BYTE, GL_TRUE, 8, (void*)4);
+
+  glEnableVertexAttribArray(0);
+  glEnableVertexAttribArray(1);
+
+  glClearColor(0.3f,0.3f,0.3f,1);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+
+#ifdef EXPLICIT_SWAP
+  emscripten_webgl_commit_frame();
+#endif
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}


### PR DESCRIPTION
WebGL2 allows packed 10_10_10 types to be passed to glVertexAttribPointer(), which Emscripten's GL_ASSERTIONS flag as being an error. A test page here shows this in operation:

https://wip.numfum.com/2018-11-06/index.html