### PR TITLE
Improve handling of missing/bad llvm version

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -55,6 +55,8 @@ def make_fake_clang(filename, version):
   """Create a fake clang that only handles --version
   --version writes to stdout (unlike -v which writes to stderr)
   """
+  if not os.path.exists(os.path.dirname(filename)):
+    os.makedirs(os.path.dirname(filename))
   with open(filename, 'w') as f:
     f.write('#!/bin/sh\n')
     f.write('echo "clang version %s"\n' % version)
@@ -68,6 +70,8 @@ def make_fake_llc(filename, targets):
   """Create a fake llc that only handles --version and writes target
   list to stdout.
   """
+  if not os.path.exists(os.path.dirname(filename)):
+    os.makedirs(os.path.dirname(filename))
   with open(filename, 'w') as f:
     f.write('#!/bin/sh\n')
     f.write('echo "llc fake output\nRegistered Targets:\n%s"' % targets)
@@ -256,9 +260,6 @@ class sanity(RunnerCore):
     with open(CONFIG_FILE, 'a') as f:
       f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake') + '"')
 
-    if not os.path.exists(path_from_root('tests', 'fake')):
-      os.makedirs(path_from_root('tests', 'fake'))
-
     with env_modify({'EM_IGNORE_SANITY': '1'}):
       for x in range(-2, 3):
         for y in range(-2, 3):
@@ -304,9 +305,6 @@ class sanity(RunnerCore):
       f.write('LLVM_ROOT = "' + path_from_root('tests', 'fake', 'bin') + '"')
     # print '1', open(CONFIG_FILE).read()
 
-    try_delete(path_from_root('tests', 'fake'))
-    os.makedirs(path_from_root('tests', 'fake', 'bin'))
-
     make_fake_clang(path_from_root('tests', 'fake', 'bin', 'clang'), expected_llvm_version())
     make_fake_llc(path_from_root('tests', 'fake', 'bin', 'llc'), 'no j-s backend for you!')
     self.check_working(EMCC, WARNING)
@@ -349,9 +347,6 @@ class sanity(RunnerCore):
     f = open(CONFIG_FILE, 'a')
     f.write('NODE_JS = "' + path_from_root('tests', 'fake', 'nodejs') + '"')
     f.close()
-
-    if not os.path.exists(path_from_root('tests', 'fake')):
-      os.makedirs(path_from_root('tests', 'fake'))
 
     with env_modify({'EM_IGNORE_SANITY': '1'}):
       for version, succeed in [('v0.8.0', False),
@@ -897,9 +892,6 @@ fi
         self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-c'], 'asmjs-unknown-emscripten')
 
     # fake llc output
-
-    try_delete(path_from_root('tests', 'fake'))
-    os.makedirs(path_from_root('tests', 'fake', 'bin'))
 
     def test_with_fake(report, expected):
       make_fake(report)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -176,6 +176,8 @@ def check_call(cmd, *args, **kw):
     return proc
   except subprocess.CalledProcessError as e:
     exit_with_error("'%s' failed (%d)", ' '.join(cmd), e.returncode)
+  except OSError as e:
+    exit_with_error("'%s' failed: %s", ' '.join(cmd), str(e))
 
 
 def generate_config(path, first_time=False):
@@ -390,13 +392,13 @@ def expected_llvm_version():
 def get_clang_version():
   global actual_clang_version
   if actual_clang_version is None:
-    response = run_process([CLANG, '--version'], stdout=PIPE).stdout
-    m = re.search(r'[Vv]ersion\s+(\d+\.\d+)', response)
+    proc = check_call([CLANG, '--version'], stdout=PIPE)
+    m = re.search(r'[Vv]ersion\s+(\d+\.\d+)', proc.stdout)
     actual_clang_version = m and m.group(1)
   return actual_clang_version
 
 
-def check_clang_version():
+def check_llvm_version():
   expected = expected_llvm_version()
   actual = get_clang_version()
   if expected in actual:
@@ -405,20 +407,15 @@ def check_clang_version():
   return False
 
 
-def check_llvm_version():
-  try:
-    check_clang_version()
-  except Exception as e:
-    logger.critical('Could not verify LLVM version: %s' % str(e))
-
-
 def get_llc_targets():
   try:
     llc_version_info = run_process([LLVM_COMPILER, '--version'], stdout=PIPE).stdout
-    pre, targets = llc_version_info.split('Registered Targets:')
-    return targets
   except Exception as e:
     return '(no targets could be identified: ' + str(e) + ')'
+  if 'Registered Targets:' not in llc_version_info:
+    return '(no targets could be identified: ' + llc_version_info + ')'
+  pre, targets = llc_version_info.split('Registered Targets:')
+  return targets
 
 
 def has_asm_js_target(targets):
@@ -526,8 +523,9 @@ def check_sanity(force=False):
   frequently, only when ${EM_CONFIG}_sanity does not exist or is older than
   EM_CONFIG (so, we re-check sanity when the settings are changed).  We also
   re-check sanity and clear the cache when the version changes"""
-  ToolchainProfiler.enter_block('sanity')
-  try:
+  with ToolchainProfiler.profile_block('sanity'):
+    check_llvm_version()
+    expected = generate_sanity()
     if os.environ.get('EMCC_SKIP_SANITY_CHECK') == '1':
       return
     reason = None
@@ -545,8 +543,8 @@ def check_sanity(force=False):
             reason = 'settings file has changed'
           else:
             sanity_data = open(sanity_file).read().rstrip('\n\r') # workaround weird bug with read() that appends new line char in some old python version
-            if sanity_data != generate_sanity():
-              reason = 'system change: %s vs %s' % (generate_sanity(), sanity_data)
+            if sanity_data != expected:
+              reason = 'system change: %s vs %s' % (expected, sanity_data)
             else:
               if not force:
                 return # all is well
@@ -558,7 +556,6 @@ def check_sanity(force=False):
       force = False # the check actually failed, so definitely write out the sanity file, to avoid others later seeing failures too
 
     # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
-    check_llvm_version()
     check_node_version()
 
     llvm_ok = check_llvm()
@@ -594,15 +591,8 @@ def check_sanity(force=False):
 
     if not force:
       # Only create/update this file if the sanity check succeeded, i.e., we got here
-      f = open(sanity_file, 'w')
-      f.write(generate_sanity())
-      f.close()
-
-  except Exception as e:
-    # Any error here is not worth failing on
-    print('WARNING: sanity check failed to run', e)
-  finally:
-    ToolchainProfiler.exit_block('sanity')
+      with open(sanity_file, 'w') as f:
+        f.write(expected)
 
 
 # Tools/paths


### PR DESCRIPTION
- Handle "OSError" file not found when running checked sub-processes.
- Errors running `clang --version` are now fatal.
- Remove some overly broad catch blocks.
- Should result in fewer hard-to-read backtraces for users.