### PR TITLE
Improve PBO handling in WebGL 2

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1322,7 +1322,11 @@ var LibraryGL = {
   glCompressedTexImage2D: function(target, level, internalFormat, width, height, border, imageSize, data) {
 #if USE_WEBGL2
     if (GL.currentContext.supportsWebGL2EntryPoints) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
-      GLctx['compressedTexImage2D'](target, level, internalFormat, width, height, border, HEAPU8, data, imageSize);
+      if (GLctx.currentPixelUnpackBufferBinding) {
+        GLctx['compressedTexImage2D'](target, level, internalFormat, width, height, border, imageSize, data);
+      } else {
+        GLctx['compressedTexImage2D'](target, level, internalFormat, width, height, border, HEAPU8, data, imageSize);
+      }
       return;
     }
 #endif
@@ -1333,7 +1337,11 @@ var LibraryGL = {
   glCompressedTexImage3D__sig: 'viiiiiiiii',
   glCompressedTexImage3D: function(target, level, internalFormat, width, height, depth, border, imageSize, data) {
     if (GL.currentContext.supportsWebGL2EntryPoints) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
-      GLctx['compressedTexImage3D'](target, level, internalFormat, width, height, depth, border, HEAPU8, data, imageSize);
+      if (GLctx.currentPixelUnpackBufferBinding) {
+        GLctx['compressedTexImage3D'](target, level, internalFormat, width, height, depth, border, imageSize, data);
+      } else {
+        GLctx['compressedTexImage3D'](target, level, internalFormat, width, height, depth, border, HEAPU8, data, imageSize);
+      }
     } else {
       GLctx['compressedTexImage3D'](target, level, internalFormat, width, height, depth, border, data ? {{{ makeHEAPView('U8', 'data', 'data+imageSize') }}} : null);
     }
@@ -1344,7 +1352,11 @@ var LibraryGL = {
   glCompressedTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, imageSize, data) {
 #if USE_WEBGL2
     if (GL.currentContext.supportsWebGL2EntryPoints) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
-      GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, HEAPU8, data, imageSize);
+      if (GLctx.currentPixelUnpackBufferBinding) {
+        GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, imageSize, data);
+      } else {
+        GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, HEAPU8, data, imageSize);
+      }
       return;
     }
 #endif
