### PR TITLE
Don't mark libc++ symbols as visibility:default

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6141,7 +6141,7 @@ int main(int argc, char** argv) {
 
     self.assertGreater(vector, 1000)
     # we can strip out almost all of libcxx when just using vector
-    self.assertLess(2.5 * vector, iostream)
+    self.assertLess(2.4 * vector, iostream)
 
   @no_wasm_backend('relies on EMULATED_FUNCTION_POINTERS')
   def test_emulated_function_pointers(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -120,6 +120,11 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     o_s = []
     commands = []
     opts = default_opts + lib_opts
+    # Make sure we don't mark symbols as default visibility.  This works around
+    # an issue with the wasm backend where all default visibility symbols are
+    # exported (and therefore can't be GC'd).
+    # FIXME(https://github.com/kripken/emscripten/issues/7383)
+    opts += ['-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS']
     if has_noexcept_version and shared.Settings.DISABLE_EXCEPTION_CATCHING:
       opts += ['-fno-exceptions']
     for src in files:


### PR DESCRIPTION
This means they won't get exports by default by lld.  This
is really workaround until we have a better way to implement
EMSCRIPTEN_KEEPALIVE.

This reduces the number of exports in C++ hello world from 1922
to 222.