### PR TITLE
One last fix to make Closure Compiler fully working with WebGL 2

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -7729,7 +7729,7 @@ var LibraryGL = {
 #if GL_ASSERTIONS
     GL.validateVertexAttribPointer(size, type, stride, ptr);
 #endif
-    GLctx.vertexAttribIPointer(index, size, type, stride, ptr);
+    GLctx['vertexAttribIPointer'](index, size, type, stride, ptr);
   },
 // ~USE_WEBGL2
 #endif


### PR DESCRIPTION
Followup to #3478 and #3585, this is the last case I found that was broken (of all the WebGL 2 APIs that I have implemented in [Magnum](https://magnum.graphics)). To clean up after myself, merging this also finally closes #3473 :)