@@ -1355,7 +1367,11 @@ var LibraryGL = {
   glCompressedTexSubImage3D__sig: 'viiiiiiiiiii',
   glCompressedTexSubImage3D: function(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data) {
     if (GL.currentContext.supportsWebGL2EntryPoints) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
-      GLctx['compressedTexSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, HEAPU8, data, imageSize);
+      if (GLctx.currentPixelUnpackBufferBinding) {
+        GLctx['compressedTexSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+      } else {
+        GLctx['compressedTexSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, HEAPU8, data, imageSize);
+      }
     } else {
       GLctx['compressedTexSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, data ? {{{ makeHEAPView('U8', 'data', 'data+imageSize') }}} : null);
     }
@@ -1770,6 +1786,10 @@ var LibraryGL = {
 
       if (id == GL.currArrayBuffer) GL.currArrayBuffer = 0;
       if (id == GL.currElementArrayBuffer) GL.currElementArrayBuffer = 0;
+#if USE_WEBGL2
+      if (id == GLctx.currentPixelPackBufferBinding) GLctx.currentPixelPackBufferBinding = 0;
+      if (id == GLctx.currentPixelUnpackBufferBinding) GLctx.currentPixelUnpackBufferBinding = 0;
+#endif
     }
   },
 
@@ -3637,9 +3657,11 @@ var LibraryGL = {
       // the proper API function to call.
       GLctx.currentPixelPackBufferBinding = buffer;
     } else if (target == 0x88EC /*GL_PIXEL_UNPACK_BUFFER*/) {
-      // In WebGL 2 glTexImage2D, glTexSubImage2D, glTexImage3D and glTexSubImage3D entry points, we need to use a different WebGL 2 API function
-      // call when a buffer is bound to GL_PIXEL_UNPACK_BUFFER_BINDING point, so must keep track whether that binding point is non-null to know what
-      // is the proper API function to call.
+      // In WebGL 2 gl(Compressed)Tex(Sub)Image[23]D entry points, we need to
+      // use a different WebGL 2 API function call when a buffer is bound to
+      // GL_PIXEL_UNPACK_BUFFER_BINDING point, so must keep track whether that
+      // binding point is non-null to know what is the proper API function to
+      // call.
       GLctx.currentPixelUnpackBufferBinding = buffer;
     }
 #endif

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2528,6 +2528,10 @@ Module["preRun"].push(function () {
   def test_webgl2_packed_types(self):
     self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'USE_WEBGL2=1', '-s', 'GL_ASSERTIONS=1'], expected='0')
 
+  @requires_graphics_hardware
+  def test_webgl2_pbo(self):
+    self.btest(path_from_root('tests', 'webgl2_pbo.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'], expected='0')
+
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1']]:
       print(opts)

--- a/tests/webgl2_pbo.cpp
+++ b/tests/webgl2_pbo.cpp
@@ -1,0 +1,107 @@
+// Copyright 2018 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#define GL_GLEXT_PROTOTYPES
+#include <GLES/gl.h>
+#include <GLES/glext.h>
+#include <GLES3/gl3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <assert.h>
+
+#include <string>
+
+int result = 0;
+
+#define GL_CALL( x ) \
+    { \
+        x; \
+        GLenum error = glGetError(); \
+        if( error != GL_NO_ERROR ) { \
+            printf( "GL ERROR: %d,  %s\n", (int)error, #x ); \
+            result = 1; \
+        } \
+    } \
+
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+
+  attrs.enableExtensionsByDefault = 1;
+  attrs.majorVersion = 2;
+  attrs.minorVersion = 0;
+
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context( 0, &attrs );
+  if (!context)
+  {
+    printf("Skipped: WebGL 2 is not supported.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT(result);
+#endif
+    return 0;
+  }
+  emscripten_webgl_make_context_current(context);
+
+  /* Two textures */
+  GLuint tex[2];
+  glGenTextures(2, tex);
+
+  /* Verify that unpack buffer binding is not used after the buffer gets destroyed */
+  glBindTexture(GL_TEXTURE_2D, tex[0]);
+  {
+    const int pixels[16] = {}; /* 4*1 all-black RGBA pixels */
+
+    GLuint buffer;
+    glGenBuffers(1, &buffer);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, 4*4, pixels, GL_STATIC_DRAW);
+
+    /* This should use the unpack buffer */
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 4, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr));
+
+    glDeleteBuffers(1, &buffer);
+
+    /* This not anymore */
+    GL_CALL(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
+  }
+
+  /* Verify that unpack buffer is used for compressed image upload as well */
+  const std::string exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+  if(exts.find("WEBGL_compressed_texture_s3tc") != std::string::npos)
+  {
+    printf("WEBGL_compressed_texture_s3tc is supported, testing ...\n");
+
+    glBindTexture(GL_TEXTURE_2D, tex[1]);
+    const char pixels[8] = {}; /* 4*4 all-black S3TC DXT1 pixels */
+
+    GLuint buffer;
+    glGenBuffers(1, &buffer);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, 8, pixels, GL_STATIC_DRAW);
+
+    /* This should all use the unpack buffer */
+    GL_CALL(glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, 4, 4, 0, 8, nullptr));
+    GL_CALL(glCompressedTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, 8, nullptr));
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+    /* This not anymore */
+    GL_CALL(glCompressedTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, 8, pixels));
+
+    glDeleteBuffers(1, &buffer);
+  }
+  else printf("WEBGL_compressed_texture_s3tc is NOT supported\n");
+
+  glDeleteTextures(2, tex);
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(result);
+#endif
+  return 0;
+}


### PR DESCRIPTION
In particular:

 * If a PBO gets deleted via `glDeleteBuffer()`, clean up the references to it so the following `glReadPixels()` / `gl(Compressed)Tex(Sub)Image[23]D()` calls are not mistakenly using the buffer overloads, leading to GL errors like "no buffer bound to GL_PIXEL_UNPACK_BUFFER".
 * If a PBO is bound, use it also for `glCompressedTex(Sub)Image[23]D()`. Previously it was used only for the non-compressed calls.

I have quite extensive tests for this in [Magnum](https://magnum.graphics), but couldn't find any matching test case here. If you have a place where a test could be updated, please point me to it :)

The `glTex(Sub)Image[23]D()` has another branch that tests for `pixels != null` ([here](https://github.com/mosra/emscripten/blob/754f0c236b73f4baba9ba78c6ea7a52fc9f0df42/src/library_gl.js#L1621-L1628)), not sure if the same should be done for the compressed variants?

Also not sure if the naming inconsistency (`GLctx.currentPixelPackBufferBinding` vs `GL.currArrayBuffer`) was intentional or accidental. Maybe renaming that to be `GL.currPixelPackBuffer` as well?