### PR TITLE
Avoid stackRestore() in wasm-backend startup

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -551,6 +551,11 @@ function JSify(data, functionsOnly) {
       if (STACK_START > 0) print('if (STACKTOP < ' + STACK_START + ') STACK_BASE = STACKTOP = alignMemory(' + STACK_START + ');\n');
       print('STACK_MAX = STACK_BASE + TOTAL_STACK;\n');
       print('DYNAMIC_BASE = alignMemory(STACK_MAX);\n');
+      if (WASM_BACKEND) {
+        // wasm backend stack goes down
+        print('STACKTOP = STACK_BASE + TOTAL_STACK;');
+        print('STACK_MAX = STACK_BASE;');
+      }
       print('HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;\n');
       print('staticSealed = true; // seal the static portion of memory\n');
       if (ASSERTIONS) print('assert(DYNAMIC_BASE < TOTAL_MEMORY, "TOTAL_MEMORY not big enough for stack");\n');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1918,14 +1918,6 @@ function integrateWasmJS() {
       if (exports.memory) mergeMemory(exports.memory);
       Module['asm'] = exports;
       Module["usingWasm"] = true;
-#if WASM_BACKEND
-      // wasm backend stack goes down
-      STACKTOP = STACK_BASE + TOTAL_STACK;
-      STACK_MAX = STACK_BASE;
-      // can't call stackRestore() here since this function can be called
-      // synchronously before stackRestore() is declared.
-      Module["asm"]["stackRestore"](STACKTOP);
-#endif
 #if USE_PTHREADS
       // Keep a reference to the compiled module so we can post it to the workers.
       Module['wasmModule'] = module;

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -5,7 +5,7 @@
 
 import os, shutil, logging
 
-TAG = 'version_58'
+TAG = 'version_59'
 
 def needed(settings, shared, ports):
   if not settings.WASM: return False


### PR DESCRIPTION
This relies on the new binaryen option to import the stack's initial position, added in

https://github.com/WebAssembly/binaryen/pull/1819
