### PR TITLE
Clarify addRunDependency assert

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1518,7 +1518,7 @@ function addRunDependency(id) {
 #if USE_PTHREADS
   // We should never get here in pthreads (could no-op this out if called in pthreads, but that might indicate a bug in caller side,
   // so good to be very explicit)
-  assert(!ENVIRONMENT_IS_PTHREAD);
+  assert(!ENVIRONMENT_IS_PTHREAD, "addRunDependency cannot be called with USE_PTHREADS=1");
 #endif
   runDependencies++;
   if (Module['monitorRunDependencies']) {


### PR DESCRIPTION
so the user doesn't get a cryptic "Assertion failed: undefined"

Bonus question: I'm using addRunDependency in Module.preInit to download the base .data files (generated independently). Is that supported somehow else?
