### PR TITLE
Fix Building.is_wasm on python3

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2647,7 +2647,7 @@ class Building(object):
 
   @staticmethod
   def is_wasm(filename):
-    magic = bytearray(open(filename, 'rb').read(4))
+    magic = asstr(open(filename, 'rb').read(4))
     return magic == '\0asm'
 
   @staticmethod


### PR DESCRIPTION
Fixes `wasmobj2.test_linker_response`.
