### PR TITLE
Fixed unnecessary argument copy in val::array()

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -298,7 +298,7 @@ namespace emscripten {
         }
 
         template<typename T>
-        static val array(const std::vector<T> vec) {
+        static val array(const std::vector<T>& vec) {
             val new_array = array();
             for(auto it = vec.begin(); it != vec.end(); it++)
                 new_array.call<void>("push", *it);


### PR DESCRIPTION
Spotted this while working with embind. Seems like an unnecessary copy to me.