### PR TITLE
Fix Closure Compiler error with OpenAL 

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -2069,7 +2069,7 @@ var LibraryOpenAL = {
   alcCloseDevice__proxy: 'sync',
   alcCloseDevice__sig: 'ii',
   alcCloseDevice: function(deviceId) {
-    if (!deviceId in AL.deviceRefCounts || AL.deviceRefCounts[deviceId] > 0) {
+    if (!(deviceId in AL.deviceRefCounts) || AL.deviceRefCounts[deviceId] > 0) {
       return 0 /* ALC_FALSE */;
     }
 
@@ -2081,7 +2081,7 @@ var LibraryOpenAL = {
   alcCreateContext__proxy: 'sync',
   alcCreateContext__sig: 'iii',
   alcCreateContext: function(deviceId, pAttrList) {
-    if (!deviceId in AL.deviceRefCounts) {
+    if (!(deviceId in AL.deviceRefCounts)) {
 #if OPENAL_DEBUG
       console.log('alcCreateContext() called with an invalid device');
 #endif

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -3103,7 +3103,7 @@ var LibraryOpenAL = {
       break;
     case 0xB004 /* AL_EXTENSIONS */:
       ret = '';
-      for (ext in AL.AL_EXTENSIONS) {
+      for (var ext in AL.AL_EXTENSIONS) {
         ret = ret.concat(ext);
         ret = ret.concat(' ');
       }


### PR DESCRIPTION
Fixes a compile error when using `--closure 1` on an app that makes use of OpenAL. Similar to https://github.com/kripken/emscripten/pull/5824, reported by Closure Compiler as:

    ERROR - variable ext is undeclared
      for (ext in AL.AL_EXTENSIONS) {
           ^^^

Besides that, while fixing the above, I also spotted the following two warnings and fixed them by wrapping the whole `in` expression in parentheses. Hope that's the proper fix:

    WARNING - Suspicious negated left operand of in operator.
     if (!deviceId in AL.deviceRefCounts || AL.deviceRefCounts[deviceId] > 0) {
         ^^^^^^^^^

    WARNING - Suspicious negated left operand of in operator.
     if (!deviceId in AL.deviceRefCounts) {
         ^^^^^^^^^

Thank you!