### PR TITLE
Change use of NO_DYNAMIC_EXECUTION in embind to DYNAMIC_EXECUTION.

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -50,10 +50,10 @@ var LibraryEmbind = {
     Module['flushPendingDeletes'] = flushPendingDeletes;
     Module['setDelayFunction'] = setDelayFunction;
 #if IN_TEST_HARNESS
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION
     // Without dynamic execution, dynamically created functions will have no
     // names. This lets the test suite know that.
-    Module['NO_DYNAMIC_EXECUTION'] = true;
+    Module['DYNAMIC_EXECUTION'] = true;
 #endif
 #if EMBIND_STD_STRING_IS_UTF8
     Module['EMBIND_STD_STRING_IS_UTF8'] = true;
@@ -194,7 +194,7 @@ var LibraryEmbind = {
   $createNamedFunction__deps: ['$makeLegalFunctionName'],
   $createNamedFunction: function(name, body) {
     name = makeLegalFunctionName(name);
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
     return function() {
       "use strict";
       return body.apply(this, arguments);
@@ -847,9 +847,9 @@ var LibraryEmbind = {
     if (!(constructor instanceof Function)) {
         throw new TypeError('new_ called with constructor type ' + typeof(constructor) + " which is not a function");
     }
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
     if (constructor === Function) {
-      throw new Error('new_ cannot create a new Function with NO_DYNAMIC_EXECUTION.');
+      throw new Error('new_ cannot create a new Function with DYNAMIC_EXECUTION == 0.');
     }
 #endif
 
@@ -913,7 +913,7 @@ var LibraryEmbind = {
 
     var returns = (argTypes[0].name !== "void");
 
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
     var argsWired = new Array(argCount - 2);
     return function() {
       if (arguments.length !== argCount - 2) {
@@ -1042,7 +1042,7 @@ var LibraryEmbind = {
     signature = readLatin1String(signature);
 
     function makeDynCaller(dynCall) {
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
       return function() {
           var args = new Array(arguments.length + 1);
           args[0] = rawFunction;

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -151,7 +151,7 @@ var LibraryEmVal = {
         var obj = new constructor(arg0, arg1, arg2);
         return __emval_register(obj);
     } */
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
     var argsList = new Array(argCount + 1);
     return function(constructor, argTypes, args) {
       argsList[0] = constructor;
@@ -202,7 +202,7 @@ var LibraryEmVal = {
     return newer(handle, argTypes, args);
   },
 
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
   $emval_get_global: function() {
     function testGlobal(obj) {
       obj['$$$embind_global$$$'] = obj;
@@ -354,7 +354,7 @@ var LibraryEmVal = {
     var types = __emval_lookupTypes(argCount, argTypes);
 
     var retType = types[0];
-#if NO_DYNAMIC_EXECUTION
+#if DYNAMIC_EXECUTION == 0
     var argN = new Array(argCount - 1);
     var invokerFunction = function(handle, name, destructors, args) {
       var offset = 0;

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -162,7 +162,7 @@ module({
         });
 
         test("setting and getting property on unrelated class throws error", function() {
-            var className = cm['NO_DYNAMIC_EXECUTION'] ? '' : 'HasTwoBases';
+            var className = cm['DYNAMIC_EXECUTION'] ? 'HasTwoBases' : '';
             var a = new cm.HasTwoBases;
             var e = assert.throws(cm.BindingError, function() {
                 Object.getOwnPropertyDescriptor(cm.HeldBySmartPtr.prototype, 'i').set.call(a, 10);
@@ -1598,7 +1598,7 @@ module({
 
         test("smart pointer object has correct constructor name", function() {
             var e = new cm.HeldBySmartPtr(10, "foo");
-            var expectedName = cm['NO_DYNAMIC_EXECUTION'] ? "" : "HeldBySmartPtr";
+            var expectedName = cm['DYNAMIC_EXECUTION'] ? "HeldBySmartPtr" : "";
             assert.equal(expectedName, e.constructor.name);
             e.delete();
         });
@@ -2342,7 +2342,7 @@ module({
     });
 
     BaseFixture.extend("function names", function() {
-        if (cm['NO_DYNAMIC_EXECUTION']) {
+        if (!cm['DYNAMIC_EXECUTION']) {
           assert.equal('', cm.ValHolder.name);
           assert.equal('', cm.ValHolder.prototype.setVal.name);
           assert.equal('', cm.ValHolder.makeConst.name);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2399,6 +2399,12 @@ int f() {
       if fail:
         self.assertNotEqual(proc.returncode, 0)
       else:
+        if 'DYNAMIC_EXECUTION=0' in args:
+          with open(self.in_dir('a.out.js'), 'r') as js_binary_file:
+            js_binary_str = js_binary_file.read()
+            self.assertNotIn('new Function(', js_binary_str, 'Found "new Function(" with DYNAMIC_EXECUTION=0')
+            self.assertNotIn('eval(', js_binary_str, 'Found "eval(" with DYNAMIC_EXECUTION=0')
+
         with open(self.in_dir('a.out.js'), 'ab') as f:
           for tf in testFiles:
             f.write(open(tf, 'rb').read())


### PR DESCRIPTION
Adds a validation step to the nodejs command when running the tests with DYNAMIC_EXECUTION=0 to ensure the generated script has no eval.  This required adding the ability to specify args to the nodejs command to jsrun.py.

The existing tests didn't catch this bug because they were also affected.  The tests check for Module['NO_DYNAMIC_EXECUTION'] which was set by embind.js for the test harness when the NO_DYNAMIC_EXECUTION=1 flag was set.