### PR TITLE
Fix wasm backend + closure + memory growth

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -962,6 +962,7 @@ function abortOnCannotGrowMemory() {
 }
 #endif
 
+#if WASM == 0
 #if ALLOW_MEMORY_GROWTH
 if (!Module['reallocBuffer']) Module['reallocBuffer'] = function(size) {
   var ret;
@@ -977,7 +978,8 @@ if (!Module['reallocBuffer']) Module['reallocBuffer'] = function(size) {
   if (!success) return false;
   return ret;
 };
-#endif
+#endif // ALLOW_MEMORY_GROWTH
+#endif // WASM == 0
 
 function enlargeMemory() {
 #if USE_PTHREADS

--- a/tests/core/test_memorygrowth.c
+++ b/tests/core/test_memorygrowth.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 
   printf("*pre: %s,%.3f*\n", buf1, buf2[0]);
 
-  int totalMemory = emscripten_run_script_int("TOTAL_MEMORY");
+  int totalMemory = EM_ASM_INT({ return TOTAL_MEMORY });
   char *buf3 = (char*)malloc(totalMemory+1);
   buf3[argc] = (int)buf2;
   if (argc % 7 == 6) printf("%d\n", (int)memcpy(buf3, buf1, argc));

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1748,8 +1748,8 @@ int main(int argc, char **argv) {
     self.do_run(src, 'success')
 
   def test_memorygrowth(self):
+    self.maybe_closure()
     self.emcc_args += ['-s', 'ALLOW_MEMORY_GROWTH=0'] # start with 0
-
     # With typed arrays in particular, it is dangerous to use more memory than TOTAL_MEMORY,
     # since we then need to enlarge the heap(s).
     src = open(path_from_root('tests', 'core', 'test_memorygrowth.c')).read()


### PR DESCRIPTION
We had some asm.js code included, and closure saw it did not have some corresponding JS for it.

Also adds a test for that combination.

Fixes #7600