### PR TITLE
Fixes for recent invoke changes in #7497

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -287,7 +287,11 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
   # List of function signatures of used 'invoke_xxx()' functions in the application
   # For backwards compatibility if one might be using a mismatching Emscripten compiler version, if 'invokeFuncs' is not present in metadata,
   # use the full list of signatures in function table and generate invoke_() functions for all signatures in the program (producing excessive code size)
-  invoke_function_names = metadata['invokeFuncs'] if 'invokeFuncs' in metadata else ['invoke_' + x for x in function_table_sigs]
+  # we must also emit the full list if we are emitting code that can be linked later
+  if 'invokeFuncs' in metadata and not shared.Settings.LINKABLE:
+    invoke_function_names = metadata['invokeFuncs']
+  else:
+    invoke_function_names = ['invoke_' + x for x in function_table_sigs]
 
   asm_setup = create_asm_setup(debug_tables, function_table_data, invoke_function_names, metadata)
   basic_funcs = create_basic_funcs(function_table_sigs, invoke_function_names)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7921,9 +7921,9 @@ int main() {
 
     print('test on hello world')
     test(path_from_root('tests', 'hello_world.cpp'), [
-      ([],      23, ['abort', 'tempDoublePtr'], ['waka'],                  46505,  24,   19, 62), # noqa
-      (['-O1'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12630,  16,   17, 34), # noqa
-      (['-O2'], 18, ['abort', 'tempDoublePtr'], ['waka'],                  12616,  16,   17, 33), # noqa
+      ([],      21, ['abort', 'tempDoublePtr'], ['waka'],                  46505,  24,   19, 62), # noqa
+      (['-O1'], 16, ['abort', 'tempDoublePtr'], ['waka'],                  12630,  16,   17, 34), # noqa
+      (['-O2'], 16, ['abort', 'tempDoublePtr'], ['waka'],                  12616,  16,   17, 33), # noqa
       (['-O3'],  7, [],                         [],  2690,  10,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
       (['-Os'],  7, [],                         [],  2690,  10,    2, 21), # noqa
       (['-Oz'],  7, [],                         [],  2690,  10,    2, 21), # noqa
@@ -7945,7 +7945,7 @@ int main() {
       }
       ''')
     test('minimal.c', [
-      ([],      23, ['abort', 'tempDoublePtr'], ['waka'],                  22712, 24, 18, 31), # noqa
+      ([],      21, ['abort', 'tempDoublePtr'], ['waka'],                  22712, 24, 18, 31), # noqa
       (['-O1'], 11, ['abort', 'tempDoublePtr'], ['waka'],                  10450,  9, 15, 15), # noqa
       (['-O2'], 11, ['abort', 'tempDoublePtr'], ['waka'],                  10440,  9, 15, 15), # noqa
       # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
@@ -7956,9 +7956,9 @@ int main() {
 
     print('test on libc++: see effects of emulated function pointers')
     test(path_from_root('tests', 'hello_libcxx.cpp'), [
-      (['-O2'], 53, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   44, 661), # noqa
+      (['-O2'], 34, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   44, 661), # noqa
       (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                54, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   25, 622), # noqa
+                34, ['abort', 'tempDoublePtr'], ['waka'],                 208677,  30,   25, 622), # noqa
     ]) # noqa
 
   # ensures runtime exports work, even with metadce


### PR DESCRIPTION
Do not eliminate unused invokes if linkable code, and update metadce test

[ci skip] since on CI here this would fail now, until we tag a new fastcomp and get that build.