### PR TITLE
Use unittest methods to signal test failures

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -494,7 +494,7 @@ class RunnerCore(unittest.TestCase):
         Building.link(inputs, object_file)
         if not os.path.exists(object_file):
           print("Failed to link LLVM binaries:\n\n", object_file)
-          raise Exception("Linkage error")
+          self.fail("Linkage error")
 
       # Finalize
       self.prep_ll_run(filename, object_file, build_ll_hook=build_ll_hook)
@@ -547,7 +547,7 @@ class RunnerCore(unittest.TestCase):
       print("[was asm.js'ified]", file=sys.stderr)
     # check for an asm.js validation error, if we expect one
     elif 'asm.js' in err and not self.is_wasm() and self.get_setting('ASM_JS') == 1:
-      raise Exception("did NOT asm.js'ify: " + err)
+      self.fail("did NOT asm.js'ify: " + err)
     err = '\n'.join([line for line in err.split('\n') if 'uccessfully compiled asm.js code' not in line])
     return err
 
@@ -589,7 +589,7 @@ class RunnerCore(unittest.TestCase):
       if '[' + what + ']' in line:
         ret = line.split(':')[1].strip()
         return int(ret)
-    raise Exception('Failed to find [%s] in wasm-opt output' % what)
+    self.fail('Failed to find [%s] in wasm-opt output' % what)
 
   def get_wasm_text(self, wasm_binary):
     return run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), wasm_binary], stdout=PIPE).stdout
@@ -639,7 +639,7 @@ class RunnerCore(unittest.TestCase):
     for x in values:
       if x == y:
         return # success
