### PR TITLE
Remove explicit .bc extension from gl-mt library

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -600,7 +600,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   if shared.Settings.USE_PTHREADS:
     system_libs += [Library('pthreads',       ext, create_pthreads,       pthreads_symbols,       [libc_name],  False), # noqa
                     Library('pthreads_asmjs', ext, create_pthreads_asmjs, asmjs_pthreads_symbols, [libc_name],  False), # noqa
-                    Library('gl-mt',         'bc', create_gl,             gl_symbols,             [libc_name],  False)] # noqa
+                    Library('gl-mt',          ext, create_gl,             gl_symbols,             [libc_name],  False)] # noqa
   else:
     system_libs += [Library('gl',             ext, create_gl,             gl_symbols,             [libc_name],  False)] # noqa
 


### PR DESCRIPTION
No libraries should be forces to build as bitcode anymroe.