### PR TITLE
Fix emscripten_set_offscreencanvas_size_on_target_thread to support

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2459,7 +2459,11 @@ var LibraryJSEvents = {
     var varargs = stackAlloc(12);
 
     // TODO: This could be optimized a bit (basically a dumb encoding agnostic strdup)
-    var targetStr = targetCanvas ? Pointer_stringify(targetCanvas) : 0;
+    var targetStr = targetCanvas
+                      ? typeof targetCanvas === 'string'
+                        ? targetCanvas
+                        : Pointer_stringify(targetCanvas)
+                      : 0;
     var targetStrHeap = targetStr ? _malloc(targetStr.length+1) : 0;
     if (targetStrHeap) stringToUTF8(targetStr, targetStrHeap, targetStr.length+1);
 


### PR DESCRIPTION
targetCanvas parmater if is string

findCanvasEventTarget() supports target as "number" (which is used in Pointer_stringify) and string (e.g. canvas element ID).  this fix will just return the string as-is if already a string.