### PR TITLE
Make strftime/strptime round trip with %c.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
  - Remove SPLIT_MEMORY option.
+ - Change `strptime()`'s handling of the "%c" to match that of `strftime()`. This is a breaking
+ change for code which depends on the old definition of "%c".
 
 v1.38.18: 11/08/2018
 --------------------

--- a/src/library.js
+++ b/src/library.js
@@ -2551,7 +2551,7 @@ LibraryManager.library = {
     var EQUIVALENT_MATCHERS = {
       '%A':  '%a',
       '%B':  '%b',
-      '%c':  '%x\\s+%X',
+      '%c':  '%a %b %d %H:%M:%S %Y',
       '%D':  '%m\\/%d\\/%y',
       '%e':  '%d',
       '%F':  '%Y-%m-%d',

--- a/tests/strptime_symmetry.cpp
+++ b/tests/strptime_symmetry.cpp
@@ -8,33 +8,64 @@
 #include <cstring>
 #include <cstdio>
 
-bool parseAndCompare(const std::string& time, std::string expectedTime) {
-  char actualTimeBuffer[256];
+typedef struct tm TimeStruct;
 
-  struct tm tm;
-  memset(&tm, 0, sizeof(struct tm));
+static std::string formatTM(TimeStruct const& tm) {
+  char actualTimeBuffer[256];
+  sprintf(actualTimeBuffer, "%04d-%02d-%02dT%02d:%02d:%02d", tm.tm_year + 1900, tm.tm_mon + 1,
+    tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+  return actualTimeBuffer;
+}
+
+static bool isTimeStructEqual(const TimeStruct& LHS, const TimeStruct& RHS) {
+  return LHS.tm_year == RHS.tm_year && LHS.tm_mon == RHS.tm_mon && LHS.tm_mday == RHS.tm_mday &&
+         LHS.tm_hour == RHS.tm_hour && LHS.tm_min == RHS.tm_min && LHS.tm_sec == RHS.tm_sec;
+}
+
+bool parseAndCompare(const std::string& time, std::string expectedTime) {
+  TimeStruct tm;
+  memset(&tm, 0, sizeof(TimeStruct));
   static const char* format = "%FT%T%z";
   strptime(time.c_str(), format, &tm);
-       
-  sprintf(actualTimeBuffer,
-    "%04d-%02d-%02dT%02d:%02d:%02d", 
-    tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, 
-    tm.tm_hour, tm.tm_min, tm.tm_sec);
 
-  std::string actualTime = actualTimeBuffer;
+  std::string actualTime = formatTM(tm);
   printf("%s: %s == %s, %s\n", time.c_str(), actualTime.c_str(), expectedTime.c_str(),
     actualTime == expectedTime ? "true" : "false");
 
   return actualTime == expectedTime;
 }
 
+// Ensure that the %c specifier can roundtrip. Meaning we use the same format
+// for strftime and strptime.
+bool roundTripCSpecifier() {
+  TimeStruct tm;
+  time_t t = time(NULL);
+  memcpy(&tm, localtime(&t), sizeof(TimeStruct));
+
+  char timeBuffer[256];
+  if (strftime(timeBuffer, sizeof(timeBuffer), "%c", &tm) == NULL) {
+    printf("Failed to format current time\n");
+    return false;
+  }
+  const std::string formattedValue = timeBuffer;
+
+  TimeStruct newTm;
+  const char* lastParsed;
+  if ((lastParsed = strptime(timeBuffer, "%c", &newTm)) == NULL) {
+    printf("Failed to parse time string '%s'\n", timeBuffer);
+    return false;
+  }
+
+  return isTimeStructEqual(tm, newTm);
+}
+
 int main(int argc, char** argv) {
-  bool testPassed = 
-    parseAndCompare("2018-03-27T19:33:09+0000", "2018-03-27T19:33:09") &&
-    parseAndCompare("2018-03-27T19:33:09-0735", "2018-03-27T19:33:09") &&
-    parseAndCompare("2018-03-27T19:33:09+1043", "2018-03-27T19:33:09") &&
-    parseAndCompare("1900-01-01T00:00:00+0000", "1900-01-01T00:00:00") &&
-    parseAndCompare("2018-12-31T23:59:59+0000", "2018-12-31T23:59:59");
+  bool testPassed = parseAndCompare("2018-03-27T19:33:09+0000", "2018-03-27T19:33:09") &&
+                    parseAndCompare("2018-03-27T19:33:09-0735", "2018-03-27T19:33:09") &&
+                    parseAndCompare("2018-03-27T19:33:09+1043", "2018-03-27T19:33:09") &&
+                    parseAndCompare("1900-01-01T00:00:00+0000", "1900-01-01T00:00:00") &&
+                    parseAndCompare("2018-12-31T23:59:59+0000", "2018-12-31T23:59:59") &&
+                    roundTripCSpecifier();
 
   if (testPassed) {
     printf("TEST PASSED\n");


### PR DESCRIPTION
Currently strftime formats %c using '%a %b %d %H:%M:%S %Y' but
strptime parses %c using '%x\s+%X'. This means that %c won't
round-trip.

This patch changes strptime to use '%a %b %d %H:%M:%S %Y'. This
seems to be the default behavior on WASM libc (given the default
environment variables and locale).

NOTE: This could change the behavior of existing code. I leave this decision up to the owners. If you would prefer a different approach to making things round trip, let me know.