### PR TITLE
Reduce error to warning when building with fetch+wasm+pthreads

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1940,8 +1940,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
       if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
         if shared.Settings.WASM:
-          exit_with_error('FETCH+USE_PTHREADS not yet compatible with wasm (shared.make_fetch_worker is asm.js-specific)')
-        shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
+          # FIXME(https://github.com/kripken/emscripten/issues/7024)
+          logging.warning('Blocking calls the fetch API do not work under WASM')
+        else:
+          shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
 
     # exit block 'memory initializer'
     log_time('memory initializer')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3911,7 +3911,7 @@ window.close = function() {
   @requires_threads
   def test_fetch_response_headers(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
-    self.btest('fetch/response_headers.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'WASM=0'])
+    self.btest('fetch/response_headers.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'], also_asmjs=True)
 
   # Test emscripten_fetch() usage to stream a XHR in to memory without storing the full file in memory
   @no_chrome('depends on moz-chunked-arraybuffer')


### PR DESCRIPTION
The fetch-worker does work with wasm, but that doesn't mean
we can't use the non-blocking parts of fetch API.

Partial fix for #7024