### PR TITLE
Allow any HTTP Success Status code call the success callback function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -372,3 +372,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mary S <ipadlover8322@gmail.com>
 * Martin Birks <mbirks@gmail.com>
 * Kirill Smelkov <kirr@nexedi.com> (copyright owned by Nexedi)
+* Lutz Hören <laitch383@gmail.com>

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -400,7 +400,7 @@ function __emscripten_fetch_xhr(fetch, onsuccess, onerror, onprogress) {
     }
     HEAPU16[fetch + Fetch.fetch_t_offset_status >> 1] = xhr.status;
     if (xhr.statusText) stringToUTF8(xhr.statusText, fetch + Fetch.fetch_t_offset_statusText, 64);
-    if (xhr.status == 200) {
+    if (xhr.status >= 200 && xhr.status < 300) {
 #if FETCH_DEBUG
       console.log('fetch: xhr of URL "' + xhr.url_ + '" / responseURL "' + xhr.responseURL + '" succeeded with status 200');
 #endif


### PR DESCRIPTION
Hey,

i am using the Fetch API for partial downloads. (Setting Range header manually)
This does by default response with the HTTP Status Code 206 for a successfully download.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206 for more Informations.

To not restrict this Pull Request for only code 206, I changed the Line in the xhr.onsuccess function
to call the onsuccess callback for every successfully Status code (200-300).