### PR TITLE
Ensure all "system" libs start with `lib`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
             # FIXME not all stuff builds in wb:
             #   - al: see https://bugs.llvm.org/show_bug.cgi?id=39591
             #   - cocos2d: source code error, cannot detect platform
-            EMCC_CORES=4 python3 ~/emscripten/embuilder.py build libc libc-mt libc-extras struct_info emmalloc dlmalloc dlmalloc_threadsafe pthreads libcxx libcxx_noexcept libcxxabi gl bullet freetype libpng ogg sdl2 sdl2-image sdl2-ttf sdl2-net vorbis zlib wasm-libc wasm_compiler_rt emmalloc_debug dlmalloc_debug dlmalloc_threadsafe_debug
+            EMCC_CORES=4 python3 ~/emscripten/embuilder.py build libc libc-mt libc-extras struct_info emmalloc dlmalloc dlmalloc_threadsafe pthreads libcxx libcxx_noexcept libcxxabi gl bullet freetype libpng ogg sdl2 sdl2-image sdl2-ttf sdl2-net vorbis zlib libc-wasm compiler_rt_wasm emmalloc_debug dlmalloc_debug dlmalloc_threadsafe_debug
             python3 ~/emscripten/tests/runner.py test_hello_world
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - System librarys have been renamed to include the `lib` prefix.  If you use
+   EMCC_FORCE_STDLIBS or EMCC_ONLY_FORCED_STDLIBS to select system libaries
+   you may need to add the `lib` prefix.
  - Rename `pthread-main.js` to `NAME.worker.js`, where `NAME` is the main
    name of your application, that is, if you emit `program.js` then you'll get
    `program.worker.js` (this allows more than one to exist in the same
@@ -2131,9 +2134,9 @@ v1.21.8: 7/28/2014
 
 v1.21.7: 7/25/2014
 ------------------
- - Added new link option -s EMCC_ONLY_FORCED_STDLIBS which can be used to
+ - Added new environment varaible EMCC_ONLY_FORCED_STDLIBS which can be used to
    restrict to only linking to the chosen set of Emscripten-provided libraries.
-   (See also -s EMCC_FORCE_STDLIBS)
+   (See also EMCC_FORCE_STDLIBS)
  - Adjusted argv[0] and environment variables USER, HOME, LANG and _ to report a
    more convenient set of default values. (#2565)
  - Fixed an issue where the application could not use environ without also

--- a/embuilder.py
+++ b/embuilder.py
@@ -4,9 +4,9 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-'''
-Tool to manage building of various useful things, such as libc, libc++, native optimizer, as well as fetch and build ports like zlib and sdl2
-'''
+"""Tool to manage building of various useful things, such as libc, libc++,
+native optimizer, as well as fetch and build ports like zlib and sdl2
+"""
 
 from __future__ import print_function
 import logging
@@ -62,8 +62,8 @@ Available operations and tasks:
         vorbis
         zlib
         cocos2d
-        wasm-libc
-        wasm_compiler_rt
+        libc-wasm
+        compiler_rt_wasm
 
 Issuing 'embuilder.py build ALL' causes each task to be built.
 
@@ -107,7 +107,7 @@ SYSTEM_TASKS = ['al', 'compiler-rt', 'gl', 'gl-mt', 'libc', 'libc-mt', 'libc-ext
 USER_TASKS = ['binaryen', 'bullet', 'freetype', 'icu', 'libpng', 'ogg', 'sdl2', 'sdl2-gfx', 'sdl2-image', 'sdl2-mixer', 'sdl2-ttf', 'sdl2-net', 'vorbis', 'zlib']
 
 temp_files = shared.configuration.get_temp_files()
-logger = logging.getLogger(__file__)
+logger = logging.getLogger('embuilder')
 
 def build(src, result_libs, args=[]):
   # build in order to generate the libraries
@@ -165,7 +165,7 @@ def main():
           c = a / b;
           return 0;
         }
-      ''', ['compiler-rt.a'])
+      ''', ['libcompiler-rt.a'])
     elif what == 'libc':
       build(C_WITH_MALLOC, ['libc.bc'])
     elif what == 'libc-extras':
@@ -178,19 +178,19 @@ def main():
     elif what == 'struct_info':
       build(C_BARE, ['generated_struct_info.json'])
     elif what == 'emmalloc':
-      build(C_WITH_MALLOC, ['emmalloc.bc'], ['-s', 'MALLOC="emmalloc"'])
+      build(C_WITH_MALLOC, ['libemmalloc.bc'], ['-s', 'MALLOC="emmalloc"'])
     elif what == 'emmalloc_debug':
-      build(C_WITH_MALLOC, ['emmalloc_debug.bc'], ['-s', 'MALLOC="emmalloc"', '-g'])
+      build(C_WITH_MALLOC, ['libemmalloc_debug.bc'], ['-s', 'MALLOC="emmalloc"', '-g'])
     elif what == 'dlmalloc':
-      build(C_WITH_MALLOC, ['dlmalloc.bc'], ['-s', 'MALLOC="dlmalloc"'])
+      build(C_WITH_MALLOC, ['libdlmalloc.bc'], ['-s', 'MALLOC="dlmalloc"'])
     elif what == 'dlmalloc_debug':
-      build(C_WITH_MALLOC, ['dlmalloc_debug.bc'], ['-g', '-s', 'MALLOC="dlmalloc"'])
+      build(C_WITH_MALLOC, ['libdlmalloc_debug.bc'], ['-g', '-s', 'MALLOC="dlmalloc"'])
     elif what == 'dlmalloc_threadsafe_debug':
-      build(C_WITH_MALLOC, ['dlmalloc_threadsafe_debug.bc'], ['-g', '-s', 'USE_PTHREADS=1', '-s', 'MALLOC="dlmalloc"'])
+      build(C_WITH_MALLOC, ['libdlmalloc_threadsafe_debug.bc'], ['-g', '-s', 'USE_PTHREADS=1', '-s', 'MALLOC="dlmalloc"'])
     elif what in ('dlmalloc_threadsafe', 'libc-mt', 'pthreads'):
-      build(C_WITH_MALLOC, ['libc-mt.bc', 'dlmalloc_threadsafe.bc', 'pthreads.bc'], ['-s', 'USE_PTHREADS=1', '-s', 'MALLOC="dlmalloc"'])
-    elif what == 'wasm-libc':
-      build(C_WITH_STDLIB, ['wasm-libc.bc'], ['-s', 'WASM=1'])
+      build(C_WITH_MALLOC, ['libc-mt.bc', 'libdlmalloc_threadsafe.bc', 'libpthreads.bc'], ['-s', 'USE_PTHREADS=1', '-s', 'MALLOC="dlmalloc"'])
+    elif what == 'libc-wasm':
+      build(C_WITH_STDLIB, ['libc-wasm.bc'], ['-s', 'WASM=1'])
     elif what == 'libcxx':
       build(CXX_WITH_STDLIB, ['libcxx.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     elif what == 'libcxx_noexcept':
@@ -211,21 +211,21 @@ def main():
         int main() {
           return int(emscripten_GetProcAddress("waka waka"));
         }
-      ''', ['gl.bc'])
+      ''', ['libgl.bc'])
     elif what == 'gl-mt':
       build('''
         extern "C" { extern void* emscripten_GetProcAddress(const char *x); }
         int main() {
           return int(emscripten_GetProcAddress("waka waka"));
         }
-      ''', ['gl-mt.bc'], ['-s', 'USE_PTHREADS=1'])
+      ''', ['libgl-mt.bc'], ['-s', 'USE_PTHREADS=1'])
     elif what == 'native_optimizer':
       build(C_BARE, ['optimizer.2.exe'], ['-O2', '-s', 'WASM=0'])
-    elif what == 'wasm_compiler_rt':
+    elif what == 'compiler_rt_wasm':
       if shared.Settings.WASM_BACKEND:
-        build(C_BARE, ['wasm_compiler_rt.a'], ['-s', 'WASM=1'])
+        build(C_BARE, ['libcompiler_rt_wasm.a'], ['-s', 'WASM=1'])
       else:
-        logger.warning('wasm_compiler_rt not built when using JSBackend')
+        logger.warning('compiler_rt_wasm not built when using JSBackend')
     elif what == 'html5':
       build('''
         #include <stdlib.h>
@@ -234,7 +234,7 @@ def main():
           return emscripten_compute_dom_pk_code(NULL);
         }
 
-      ''', ['html5.bc'])
+      ''', ['libhtml5.bc'])
     elif what == 'al':
       build('''
         #include "AL/al.h"
@@ -242,7 +242,7 @@ def main():
           alGetProcAddress(0);
           return 0;
         }
-      ''', ['al.bc'])
+      ''', ['libal.bc'])
     elif what == 'icu':
       build_port('icu', 'libicuuc.bc', ['-s', 'USE_ICU=1'])
     elif what == 'zlib':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4686,7 +4686,7 @@ int main()
   }
 }
 ''')
