### PR TITLE
ldso: loadedDynamicLibraries is not used anymore - kill it

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -84,7 +84,6 @@ var asm2wasmImports = { // special asm2wasm imports
 };
 
 #if RELOCATABLE
-var loadedDynamicLibraries = [];
 
 function loadDynamicLibrary(lib) {
   var libModule;
@@ -120,7 +119,6 @@ function loadDynamicLibrary(lib) {
     }
 #endif
   }
-  loadedDynamicLibraries.push(libModule);
 }
 
 #if WASM


### PR DESCRIPTION
This variable stoped being used after d6e54c28 (simplify shared library
initialization: use the system atprerun/atinit logic, except when the
system is already loaded as in the dlopen case).