### PR TITLE
Support use of memory init file with wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1807,7 +1807,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if embed_memfile(options):
         shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
 
-      final = shared.Building.emscripten(final, js_libraries)
+      final = shared.Building.emscripten(final, target + '.mem', js_libraries)
       save_intermediate('original')
 
       if shared.Settings.WASM_BACKEND:
@@ -1892,9 +1892,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     with ToolchainProfiler.profile_block('memory initializer'):
       memfile = None
-
       if shared.Settings.MEM_INIT_METHOD > 0 or embed_memfile(options):
         memfile = target + '.mem'
+
+      if memfile and not shared.Settings.WASM_BACKEND:
+        # Strip the memory initializer out of the asmjs file
         shared.try_delete(memfile)
 
         def repl(m):

--- a/emscripten.py
+++ b/emscripten.py
@@ -1936,7 +1936,6 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
   except:
     pass
 
-
   sending = create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json,
                                 metadata)
   receiving = create_receiving_wasm(exported_implemented_functions)

--- a/emscripten.py
+++ b/emscripten.py
@@ -63,7 +63,7 @@ def access_quote(prop):
     return '.' + prop
 
 
-def emscript(infile, outfile, libraries, compiler_engine, temp_files,
+def emscript(infile, outfile, memfile, libraries, compiler_engine, temp_files,
              DEBUG):
   """Runs the emscripten LLVM-to-JS compiler.
 
@@ -1862,14 +1862,14 @@ HEAP_TYPE_INFOS = [
 ]
 
 
-def emscript_wasm_backend(infile, outfile, libraries, compiler_engine,
+def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
                           temp_files, DEBUG):
   # Overview:
   #   * Run wasm-emscripten-finalize to extract metadata and modify the binary
   #     to use emscripten's wasm<->JS ABI
   #   * Use the metadata to generate the JS glue that goes with the wasm
 
-  metadata = finalize_wasm(temp_files, infile, outfile, DEBUG)
+  metadata = finalize_wasm(temp_files, infile, outfile, memfile, DEBUG)
   if shared.Settings.SIDE_MODULE:
     return
 
@@ -1950,7 +1950,7 @@ def emscript_wasm_backend(infile, outfile, libraries, compiler_engine,
   outfile.close()
 
 
-def finalize_wasm(temp_files, infile, outfile, DEBUG):
+def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
   wasm_emscripten_finalize = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-emscripten-finalize')
   wasm_dis = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-dis')
 
@@ -1992,12 +1992,11 @@ def finalize_wasm(temp_files, infile, outfile, DEBUG):
     cmd.append('--output-source-map=' + wasm + '.map')
     cmd.append('--output-source-map-url=' + shared.Settings.SOURCE_MAP_BASE + os.path.basename(shared.Settings.WASM_BINARY_FILE) + '.map')
   if not shared.Settings.MEM_INIT_IN_WASM:
-    memory_init_file = wasm + '.mem'
-    cmd.append('--separate-data-segments=' + memory_init_file)
+    cmd.append('--separate-data-segments=' + memfile)
   shared.check_call(cmd, stdout=open(metadata_file, 'w'))
   if write_source_map:
     debug_copy(wasm + '.map', 'post_finalize.map')
-    debug_copy(wasm, 'post_finalize.wasm')
+  debug_copy(wasm, 'post_finalize.wasm')
 
   return create_metadata_wasm(open(metadata_file).read(), DEBUG)
 
@@ -2275,7 +2274,7 @@ def normalize_line_endings(text):
   return text
 
 
-def main(infile, outfile, libraries):
+def main(infile, outfile, memfile, libraries):
   temp_files = get_configuration().get_temp_files()
   infile, outfile = substitute_response_files([infile, outfile])
 
@@ -2295,5 +2294,5 @@ def main(infile, outfile, libraries):
 
   emscripter = emscript_wasm_backend if shared.Settings.WASM_BACKEND else emscript
   return temp_files.run_and_clean(lambda: emscripter(
-      infile, outfile_obj, libraries, shared.COMPILER_ENGINE, temp_files, get_configuration().DEBUG)
+      infile, outfile_obj, memfile, libraries, shared.COMPILER_ENGINE, temp_files, get_configuration().DEBUG)
   )

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1900,6 +1900,8 @@ class Building(object):
       cmd.append('--max-memory=%d' % Settings.WASM_MEM_MAX)
     elif not Settings.ALLOW_MEMORY_GROWTH:
       cmd.append('--max-memory=%d' % Settings.TOTAL_MEMORY)
+    if Settings.USE_PTHREADS:
+      cmd.append('--shared-memory')
 
     for a in Building.llvm_backend_args():
       cmd += ['-mllvm', a]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2233,20 +2233,19 @@ class Building(object):
       assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
 
   @staticmethod
-  def emscripten(filename, js_libraries):
+  def emscripten(infile, memfile, js_libraries):
     if path_from_root() not in sys.path:
       sys.path += [path_from_root()]
     import emscripten
     # Run Emscripten
-    infile = filename
-    outfile = filename + '.o.js'
+    outfile = infile + '.o.js'
     with ToolchainProfiler.profile_block('emscripten.py'):
-      emscripten.main(infile, outfile, js_libraries)
+      emscripten.main(infile, outfile, memfile, js_libraries)
 
     # Detect compilation crashes and errors
-    assert os.path.exists(filename + '.o.js'), 'Emscripten failed to generate .js'
+    assert os.path.exists(outfile), 'Emscripten failed to generate .js'
 
-    return filename + '.o.js'
+    return outfile
 
   @staticmethod
   def can_inline():


### PR DESCRIPTION
This plumbs the mem file name through to `emscript` and causes `wasm-emscripten-finalize` to write the file if we don't have `MEM_INIT_IN_WASM` (which is true for pthreads util we get conditional segment init).