### PR TITLE
Allow user to override default for EMULATED_FUNCTION_POINTERS

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2314,8 +2314,9 @@ class Building(object):
       # if the JS optimizer runs, it must run on valid asm.js
       return False
     if Settings.RELOCATABLE and Settings.EMULATED_FUNCTION_POINTERS:
-      # FIXME emulation function pointers work properly, but calling between
-      #       modules as wasm-only needs more work
+      # FIXME(https://github.com/kripken/emscripten/issues/5370)
+      # emulation function pointers work properly, but calling between
+      # modules as wasm-only needs more work
       return False
     return True
 


### PR DESCRIPTION
If the user explicitly asks for EMULATED_FUNCTION_POINTERS=0 on the
command line we were not honoring that.

Partial workaround for #5370