### PR TITLE
Fix firefox version used for testing to 64.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,11 +128,8 @@ jobs:
       - run:
           name: download firefox
           command: |
-            # wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.2/linux-x86_64/en-US/firefox-62.0.2.tar.bz2
-            # tar xf firefox-62.0.2.tar.bz2
-            # Currently we need firefox nightly to test wasm threads
-            wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-            tar xf nightly.tar.bz2
+            wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/64.0/linux-x86_64/en-US/firefox-64.0.tar.bz2
+            tar xf firefox-64.0.tar.bz2
       - run:
           name: configure firefox
           command: |


### PR DESCRIPTION
The nightly URL is currently broken.  Pinning to a specific version
is preferable and hopefully 64.0 has the wasm threads feature we
need.