### PR TITLE
Update binaryen port

### DIFF
--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -5,7 +5,7 @@
 
 import os, shutil, logging
 
-TAG = 'version_53'
+TAG = 'version_54'
 
 def needed(settings, shared, ports):
   if not settings.WASM: return False


### PR DESCRIPTION
This fixes wasm.js to use the new `__memory_base` etc. notation, and should get everything green again.