### PR TITLE
ldso: Switch dlopen to use loadDynamicLibrary instead of duplicating it

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1627,7 +1627,8 @@ addOnPreRun(function() {
   function loadDynamicLibraries(libs) {
     if (libs) {
       libs.forEach(function(lib) {
-        loadDynamicLibrary(lib);
+        // libraries linked to main never go away
+        loadDynamicLibrary(lib, {global: true, nodelete: true});
       });
     }
     runPostSets();
@@ -1638,7 +1639,7 @@ addOnPreRun(function() {
     // we can't read binary data synchronously, so preload
     addRunDependency('preload_dynamicLibraries');
     Promise.all(Module['dynamicLibraries'].map(function(lib) {
-      return loadDynamicLibrary(lib, {loadAsync: true});
+      return loadDynamicLibrary(lib, {loadAsync: true, global: true, nodelete: true});
     })).then(function() {
       // we got them all, wonderful
       runPostSets();

--- a/src/support.js
+++ b/src/support.js
@@ -84,6 +84,29 @@ var asm2wasmImports = { // special asm2wasm imports
 };
 
 #if RELOCATABLE
+// dynamic linker/loader (a-la ld.so on ELF systems)
+var LDSO = {
+  // next free handle to use for a loaded dso.
+  // (handle=0 is avoided as it means "error" in dlopen)
+  nextHandle: 1,
+
+  loadedLibs: {         // handle -> dso [refcount, name, module, global]
+    // program itself
+    // XXX uglifyjs fails on "[-1]: {"
+    '-1': {
+      refcount: Infinity,   // = nodelete
+      name:     '__self__',
+      module:   Module,
+      global:   true
+    }
+  },
+
+  loadedLibNames: {     // name   -> handle
+    // program itself
+    '__self__': -1
+  },
+}
+
 // fetchBinary fetches binaray data @ url. (async)
 function fetchBinary(url) {
   return fetch(url, { credentials: 'same-origin' }).then(function(response) {
@@ -96,28 +119,89 @@ function fetchBinary(url) {
   });
 }
 
-// loadDynamicLibrary loads dynamic library @ lib URL / path.
+// loadDynamicLibrary loads dynamic library @ lib URL / path and returns handle for loaded DSO.
 //
 // Several flags affect the loading:
 //
+// - if flags.global=true, symbols from the loaded library are merged into global
+//   process namespace. Flags.global is thus similar to RTLD_GLOBAL in ELF.
+//
+// - if flags.nodelete=true, the library will be never unloaded. Flags.nodelete
+//   is thus similar to RTLD_NODELETE in ELF.
+//
 // - if flags.loadAsync=true, the loading is performed asynchronously and
 //   loadDynamicLibrary returns corresponding promise.
+//
+// - if flags.fs is provided, it is used as FS-like interface to load library data.
+//   By default, when flags.fs=undefined, native loading capabilities of the
+//   environment are used.
+//
+// If a library was already loaded, it is not loaded a second time. However
+// flags.global and flags.nodelete are handled every time a load request is made.
+// Once a library becomes "global" or "nodelete", it cannot be removed or unloaded.
 function loadDynamicLibrary(lib, flags) {
-  flags = flags || {};
+  // when loadDynamicLibrary did not have flags, libraries were loaded globally & permanently
+  flags = flags || {global: true, nodelete: true}
+
+  var handle = LDSO.loadedLibNames[lib];
+  var dso;
+  if (handle) {
+    // the library is being loaded or has been loaded already.
+    //
+    // however it could be previously loaded only locally and if we get
+    // load request with global=true we have to make it globally visible now.
+    dso = LDSO.loadedLibs[handle];
+    if (flags.global && !dso.global) {
+      dso.global = true;
+      if (dso.module !== 'loading') {
+        // ^^^ if module is 'loading' - symbols merging will be eventually done by the loader.
+        mergeLibSymbols(dso.module)
+      }
+    }
+    // same for "nodelete"
+    if (flags.nodelete && dso.refcount !== Infinity) {
+      dso.refcount = Infinity;
+    }
+    dso.refcount++
+    return flags.loadAsync ? Promise.resolve(handle) : handle;
+  }
+
+  // allocate new DSO & handle
+  handle = LDSO.nextHandle++;
+  dso = {
+    refcount: flags.nodelete ? Infinity : 1,
+    name:     lib,
+    module:   'loading',
+    global:   flags.global,
+  };
+  LDSO.loadedLibNames[lib] = handle;
+  LDSO.loadedLibs[handle] = dso;
 
   // libData <- lib
   function loadLibData() {
 #if WASM
-    // for wasm, we can use fetch for async
+    // for wasm, we can use fetch for async, but for fs mode we can only imitate it
+    if (flags.fs) {
+      var libData = flags.fs.readFile(lib, {encoding: 'binary'});
+      if (!(libData instanceof Uint8Array)) {
+        libData = new Uint8Array(lib_data);
+      }
+      return flags.loadAsync ? Promise.resolve(libData) : libData;
+    }
+
     if (flags.loadAsync) {
       return fetchBinary(lib);
     }
     // load the binary synchronously
     return Module['readBinary'](lib);
 #else
-    // for js we only imitate async
+    // for js we only imitate async for both native & fs modes.
     var libData;
-    libData = Module['read'](lib);
+    if (flags.fs) {
+      libData = flags.fs.readFile(lib, {encoding: 'utf8'});
+    } else {
+      libData = Module['read'](lib);
+    }
     return flags.loadAsync ? Promise.resolve(libData) : libData;
 #endif
   }
@@ -137,6 +221,14 @@ function loadDynamicLibrary(lib, flags) {
 
   // libModule <- lib
   function getLibModule() {
+    // lookup preloaded cache first
+    if (Module['preloadedWasm'] !== undefined &&
+        Module['preloadedWasm'][lib] !== undefined) {
+      var libModule = Module['preloadedWasm'][lib];
+      return flags.loadAsync ? Promise.resolve(libModule) : libModule;
+    }
+
+    // module not preloaded - load lib data and create new module from it
     if (flags.loadAsync) {
       return loadLibData(lib).then(function(libData) {
         return createLibModule(libData);
@@ -150,11 +242,32 @@ function loadDynamicLibrary(lib, flags) {
   function mergeLibSymbols(libModule) {
     // add symbols into global namespace TODO: weak linking etc.
     for (var sym in libModule) {
+      if (!libModule.hasOwnProperty(sym)) {
+        continue;
+      }
+
+      // When RTLD_GLOBAL is enable, the symbols defined by this shared object will be made
+      // available for symbol resolution of subsequently loaded shared objects.
+      //
+      // We should copy the symbols (which include methods and variables) from SIDE_MODULE to MAIN_MODULE.
+      //
+      // Module of SIDE_MODULE has not only the symbols (which should be copied)
+      // but also others (print*, asmGlobal*, FUNCTION_TABLE_**, NAMED_GLOBALS, and so on).
+      //
+      // When the symbol (which should be copied) is method, Module._* 's type becomes function.
+      // When the symbol (which should be copied) is variable, Module._* 's type becomes number.
+      //
+      // Except for the symbol prefix (_), there is no difference in the symbols (which should be copied) and others.
+      // So this just copies over compiled symbols (which start with _).
+      if (sym[0] !== '_') {
+        continue;
+      }
+
       if (!Module.hasOwnProperty(sym)) {
         Module[sym] = libModule[sym];
       }
 #if ASSERTIONS == 2
-      else if (sym[0] === '_') {
+      else {
         var curr = Module[sym], next = libModule[sym];
         // don't warn on functions - might be odr, linkonce_odr, etc.
         if (!(typeof curr === 'function' && typeof next === 'function')) {
@@ -165,18 +278,23 @@ function loadDynamicLibrary(lib, flags) {
     }
   }
 
-  // module for lib is loaded - update the global namespace
+  // module for lib is loaded - update the dso & global namespace
   function moduleLoaded(libModule) {
-    mergeLibSymbols(libModule);
+    if (dso.global) {
+      mergeLibSymbols(libModule);
+    }
+    dso.module = libModule;
   }
 
   if (flags.loadAsync) {
     return getLibModule().then(function(libModule) {
       moduleLoaded(libModule);
+      return handle;
     })
   }
 
   moduleLoaded(getLibModule());
+  return handle;
 }
 
 #if WASM

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2433,7 +2433,7 @@ The current type of b is: 9
         return 0;
       }
       '''
-    self.do_run(src, 'error: Could not find dynamic lib: libfoo.so\n')
+    self.do_run(src, 'error: Could not load dynamic lib: libfoo.so\nError: No such file or directory')
 
   @needs_dlfcn
   def test_dlfcn_basic(self):


### PR DESCRIPTION
Currently dlopen duplicate loadDynamicLibrary in many ways. Since
logic to load dynamic libraries will be soon reworked to support DSO ->
DSO linking, instead of adding more duplication, as a preparatory step
dlopen is first reworked to use loadDynamicLibrary itself.

This moves functionality to keep track of loaded DSO, their handles,
refcounts, etc into the dynamic linker itself, with loadDynamicLibrary now
accepting various flags (global/nodelete) to handle e.g.
RTLD_LOCAL/RTLD_GLOBAL and RTLD_NODELETE dlopen cases (RTLD_NODELETE
semantic is needed for initially-linked-in libraries).

Also, since dlopen was using FS to read libraries, and loadDynamicLibrary was
previously using Module['read'] and friends, loadDynamicLibrary now also
accepts fs interface, which if provided, is used as FS-like interface to load
library data, and if not - native loading capabilities of the environment
are still used.

Another aspect related to deduplication is that loadDynamicLibrary now also
uses preloaded/precompiled wasm modules, that were previously only used by
dlopen (see a5866a5 "Add preload plugin to compile wasm side modules async
(#6663)").