### PR TITLE
Preparations for running the atomic_cxx tests with actual atomics

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -34,7 +34,7 @@ void emscripten_force_num_logical_cores(int cores);
 uint8_t emscripten_atomic_exchange_u8(void/*uint8_t*/ *addr, uint8_t newVal);
 uint16_t emscripten_atomic_exchange_u16(void/*uint16_t*/ *addr, uint16_t newVal);
 uint32_t emscripten_atomic_exchange_u32(void/*uint32_t*/ *addr, uint32_t newVal);
-uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
+uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal); // In asm.js/asm2wasm this is emulated with locks, very slow!
 
 // CAS returns the *old* value that was in the memory location before the operation took place.
 // That is, if the return value when calling this function equals to 'oldVal', then the operation succeeded,

--- a/tests/core/test_atomic_cxx.cpp
+++ b/tests/core/test_atomic_cxx.cpp
@@ -28,7 +28,11 @@ template<typename TYPE, typename UNSIGNED_TYPE> void test(TYPE mask0, TYPE mask1
 
     // test atomic<int>
     std::atomic<dog> atomicDog(5);
-    printf("atomic<int>.is_lock_free(): %s\n", atomicDog.is_lock_free() ? "true" : "false");
+    if (sizeof(TYPE) < 8) {
+      printf("atomic<int>.is_lock_free(): %s\n", atomicDog.is_lock_free() ? "true" : "false");
+    } else {
+      printf("atomic<int>.is_lock_free(): %s\n", atomicDog.is_lock_free() == IS_64BIT_LOCK_FREE ? "ok" : "bad :(");
+    }
     printf("atomic<int> value: %lld\n", (long long)TYPE(atomicDog));
 
     // test store/load

--- a/tests/core/test_atomic_cxx.txt
+++ b/tests/core/test_atomic_cxx.txt
@@ -169,7 +169,7 @@ operator^=: ffffffff
 
 64 bits
 
-atomic<int>.is_lock_free(): false
+atomic<int>.is_lock_free(): ok
 atomic<int> value: 5
 store/load 0: 0
 store/load 1: 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5138,17 +5138,24 @@ PORT: 3979
   def test_atomic(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_atomic')
 
-  @no_wasm_backend('wasm has 64bit lockfree atomics')
   def test_atomic_cxx(self):
     test_path = path_from_root('tests', 'core', 'test_atomic_cxx')
     src, output = (test_path + s for s in ('.cpp', '.txt'))
     Building.COMPILER_TEST_OPTS += ['-std=c++11']
+    # the wasm backend has lock-free atomics, but not asm.js or asm2wasm
+    is_lock_free = self.is_wasm_backend()
+    Building.COMPILER_TEST_OPTS += ['-DIS_64BIT_LOCK_FREE=%d' % is_lock_free]
     self.do_run_from_file(src, output)
 
     if self.get_setting('ALLOW_MEMORY_GROWTH') == 0 and not self.is_wasm():
       print('main module')
       self.set_setting('MAIN_MODULE', 1)
       self.do_run_from_file(src, output)
+    # TODO
+    # elif self.is_wasm_backend():
+    #   print('pthreads')
+    #   self.set_setting('USE_PTHREADS', 1)
+    #   self.do_run_from_file(src, output)
 
   def test_phiundef(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_phiundef')


### PR DESCRIPTION
This test checks 64-bit atomics, and they were broken in asm.js and asm2wasm but we didn't notice since the test doesn't run with pthreads/atomics enabled. This prepares for that, anticipating the landing of https://github.com/kripken/emscripten-fastcomp/pull/244 which is necessary for that to pass (comment in threading.h is for that). Also get the current test running in the wasm backend (which has lock-free 64-bit atomics). With these changes we can flip on the pthreads-enabled bit when ready.