### PR TITLE
Remove cache __last_clear indicator file

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -83,10 +83,6 @@ class Cache(object):
 
   def erase(self):
     tempfiles.try_delete(self.root_dirname)
-    try:
-      open(self.dirname + '__last_clear', 'w').write('last clear: ' + time.asctime() + '\n')
-    except Exception as e:
-      print('failed to save last clear time: ', e, file=sys.stderr)
     self.filelock = None
     tempfiles.try_delete(self.filelock_name)
     self.filelock = filelock.FileLock(self.filelock_name)


### PR DESCRIPTION
It broke in #7522, and while it's easy to fix, it seems of zero utility at this point.

This PR removes the warning that is currently shown when clearing the cache.