### PR TITLE
Allow pre-js to configure wasm/asmjs path

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1760,9 +1760,9 @@ function integrateWasmJS() {
 
   var method = '{{{ BINARYEN_METHOD }}}';
 
-  var wasmTextFile = '{{{ WASM_TEXT_FILE }}}';
-  var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
-  var asmjsCodeFile = '{{{ ASMJS_CODE_FILE }}}';
+  var wasmTextFile = Module['wasmTextFile'] || '{{{ WASM_TEXT_FILE }}}';
+  var wasmBinaryFile = Module['wasmBinaryFile'] || '{{{ WASM_BINARY_FILE }}}';
+  var asmjsCodeFile = Module['asmjsCodeFile'] || '{{{ ASMJS_CODE_FILE }}}';
 
   if (!isDataURI(wasmTextFile)) {
     wasmTextFile = locateFile(wasmTextFile);


### PR DESCRIPTION
This partially reverts #5859
Before #5859, I could change the path .wasm by setting `Module['wasmBinaryFile']` in pre-js.

[Some people](https://stackoverflow.com/a/46340091/4661625), including me, looks for this feature. I know there still is `Module['locateFile']` for custom file path function, but static file path is often useful when you use it with other build systems like NPM.

For example, when you use [Webpack file-loader](https://www.npmjs.com/package/file-loader) with `Module['wasmBinaryFile']` you can do the following in the pre-js:

```javascript
// With file-loader, WASM_PATH will be automatically
// converted to a string of the public URL path you like.
import WASM_PATH from './wasm_binary.wasm';

Module['wasmBinaryFile'] = WASM_PATH; // This will be the public URL path.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kripken/emscripten/7566)
<!-- Reviewable:end -->
