### PR TITLE
Improve performance of invoke calls

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1288,11 +1288,13 @@ def create_asm_setup(debug_tables, function_table_data, invoke_function_names, m
       asm_setup += 'var g$' + extern + ' = function() { ' + check(extern) + ' return ' + side + 'Module["' + extern + '"] };\n'
 
   asm_setup += create_invoke_wrappers(invoke_function_names)
-  asm_setup += setup_function_pointers(function_table_sigs)
 
-  if shared.Settings.EMULATED_FUNCTION_POINTERS:
-    function_tables_impls = make_function_tables_impls(function_table_data)
-    asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'
+  if not shared.Settings.WASM:
+    asm_setup += setup_function_pointers(function_table_sigs)
+
+    if shared.Settings.EMULATED_FUNCTION_POINTERS:
+      function_tables_impls = make_function_tables_impls(function_table_data)
+      asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'
 
   return asm_setup
 
@@ -1478,8 +1480,9 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
       receiving += table + '\n'
 
   if shared.Settings.EMULATED_FUNCTION_POINTERS:
-    receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '') + '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
+    receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '')
     if not shared.Settings.WASM:
+      receiving += '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
       for sig in function_table_data.keys():
         name = 'FUNCTION_TABLE_' + sig
         fullname = name if not shared.Settings.SIDE_MODULE else ('SIDE_' + name)

--- a/emscripten.py
+++ b/emscripten.py
@@ -1288,13 +1288,11 @@ def create_asm_setup(debug_tables, function_table_data, invoke_function_names, m
       asm_setup += 'var g$' + extern + ' = function() { ' + check(extern) + ' return ' + side + 'Module["' + extern + '"] };\n'
 
   asm_setup += create_invoke_wrappers(invoke_function_names)
+  asm_setup += setup_function_pointers(function_table_sigs)
 
-  if not shared.Settings.WASM:
-    asm_setup += setup_function_pointers(function_table_sigs)
-
-    if shared.Settings.EMULATED_FUNCTION_POINTERS:
-      function_tables_impls = make_function_tables_impls(function_table_data)
-      asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'
+  if shared.Settings.EMULATED_FUNCTION_POINTERS:
+    function_tables_impls = make_function_tables_impls(function_table_data)
+    asm_setup += '\n' + '\n'.join(function_tables_impls) + '\n'
 
   return asm_setup
 
@@ -1480,9 +1478,8 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
       receiving += table + '\n'
 
   if shared.Settings.EMULATED_FUNCTION_POINTERS:
-    receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '')
+    receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '') + '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
     if not shared.Settings.WASM:
-      receiving += '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
       for sig in function_table_data.keys():
         name = 'FUNCTION_TABLE_' + sig
         fullname = name if not shared.Settings.SIDE_MODULE else ('SIDE_' + name)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2860,9 +2860,12 @@ class JS(object):
     else:
       legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
       args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
-      args = 'index' + (',' if args else '') + args
       ret = 'return ' if sig[0] != 'v' else ''
-      body = '%sModule["dynCall_%s"](%s);' % (ret, sig, args)
+      body = '%sModule["wasmTable"].get(index)(%s);' % (ret, args)
+      args = 'index' + (',' if args else '') + args
+      if not Settings.WASM:
+        body = '%sModule["dynCall_%s"](%s);' % (ret, sig, args)
+
     # C++ exceptions are numbers, and longjmp is a string 'longjmp'
     ret = '''function%s(%s) {
   var sp = stackSave();


### PR DESCRIPTION
The idea is to improve the performance of the invoke calls by directly accessing the wasm table instead of going through the hoops of dyncalls and ftcalls.
Seeing that dyncall_ and ftcall_ functions are no longer referenced, I also attempted to clean those up.