### PR TITLE
Do not generate redundant invoke_() functions for asm.js or wasm

### DIFF
--- a/tests/invoke_i.cpp
+++ b/tests/invoke_i.cpp
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int func1()
+{
+	throw 1;
+}
+
+typedef int (*foo)(void);
+
+int main()
+{
+	foo f = func1;
+	try {
+		f();
+	} catch(...)
+	{
+	}
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8767,3 +8767,22 @@ int main () {
 
         check_size('a.js', 150000)
         check_size('a.wasm', 80000)
+
+  # Checks that C++ exceptions managing invoke_*() wrappers will not be generated if exceptions are disabled
+  def test_no_invoke_functions_are_generated_if_exception_catching_is_disabled(self):
+    self.skipTest('Skipping other.test_no_invoke_functions_are_generated_if_exception_catching_is_disabled: Enable after new version of fastcomp has been tagged')
+    for args in [[], ['-s', 'WASM=0']]:
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=1', '-o', 'a.html'] + args)
+      output = open('a.js', 'r').read()
+      self.assertContained('_main', output) # Smoke test that we actually compiled
+      self.assertNotContained('invoke_', output)
+
+  # Verifies that only the minimal needed set of invoke_*() functions will be generated when C++ exceptions are enabled
+  def test_no_excessive_invoke_functions_are_generated_when_exceptions_are_enabled(self):
+    self.skipTest('Skipping other.test_no_excessive_invoke_functions_are_generated_when_exceptions_are_enabled: Enable after new version of fastcomp has been tagged')
+    for args in [[], ['-s', 'WASM=0']]:
+      run_process([PYTHON, EMCC, path_from_root('tests', 'invoke_i.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0', '-o', 'a.html'] + args)
+      output = open('a.js', 'r').read()
+      self.assertContained('invoke_i', output)
+      self.assertNotContained('invoke_ii', output)
+      self.assertNotContained('invoke_v', output)


### PR DESCRIPTION
Here is another code size increase issue that Closure is not able to tackle. Currently the C++ exception handling `invoke_*()` functions are generated for all function signatures in the program, not just for those that are needed. Also the generation was done even if C++ exception catching is disabled.

This PR changes the generation to only occur for those functions that have a `invoke_*()` call generated in fastcomp backend side, so in C++ exceptions disabled mode the invoke handlers will then not be present at all, and in exceptions enabled mode they will only be present for types that need them.

Needs https://github.com/kripken/emscripten-fastcomp/pull/242 to work. This change is backwards compatible, so if mixed use with fastcomp from before the above 242 lands, this will revert to the old behavior of generating invoke functions for all signatures.