### PR TITLE
2 determinism fixes for wasm backend on python3

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2033,6 +2033,7 @@ def create_exported_implemented_functions_wasm(pre, forwarded_json, metadata):
       exported_implemented_functions.add(key)
 
   check_all_implemented(all_implemented, pre)
+  exported_implemented_functions = sorted(exported_implemented_functions)
   return exported_implemented_functions
 
 
@@ -2143,7 +2144,8 @@ def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
       exit_with_error('duplicate symbol in exports to wasm: %s', name)
     send_items_map[internal_name] = name
 
-  return '{ ' + ', '.join('"' + k + '": ' + v for k, v in send_items_map.items()) + ' }'
+  sorted_keys = sorted(send_items_map.keys())
+  return '{ ' + ', '.join('"' + k + '": ' + send_items_map[k] for k in sorted_keys) + ' }'
 
 
 def create_receiving_wasm(exported_implemented_functions):


### PR DESCRIPTION
Interestingly, this code appears deterministic in practice in python2, but on python3 it is different every single run...

After this, `binaryen2.test_iostream_and_determinism` passes on python3.

Noticed while running wasm backend stuff on python3 on circle.