-    raise Exception("Expected to have '%s' == '%s', diff:\n\n%s" % (
+    self.fail("Expected to have '%s' == '%s', diff:\n\n%s" % (
       limit_size(values[0]), limit_size(y),
       limit_size(''.join([a.rstrip() + '\n' for a in difflib.unified_diff(x.split('\n'), y.split('\n'), fromfile='expected', tofile='actual')]))
     ))
@@ -658,7 +658,7 @@ class RunnerCore(unittest.TestCase):
     for value in values:
       if value in string:
         return # success
-    raise Exception("Expected to find '%s' in '%s', diff:\n\n%s\n%s" % (
+    self.fail("Expected to find '%s' in '%s', diff:\n\n%s\n%s" % (
       limit_size(values[0]), limit_size(string),
       limit_size(''.join([a.rstrip() + '\n' for a in difflib.unified_diff(values[0].split('\n'), string.split('\n'), fromfile='expected', tofile='actual')])),
       additional_info
@@ -670,7 +670,7 @@ class RunnerCore(unittest.TestCase):
     if callable(string):
       string = string()
     if value in string:
-      raise Exception("Expected to NOT find '%s' in '%s', diff:\n\n%s" % (
+      self.fail("Expected to NOT find '%s' in '%s', diff:\n\n%s" % (
         limit_size(value), limit_size(string),
         limit_size(''.join([a.rstrip() + '\n' for a in difflib.unified_diff(value.split('\n'), string.split('\n'), fromfile='expected', tofile='actual')]))
       ))
@@ -827,7 +827,7 @@ class RunnerCore(unittest.TestCase):
           self.assertNotContained('ERROR', js_output)
       except Exception as e:
         print('(test did not pass in JS engine: %s)' % engine)
-        raise e
+        raise
 
     # shutil.rmtree(dirname) # TODO: leave no trace in memory. But for now nice for debugging
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -825,7 +825,7 @@ class RunnerCore(unittest.TestCase):
         else:
           self.assertContained(expected_output, js_output)
           self.assertNotContained('ERROR', js_output)
-      except Exception as e:
+      except Exception:
         print('(test did not pass in JS engine: %s)' % engine)
         raise
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2869,7 +2869,7 @@ The current type of b is: 9
             table = line
             break
         else:
-          raise Exception('Could not find symbol table!')
+          self.fail('Could not find symbol table!')
       table = table[table.find('{'):table.find('}') + 1]
       # ensure there aren't too many globals; we don't want unnamed_addr
       assert table.count(',') <= 30, table.count(',')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -606,7 +606,7 @@ f.close()
           if ret.stderr is not None and 'error' in ret.stderr.lower():
             print('Failed command: ' + ' '.join(cmd))
             print('Result:\n' + ret.stderr)
-            raise Exception('cmake call failed!')
+            self.fail('cmake call failed!')
 
           if prebuild:
             prebuild(tempdirname)
@@ -621,7 +621,7 @@ f.close()
           if ret.stdout is not None and 'error' in ret.stdout.lower() and '0 error(s)' not in ret.stdout.lower():
             print('Failed command: ' + ' '.join(cmd))
             print('Result:\n' + ret.stdout)
-            raise Exception('make failed!')
+            self.fail('make failed!')
           assert os.path.exists(tempdirname + '/' + output_file), 'Building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + output_file
 
           # Run through node, if CMake produced a .js file.
@@ -3700,8 +3700,7 @@ int main()
     LLVM_LIT = os.path.join(LLVM_ROOT, 'llvm-lit.py')
     if not os.path.exists(LLVM_LIT):
       LLVM_LIT = os.path.join(LLVM_ROOT, 'llvm-lit')
-      if not os.path.exists(LLVM_LIT):
-        raise Exception('cannot find llvm-lit tool')
+      self.assertTrue(os.path.exists(LLVM_LIT))
     cmd = [PYTHON, LLVM_LIT, '-v', os.path.join(llvm_src, 'test', 'CodeGen', 'JS')]
     print(cmd)
     run_process(cmd)

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -917,7 +917,7 @@ if __name__ == '__main__':
         func, curr, absolute_targets = json.loads(line[len('// EMTERPRET_INFO '):])
       except Exception as e:
         print('failed to parse code from', line, file=sys.stderr)
-        raise e
+        raise
       assert len(curr) % 4 == 0, len(curr)
       funcs[func] = len(all_code) # no operation here should change the length
       if LOG_CODE: print('raw bytecode for %s:' % func, curr, 'insts:', len(curr)//4, file=sys.stderr)

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -593,5 +593,5 @@ if __name__ == '__main__':
     shutil.copyfile(out, sys.argv[1] + '.jsopt.js')
   except Exception as e:
     ToolchainProfiler.record_process_exit(1)
-    raise e
+    raise
   ToolchainProfiler.record_process_exit(0)

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -127,7 +127,7 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
     if not skip_check:
       require_engine(engine)
     # if we got here, then require_engine succeeded, so we can raise the original error
-    raise e
+    raise
   timeout = 15*60 if check_timeout else None
   if TRACK_PROCESS_SPAWNS:
     logging.info('Blocking on process ' + str(proc.pid) + ': ' + str(command) + (' for ' + str(timeout) + ' seconds' if timeout else ' until it finishes.'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -81,7 +81,7 @@ class WindowsPopen(object):
       self.pid = self.process.pid
     except Exception as e:
       logging.error('\nsubprocess.Popen(args=%s) failed! Exception %s\n' % (' '.join(args), str(e)))
-      raise e
+      raise
 
   def communicate(self, input=None):
     output = self.process.communicate(input)
@@ -835,7 +835,7 @@ def safe_ensure_dirs(dirname):
     # Python 2 compatibility: makedirs does not support exist_ok parameter
     # Ignore error for already existing dirname as exist_ok does
     if not os.path.isdir(dirname):
-      raise e
+      raise
 
 
 # Returns a path to EMSCRIPTEN_TEMP_DIR, creating one if it didn't exist.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -831,7 +831,7 @@ FILE_PACKAGER = path_from_root('tools', 'file_packager.py')
 def safe_ensure_dirs(dirname):
   try:
     os.makedirs(dirname)
-  except OSError as e:
+  except OSError:
     # Python 2 compatibility: makedirs does not support exist_ok parameter
     # Ignore error for already existing dirname as exist_ok does
     if not os.path.isdir(dirname):

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -29,7 +29,7 @@ if EM_PROFILE_TOOLCHAIN:
       returncode = original_subprocess_call(cmd, *args, **kw)
     except Exception as e:
       ToolchainProfiler.record_subprocess_finish(pid, 1)
-      raise e
+      raise
     ToolchainProfiler.record_subprocess_finish(pid, returncode)
     return returncode
 
@@ -40,7 +40,7 @@ if EM_PROFILE_TOOLCHAIN:
       ret = original_subprocess_check_call(cmd, *args, **kw)
     except Exception as e:
       ToolchainProfiler.record_subprocess_finish(pid, e.returncode)
-      raise e
+      raise
     ToolchainProfiler.record_subprocess_finish(pid, 0)
     return ret
 
@@ -51,7 +51,7 @@ if EM_PROFILE_TOOLCHAIN:
       ret = original_subprocess_check_output(cmd, *args, **kw)
     except Exception as e:
       ToolchainProfiler.record_subprocess_finish(pid, e.returncode)
-      raise e
+      raise
     ToolchainProfiler.record_subprocess_finish(pid, 0)
     return ret
 


### PR DESCRIPTION
Also, use bare `raise` when re-raising so the original call
stack is preserved.