-    with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libcxxabi,libcxx,dlmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
+    with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libcxxabi,libcxx,libdlmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
       run_process([PYTHON, EMXX, 'src.cpp', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Caught exception: std::exception', run_js('a.out.js', stderr=PIPE))
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -719,17 +719,17 @@ fi
       ([PYTHON, EMBUILDER, 'build', 'libc'], ['building and verifying libc', 'success'], True, ['libc.bc']),
       ([PYTHON, EMBUILDER, 'build', 'libc-mt'], ['building and verifying libc-mt', 'success'], True, ['libc-mt.bc']),
       ([PYTHON, EMBUILDER, 'build', 'libc-extras'], ['building and verifying libc-extras', 'success'], True, ['libc-extras.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'dlmalloc'], ['building and verifying dlmalloc', 'success'], True, ['dlmalloc.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_debug'], ['building and verifying dlmalloc', 'success'], True, ['dlmalloc_debug.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_threadsafe'], ['building and verifying dlmalloc_threadsafe', 'success'], True, ['dlmalloc_threadsafe.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_threadsafe_debug'], ['building and verifying dlmalloc', 'success'], True, ['dlmalloc_threadsafe_debug.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'emmalloc'], ['building and verifying emmalloc', 'success'], True, ['emmalloc.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'emmalloc_debug'], ['building and verifying emmalloc', 'success'], True, ['emmalloc_debug.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'pthreads'], ['building and verifying pthreads', 'success'], True, ['pthreads.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'dlmalloc'], ['building and verifying dlmalloc', 'success'], True, ['libdlmalloc.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_debug'], ['building and verifying dlmalloc', 'success'], True, ['libdlmalloc_debug.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_threadsafe'], ['building and verifying dlmalloc_threadsafe', 'success'], True, ['libdlmalloc_threadsafe.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'dlmalloc_threadsafe_debug'], ['building and verifying dlmalloc', 'success'], True, ['libdlmalloc_threadsafe_debug.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'emmalloc'], ['building and verifying emmalloc', 'success'], True, ['libemmalloc.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'emmalloc_debug'], ['building and verifying emmalloc', 'success'], True, ['libemmalloc_debug.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'pthreads'], ['building and verifying pthreads', 'success'], True, ['libpthreads.bc']),
       ([PYTHON, EMBUILDER, 'build', 'libcxx'], ['success'], True, ['libcxx.a']),
       ([PYTHON, EMBUILDER, 'build', 'libcxx_noexcept'], ['success'], True, ['libcxx_noexcept.a']),
       ([PYTHON, EMBUILDER, 'build', 'libcxxabi'], ['success'], True, ['libcxxabi.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'gl'], ['success'], True, ['gl.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'gl'], ['success'], True, ['libgl.bc']),
       ([PYTHON, EMBUILDER, 'build', 'native_optimizer'], ['success'], True, ['optimizer.2.exe']),
       ([PYTHON, EMBUILDER, 'build', 'zlib'], ['building and verifying zlib', 'success'], True, ['zlib.bc']),
       ([PYTHON, EMBUILDER, 'build', 'libpng'], ['building and verifying libpng', 'success'], True, ['libpng.bc']),
@@ -747,10 +747,10 @@ fi
       ([PYTHON, EMBUILDER, 'build', 'sdl2-mixer'], ['building and verifying sdl2-mixer', 'success'], True, ['sdl2-mixer.bc']),
       ([PYTHON, EMBUILDER, 'build', 'binaryen'], ['building and verifying binaryen', 'success'], True, []),
       ([PYTHON, EMBUILDER, 'build', 'cocos2d'], ['building and verifying cocos2d', 'success'], True, ['libCocos2d.bc']),
-      ([PYTHON, EMBUILDER, 'build', 'wasm-libc'], ['building and verifying wasm-libc', 'success'], True, ['wasm-libc.bc']),
+      ([PYTHON, EMBUILDER, 'build', 'libc-wasm'], ['building and verifying libc-wasm', 'success'], True, ['libc-wasm.bc']),
     ]
     if Settings.WASM_BACKEND:
-      tests.append(([PYTHON, EMBUILDER, 'build', 'wasm_compiler_rt'], ['building and verifying wasm_compiler_rt', 'success'], True, ['wasm_compiler_rt.a']),)
+      tests.append(([PYTHON, EMBUILDER, 'build', 'libcompiler_rt_wasm'], ['building and verifying libcompiler_rt_wasm', 'success'], True, ['libcompiler_rt_wasm.a']),)
 
     Cache.erase()
 


### PR DESCRIPTION
This is the first step towards making the emscripten_cache directory
look more like a normal library directory.

Possible followups:
- rename libcxx and compiler-rt to libc++ and compiler-rt to match
  upstream.
- use -L and -l for including system libraries.
  This should allow things like `-lc` on the command line.
- implement -nostdlib flag (replace ONLY_MY_CODE?).