### PR TITLE
Cleanup package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+      "dev": true
+    },
+    "nan": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+      "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg=",
+      "dev": true
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ=",
+      "dev": true
+    },
+    "ws": {
+      "version": "0.4.32",
+      "resolved": "http://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+      "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
+      "dev": true,
+      "requires": {
+        "commander": "2.1.0",
+        "nan": "1.0.0",
+        "options": "0.0.6",
+        "tinycolor": "0.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "emscripten",
-  "version": "1.13.0",
-  "dependencies": {
+  "private": true,
+  "devDependencies": {
     "ws": "~0.4.28"
   }
 }

--- a/tests/sockets/test_sockets_echo_client.c
+++ b/tests/sockets/test_sockets_echo_client.c
@@ -210,7 +210,7 @@ int main() {
     sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
     // TODO: This is not the correct result: We should have a auto-bound address
     char *correct = "0.0.0.0:0";
-    printf("got (expected) socket: %s (%s), size %d (%d)\n", buffer, correct, strlen(buffer), strlen(correct));
+    printf("got (expected) socket: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
     assert(strlen(buffer) == strlen(correct));
     assert(strcmp(buffer, correct) == 0);
   }
@@ -228,7 +228,7 @@ int main() {
     sprintf(buffer, "%s:%u", inet_ntoa(adr_inet.sin_addr), (unsigned)ntohs(adr_inet.sin_port));
     char correct[1000];
     sprintf(correct, "127.0.0.1:%u", SOCKK);
-    printf("got (expected) socket: %s (%s), size %d (%d)\n", buffer, correct, strlen(buffer), strlen(correct));
+    printf("got (expected) socket: %s (%s), size %lu (%lu)\n", buffer, correct, strlen(buffer), strlen(correct));
     assert(strlen(buffer) == strlen(correct));
     assert(strcmp(buffer, correct) == 0);
   }


### PR DESCRIPTION
This is part of a larger change to remove the two checked in
node_modules trees that we have in the emscripten and rely instead
on developers running `npm install` after cloning/syncing.

- Switch ws dependency to devDevpendency since its only used
  for testing
- Add private:true since we are not (yet) publishing emscripten as
  a node package.
- Remove running on npm install from sockets test;  We can rely on
  developers doing this before running the tests.
- Don't try to run npm install in test_sockets.py.  Assume that
  developers to used "git clone" will also run npm install