### PR TITLE
Implement ftCall_<sig> functions with non-legal signatures in emulate…

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1209,6 +1209,35 @@ int main(int argc, char **argv)
       '''
       self.do_run(src, 'OK\n')
 
+  def test_exceptions_i64_emulated_function_pointers(self):
+      self.set_setting('EMULATED_FUNCTION_POINTERS', 1)
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+      # needs to flush stdio streams
+      self.set_setting('EXIT_RUNTIME', 1)
+      src = r'''
+        #include <iostream>
+        #include <exception>
+
+        int64_t long_func(int64_t l) {
+          return l + 1;
+        }
+
+        int main() {
+          int64_t res;
+
+          try {
+              res = long_func(0x121212123434);
+              if (res == 0x121212123435)
+                std::cout << "OK";
+          } catch(std::exception) {
+            try {
+              throw;
+            } catch(std::exception) {}
+          }
+        }
+      '''
+      self.do_run(src, 'OK\n')
+
   def test_exceptions_typed(self):
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
     # needs to flush stdio streams


### PR DESCRIPTION
…d function pointer mode correctly by

calling the ftCall_helper_<sig> functions exported by the wasm mode.

Part of the fix for:
https://github.com/kripken/emscripten/issues/7399