### PR TITLE
 Remove command-line interface from emscripten.py

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1806,7 +1806,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if embed_memfile(options):
         shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
 
-      final = shared.Building.emscripten(final, append_ext=False, extra_args=extra_args)
+      final = shared.Building.emscripten(final, js_libraries)
       save_intermediate('original')
 
       if shared.Settings.WASM_BACKEND:

--- a/emcc.py
+++ b/emcc.py
@@ -1795,8 +1795,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Emscripten
       logging.debug('LLVM => JS')
       extra_args = []
+      js_libraries = None
       if options.js_libraries:
-        extra_args = ['--libraries', ','.join(map(os.path.abspath, options.js_libraries))]
+        js_libraries = map(os.path.abspath, options.js_libraries)
       if options.memory_init_file:
         shared.Settings.MEM_INIT_METHOD = 1
       else:

--- a/emcc.py
+++ b/emcc.py
@@ -1794,10 +1794,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     with ToolchainProfiler.profile_block('emscript'):
       # Emscripten
       logging.debug('LLVM => JS')
-      extra_args = []
       js_libraries = None
       if options.js_libraries:
-        js_libraries = map(os.path.abspath, options.js_libraries)
+        js_libraries = [os.path.abspath(lib) for lib in options.js_libraries]
       if options.memory_init_file:
         shared.Settings.MEM_INIT_METHOD = 1
       else:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2279,11 +2279,6 @@ def main(infile, outfile, libraries):
   cache = tools.cache.Cache()
   temp_files = get_configuration().get_temp_files()
   infile, outfile = substitute_response_files([infile, outfile])
-  #assert len(libraries) <= 1
-  # TODO: why do we take 'libraries' as a list and then throw away all but the first?
-  if len(libraries):
-    assert not ',' in libraries[0]
-  libraries = libraries[0].split(',') if len(libraries) else []
 
   if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and not shared.Settings.ONLY_MY_CODE:
     generated_struct_info_name = 'generated_struct_info.json'

--- a/emscripten.py
+++ b/emscripten.py
@@ -20,7 +20,6 @@ import shutil
 import pprint
 from collections import OrderedDict
 
-import tools
 from tools import shared
 from tools import gen_struct_info
 from tools import jsrun

--- a/emscripten.py
+++ b/emscripten.py
@@ -11,9 +11,7 @@ headers, for the libc implementation in JS).
 
 import difflib
 import os
-import sys
 import json
-import argparse
 import subprocess
 import re
 import time
@@ -25,7 +23,7 @@ from collections import OrderedDict
 import tools
 from tools import shared
 from tools import gen_struct_info
-from tools import jsrun, tempfiles
+from tools import jsrun
 from tools.response_file import substitute_response_files
 from tools.shared import WINDOWS, asstr, path_from_root, exit_with_error
 from tools.toolchain_profiler import ToolchainProfiler
@@ -2276,7 +2274,6 @@ def normalize_line_endings(text):
 
 
 def main(infile, outfile, libraries):
-  cache = tools.cache.Cache()
   temp_files = get_configuration().get_temp_files()
   infile, outfile = substitute_response_files([infile, outfile])
 
@@ -2291,7 +2288,6 @@ def main(infile, outfile, libraries):
 
     shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, ensure_struct_info, extension='json')
   # do we need an else, to define it for the bootstrap case?
-
 
   outfile_obj = open(outfile, 'w')
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -2275,12 +2275,15 @@ def normalize_line_endings(text):
   return text
 
 
-def main(infile, outfile):
-  cache = tools.Cache.Cache()
+def main(infile, outfile, libraries):
+  cache = tools.cache.Cache()
   temp_files = get_configuration().get_temp_files()
   infile, outfile = substitute_response_files([infile, outfile])
-
-  libraries = args.libraries[0].split(',') if len(args.libraries) else []
+  #assert len(libraries) <= 1
+  # TODO: why do we take 'libraries' as a list and then throw away all but the first?
+  if len(libraries):
+    assert not ',' in libraries[0]
+  libraries = libraries[0].split(',') if len(libraries) else []
 
   if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and not shared.Settings.ONLY_MY_CODE:
     generated_struct_info_name = 'generated_struct_info.json'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2277,7 +2277,6 @@ class Building(object):
     with ToolchainProfiler.profile_block('emscripten.py'):
       emscripten.main(infile, outfile, js_libraries)
 
-
     # Detect compilation crashes and errors
     assert os.path.exists(filename + '.o.js'), 'Emscripten failed to generate .js'
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2267,7 +2267,7 @@ class Building(object):
       assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
 
   @staticmethod
-  def emscripten(filename, js_libraries=None):
+  def emscripten(filename, js_libraries):
     if path_from_root() not in sys.path:
       sys.path += [path_from_root()]
     import emscripten
@@ -2277,7 +2277,7 @@ class Building(object):
     if jsrun.TRACK_PROCESS_SPAWNS:
       logging.info('Executing emscripten.py compiler with cmdline "' + ' '.join([infile, outfile]) + '"')
     with ToolchainProfiler.profile_block('emscripten.py'):
-      emscripten.main(infile, outfile)
+      emscripten.main(infile, outfile, js_libraries)
 
 
     # Detect compilation crashes and errors

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2267,16 +2267,18 @@ class Building(object):
       assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
 
   @staticmethod
-  def emscripten(filename, append_ext=True, extra_args=[]):
+  def emscripten(filename, js_libraries=None):
     if path_from_root() not in sys.path:
       sys.path += [path_from_root()]
     import emscripten
     # Run Emscripten
-    cmdline = [filename + ('.o.ll' if append_ext else ''), '-o', filename + '.o.js'] + extra_args
+    infile = filename
+    outfile = filename + '.o.js'
     if jsrun.TRACK_PROCESS_SPAWNS:
-      logging.info('Executing emscripten.py compiler with cmdline "' + ' '.join(cmdline) + '"')
+      logging.info('Executing emscripten.py compiler with cmdline "' + ' '.join([infile, outfile]) + '"')
     with ToolchainProfiler.profile_block('emscripten.py'):
-      emscripten._main(cmdline)
+      emscripten.main(infile, outfile)
+
 
     # Detect compilation crashes and errors
     assert os.path.exists(filename + '.o.js'), 'Emscripten failed to generate .js'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2274,8 +2274,6 @@ class Building(object):
     # Run Emscripten
     infile = filename
     outfile = filename + '.o.js'
-    if jsrun.TRACK_PROCESS_SPAWNS:
-      logging.info('Executing emscripten.py compiler with cmdline "' + ' '.join([infile, outfile]) + '"')
     with ToolchainProfiler.profile_block('emscripten.py'):
       emscripten.main(infile, outfile, js_libraries)
 


### PR DESCRIPTION
There are no more uses of emscripten.py other than being called directly from `Shared.Building.emscripten`. So stop building and then parsing a command line.