### PR TITLE
Error in the case that WASM and EXPORT_FUNCTION_TABLES are both defined at the same time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -373,3 +373,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Martin Birks <mbirks@gmail.com>
 * Kirill Smelkov <kirr@nexedi.com> (copyright owned by Nexedi)
 * Lutz Hören <laitch383@gmail.com>
+* Pedro K Custodio <git@pedrokcustodio.com>

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1286,6 +1286,9 @@ class SettingsManager(object):
 
 
 def verify_settings():
+  if Settings.WASM and Settings.EXPORT_FUNCTION_TABLES:
+      exit_with_error('emcc: EXPORT_FUNCTION_TABLES incompatible with WASM')
+
   if Settings.WASM_BACKEND:
     if not Settings.WASM:
       # TODO(sbc): Make this into a hard error.  We still have a few places that


### PR DESCRIPTION
If WASM and EXPORT_FUNCTION_TABLES are indeed incompatible, this should resolve #7532