### PR TITLE
ldso: dlopen could allocate a handle that was already in use

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1699,6 +1699,11 @@ LibraryManager.library = {
   $DLFCN: {
     error: null,
     errorMsg: null,
+
+    // next free handle to use for a loaded dso.
+    // (handle=0 is avoided as it means "error" in dlopen)
+    nextHandle: 1,
+
     loadedLibs: {}, // handle -> [refcount, name, lib_object]
     loadedLibNames: {}, // name -> handle
   },
@@ -1786,11 +1791,7 @@ LibraryManager.library = {
         }
       }
 
-      // Not all browsers support Object.keys().
-      var handle = 1;
-      for (var key in DLFCN.loadedLibs) {
-        if (DLFCN.loadedLibs.hasOwnProperty(key)) handle++;
-      }
+      var handle = DLFCN.nextHandle++;
 
       // We don't care about RTLD_NOW and RTLD_LAZY.
       if (flag & 256) { // RTLD_GLOBAL


### PR DESCRIPTION
Currently dlopen allocates DSO handles by iterating loaded libraries
while counting them from 1. This would work if libraries would be never
unloaded, but it breaks in the presense of dlcose, e.g.:

	dlopen('A') -> 1
	dlopen('B') -> 2
	dlopen('C') -> 3
	dlclose('A') ; 1 is deleted from loadedLibs
	dlopen('D') : should be either 1 or 4 but it gives 3, thus erroneously overwriting C.

Fix it by always using simply incrementing integer for next allocated
handle.

Suggested-by: @sbc100