### PR TITLE
Simplify handling of temporary test files. NFC.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -210,6 +210,13 @@ def limit_size(string, MAX=800 * 20):
   return string[0:MAX / 2] + '\n[..]\n' + string[-MAX / 2:]
 
 
+def create_test_file(name, contents, binary=False):
+  assert not os.path.isabs(name)
+  mode = 'wb' if binary else 'w'
+  with open(name, mode) as f:
+    f.write(contents)
+
+
 # The core test modes
 core_test_modes = [
   'asm0',
@@ -397,7 +404,7 @@ class RunnerCore(unittest.TestCase):
     if not args:
       return
     js = open(filename).read()
-    open(filename, 'w').write(js.replace('run();', 'run(%s + Module["arguments"]);' % str(args)))
+    create_test_file(filename, js.replace('run();', 'run(%s + Module["arguments"]);' % str(args)))
 
   def prep_ll_run(self, filename, ll_file, force_recompile=False, build_ll_hook=None):
     # force_recompile = force_recompile or os.path.getsize(filename + '.o.ll') > 50000
@@ -774,7 +781,7 @@ class RunnerCore(unittest.TestCase):
       int suppInt = 76;
     '''
     supp_name = os.path.join(self.get_dir(), 'supp.cpp')
-    open(supp_name, 'w').write(supp)
+    create_test_file(supp_name, supp)
 
     main = r'''
       #include <stdio.h>
@@ -814,8 +821,7 @@ class RunnerCore(unittest.TestCase):
   # when run under broswer it excercises how dynamic linker handles concurrency
   # - because B and C are loaded in parallel.
   def _test_dylink_dso_needed(self, do_run):
-    with open('liba.cpp', 'w') as f:
-      f.write(r'''
+    create_test_file('liba.cpp', r'''
         #include <stdio.h>
         #include <emscripten.h>
 
@@ -836,8 +842,7 @@ class RunnerCore(unittest.TestCase):
         static ainit _;
       ''')
 
-    with open('libb.cpp', 'w') as f:
-      f.write(r'''
+    create_test_file('libb.cpp', r'''
         #include <emscripten.h>
 
         void afunc(const char *s);
@@ -847,8 +852,7 @@ class RunnerCore(unittest.TestCase):
         }
       ''')
 
-    with open('libc.cpp', 'w') as f:
-      f.write(r'''
+    create_test_file('libc.cpp', r'''
         #include <emscripten.h>
 
         void afunc(const char *s);

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -756,14 +756,12 @@ class RunnerCore(unittest.TestCase):
   # Shared test code between main suite and others
 
   def setup_runtimelink_test(self):
-    header = r'''
+    create_test_file('header.h', r'''
       struct point
       {
         int x, y;
       };
-
-    '''
-    open(os.path.join(self.get_dir(), 'header.h'), 'w').write(header)
+    ''')
 
     supp = r'''
       #include <stdio.h>
@@ -780,8 +778,7 @@ class RunnerCore(unittest.TestCase):
 
       int suppInt = 76;
     '''
-    supp_name = os.path.join(self.get_dir(), 'supp.cpp')
-    create_test_file(supp_name, supp)
+    create_test_file('supp.cpp', supp)
 
     main = r'''
       #include <stdio.h>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -19,7 +19,7 @@ import unittest
 import webbrowser
 import zlib
 
-from runner import BrowserCore, path_from_root, has_browser, EMTEST_BROWSER, no_wasm_backend, flaky
+from runner import BrowserCore, path_from_root, has_browser, EMTEST_BROWSER, no_wasm_backend, flaky, create_test_file
 from tools import system_libs
 from tools.shared import PYTHON, EMCC, WINDOWS, FILE_PACKAGER, PIPE, SPIDERMONKEY_ENGINE, JS_ENGINES
 from tools.shared import try_delete, Building, run_process, run_js
@@ -128,8 +128,8 @@ class browser(BrowserCore):
   def test_zzz_html_source_map(self):
     if not has_browser():
       self.skipTest('need a browser')
-    cpp_file = os.path.join(self.get_dir(), 'src.cpp')
-    html_file = os.path.join(self.get_dir(), 'src.html')
+    cpp_file = 'src.cpp'
+    html_file = 'src.html'
     # browsers will try to 'guess' the corresponding original line if a
     # generated line is unmapped, so if we want to make sure that our
     # numbering is correct, we need to provide a couple of 'possible wrong
@@ -167,8 +167,8 @@ If manually bisecting:
 
   def test_emscripten_log(self):
     # TODO: wasm support for source maps
-    src = os.path.join(self.get_dir(), 'src.cpp')
-    open(src, 'w').write(self.with_report_result(open(path_from_root('tests', 'emscripten_log', 'emscripten_log.cpp')).read()))
+    src = 'src.cpp'
+    create_test_file(src, self.with_report_result(open(path_from_root('tests', 'emscripten_log', 'emscripten_log.cpp')).read()))
 
     run_process([PYTHON, EMCC, src, '--pre-js', path_from_root('src', 'emscripten-source-map.min.js'), '-g', '-o', 'page.html', '-s', 'DEMANGLE_SUPPORT=1', '-s', 'WASM=0'])
     self.run_browser('page.html', None, '/report_result?1')
@@ -202,7 +202,7 @@ If manually bisecting:
     def make_main(path):
       print('make main at', path)
       path = path.replace('\\', '\\\\').replace('"', '\\"') # Escape tricky path name for use inside a C string.
-      open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+      create_test_file('main.cpp', self.with_report_result(r'''
         #include <stdio.h>
         #include <string.h>
         #include <emscripten.h>
@@ -243,7 +243,7 @@ If manually bisecting:
       (srcpath, dstpath) = test
       print('Testing', srcpath, dstpath)
       make_main(dstpath)
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', srcpath, '-o', 'page.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', srcpath, '-o', 'page.html'])
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
     # Test that '--no-heap-copy' works.
     if WINDOWS:
@@ -256,27 +256,27 @@ If manually bisecting:
     open(os.path.join(self.get_dir(), tricky_filename), 'w').write('''load me right before running the code please''')
     make_main(tricky_filename)
     # As an Emscripten-specific feature, the character '@' must be escaped in the form '@@' to not confuse with the 'src@dst' notation.
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', tricky_filename.replace('@', '@@'), '--no-heap-copy', '-o', 'page.html'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', tricky_filename.replace('@', '@@'), '--no-heap-copy', '-o', 'page.html'])
     self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
 
     # By absolute path
 
     make_main('somefile.txt') # absolute becomes relative
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', absolute_src_path, '-o', 'page.html'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', absolute_src_path, '-o', 'page.html'])
     self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
 
     # Test subdirectory handling with asset packaging.
-    try_delete(self.in_dir('assets'))
-    os.makedirs(os.path.join(self.get_dir(), 'assets/sub/asset1/').replace('\\', '/'))
-    os.makedirs(os.path.join(self.get_dir(), 'assets/sub/asset1/.git').replace('\\', '/')) # Test adding directory that shouldn't exist.
-    os.makedirs(os.path.join(self.get_dir(), 'assets/sub/asset2/').replace('\\', '/'))
-    open(os.path.join(self.get_dir(), 'assets/sub/asset1/file1.txt'), 'w').write('''load me right before running the code please''')
-    open(os.path.join(self.get_dir(), 'assets/sub/asset1/.git/shouldnt_be_embedded.txt'), 'w').write('''this file should not get embedded''')
-    open(os.path.join(self.get_dir(), 'assets/sub/asset2/file2.txt'), 'w').write('''load me right before running the code please''')
-    absolute_assets_src_path = os.path.join(self.get_dir(), 'assets').replace('\\', '/')
+    try_delete('assets')
+    os.makedirs('assets/sub/asset1/'.replace('\\', '/'))
+    os.makedirs('assets/sub/asset1/.git'.replace('\\', '/')) # Test adding directory that shouldn't exist.
+    os.makedirs('assets/sub/asset2/'.replace('\\', '/'))
+    create_test_file('assets/sub/asset1/file1.txt', '''load me right before running the code please''')
+    create_test_file('assets/sub/asset1/.git/shouldnt_be_embedded.txt', '''this file should not get embedded''')
+    create_test_file('assets/sub/asset2/file2.txt', '''load me right before running the code please''')
+    absolute_assets_src_path = 'assets'.replace('\\', '/')
 
     def make_main_two_files(path1, path2, nonexistingpath):
-      open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+      create_test_file('main.cpp', self.with_report_result(r'''
         #include <stdio.h>
         #include <string.h>
         #include <emscripten.h>
@@ -318,40 +318,38 @@ If manually bisecting:
       (srcpath, dstpath1, dstpath2, nonexistingpath) = test
       make_main_two_files(dstpath1, dstpath2, nonexistingpath)
       print(srcpath)
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', srcpath, '--exclude-file', '*/.*', '-o', 'page.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', srcpath, '--exclude-file', '*/.*', '-o', 'page.html'])
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
 
     # Should still work with -o subdir/..
 
     make_main('somefile.txt') # absolute becomes relative
     try:
-      os.mkdir(os.path.join(self.get_dir(), 'dirrey'))
+      os.mkdir('dirrey')
     except:
       pass
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', absolute_src_path, '-o', 'dirrey/page.html'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', absolute_src_path, '-o', 'dirrey/page.html'])
     self.run_browser('dirrey/page.html', 'You should see |load me right before|.', '/report_result?1')
 
     # With FS.preloadFile
 
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module.preRun = function() {
         FS.createPreloadedFile('/', 'someotherfile.txt', 'somefile.txt', true, false); // we need --use-preload-plugins for this.
       };
     ''')
     make_main('someotherfile.txt')
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--pre-js', 'pre.js', '-o', 'page.html', '--use-preload-plugins'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js', '-o', 'page.html', '--use-preload-plugins'])
     self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
 
   # Tests that user .html shell files can manually download .data files created with --preload-file cmdline.
   def test_preload_file_with_manual_data_download(self):
-    src = os.path.join(self.get_dir(), 'src.cpp')
-    open(src, 'w').write(self.with_report_result(open(os.path.join(path_from_root('tests/manual_download_data.cpp'))).read()))
+    create_test_file('src.cpp', self.with_report_result(open(os.path.join(path_from_root('tests/manual_download_data.cpp'))).read()))
 
-    data = os.path.join(self.get_dir(), 'file.txt')
-    open(data, 'w').write('''Hello!''')
+    create_test_file('file.txt', '''Hello!''')
 
-    run_process([PYTHON, EMCC, 'src.cpp', '-o', 'manual_download_data.js', '--preload-file', data + '@/file.txt'])
-    shutil.copyfile(path_from_root('tests', 'manual_download_data.html'), os.path.join(self.get_dir(), 'manual_download_data.html'))
+    run_process([PYTHON, EMCC, 'src.cpp', '-o', 'manual_download_data.js', '--preload-file', 'file.txt@/file.txt'])
+    shutil.copyfile(path_from_root('tests', 'manual_download_data.html'), 'manual_download_data.html')
     self.run_browser('manual_download_data.html', 'Hello!', '/report_result?1')
 
   # Tests that if the output files have single or double quotes in them, that it will be handled by correctly escaping the names.
@@ -395,7 +393,7 @@ If manually bisecting:
     self.run_browser(page_file, '|load me right before|.', '/report_result?0')
 
   def test_preload_caching(self):
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+    create_test_file('main.cpp', self.with_report_result(r'''
       #include <stdio.h>
       #include <string.h>
       #include <emscripten.h>
@@ -422,7 +420,7 @@ If manually bisecting:
       }
     ''' % 'somefile.txt'))
 
-    open(os.path.join(self.get_dir(), 'test.js'), 'w').write('''
+    create_test_file('test.js', '''
       mergeInto(LibraryManager.library, {
         checkPreloadResults: function() {
           var cached = 0;
@@ -442,18 +440,18 @@ If manually bisecting:
     # https://cs.chromium.org/chromium/src/content/renderer/indexed_db/webidbdatabase_impl.cc?type=cs&q=%22The+serialized+value+is+too+large%22&sq=package:chromium&g=0&l=177
     # https://cs.chromium.org/chromium/src/out/Debug/gen/third_party/blink/public/mojom/indexeddb/indexeddb.mojom.h?type=cs&sq=package:chromium&g=0&l=60
     for extra_size in (0, 50 * 1024 * 1024, 100 * 1024 * 1024, 150 * 1024 * 1024):
-      open(os.path.join(self.get_dir(), 'somefile.txt'), 'w').write('''load me right before running the code please''' + ('_' * extra_size))
+      create_test_file('somefile.txt', '''load me right before running the code please''' + ('_' * extra_size))
       print(os.path.getsize('somefile.txt'))
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--use-preload-cache', '--js-library', os.path.join(self.get_dir(), 'test.js'), '--preload-file', 'somefile.txt', '-o', 'page.html', '-s', 'ALLOW_MEMORY_GROWTH=1'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--use-preload-cache', '--js-library', 'test.js', '--preload-file', 'somefile.txt', '-o', 'page.html', '-s', 'ALLOW_MEMORY_GROWTH=1'])
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?2')
 
   def test_preload_caching_indexeddb_name(self):
-    open(os.path.join(self.get_dir(), 'somefile.txt'), 'w').write('''load me right before running the code please''')
+    create_test_file('somefile.txt', '''load me right before running the code please''')
 
     def make_main(path):
       print(path)
-      open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+      create_test_file('main.cpp', self.with_report_result(r'''
         #include <stdio.h>
         #include <string.h>
         #include <emscripten.h>
@@ -480,7 +478,7 @@ If manually bisecting:
         }
       ''' % path))
 
-    open(os.path.join(self.get_dir(), 'test.js'), 'w').write('''
+    create_test_file('test.js', '''
       mergeInto(LibraryManager.library, {
         checkPreloadResults: function() {
           var cached = 0;
@@ -496,19 +494,19 @@ If manually bisecting:
     ''')
 
     make_main('somefile.txt')
-    run_process([PYTHON, FILE_PACKAGER, os.path.join(self.get_dir(), 'somefile.data'), '--use-preload-cache', '--indexedDB-name=testdb', '--preload', os.path.join(self.get_dir(), 'somefile.txt'), '--js-output=' + os.path.join(self.get_dir(), 'somefile.js')])
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--js-library', os.path.join(self.get_dir(), 'test.js'), '--pre-js', 'somefile.js', '-o', 'page.html', '-s', 'FORCE_FILESYSTEM=1'])
+    run_process([PYTHON, FILE_PACKAGER, 'somefile.data', '--use-preload-cache', '--indexedDB-name=testdb', '--preload', 'somefile.txt', '--js-output=' + 'somefile.js'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--js-library', 'test.js', '--pre-js', 'somefile.js', '-o', 'page.html', '-s', 'FORCE_FILESYSTEM=1'])
     self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
     self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?2')
 
   def test_multifile(self):
     # a few files inside a directory
     self.clear()
-    os.makedirs(os.path.join(self.get_dir(), 'subdirr'))
-    os.makedirs(os.path.join(self.get_dir(), 'subdirr', 'moar'))
-    open(os.path.join(self.get_dir(), 'subdirr', 'data1.txt'), 'w').write('''1214141516171819''')
-    open(os.path.join(self.get_dir(), 'subdirr', 'moar', 'data2.txt'), 'w').write('''3.14159265358979''')
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+    os.makedirs('subdirr')
+    os.makedirs('subdirr', 'moar')
+    open('subdirr', 'data1.txt', 'w').write('''1214141516171819''')
+    open('subdirr', 'moar', 'data2.txt', 'w').write('''3.14159265358979''')
+    create_test_file('main.cpp', self.with_report_result(r'''
       #include <stdio.h>
       #include <string.h>
       #include <emscripten.h>
@@ -535,25 +533,25 @@ If manually bisecting:
     '''))
 
     # by individual files
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', 'subdirr/data1.txt', '--preload-file', 'subdirr/moar/data2.txt', '-o', 'page.html'])
+    run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', 'subdirr/data1.txt', '--preload-file', 'subdirr/moar/data2.txt', '-o', 'page.html'])
     self.run_browser('page.html', 'You should see two cool numbers', '/report_result?1')
     os.remove('page.html')
 
     # by directory, and remove files to make sure
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--preload-file', 'subdirr', '-o', 'page.html'])
-    shutil.rmtree(os.path.join(self.get_dir(), 'subdirr'))
+    run_process([PYTHON, EMCC, 'main.cpp', '--preload-file', 'subdirr', '-o', 'page.html'])
+    shutil.rmtree('subdirr')
     self.run_browser('page.html', 'You should see two cool numbers', '/report_result?1')
 
   def test_custom_file_package_url(self):
     # a few files inside a directory
     self.clear()
-    os.makedirs(os.path.join(self.get_dir(), 'subdirr'))
-    os.makedirs(os.path.join(self.get_dir(), 'cdn'))
-    open(os.path.join(self.get_dir(), 'subdirr', 'data1.txt'), 'w').write('''1214141516171819''')
+    os.makedirs('subdirr')
+    os.makedirs('cdn')
+    open('subdirr', 'data1.txt', 'w').write('''1214141516171819''')
     # change the file package base dir to look in a "cdn". note that normally you would add this in your own custom html file etc., and not by
     # modifying the existing shell in this manner
-    open(self.in_dir('shell.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+    create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
+    create_test_file('main.cpp', self.with_report_result(r'''
       #include <stdio.h>
       #include <string.h>
       #include <emscripten.h>
@@ -573,7 +571,7 @@ If manually bisecting:
     '''))
 
     def test():
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'shell.html', '--preload-file', 'subdirr/data1.txt', '-o', 'test.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell.html', '--preload-file', 'subdirr/data1.txt', '-o', 'test.html'])
       shutil.move('test.data', os.path.join('cdn', 'test.data'))
       self.run_browser('test.html', '', '/report_result?1')
 
@@ -582,8 +580,8 @@ If manually bisecting:
   def test_missing_data_throws_error(self):
     def setup(assetLocalization):
       self.clear()
-      open(self.in_dir("data.txt"), "w").write('''data''')
-      open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+      create_test_file('data.txt', 'data')
+      create_test_file('main.cpp', self.with_report_result(r'''
         #include <stdio.h>
         #include <string.h>
         #include <emscripten.h>
@@ -593,7 +591,7 @@ If manually bisecting:
           return 0;
         }
       '''))
-      open(os.path.join(self.get_dir(), 'on_window_error_shell.html'), 'w').write(r'''
+      create_test_file('on_window_error_shell.html', r'''
       <html>
           <center><canvas id='canvas' width='256' height='256'></canvas></center>
           <hr><div id='output'></div><hr>
@@ -622,24 +620,24 @@ If manually bisecting:
     def test():
       # test test missing file should run xhr.onload with status different than 200, 304 or 206
       setup("")
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
       shutil.move('test.data', 'missing.data')
       self.run_browser('test.html', '', '/report_result?1')
 
       # test unknown protocol should go through xhr.onerror
       setup("unknown_protocol://")
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
       self.run_browser('test.html', '', '/report_result?1')
 
       # test wrong protocol and port
       setup("https://localhost:8800/")
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
+      run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'on_window_error_shell.html', '--preload-file', 'data.txt', '-o', 'test.html'])
       self.run_browser('test.html', '', '/report_result?1')
 
     test()
 
     # TODO: CORS, test using a full url for locateFile
-    # open(self.in_dir('shell.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path) {return "http:/localhost:8888/cdn/" + path;}, '))
+    # create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path) {return "http:/localhost:8888/cdn/" + path;}, '))
     # test()
 
   def test_sdl_swsurface(self):
@@ -651,75 +649,75 @@ If manually bisecting:
 
   def test_sdl_image(self):
     # load an image file, get pixel data. Also O2 coverage for --preload-file, and memory-init
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpg'))
-    open(os.path.join(self.get_dir(), 'sdl_image.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_image.c')).read()))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpg')
+    create_test_file('sdl_image.c', self.with_report_result(open(path_from_root('tests', 'sdl_image.c')).read()))
 
     for mem in [0, 1]:
       for dest, dirname, basename in [('screenshot.jpg', '/', 'screenshot.jpg'),
                                       ('screenshot.jpg@/assets/screenshot.jpg', '/assets', 'screenshot.jpg')]:
         run_process([
-          PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_image.c'), '-o', 'page.html', '-O2', '-lSDL', '-lGL', '--memory-init-file', str(mem),
+          PYTHON, EMCC, 'sdl_image.c', '-o', 'page.html', '-O2', '-lSDL', '-lGL', '--memory-init-file', str(mem),
           '--preload-file', dest, '-DSCREENSHOT_DIRNAME="' + dirname + '"', '-DSCREENSHOT_BASENAME="' + basename + '"', '--use-preload-plugins'
         ])
         self.run_browser('page.html', '', '/report_result?600')
 
   def test_sdl_image_jpeg(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpeg'))
-    open(os.path.join(self.get_dir(), 'sdl_image_jpeg.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_image.c')).read()))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpeg')
+    create_test_file('sdl_image_jpeg.c', self.with_report_result(open(path_from_root('tests', 'sdl_image.c')).read()))
     run_process([
-      PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_image_jpeg.c'), '-o', 'page.html', '-lSDL', '-lGL',
+      PYTHON, EMCC, 'sdl_image_jpeg.c', '-o', 'page.html', '-lSDL', '-lGL',
       '--preload-file', 'screenshot.jpeg', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"', '--use-preload-plugins'
     ])
     self.run_browser('page.html', '', '/report_result?600')
 
   def test_sdl_image_prepare(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_image_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'], also_proxied=True, manually_trigger_reftest=True)
 
   def test_sdl_image_prepare_data(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_image_prepare_data.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'], manually_trigger_reftest=True)
 
   def test_sdl_image_must_prepare(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpg'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpg')
     self.btest('sdl_image_must_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_stb_image.c', reference='screenshot.jpg', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_bpp(self):
     # load grayscale image without alpha
     self.clear()
-    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp1.png'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp1.png'), 'screenshot.not')
     self.btest('sdl_stb_image.c', reference='sdl-stb-bpp1.png', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load grayscale image with alpha
     self.clear()
-    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp2.png'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp2.png'), 'screenshot.not')
     self.btest('sdl_stb_image.c', reference='sdl-stb-bpp2.png', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load RGB image
     self.clear()
-    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp3.png'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp3.png'), 'screenshot.not')
     self.btest('sdl_stb_image.c', reference='sdl-stb-bpp3.png', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
     # load RGBA image
     self.clear()
-    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp4.png'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'sdl-stb-bpp4.png'), 'screenshot.not')
     self.btest('sdl_stb_image.c', reference='sdl-stb-bpp4.png', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_data(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_stb_image_data.c', reference='screenshot.jpg', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL'])
 
   def test_sdl_stb_image_cleanup(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_stb_image_cleanup.c', expected='0', args=['-s', 'STB_IMAGE=1', '--preload-file', 'screenshot.not', '-lSDL', '-lGL', '--memoryprofiler'])
 
   def test_sdl_canvas(self):
@@ -751,10 +749,10 @@ window.close = function() {
 };
 </script>
 </body>''' % open('reftest.js').read())
-    open('test.html', 'w').write(html)
+    create_test_file('test.html', html)
 
   def test_sdl_canvas_proxy(self):
-    open('data.txt', 'w').write('datum')
+    create_test_file('data.txt', 'datum')
     self.btest('sdl_canvas_proxy.c', reference='sdl_canvas_proxy.png', args=['--proxy-to-worker', '--preload-file', 'data.txt', '-lSDL', '-lGL'], manual_reference=True, post_build=self.post_manual_reftest)
 
   @requires_graphics_hardware
@@ -771,8 +769,8 @@ window.close = function() {
     self.run_browser('test.html?noProxy', None, ['/report_result?0'])
 
     def copy(to, js_mod, html_mod=lambda x: x):
-      open(to + '.html', 'w').write(html_mod(open('test.html').read().replace('test.js', to + '.js')))
-      open(to + '.js', 'w').write(js_mod(open('test.js').read()))
+      create_test_file(to + '.html', html_mod(open('test.html').read().replace('test.js', to + '.js')))
+      create_test_file(to + '.js', js_mod(open('test.js').read()))
 
     # run with noProxy, but make main thread fail
     copy('two', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WEB) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.test_port, original),
@@ -799,7 +797,7 @@ window.close = function() {
   def test_sdl_canvas_alpha(self):
     # N.B. On Linux with Intel integrated graphics cards, this test needs Firefox 49 or newer.
     # See https://github.com/kripken/emscripten/issues/4069.
-    open(os.path.join(self.get_dir(), 'flag_0.js'), 'w').write('''
+    create_test_file('flag_0.js', '''
       Module['arguments'] = ['-0'];
     ''')
 
@@ -817,7 +815,7 @@ window.close = function() {
           ['-DTEST_SLEEP', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'ASSERTIONS=1', '-s', "SAFE_HEAP=1"]
         ]:
           print(delay, defines, emterps)
-          open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+          create_test_file('pre.js', '''
             function keydown(c) {
              %s
               var event = new KeyboardEvent("keydown", { 'keyCode': c, 'charCode': c, 'view': window, 'bubbles': true, 'cancelable': true });
@@ -832,13 +830,13 @@ window.close = function() {
              %s
             }
           ''' % ('setTimeout(function() {' if delay else '', '}, 1);' if delay else '', 'setTimeout(function() {' if delay else '', '}, 1);' if delay else ''))
-          open(os.path.join(self.get_dir(), 'sdl_key.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_key.c')).read()))
+          create_test_file('sdl_key.c', self.with_report_result(open(path_from_root('tests', 'sdl_key.c')).read()))
 
-          run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_key.c'), '-o', 'page.html'] + defines + emterps + ['--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main']''', '-lSDL', '-lGL'])
+          run_process([PYTHON, EMCC, 'sdl_key.c', '-o', 'page.html'] + defines + emterps + ['--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main']''', '-lSDL', '-lGL'])
           self.run_browser('page.html', '', '/report_result?223092870')
 
   def test_sdl_key_proxy(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       var Module = {};
       Module.postRun = function() {
         function doOne() {
@@ -873,7 +871,7 @@ keydown(100);keyup(100); // trigger the end
 
 </script>
 </body>''')
-      open('test.html', 'w').write(html)
+      create_test_file('test.html', html)
 
     self.btest('sdl_key_proxy.c', '223092870', args=['--proxy-to-worker', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']''', '-lSDL', '-lGL'], manual_reference=True, post_build=post)
 
@@ -923,12 +921,12 @@ keydown(100);keyup(100); // trigger the end
 </script>
 </body>''')
 
-      open('test.html', 'w').write(html)
+      create_test_file('test.html', html)
 
     self.btest('keydown_preventdefault_proxy.cpp', '300', args=['--proxy-to-worker', '-s', '''EXPORTED_FUNCTIONS=['_main']'''], manual_reference=True, post_build=post)
 
   def test_sdl_text(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module.postRun = function() {
         function doOne() {
           Module._one();
@@ -942,13 +940,13 @@ keydown(100);keyup(100); // trigger the end
         document.body.dispatchEvent(event);
       }
     ''')
-    open(os.path.join(self.get_dir(), 'sdl_text.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_text.c')).read()))
+    create_test_file('sdl_text.c', self.with_report_result(open(path_from_root('tests', 'sdl_text.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_text.c'), '-o', 'page.html', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']''', '-lSDL', '-lGL'])
+    run_process([PYTHON, EMCC, 'sdl_text.c', '-o', 'page.html', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']''', '-lSDL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?1')
 
   def test_sdl_mouse(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function simulateMouseEvent(x, y, button) {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
@@ -975,13 +973,13 @@ keydown(100);keyup(100); // trigger the end
       }
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
-    open(os.path.join(self.get_dir(), 'sdl_mouse.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_mouse.c')).read()))
+    create_test_file('sdl_mouse.c', self.with_report_result(open(path_from_root('tests', 'sdl_mouse.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_mouse.c'), '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    run_process([PYTHON, EMCC, 'sdl_mouse.c', '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?1')
 
   def test_sdl_mouse_offsets(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function simulateMouseEvent(x, y, button) {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
@@ -1008,7 +1006,7 @@ keydown(100);keyup(100); // trigger the end
       }
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
-    open(os.path.join(self.get_dir(), 'page.html'), 'w').write('''
+    create_test_file('page.html', '''
       <html>
         <head>
           <style type="text/css">
@@ -1053,9 +1051,9 @@ keydown(100);keyup(100); // trigger the end
         </body>
       </html>
     ''')
-    open(os.path.join(self.get_dir(), 'sdl_mouse.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_mouse.c')).read()))
+    create_test_file('sdl_mouse.c', self.with_report_result(open(path_from_root('tests', 'sdl_mouse.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS', '-O2', '--minify', '0', '-o', 'sdl_mouse.js', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    run_process([PYTHON, EMCC, 'sdl_mouse.c', '-DTEST_SDL_MOUSE_OFFSETS', '-O2', '--minify', '0', '-o', 'sdl_mouse.js', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?1')
 
   def test_glut_touchevents(self):
@@ -1078,7 +1076,7 @@ keydown(100);keyup(100); // trigger the end
   def test_sdl_joystick_1(self):
     # Generates events corresponding to the Working Draft of the HTML5 Gamepad API.
     # http://www.w3.org/TR/2012/WD-gamepad-20120529/#gamepad-interface
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       var gamepads = [];
       // Spoof this function.
       navigator['getGamepads'] = function() {
@@ -1106,15 +1104,15 @@ keydown(100);keyup(100); // trigger the end
         gamepads[index].axes[axis] = value;
       };
     ''')
-    open(os.path.join(self.get_dir(), 'sdl_joystick.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_joystick.c')).read()))
+    create_test_file('sdl_joystick.c', self.with_report_result(open(path_from_root('tests', 'sdl_joystick.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_joystick.c'), '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    run_process([PYTHON, EMCC, 'sdl_joystick.c', '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?2')
 
   def test_sdl_joystick_2(self):
     # Generates events corresponding to the Editor's Draft of the HTML5 Gamepad API.
     # https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#idl-def-Gamepad
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       var gamepads = [];
       // Spoof this function.
       navigator['getGamepads'] = function() {
@@ -1146,16 +1144,16 @@ keydown(100);keyup(100); // trigger the end
         gamepads[index].axes[axis] = value;
       };
     ''')
-    open(os.path.join(self.get_dir(), 'sdl_joystick.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_joystick.c')).read()))
+    create_test_file('sdl_joystick.c', self.with_report_result(open(path_from_root('tests', 'sdl_joystick.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_joystick.c'), '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    run_process([PYTHON, EMCC, 'sdl_joystick.c', '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lSDL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?2')
 
   @requires_graphics_hardware
   def test_glfw_joystick(self):
     # Generates events corresponding to the Editor's Draft of the HTML5 Gamepad API.
     # https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#idl-def-Gamepad
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       var gamepads = [];
       // Spoof this function.
       navigator['getGamepads'] = function() {
@@ -1193,9 +1191,9 @@ keydown(100);keyup(100); // trigger the end
         gamepads[index].axes[axis] = value;
       };
     ''')
-    open(os.path.join(self.get_dir(), 'test_glfw_joystick.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'test_glfw_joystick.c')).read()))
+    create_test_file('test_glfw_joystick.c', self.with_report_result(open(path_from_root('tests', 'test_glfw_joystick.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'test_glfw_joystick.c'), '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lGL', '-lglfw3', '-s', 'USE_GLFW=3'])
+    run_process([PYTHON, EMCC, 'test_glfw_joystick.c', '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-lGL', '-lglfw3', '-s', 'USE_GLFW=3'])
     self.run_browser('page.html', '', '/report_result?2')
 
   @requires_graphics_hardware
@@ -1203,7 +1201,7 @@ keydown(100);keyup(100); // trigger the end
     # Javascript code to check the attributes support we want to test in the WebGL implementation
     # (request the attribute, create a context and check its value afterwards in the context attributes).
     # Tests will succeed when an attribute is not supported.
-    open(os.path.join(self.get_dir(), 'check_webgl_attributes_support.js'), 'w').write('''
+    create_test_file('check_webgl_attributes_support.js', '''
       mergeInto(LibraryManager.library, {
         webglAntialiasSupported: function() {
           canvas = document.createElement('canvas');
@@ -1264,12 +1262,12 @@ keydown(100);keyup(100); // trigger the end
 
   def test_file_db(self):
     secret = str(time.time())
-    open('moar.txt', 'w').write(secret)
+    create_test_file('moar.txt', secret)
     self.btest('file_db.cpp', '1', args=['--preload-file', 'moar.txt', '-DFIRST'])
     shutil.copyfile('test.html', 'first.html')
     self.btest('file_db.cpp', secret, args=['-s', 'FORCE_FILESYSTEM=1'])
     shutil.copyfile('test.html', 'second.html')
-    open('moar.txt', 'w').write('aliantha')
+    create_test_file('moar.txt', 'aliantha')
     self.btest('file_db.cpp', secret, args=['--preload-file', 'moar.txt']) # even with a file there, we load over it
     shutil.move('test.html', 'third.html')
 
@@ -1282,7 +1280,7 @@ keydown(100);keyup(100); // trigger the end
 
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module.preRun = function() {
         addRunDependency('syncfs');
 
@@ -1310,7 +1308,7 @@ keydown(100);keyup(100); // trigger the end
   def test_fs_workerfs_read(self):
     secret = 'a' * 10
     secret2 = 'b' * 10
-    open(self.in_dir('pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       var Module = {};
       Module.preRun = function() {
         var blob = new Blob(['%s']);
@@ -1325,7 +1323,7 @@ keydown(100);keyup(100); // trigger the end
     self.btest(path_from_root('tests', 'fs', 'test_workerfs_read.c'), '1', force_c=True, args=['-lworkerfs.js', '--pre-js', 'pre.js', '-DSECRET=\"' + secret + '\"', '-DSECRET2=\"' + secret2 + '\"', '--proxy-to-worker'])
 
   def test_fs_workerfs_package(self):
-    open('file1.txt', 'w').write('first')
+    create_test_file('file1.txt', 'first')
     if not os.path.exists('sub'):
       os.makedirs('sub')
     open(os.path.join('sub', 'file2.txt'), 'w').write('second')
@@ -1336,7 +1334,7 @@ keydown(100);keyup(100); // trigger the end
     # generate data
     self.clear()
     os.mkdir('subdir')
-    open('file1.txt', 'w').write('0123456789' * (1024 * 128))
+    create_test_file('file1.txt', '0123456789' * (1024 * 128))
     open(os.path.join('subdir', 'file2.txt'), 'w').write('1234567890' * (1024 * 128))
     random_data = bytearray(random.randint(0, 255) for x in range(1024 * 128 * 10 + 1))
     random_data[17] = ord('X')
@@ -1383,7 +1381,7 @@ keydown(100);keyup(100); // trigger the end
     # see issue #6654 - we need to handle separate-metadata both when we run before
     # the main program, and when we are run later
 
-    open('data.dat', 'w').write(' ')
+    create_test_file('data.dat', ' ')
     run_process([PYTHON, FILE_PACKAGER, 'more.data', '--preload', 'data.dat', '--separate-metadata', '--js-output=more.js'])
     self.btest(os.path.join('browser', 'separate_metadata_later.cpp'), '1', args=['-s', 'FORCE_FILESYSTEM=1'])
 
@@ -1410,7 +1408,7 @@ keydown(100);keyup(100); // trigger the end
 
   def test_sdl_pumpevents(self):
     # key events should be detected using SDL_PumpEvents
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function keydown(c) {
         var event = new KeyboardEvent("keydown", { 'keyCode': c, 'charCode': c, 'view': window, 'bubbles': true, 'cancelable': true });
         document.dispatchEvent(event);
@@ -1426,8 +1424,8 @@ keydown(100);keyup(100); // trigger the end
   @requires_graphics_hardware
   def test_sdl_gl_read(self):
     # SDL, OpenGL, readPixels
-    open(os.path.join(self.get_dir(), 'sdl_gl_read.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_gl_read.c')).read()))
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl_gl_read.c'), '-o', 'something.html', '-lSDL', '-lGL'])
+    create_test_file('sdl_gl_read.c', self.with_report_result(open(path_from_root('tests', 'sdl_gl_read.c')).read()))
+    run_process([PYTHON, EMCC, 'sdl_gl_read.c', '-o', 'something.html', '-lSDL', '-lGL'])
     self.run_browser('something.html', '.', '/report_result?1')
 
   @requires_graphics_hardware
@@ -1437,14 +1435,14 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_sdl_ogl(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_ogl.c', reference='screenshot-gray-purple.png', reference_slack=1,
                args=['-O2', '--minify', '0', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with gray at the top.')
 
   @requires_graphics_hardware
   def test_sdl_ogl_defaultmatrixmode(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_ogl_defaultMatrixMode.c', reference='screenshot-gray-purple.png', reference_slack=1,
                args=['--minify', '0', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with gray at the top.')
@@ -1452,48 +1450,48 @@ keydown(100);keyup(100); // trigger the end
   @requires_graphics_hardware
   def test_sdl_ogl_p(self):
     # Immediate mode with pointers
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_ogl_p.c', reference='screenshot-gray.png', reference_slack=1,
                args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with gray at the top.')
 
   @requires_graphics_hardware
   def test_sdl_ogl_proc_alias(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_ogl_proc_alias.c', reference='screenshot-gray-purple.png', reference_slack=1,
                args=['-O2', '-g2', '-s', 'INLINING_LIMIT=1', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'])
 
   @requires_graphics_hardware
   def test_sdl_fog_simple(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_fog_simple.c', reference='screenshot-fog-simple.png',
                args=['-O2', '--minify', '0', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl_fog_negative(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_fog_negative.c', reference='screenshot-fog-negative.png',
                args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl_fog_density(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_fog_density.c', reference='screenshot-fog-density.png',
                args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl_fog_exp2(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_fog_exp2.c', reference='screenshot-fog-exp2.png',
                args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl_fog_linear(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_fog_linear.c', reference='screenshot-fog-linear.png', reference_slack=1,
                args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins', '-lSDL', '-lGL'],
                message='You should see an image with fog.')
@@ -1512,20 +1510,20 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_egl(self):
-    open(os.path.join(self.get_dir(), 'test_egl.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'test_egl.c')).read()))
+    create_test_file('test_egl.c', self.with_report_result(open(path_from_root('tests', 'test_egl.c')).read()))
 
-    run_process([PYTHON, EMCC, '-O2', os.path.join(self.get_dir(), 'test_egl.c'), '-o', 'page.html', '-lEGL', '-lGL'])
+    run_process([PYTHON, EMCC, '-O2', 'test_egl.c', '-o', 'page.html', '-lEGL', '-lGL'])
     self.run_browser('page.html', '', '/report_result?1')
 
   def test_egl_width_height(self):
-    open(os.path.join(self.get_dir(), 'test_egl_width_height.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'test_egl_width_height.c')).read()))
+    create_test_file('test_egl_width_height.c', self.with_report_result(open(path_from_root('tests', 'test_egl_width_height.c')).read()))
 
-    run_process([PYTHON, EMCC, '-O2', os.path.join(self.get_dir(), 'test_egl_width_height.c'), '-o', 'page.html', '-lEGL', '-lGL'])
+    run_process([PYTHON, EMCC, '-O2', 'test_egl_width_height.c', '-o', 'page.html', '-lEGL', '-lGL'])
     self.run_browser('page.html', 'Should print "(300, 150)" -- the size of the canvas in pixels', '/report_result?1')
 
   def do_test_worker(self, args=[]):
     # Test running in a web worker
-    open('file.dat', 'w').write('data for worker')
+    create_test_file('file.dat', 'data for worker')
     html_file = open('main.html', 'w')
     html_file.write('''
       <html>
@@ -1685,11 +1683,11 @@ keydown(100);keyup(100); // trigger the end
       basename = os.path.basename(program)
       args = ['-lGL', '-lEGL', '-lX11']
       if basename == 'CH10_MultiTexture.bc':
-        shutil.copyfile(book_path('Chapter_10', 'MultiTexture', 'basemap.tga'), os.path.join(self.get_dir(), 'basemap.tga'))
-        shutil.copyfile(book_path('Chapter_10', 'MultiTexture', 'lightmap.tga'), os.path.join(self.get_dir(), 'lightmap.tga'))
+        shutil.copyfile(book_path('Chapter_10', 'MultiTexture', 'basemap.tga'), 'basemap.tga')
+        shutil.copyfile(book_path('Chapter_10', 'MultiTexture', 'lightmap.tga'), 'lightmap.tga')
         args += ['--preload-file', 'basemap.tga', '--preload-file', 'lightmap.tga']
       elif basename == 'CH13_ParticleSystem.bc':
-        shutil.copyfile(book_path('Chapter_13', 'ParticleSystem', 'smoke.tga'), os.path.join(self.get_dir(), 'smoke.tga'))
+        shutil.copyfile(book_path('Chapter_13', 'ParticleSystem', 'smoke.tga'), 'smoke.tga')
         args += ['--preload-file', 'smoke.tga', '-O2'] # test optimizations and closure here as well for more coverage
 
       self.btest(program,
@@ -1699,9 +1697,9 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_gles2_emulation(self):
-    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_10', 'MultiTexture', 'basemap.tga'), self.in_dir('basemap.tga'))
-    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_10', 'MultiTexture', 'lightmap.tga'), self.in_dir('lightmap.tga'))
-    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_13', 'ParticleSystem', 'smoke.tga'), self.in_dir('smoke.tga'))
+    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_10', 'MultiTexture', 'basemap.tga'), 'basemap.tga')
+    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_10', 'MultiTexture', 'lightmap.tga'), 'lightmap.tga')
+    shutil.copyfile(path_from_root('tests', 'glbook', 'Chapter_13', 'ParticleSystem', 'smoke.tga'), 'smoke.tga')
 
     for source, reference in [
       (os.path.join('glbook', 'Chapter_2', 'Hello_Triangle', 'Hello_Triangle_orig.c'), path_from_root('tests', 'glbook', 'CH02_HelloTriangle.png')),
@@ -1735,11 +1733,11 @@ keydown(100);keyup(100); // trigger the end
 
   def test_emscripten_api2(self):
     def setup():
-      open('script1.js', 'w').write('''
+      create_test_file('script1.js', '''
         Module._set(456);
       ''')
-      open('file1.txt', 'w').write('first')
-      open('file2.txt', 'w').write('second')
+      create_test_file('file1.txt', 'first')
+      create_test_file('file2.txt', 'second')
 
     setup()
     run_process([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'file1.txt', 'file2.txt'], stdout=open('script2.js', 'w'))
@@ -1757,7 +1755,7 @@ keydown(100);keyup(100); // trigger the end
     self.btest('emscripten_api_browser_infloop.cpp', '7')
 
   def test_emscripten_fs_api(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png')) # preloaded *after* run
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png') # preloaded *after* run
     self.btest('emscripten_fs_api_browser.cpp', '1', args=['-lSDL'])
 
   def test_emscripten_fs_api2(self):
@@ -1827,23 +1825,23 @@ keydown(100);keyup(100); // trigger the end
   @requires_graphics_hardware
   def test_gl_ps(self):
     # pointers and a shader
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('gl_ps.c', reference='gl_ps.png', args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
 
   @requires_graphics_hardware
   def test_gl_ps_packed(self):
     # packed data that needs to be strided
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('gl_ps_packed.c', reference='gl_ps.png', args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1)
 
   @requires_graphics_hardware
   def test_gl_ps_strides(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('gl_ps_strides.c', reference='gl_ps_strides.png', args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_gl_ps_worker(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('gl_ps_worker.c', reference='gl_ps.png', args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL', '--use-preload-plugins'], reference_slack=1, also_proxied=True)
 
   @requires_graphics_hardware
@@ -1900,7 +1898,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_cubegeom_proc(self):
-    open('side.c', 'w').write(r'''
+    create_test_file('side.c', r'''
 
 extern void* SDL_GL_GetProcAddress(const char *);
 
@@ -2013,28 +2011,28 @@ void *getBindBuffer() {
     self.btest('sdl_create_rgb_surface_from.c', args=['-lSDL', '-lGL'], reference='sdl_create_rgb_surface_from.png')
 
   def test_sdl_rotozoom(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl_rotozoom.c', reference='sdl_rotozoom.png', args=['--preload-file', 'screenshot.png', '--use-preload-plugins', '-lSDL', '-lGL'], reference_slack=3)
 
   def test_sdl_gfx_primitives(self):
     self.btest('sdl_gfx_primitives.c', args=['-lSDL', '-lGL'], reference='sdl_gfx_primitives.png', reference_slack=1)
 
   def test_sdl_canvas_palette_2(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module['preRun'].push(function() {
         SDL.defaults.copyOnLock = false;
       });
     ''')
 
-    open(os.path.join(self.get_dir(), 'args-r.js'), 'w').write('''
+    create_test_file('args-r.js', '''
       Module['arguments'] = ['-r'];
     ''')
 
-    open(os.path.join(self.get_dir(), 'args-g.js'), 'w').write('''
+    create_test_file('args-g.js', '''
       Module['arguments'] = ['-g'];
     ''')
 
-    open(os.path.join(self.get_dir(), 'args-b.js'), 'w').write('''
+    create_test_file('args-b.js', '''
       Module['arguments'] = ['-b'];
     ''')
 
@@ -2056,17 +2054,17 @@ void *getBindBuffer() {
 
   @requires_graphics_hardware
   def test_glbegin_points(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('glbegin_points.c', reference='glbegin_points.png', args=['--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL', '--use-preload-plugins'])
 
   @requires_graphics_hardware
   def test_s3tc(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.dds'), os.path.join(self.get_dir(), 'screenshot.dds'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.dds'), 'screenshot.dds')
     self.btest('s3tc.c', reference='s3tc.png', args=['--preload-file', 'screenshot.dds', '-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   def test_s3tc_ffp_only(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.dds'), os.path.join(self.get_dir(), 'screenshot.dds'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.dds'), 'screenshot.dds')
     self.btest('s3tc.c', reference='s3tc.png', args=['--preload-file', 'screenshot.dds', '-s', 'LEGACY_GL_EMULATION=1', '-s', 'GL_FFP_ONLY=1', '-lGL', '-lSDL'])
 
   @no_chrome('see #7117')
@@ -2114,13 +2112,13 @@ void *getBindBuffer() {
     for wasm in [0, 1]:
       print(wasm)
       main, supp = self.setup_runtimelink_test()
-      open('supp.cpp', 'w').write(supp)
+      create_test_file('supp.cpp', supp)
       run_process([PYTHON, EMCC, 'supp.cpp', '-o', 'supp.' + ('wasm' if wasm else 'js'), '-s', 'SIDE_MODULE=1', '-O2', '-s', 'WASM=%d' % wasm, '-s', 'EXPORT_ALL=1'])
       self.btest(main, args=['-DBROWSER=1', '-s', 'MAIN_MODULE=1', '-O2', '-s', 'WASM=%d' % wasm, '-s', 'RUNTIME_LINKED_LIBS=["supp.' + ('wasm' if wasm else 'js') + '"]', '-s', 'EXPORT_ALL=1'], expected='76')
 
   def test_pre_run_deps(self):
     # Adding a dependency in preRun will delay run
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module.preRun = function() {
         addRunDependency();
         out('preRun called, added a dependency...');
@@ -2135,7 +2133,7 @@ void *getBindBuffer() {
       self.btest('pre_run_deps.cpp', expected='10', args=['--pre-js', 'pre.js', '--memory-init-file', str(mem)])
 
   def test_mem_init(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function myJSCallback() { // called from main()
         Module._note(1);
       }
@@ -2145,7 +2143,7 @@ void *getBindBuffer() {
         });
       };
     ''')
-    open(os.path.join(self.get_dir(), 'post.js'), 'w').write('''
+    create_test_file('post.js', '''
       var assert = function(check, text) {
         if (!check) {
           var xhr = new XMLHttpRequest();
@@ -2167,7 +2165,7 @@ void *getBindBuffer() {
   def test_mem_init_request(self):
     def test(what, status):
       print(what, status)
-      open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+      create_test_file('pre.js', '''
         var xhr = Module.memoryInitializerRequest = new XMLHttpRequest();
         xhr.open('GET', "''' + what + '''", true);
         xhr.responseType = 'arraybuffer';
@@ -2260,7 +2258,7 @@ void *getBindBuffer() {
       }, 1000);
     ''' % self.test_port
 
-    open('pre_runtime.js', 'w').write(r'''
+    create_test_file('pre_runtime.js', r'''
       Module.onRuntimeInitialized = function(){
         myJSCallback();
       };
@@ -2273,13 +2271,13 @@ void *getBindBuffer() {
       for mode in [[], ['-s', 'WASM=1']]:
         print('\n', filename, extra_args, mode)
         print('mem init, so async, call too early')
-        open(os.path.join(self.get_dir(), 'post.js'), 'w').write(post_prep + post_test + post_hook)
+        create_test_file('post.js', post_prep + post_test + post_hook)
         self.btest(filename, expected='600', args=['--post-js', 'post.js', '--memory-init-file', '1', '-s', 'EXIT_RUNTIME=1'] + extra_args + mode)
         print('sync startup, call too late')
-        open(os.path.join(self.get_dir(), 'post.js'), 'w').write(post_prep + 'Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
+        create_test_file('post.js', post_prep + 'Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
         self.btest(filename, expected=str(second_code), args=['--post-js', 'post.js', '--memory-init-file', '0', '-s', 'EXIT_RUNTIME=1'] + extra_args + mode)
         print('sync, runtime still alive, so all good')
-        open(os.path.join(self.get_dir(), 'post.js'), 'w').write(post_prep + 'expected_ok = true; Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
+        create_test_file('post.js', post_prep + 'expected_ok = true; Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
         self.btest(filename, expected='606', args=['--post-js', 'post.js', '--memory-init-file', '0'] + extra_args + mode)
 
   def test_cwrap_early(self):
@@ -2311,7 +2309,7 @@ void *getBindBuffer() {
     self.btest('browser_main.cpp', args=['-O2', '-s', 'MAIN_MODULE=1', '-s', 'DLOPEN_SUPPORT=1', '-s', 'EXPORT_ALL=1'], expected='8')
 
   def test_preload_module(self):
-    open('library.c', 'w').write(r'''
+    create_test_file('library.c', r'''
       #include <stdio.h>
       int library_func() {
         return 42;
@@ -2352,7 +2350,7 @@ void *getBindBuffer() {
       expected='0')
 
   def test_mmap_file(self):
-    open(self.in_dir('data.dat'), 'w').write('data from the file ' + ('.' * 9000))
+    create_test_file('data.dat', 'data from the file ' + ('.' * 9000))
     for extra_args in [[], ['--no-heap-copy']]:
       self.btest(path_from_root('tests', 'mmap_file.c'), expected='1', args=['--preload-file', 'data.dat'] + extra_args)
 
@@ -2447,7 +2445,7 @@ void *getBindBuffer() {
     self.btest(path_from_root('tests', 'glew.c'), args=['-lGL', '-lSDL', '-lGLEW', '-s', 'LEGACY_GL_EMULATION=1', '-DGLEW_MX'], expected='1')
 
   def test_doublestart_bug(self):
-    open('pre.js', 'w').write(r'''
+    create_test_file('pre.js', r'''
 if (!Module['preRun']) Module['preRun'] = [];
 Module["preRun"].push(function () {
   addRunDependency('test_run_dependency');
@@ -2558,7 +2556,7 @@ Module["preRun"].push(function () {
       self.btest(path_from_root('tests', 'codemods.cpp'), expected='1', args=opts + ['-s', 'PRECISE_F32=2', '--separate-asm']) # empty polyfill, but browser has support, so semantics are like float
 
   def test_wget(self):
-    with open(os.path.join(self.get_dir(), 'test.txt'), 'w') as f:
+    with open('test.txt', 'w') as f:
       f.write('emscripten')
     self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1'])
     print('asyncify+emterpreter')
@@ -2567,7 +2565,7 @@ Module["preRun"].push(function () {
     self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
 
   def test_wget_data(self):
-    with open(os.path.join(self.get_dir(), 'test.txt'), 'w') as f:
+    with open('test.txt', 'w') as f:
       f.write('emscripten')
     self.btest(path_from_root('tests', 'test_wget_data.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-O2', '-g2'])
     self.btest(path_from_root('tests', 'test_wget_data.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-O2', '-g2', '-s', 'ASSERTIONS=1'])
@@ -2576,7 +2574,7 @@ Module["preRun"].push(function () {
     for wasm in [0, 1]:
       print('wasm', wasm)
       self.clear()
-      open('src.cpp', 'w').write(self.with_report_result(r'''
+      create_test_file('src.cpp', self.with_report_result(r'''
         #include <stdio.h>
         #include <string.h>
         #include <assert.h>
@@ -2594,8 +2592,8 @@ Module["preRun"].push(function () {
           return 0;
         }
       '''))
-      open('data.txt', 'w').write('load me right before...')
-      open('pre.js', 'w').write('Module.locateFile = function(x) { return "sub/" + x };')
+      create_test_file('data.txt', 'load me right before...')
+      create_test_file('pre.js', 'Module.locateFile = function(x) { return "sub/" + x };')
       run_process([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data.txt'], stdout=open('data.js', 'w'))
       # put pre.js first, then the file packager data, so locateFile is there for the file loading code
       run_process([PYTHON, EMCC, 'src.cpp', '-O2', '-g', '--pre-js', 'pre.js', '--pre-js', 'data.js', '-o', 'page.html', '-s', 'FORCE_FILESYSTEM=1', '-s', 'WASM=' + str(wasm)])
@@ -2610,7 +2608,7 @@ Module["preRun"].push(function () {
       # alternatively, put locateFile in the HTML
       print('in html')
 
-      open('shell.html', 'w').write('''
+      create_test_file('shell.html', '''
         <body>
           <script>
             var Module = {
@@ -2634,7 +2632,7 @@ Module["preRun"].push(function () {
 
       # verify that the mem init request succeeded in the latter case
       if not wasm:
-        open('src.cpp', 'w').write(self.with_report_result(r'''
+        create_test_file('src.cpp', self.with_report_result(r'''
   #include <stdio.h>
   #include <emscripten.h>
 
@@ -2663,7 +2661,7 @@ Module["preRun"].push(function () {
 
   def test_asm_swapping(self):
     self.clear()
-    open('run.js', 'w').write(r'''
+    create_test_file('run.js', r'''
 Module['onRuntimeInitialized'] = function() {
   // test proper initial result
   var result = Module._func();
@@ -2691,7 +2689,7 @@ Module['onRuntimeInitialized'] = function() {
     for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2']]:
       print(opts)
       opts += ['-s', 'WASM=0', '--pre-js', 'run.js', '-s', 'SWAPPABLE_ASM_MODULE=1'] # important that both modules are built with the same opts
-      open('second.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'asm_swap2.cpp')).read()))
+      create_test_file('second.cpp', self.with_report_result(open(path_from_root('tests', 'asm_swap2.cpp')).read()))
       run_process([PYTHON, EMCC, 'second.cpp'] + opts)
       run_process([PYTHON, path_from_root('tools', 'distill_asm.py'), 'a.out.js', 'second.js', 'swap-in'])
       assert os.path.exists('second.js')
@@ -2706,35 +2704,35 @@ Module['onRuntimeInitialized'] = function() {
 
   def test_sdl2_image(self):
     # load an image file, get pixel data. Also O2 coverage for --preload-file, and memory-init
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpg'))
-    open(os.path.join(self.get_dir(), 'sdl2_image.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_image.c')).read()))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpg')
+    create_test_file('sdl2_image.c', self.with_report_result(open(path_from_root('tests', 'sdl2_image.c')).read()))
 
     for mem in [0, 1]:
       for dest, dirname, basename in [('screenshot.jpg', '/', 'screenshot.jpg'),
                                       ('screenshot.jpg@/assets/screenshot.jpg', '/assets', 'screenshot.jpg')]:
         run_process([
-          PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_image.c'), '-o', 'page.html', '-O2', '--memory-init-file', str(mem),
+          PYTHON, EMCC, 'sdl2_image.c', '-o', 'page.html', '-O2', '--memory-init-file', str(mem),
           '--preload-file', dest, '-DSCREENSHOT_DIRNAME="' + dirname + '"', '-DSCREENSHOT_BASENAME="' + basename + '"', '-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--use-preload-plugins'
         ])
         self.run_browser('page.html', '', '/report_result?600')
 
   def test_sdl2_image_jpeg(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpeg'))
-    open(os.path.join(self.get_dir(), 'sdl2_image_jpeg.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_image.c')).read()))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpeg')
+    create_test_file('sdl2_image_jpeg.c', self.with_report_result(open(path_from_root('tests', 'sdl2_image.c')).read()))
     run_process([
-      PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_image_jpeg.c'), '-o', 'page.html',
+      PYTHON, EMCC, 'sdl2_image_jpeg.c', '-o', 'page.html',
       '--preload-file', 'screenshot.jpeg', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"', '-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--use-preload-plugins'
     ])
     self.run_browser('page.html', '', '/report_result?600')
 
   def test_sdl2_image_formats(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_image.c', expected='512', args=['--preload-file', 'screenshot.png', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.png"',
                                                      '-DNO_PRELOADED', '-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
 
   def test_sdl2_key(self):
     for defines in [[]]:
-      open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+      create_test_file('pre.js', '''
         Module.postRun = function() {
           function doOne() {
             Module._one();
@@ -2759,13 +2757,13 @@ Module['onRuntimeInitialized'] = function() {
           document.dispatchEvent(event);
         }
       ''')
-      open(os.path.join(self.get_dir(), 'sdl2_key.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_key.c')).read()))
+      create_test_file('sdl2_key.c', self.with_report_result(open(path_from_root('tests', 'sdl2_key.c')).read()))
 
-      run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_key.c'), '-o', 'page.html'] + defines + ['-s', 'USE_SDL=2', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']'''])
+      run_process([PYTHON, EMCC, 'sdl2_key.c', '-o', 'page.html'] + defines + ['-s', 'USE_SDL=2', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']'''])
       self.run_browser('page.html', '', '/report_result?37182145')
 
   def test_sdl2_text(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module.postRun = function() {
         function doOne() {
           Module._one();
@@ -2779,14 +2777,14 @@ Module['onRuntimeInitialized'] = function() {
         document.body.dispatchEvent(event);
       }
     ''')
-    open(os.path.join(self.get_dir(), 'sdl2_text.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_text.c')).read()))
+    create_test_file('sdl2_text.c', self.with_report_result(open(path_from_root('tests', 'sdl2_text.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_text.c'), '-o', 'page.html', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']''', '-s', 'USE_SDL=2'])
+    run_process([PYTHON, EMCC, 'sdl2_text.c', '-o', 'page.html', '--pre-js', 'pre.js', '-s', '''EXPORTED_FUNCTIONS=['_main', '_one']''', '-s', 'USE_SDL=2'])
     self.run_browser('page.html', '', '/report_result?1')
 
   @flaky
   def test_sdl2_mouse(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function simulateMouseEvent(x, y, button) {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
@@ -2813,13 +2811,13 @@ Module['onRuntimeInitialized'] = function() {
       }
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
-    open(os.path.join(self.get_dir(), 'sdl2_mouse.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_mouse.c')).read()))
+    create_test_file('sdl2_mouse.c', self.with_report_result(open(path_from_root('tests', 'sdl2_mouse.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_mouse.c'), '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-s', 'USE_SDL=2'])
+    run_process([PYTHON, EMCC, 'sdl2_mouse.c', '-O2', '--minify', '0', '-o', 'page.html', '--pre-js', 'pre.js', '-s', 'USE_SDL=2'])
     self.run_browser('page.html', '', '/report_result?1', timeout=30)
 
   def test_sdl2_mouse_offsets(self):
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function simulateMouseEvent(x, y, button) {
         var event = document.createEvent("MouseEvents");
         if (button >= 0) {
@@ -2846,7 +2844,7 @@ Module['onRuntimeInitialized'] = function() {
       }
       window['simulateMouseEvent'] = simulateMouseEvent;
     ''')
-    open(os.path.join(self.get_dir(), 'page.html'), 'w').write('''
+    create_test_file('page.html', '''
       <html>
         <head>
           <style type="text/css">
@@ -2891,9 +2889,9 @@ Module['onRuntimeInitialized'] = function() {
         </body>
       </html>
     ''')
-    open(os.path.join(self.get_dir(), 'sdl2_mouse.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_mouse.c')).read()))
+    create_test_file('sdl2_mouse.c', self.with_report_result(open(path_from_root('tests', 'sdl2_mouse.c')).read()))
 
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_mouse.c'), '-DTEST_SDL_MOUSE_OFFSETS=1', '-O2', '--minify', '0', '-o', 'sdl2_mouse.js', '--pre-js', 'pre.js', '-s', 'USE_SDL=2'])
+    run_process([PYTHON, EMCC, 'sdl2_mouse.c', '-DTEST_SDL_MOUSE_OFFSETS=1', '-O2', '--minify', '0', '-o', 'sdl2_mouse.js', '--pre-js', 'pre.js', '-s', 'USE_SDL=2'])
     self.run_browser('page.html', '', '/report_result?1')
 
   @requires_graphics_hardware
@@ -2914,15 +2912,15 @@ Module['onRuntimeInitialized'] = function() {
     self.btest('sdl2_gfx.cpp', args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_GFX=2'], reference='sdl2_gfx.png', reference_slack=2)
 
   def test_sdl2_canvas_palette_2(self):
-    open(os.path.join(self.get_dir(), 'args-r.js'), 'w').write('''
+    create_test_file('args-r.js', '''
       Module['arguments'] = ['-r'];
     ''')
 
-    open(os.path.join(self.get_dir(), 'args-g.js'), 'w').write('''
+    create_test_file('args-g.js', '''
       Module['arguments'] = ['-g'];
     ''')
 
-    open(os.path.join(self.get_dir(), 'args-b.js'), 'w').write('''
+    create_test_file('args-b.js', '''
       Module['arguments'] = ['-b'];
     ''')
 
@@ -2935,12 +2933,12 @@ Module['onRuntimeInitialized'] = function() {
 
   def test_sdl2_image_prepare(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl2_image_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'], manually_trigger_reftest=True)
 
   def test_sdl2_image_prepare_data(self):
     # load an image file, get pixel data.
-    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.not'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.not')
     self.btest('sdl2_image_prepare_data.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'], manually_trigger_reftest=True)
 
   @requires_graphics_hardware
@@ -2963,15 +2961,15 @@ window.close = function() {
 };
 </script>
 </body>''' % open('reftest.js').read())
-      open('test.html', 'w').write(html)
+      create_test_file('test.html', html)
 
-    open('data.txt', 'w').write('datum')
+    create_test_file('data.txt', 'datum')
 
     self.btest('sdl2_canvas_proxy.c', reference='sdl2_canvas.png', args=['-s', 'USE_SDL=2', '--proxy-to-worker', '--preload-file', 'data.txt', '-s', 'GL_TESTING=1'], manual_reference=True, post_build=post)
 
   def test_sdl2_pumpevents(self):
     # key events should be detected using SDL_PumpEvents
-    open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       function keydown(c) {
         var event = new KeyboardEvent("keydown", { 'keyCode': c, 'charCode': c, 'view': window, 'bubbles': true, 'cancelable': true });
         document.dispatchEvent(event);
@@ -2988,41 +2986,41 @@ window.close = function() {
   @requires_graphics_hardware
   def test_sdl2_gl_read(self):
     # SDL, OpenGL, readPixels
-    open(os.path.join(self.get_dir(), 'sdl2_gl_read.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_gl_read.c')).read()))
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'sdl2_gl_read.c'), '-o', 'something.html', '-s', 'USE_SDL=2'])
+    create_test_file('sdl2_gl_read.c', self.with_report_result(open(path_from_root('tests', 'sdl2_gl_read.c')).read()))
+    run_process([PYTHON, EMCC, 'sdl2_gl_read.c', '-o', 'something.html', '-s', 'USE_SDL=2'])
     self.run_browser('something.html', '.', '/report_result?1')
 
   @requires_graphics_hardware
   def test_sdl2_fog_simple(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_fog_simple.c', reference='screenshot-fog-simple.png',
                args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-O2', '--minify', '0', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl2_fog_negative(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_fog_negative.c', reference='screenshot-fog-negative.png',
                args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl2_fog_density(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_fog_density.c', reference='screenshot-fog-density.png',
                args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl2_fog_exp2(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_fog_exp2.c', reference='screenshot-fog-exp2.png',
                args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins'],
                message='You should see an image with fog.')
 
   @requires_graphics_hardware
   def test_sdl2_fog_linear(self):
-    shutil.copyfile(path_from_root('tests', 'screenshot.png'), os.path.join(self.get_dir(), 'screenshot.png'))
+    shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'screenshot.png')
     self.btest('sdl2_fog_linear.c', reference='screenshot-fog-linear.png', reference_slack=1,
                args=['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '--preload-file', 'screenshot.png', '-s', 'LEGACY_GL_EMULATION=1', '--use-preload-plugins'],
                message='You should see an image with fog.')
@@ -3040,7 +3038,7 @@ window.close = function() {
       html = open('test.html').read()
       html2 = html.replace('''Module['postRun'] = doReftest;''', '') # we don't want the very first frame
       assert html != html2
-      open('test.html', 'w').write(html2)
+      create_test_file('test.html', html2)
     self.btest('sdl2_gl_frames_swap.c', reference='sdl2_gl_frames_swap.png', args=['--proxy-to-worker', '-s', 'GL_TESTING=1', '-s', 'USE_SDL=2'], manual_reference=True, post_build=post_build)
 
   @requires_graphics_hardware
@@ -3052,21 +3050,21 @@ window.close = function() {
                timeout=30)
 
   def test_sdl2_custom_cursor(self):
-    shutil.copyfile(path_from_root('tests', 'cursor.bmp'), os.path.join(self.get_dir(), 'cursor.bmp'))
+    shutil.copyfile(path_from_root('tests', 'cursor.bmp'), 'cursor.bmp')
     self.btest('sdl2_custom_cursor.c', expected='1', args=['--preload-file', 'cursor.bmp', '-s', 'USE_SDL=2'])
 
   def test_sdl2_misc(self):
     self.btest('sdl2_misc.c', expected='1', args=['-s', 'USE_SDL=2'])
     print('also test building to object files first')
     src = open(path_from_root('tests', 'sdl2_misc.c')).read()
-    open('test.c', 'w').write(self.with_report_result(src))
+    create_test_file('test.c', self.with_report_result(src))
     run_process([PYTHON, EMCC, 'test.c', '-s', 'USE_SDL=2', '-o', 'test.o'])
     run_process([PYTHON, EMCC, 'test.o', '-s', 'USE_SDL=2', '-o', 'test.html'])
     self.run_browser('test.html', '...', '/report_result?1')
 
   @requires_sound_hardware
   def test_sdl2_mixer(self):
-    shutil.copyfile(path_from_root('tests', 'sounds', 'alarmvictory_1.ogg'), os.path.join(self.get_dir(), 'sound.ogg'))
+    shutil.copyfile(path_from_root('tests', 'sounds', 'alarmvictory_1.ogg'), 'sound.ogg')
     self.btest('sdl2_mixer.c', expected='1', args=['--preload-file', 'sound.ogg', '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'TOTAL_MEMORY=33554432'])
 
   @requires_graphics_hardware
@@ -3086,8 +3084,7 @@ window.close = function() {
   def test_emterpreter_async_2(self):
     # Error.stackTraceLimit default to 10 in chrome but this test relies on more
     # than 40 stack frames being reported.
-    with open('pre.js', 'w') as f:
-      f.write('Error.stackTraceLimit = 80;\n')
+    create_test_file('pre.js', 'Error.stackTraceLimit = 80;\n')
     self.btest('emterpreter_async_2.cpp', '40', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-O3', '--pre-js', 'pre.js', ])
 
   def test_emterpreter_async_virtual(self):
@@ -3184,10 +3181,10 @@ window.close = function() {
       ]:
         print('test on', opts, args, code)
         src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
-        open('test.c', 'w').write(self.with_report_result(src))
+        create_test_file('test.c', self.with_report_result(src))
         # this test is synchronous, so avoid async startup due to wasm features
         run_process([PYTHON, EMCC, 'test.c', '-s', 'MODULARIZE=1', '-s', 'BINARYEN_ASYNC_COMPILATION=0', '-s', 'SINGLE_FILE=1'] + args + opts)
-        open('a.html', 'w').write('''
+        create_test_file('a.html', '''
           <script src="a.out.js"></script>
           <script>
             %s
@@ -3215,13 +3212,13 @@ window.close = function() {
           return 0;
         }
       ''' % totalMemory
-      open('test.c', 'w').write(self.with_report_result(src))
+      create_test_file('test.c', self.with_report_result(src))
       # generate a dummy file
-      open('dummy_file', 'w').write('dummy')
+      create_test_file('dummy_file', 'dummy')
       # compile the code with the modularize feature and the preload-file option enabled
       # no wasm, since this tests customizing total memory at runtime
       run_process([PYTHON, EMCC, 'test.c', '-s', 'WASM=0', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="Foo"', '--preload-file', 'dummy_file'] + opts)
-      open('a.html', 'w').write('''
+      create_test_file('a.html', '''
         <script src="a.out.js"></script>
         <script>
           // instantiate the Foo module with custom TOTAL_MEMORY value
@@ -3243,10 +3240,10 @@ window.close = function() {
 
   @requires_sync_compilation
   def test_dynamic_link(self):
-    open('pre.js', 'w').write('''
+    create_test_file('pre.js', '''
       Module.dynamicLibraries = ['side.wasm'];
   ''')
-    open('main.cpp', 'w').write(r'''
+    create_test_file('main.cpp', r'''
       #include <stdio.h>
       #include <stdlib.h>
       #include <string.h>
@@ -3270,7 +3267,7 @@ window.close = function() {
         return 0;
       }
     ''')
-    open('side.cpp', 'w').write(r'''
+    create_test_file('side.cpp', r'''
       #include <stdlib.h>
       #include <string.h>
       char *side(const char *data);
@@ -3281,23 +3278,23 @@ window.close = function() {
       }
     ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-s', 'EXPORT_ALL=1'])
-    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
+    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
 
     print('wasm in worker (we can read binary data synchronously there)')
 
-    open('pre.js', 'w').write('''
+    create_test_file('pre.js', '''
       var Module = { dynamicLibraries: ['side.wasm'] };
   ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
-    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '--proxy-to-worker', '-s', 'EXPORT_ALL=1'])
+    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '--proxy-to-worker', '-s', 'EXPORT_ALL=1'])
 
     print('wasm (will auto-preload since no sync binary reading)')
 
-    open('pre.js', 'w').write('''
+    create_test_file('pre.js', '''
       Module.dynamicLibraries = ['side.wasm'];
   ''')
     # same wasm side module works
-    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
+    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
 
   # verify that dynamic linking works in all kinds of in-browser environments.
   # don't mix different kinds in a single test.
@@ -3328,8 +3325,7 @@ window.close = function() {
       # (in main we won't be able to catch what static constructors inside
       # linked dynlibs printed), and in pre.js it is too early (out is not yet
       # setup by the shell).
-      with open('post.js', 'w') as f:
-        f.write(r'''
+      create_test_file('post.js', r'''
           Module.realPrint = out;
           out = function(x) {
             if (!Module.printed) Module.printed = "";
@@ -3357,10 +3353,10 @@ window.close = function() {
   @requires_graphics_hardware
   @requires_sync_compilation
   def test_dynamic_link_glemu(self):
-    open('pre.js', 'w').write('''
+    create_test_file('pre.js', '''
       Module.dynamicLibraries = ['side.wasm'];
   ''')
-    open('main.cpp', 'w').write(r'''
+    create_test_file('main.cpp', r'''
       #include <stdio.h>
       #include <string.h>
       #include <assert.h>
@@ -3373,7 +3369,7 @@ window.close = function() {
         return 0;
       }
     ''')
-    open('side.cpp', 'w').write(r'''
+    create_test_file('side.cpp', r'''
       #include "SDL/SDL.h"
       #include "SDL/SDL_opengl.h"
       const char *side() {
@@ -3384,16 +3380,16 @@ window.close = function() {
     ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-lSDL', '-s', 'EXPORT_ALL=1'])
 
-    self.btest(self.in_dir('main.cpp'), '1', args=['-s', 'MAIN_MODULE=1', '-O2', '-s', 'LEGACY_GL_EMULATION=1', '-lSDL', '-lGL', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
+    self.btest('main.cpp', '1', args=['-s', 'MAIN_MODULE=1', '-O2', '-s', 'LEGACY_GL_EMULATION=1', '-lSDL', '-lGL', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
 
   def test_memory_growth_during_startup(self):
-    open('data.dat', 'w').write('X' * (30 * 1024 * 1024))
+    create_test_file('data.dat', 'X' * (30 * 1024 * 1024))
     self.btest('browser_test_hello_world.c', '0', args=['-s', 'ASSERTIONS=1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'TOTAL_MEMORY=16MB', '-s', 'TOTAL_STACK=5000', '--preload-file', 'data.dat'])
 
   # pthreads tests
 
   def prep_no_SAB(self):
-    open('html.html', 'w').write(open(path_from_root('src', 'shell_minimal.html')).read().replace('''<body>''', '''<body>
+    create_test_file('html.html', open(path_from_root('src', 'shell_minimal.html')).read().replace('''<body>''', '''<body>
       <script>
         SharedArrayBuffer = undefined;
         Atomics = undefined;
@@ -3585,8 +3581,8 @@ window.close = function() {
   @requires_threads
   def test_pthread_custom_pthread_main_url(self):
     self.clear()
-    os.makedirs(os.path.join(self.get_dir(), 'cdn'))
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write(self.with_report_result(r'''
+    os.makedirs('cdn')
+    create_test_file('main.cpp', self.with_report_result(r'''
       #include <stdio.h>
       #include <string.h>
       #include <emscripten/emscripten.h>
@@ -3611,14 +3607,14 @@ window.close = function() {
     '''))
 
     # Test that it is possible to define "Module.locateFile" string to locate where worker.js will be loaded from.
-    open(self.in_dir('shell.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'shell.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS=1', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-o', 'test.html'])
+    create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
+    run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS=1', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-o', 'test.html'])
     shutil.move('test.worker.js', os.path.join('cdn', 'test.worker.js'))
     self.run_browser('test.html', '', '/report_result?1')
 
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
-    open(self.in_dir('shell2.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
-    run_process([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'shell2.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS=1', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-o', 'test2.html'])
+    create_test_file('shell2.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
+    run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell2.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS=1', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-o', 'test2.html'])
     try_delete('test.worker.js')
     self.run_browser('test2.html', '', '/report_result?1')
 
@@ -3746,17 +3742,17 @@ window.close = function() {
   def test_separate_asm(self):
     for opts in [['-O0'], ['-O1'], ['-O2'], ['-O2', '--closure', '1']]:
       print(opts)
-      open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+      create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
       run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.html', '-s', 'WASM=0'] + opts)
       self.run_browser('test.html', None, '/report_result?0')
 
       print('run one')
-      open('one.html', 'w').write('<script src="test.js"></script>')
+      create_test_file('one.html', '<script src="test.js"></script>')
       self.run_browser('one.html', None, '/report_result?0')
 
       print('run two')
       run_process([PYTHON, path_from_root('tools', 'separate_asm.py'), 'test.js', 'asm.js', 'rest.js'])
-      open('two.html', 'w').write('''
+      create_test_file('two.html', '''
         <script>
           var Module = {};
         </script>
@@ -3776,7 +3772,7 @@ window.close = function() {
       self.run_browser('test.html', None, '[no http server activity]', timeout=5) # fail without the asm
 
   def test_emterpretify_file(self):
-    open('shell.html', 'w').write('''
+    create_test_file('shell.html', '''
       <!--
         {{{ SCRIPT }}} // ignore this, we do it ourselves
       -->
@@ -3805,9 +3801,9 @@ window.close = function() {
   def test_vanilla_html_when_proxying(self):
     for opts in [0, 1, 2]:
       print(opts)
-      open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+      create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
       run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '-O' + str(opts), '--proxy-to-worker'])
-      open('test.html', 'w').write('<script src="test.js"></script>')
+      create_test_file('test.html', '<script src="test.js"></script>')
       self.run_browser('test.html', None, '/report_result?0')
 
   def test_in_flight_memfile_request(self):
@@ -3817,9 +3813,9 @@ window.close = function() {
       opts = ['-O' + str(o), '-s', 'WASM=0']
 
       print('plain html')
-      open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'in_flight_memfile_request.c')).read()))
+      create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'in_flight_memfile_request.c')).read()))
       run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js'] + opts)
-      open('test.html', 'w').write('<script src="test.js"></script>')
+      create_test_file('test.html', '<script src="test.js"></script>')
       self.run_browser('test.html', None, '/report_result?0') # never when we provide our own HTML like this.
 
       print('default html')
@@ -3876,10 +3872,10 @@ window.close = function() {
 
   # Test that implementing Module.instantiateWasm() callback works.
   def test_manual_wasm_instantiate(self):
-    src = os.path.join(self.get_dir(), 'src.cpp')
-    open(src, 'w').write(self.with_report_result(open(os.path.join(path_from_root('tests/manual_wasm_instantiate.cpp'))).read()))
+    src = 'src.cpp'
+    create_test_file(src, self.with_report_result(open(os.path.join(path_from_root('tests/manual_wasm_instantiate.cpp'))).read()))
     run_process([PYTHON, EMCC, 'src.cpp', '-o', 'manual_wasm_instantiate.js', '-s', 'BINARYEN=1'])
-    shutil.copyfile(path_from_root('tests', 'manual_wasm_instantiate.html'), os.path.join(self.get_dir(), 'manual_wasm_instantiate.html'))
+    shutil.copyfile(path_from_root('tests', 'manual_wasm_instantiate.html'), 'manual_wasm_instantiate.html')
     self.run_browser('manual_wasm_instantiate.html', 'wasm instantiation succeeded', '/report_result?1')
 
   def test_binaryen_worker(self):
@@ -3888,9 +3884,9 @@ window.close = function() {
   def test_wasm_locate_file(self):
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
     self.clear()
-    os.makedirs(os.path.join(self.get_dir(), 'cdn'))
-    open('shell2.html', 'w').write(open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.wasm") return "cdn/test.wasm"; else return filename; }, '))
-    open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+    os.makedirs('cdn')
+    create_test_file('shell2.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.wasm") return "cdn/test.wasm"; else return filename; }, '))
+    create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
     subprocess.check_call([PYTHON, EMCC, 'src.cpp', '--shell-file', 'shell2.html', '-s', 'WASM=1', '-o', 'test.html'])
     shutil.move('test.wasm', os.path.join('cdn', 'test.wasm'))
     self.run_browser('test.html', '', '/report_result?0')
@@ -3972,14 +3968,14 @@ window.close = function() {
                also_asmjs=True)
 
     # Test the positive case when the file URL exists. (http 200)
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/to_memory.cpp',
                expected='1',
                args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
                also_asmjs=True)
 
   def test_fetch_to_indexdb(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/to_indexeddb.cpp',
                expected='1',
                args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
@@ -3987,7 +3983,7 @@ window.close = function() {
 
   # Tests emscripten_fetch() usage to persist an XHR into IndexedDB and subsequently load up from there.
   def test_fetch_cached_xhr(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/cached_xhr.cpp',
                expected='1',
                args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
@@ -3996,7 +3992,7 @@ window.close = function() {
   # Tests that response headers get set on emscripten_fetch_t values.
   @requires_threads
   def test_fetch_response_headers(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/response_headers.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'], also_asmjs=True)
 
   # Test emscripten_fetch() usage to stream a XHR in to memory without storing the full file in memory
@@ -4019,13 +4015,13 @@ window.close = function() {
   # thread proxied to a Worker with -s PROXY_TO_PTHREAD=1 option.
   @requires_threads
   def test_fetch_sync_xhr(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/sync_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   # Tests that the Fetch API works for synchronous XHRs when used with --proxy-to-worker.
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/sync_xhr.cpp',
                expected='1',
                args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '--proxy-to-worker'],
@@ -4034,7 +4030,7 @@ window.close = function() {
   # Tests waiting on EMSCRIPTEN_FETCH_WAITABLE request from a worker thread
   @requires_threads
   def test_fetch_sync_fetch_in_main_thread(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/sync_fetch_in_main_thread.cpp', expected='0', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   def test_fetch_idb_store(self):
@@ -4042,19 +4038,19 @@ window.close = function() {
 
   @requires_threads
   def test_fetch_idb_delete(self):
-    shutil.copyfile(path_from_root('tests', 'gears.png'), os.path.join(self.get_dir(), 'gears.png'))
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/idb_delete.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'PROXY_TO_PTHREAD=1'])
 
   @requires_threads
   def test_asmfs_hello_file(self):
     # Test basic file loading and the valid character set for files.
-    os.mkdir(os.path.join(self.get_dir(), 'dirrey'))
+    os.mkdir('dirrey')
     shutil.copyfile(path_from_root('tests', 'asmfs', 'hello_file.txt'), os.path.join(self.get_dir(), 'dirrey', 'hello file !#$%&\'()+,-.;=@[]^_`{}~ %%.txt'))
     self.btest('asmfs/hello_file.cpp', expected='0', args=['-s', 'ASMFS=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   @requires_threads
   def test_asmfs_read_file_twice(self):
-    shutil.copyfile(path_from_root('tests', 'asmfs', 'hello_file.txt'), os.path.join(self.get_dir(), 'hello_file.txt'))
+    shutil.copyfile(path_from_root('tests', 'asmfs', 'hello_file.txt'), 'hello_file.txt')
     self.btest('asmfs/read_file_twice.cpp', expected='0', args=['-s', 'ASMFS=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   @requires_threads
@@ -4144,10 +4140,10 @@ window.close = function() {
   @requires_threads
   def test_load_js_from_blob_with_pthreads(self):
     # TODO: enable this with wasm, currently pthreads/atomics have limitations
-    src = os.path.join(self.get_dir(), 'src.c')
-    open(src, 'w').write(self.with_report_result(open(path_from_root('tests', 'pthread', 'hello_thread.c')).read()))
+    src = 'src.c'
+    create_test_file(src, self.with_report_result(open(path_from_root('tests', 'pthread', 'hello_thread.c')).read()))
     run_process([PYTHON, EMCC, 'src.c', '-s', 'USE_PTHREADS=1', '-o', 'hello_thread_with_blob_url.js', '-s', 'WASM=0'])
-    shutil.copyfile(path_from_root('tests', 'pthread', 'main_js_as_blob_loader.html'), os.path.join(self.get_dir(), 'hello_thread_with_blob_url.html'))
+    shutil.copyfile(path_from_root('tests', 'pthread', 'main_js_as_blob_loader.html'), 'hello_thread_with_blob_url.html')
     self.run_browser('hello_thread_with_blob_url.html', 'hello from thread!', '/report_result?1')
 
   # Tests that base64 utils work in browser with no native atob function
@@ -4161,12 +4157,12 @@ window.close = function() {
         return 0;
       }
     '''
-    open('test.c', 'w').write(self.with_report_result(src))
+    create_test_file('test.c', self.with_report_result(src))
     # generate a dummy file
-    open('dummy_file', 'w').write('dummy')
+    create_test_file('dummy_file', 'dummy')
     # compile the code with the modularize feature and the preload-file option enabled
     run_process([PYTHON, EMCC, 'test.c', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="Foo"', '--preload-file', 'dummy_file'] + opts)
-    open('a.html', 'w').write('''
+    create_test_file('a.html', '''
       <script>
         atob = undefined;
         fetch = undefined;
@@ -4185,7 +4181,7 @@ window.close = function() {
 
   # Tests that SINGLE_FILE works as intended with locateFile
   def test_single_file_locate_file(self):
-    open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+    create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
 
     for wasm_enabled in [True, False]:
       args = [PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '-s', 'SINGLE_FILE=1']
@@ -4195,7 +4191,7 @@ window.close = function() {
 
       run_process(args)
 
-      open('test.html', 'w').write('''
+      create_test_file('test.html', '''
         <script>
           var Module = {
             locateFile: function (path) {
@@ -4214,15 +4210,15 @@ window.close = function() {
 
   # Tests that SINGLE_FILE works as intended in a Worker in JS output
   def test_single_file_worker_js(self):
-    open('src.cpp', 'w').write(self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
+    create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
     run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
-    open('test.html', 'w').write('<script src="test.js"></script>')
+    create_test_file('test.html', '<script src="test.js"></script>')
     self.run_browser('test.html', None, '/report_result?0')
     assert os.path.exists('test.js') and not os.path.exists('test.worker.js')
 
   def test_access_file_after_heap_resize(self):
-    open('test.txt', 'w').write('hello from file')
-    open('page.c', 'w').write(self.with_report_result(open(path_from_root('tests', 'access_file_after_heap_resize.c'), 'r').read()))
+    create_test_file('test.txt', 'hello from file')
+    create_test_file('page.c', self.with_report_result(open(path_from_root('tests', 'access_file_after_heap_resize.c'), 'r').read()))
     run_process([PYTHON, EMCC, 'page.c', '-s', 'WASM=1', '-s', 'ALLOW_MEMORY_GROWTH=1', '--preload-file', 'test.txt', '-o', 'page.html'])
     self.run_browser('page.html', 'hello from file', '/report_result?15')
 
@@ -4235,14 +4231,14 @@ window.close = function() {
       self.run_browser('page.html', 'hello from file', '/report_result?15')
 
   def test_unicode_html_shell(self):
-    open(self.in_dir('main.cpp'), 'w').write(self.with_report_result(r'''
+    create_test_file('main.cpp', self.with_report_result(r'''
       int main() {
         REPORT_RESULT(0);
         return 0;
       }
     '''))
-    open(self.in_dir('shell.html'), 'w').write(open(path_from_root('src', 'shell.html')).read().replace('Emscripten-Generated Code', 'Emscripten-Generated Emoji 😅'))
-    subprocess.check_output([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--shell-file', 'shell.html', '-o', 'test.html'])
+    create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('Emscripten-Generated Code', 'Emscripten-Generated Emoji 😅'))
+    subprocess.check_output([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell.html', '-o', 'test.html'])
     self.run_browser('test.html', None, '/report_result?0')
 
   # Tests the functionality of the emscripten_thread_sleep() function.
@@ -4253,7 +4249,7 @@ window.close = function() {
   # Tests that Emscripten-compiled applications can be run from a relative path in browser that is different than the address of the current page
   def test_browser_run_from_different_directory(self):
     src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
-    open('test.c', 'w').write(self.with_report_result(src))
+    create_test_file('test.c', self.with_report_result(src))
     run_process([PYTHON, EMCC, 'test.c', '-o', 'test.html', '-O3'])
 
     if not os.path.exists('subdir'):
@@ -4262,13 +4258,13 @@ window.close = function() {
     shutil.move('test.wasm', os.path.join('subdir', 'test.wasm'))
     src = open('test.html').read()
     # Make sure JS is loaded from subdirectory
-    open('test-subdir.html', 'w').write(src.replace('test.js', 'subdir/test.js'))
+    create_test_file('test-subdir.html', src.replace('test.js', 'subdir/test.js'))
     self.run_browser('test-subdir.html', None, '/report_result?0')
 
   # Similar to `test_browser_run_from_different_directory`, but asynchronous because of `-s MODULARIZE=1`
   def test_browser_run_from_different_directory_async(self):
     src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
-    open('test.c', 'w').write(self.with_report_result(src))
+    create_test_file('test.c', self.with_report_result(src))
     for args, creations in [
       (['-s', 'MODULARIZE=1'], [
         'Module();',    # documented way for using modularize
@@ -4286,7 +4282,7 @@ window.close = function() {
       for creation in creations:
         print(creation)
         # Make sure JS is loaded from subdirectory
-        open('test-subdir.html', 'w').write('''
+        create_test_file('test-subdir.html', '''
           <script src="subdir/test.js"></script>
           <script>
             %s
@@ -4300,7 +4296,7 @@ window.close = function() {
   # normal case of finding in the current dir.
   def test_browser_modularize_no_current_script(self):
     src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
-    open('test.c', 'w').write(self.with_report_result(src))
+    create_test_file('test.c', self.with_report_result(src))
     # test both modularize (and creating an instance) and modularize-instance
     # (which creates by itself)
     for path, args, creation in [

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -501,11 +501,9 @@ If manually bisecting:
 
   def test_multifile(self):
     # a few files inside a directory
-    self.clear()
-    os.makedirs('subdirr')
-    os.makedirs('subdirr', 'moar')
-    open('subdirr', 'data1.txt', 'w').write('''1214141516171819''')
-    open('subdirr', 'moar', 'data2.txt', 'w').write('''3.14159265358979''')
+    os.makedirs(os.path.join('subdirr', 'moar'))
+    create_test_file(os.path.join('subdirr', 'data1.txt'), '1214141516171819')
+    create_test_file(os.path.join('subdirr', 'moar', 'data2.txt'), '3.14159265358979')
     create_test_file('main.cpp', self.with_report_result(r'''
       #include <stdio.h>
       #include <string.h>
@@ -547,8 +545,9 @@ If manually bisecting:
     self.clear()
     os.makedirs('subdirr')
     os.makedirs('cdn')
-    open('subdirr', 'data1.txt', 'w').write('''1214141516171819''')
-    # change the file package base dir to look in a "cdn". note that normally you would add this in your own custom html file etc., and not by
+    create_test_file(os.path.join('subdirr', 'data1.txt'), '1214141516171819')
+    # change the file package base dir to look in a "cdn". note that normally
+    # you would add this in your own custom html file etc., and not by
     # modifying the existing shell in this manner
     create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
     create_test_file('main.cpp', self.with_report_result(r'''
@@ -570,12 +569,9 @@ If manually bisecting:
       }
     '''))
 
-    def test():
-      run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell.html', '--preload-file', 'subdirr/data1.txt', '-o', 'test.html'])
-      shutil.move('test.data', os.path.join('cdn', 'test.data'))
-      self.run_browser('test.html', '', '/report_result?1')
-
-    test()
+    run_process([PYTHON, EMCC, 'main.cpp', '--shell-file', 'shell.html', '--preload-file', 'subdirr/data1.txt', '-o', 'test.html'])
+    shutil.move('test.data', os.path.join('cdn', 'test.data'))
+    self.run_browser('test.html', '', '/report_result?1')
 
   def test_missing_data_throws_error(self):
     def setup(assetLocalization):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3238,7 +3238,7 @@ window.close = function() {
   def test_dynamic_link(self):
     create_test_file('pre.js', '''
       Module.dynamicLibraries = ['side.wasm'];
-  ''')
+    ''')
     create_test_file('main.cpp', r'''
       #include <stdio.h>
       #include <stdlib.h>
@@ -3274,7 +3274,7 @@ window.close = function() {
       }
     ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-s', 'EXPORT_ALL=1'])
-    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
+    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
 
     print('wasm in worker (we can read binary data synchronously there)')
 
@@ -3282,7 +3282,7 @@ window.close = function() {
       var Module = { dynamicLibraries: ['side.wasm'] };
   ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
-    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '--proxy-to-worker', '-s', 'EXPORT_ALL=1'])
+    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '--proxy-to-worker', '-s', 'EXPORT_ALL=1'])
 
     print('wasm (will auto-preload since no sync binary reading)')
 
@@ -3290,7 +3290,7 @@ window.close = function() {
       Module.dynamicLibraries = ['side.wasm'];
   ''')
     # same wasm side module works
-    self.btest('main.cpp', '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
+    self.btest(self.in_dir('main.cpp'), '2', args=['-s', 'MAIN_MODULE=1', '-O2', '--pre-js', 'pre.js', '-s', 'WASM=1', '-s', 'EXPORT_ALL=1'])
 
   # verify that dynamic linking works in all kinds of in-browser environments.
   # don't mix different kinds in a single test.
@@ -3376,7 +3376,7 @@ window.close = function() {
     ''')
     run_process([PYTHON, EMCC, 'side.cpp', '-s', 'SIDE_MODULE=1', '-O2', '-o', 'side.wasm', '-lSDL', '-s', 'EXPORT_ALL=1'])
 
-    self.btest('main.cpp', '1', args=['-s', 'MAIN_MODULE=1', '-O2', '-s', 'LEGACY_GL_EMULATION=1', '-lSDL', '-lGL', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
+    self.btest(self.in_dir('main.cpp'), '1', args=['-s', 'MAIN_MODULE=1', '-O2', '-s', 'LEGACY_GL_EMULATION=1', '-lSDL', '-lGL', '--pre-js', 'pre.js', '-s', 'EXPORT_ALL=1'])
 
   def test_memory_growth_during_startup(self):
     create_test_file('data.dat', 'X' * (30 * 1024 * 1024))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,7 @@ from tools.shared import Building, STDOUT, PIPE, run_js, run_process, try_delete
 from tools.shared import NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, PYTHON, EMCC, EMAR, CLANG, WINDOWS, AUTODEBUGGER
 from tools import jsrun, shared
 from runner import RunnerCore, path_from_root, core_test_modes, get_bullet_library, get_freetype_library, get_poppler_library
-from runner import skip_if, no_wasm_backend, needs_dlfcn, no_windows, env_modify, with_env_modify, is_slow_test
+from runner import skip_if, no_wasm_backend, needs_dlfcn, no_windows, env_modify, with_env_modify, is_slow_test, create_test_file
 
 # decorators for limiting which modes a test can run in
 
@@ -114,7 +114,7 @@ class TestCoreBase(RunnerCore):
   def test_hello_world(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
-    src = open(self.in_dir('src.cpp.o.js')).read()
+    src = open('src.cpp.o.js').read()
     assert 'EMSCRIPTEN_GENERATED_FUNCTIONS' not in src, 'must not emit this unneeded internal thing'
 
   def test_intvars(self):
@@ -161,7 +161,7 @@ class TestCoreBase(RunnerCore):
     self.set_setting('PRECISE_I64_MATH', 1)
     self.do_run_in_out_file_test('tests', 'core', 'test_i64_precise_unneeded')
 
-    code = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
+    code = open('src.cpp.o.js').read()
     assert 'goog.math.Long' not in code, 'i64 precise math should never be included, musl does its own printfing'
 
   def test_i64_precise_needed(self):
@@ -229,7 +229,7 @@ class TestCoreBase(RunnerCore):
     self.do_run_in_out_file_test('tests', 'core', 'test_negative_zero')
 
   def test_line_endings(self):
-    self.build(open(path_from_root('tests', 'hello_world.cpp')).read(), self.get_dir(), self.in_dir('hello_world.cpp'))
+    self.build(open(path_from_root('tests', 'hello_world.cpp')).read(), self.get_dir(), 'hello_world.cpp')
 
   def test_literal_negative_zero(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_literal_negative_zero')
@@ -270,7 +270,7 @@ class TestCoreBase(RunnerCore):
 
   def test_cube2md5(self):
     self.emcc_args += ['--embed-file', 'cube2md5.txt']
-    shutil.copyfile(path_from_root('tests', 'cube2md5.txt'), os.path.join(self.get_dir(), 'cube2md5.txt'))
+    shutil.copyfile(path_from_root('tests', 'cube2md5.txt'), 'cube2md5.txt')
     self.do_run(open(path_from_root('tests', 'cube2md5.cpp')).read(), open(path_from_root('tests', 'cube2md5.ok')).read())
 
   def test_cube2hash(self):
@@ -554,8 +554,8 @@ int main()
     self.do_run_in_out_file_test('tests', 'core', 'test_erf')
 
   def test_math_hyperbolic(self):
-    src = open(path_from_root('tests', 'hyperbolic', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'hyperbolic', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'hyperbolic', 'src.c')).read()
+    expected = open(path_from_root('tests', 'hyperbolic', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_math_lgamma(self):
@@ -599,44 +599,31 @@ int main()
     self.do_run_in_out_file_test('tests', 'core', 'test_getgep')
 
   def test_multiply_defined_symbols(self):
-    a1 = "int f() { return 1; }"
-    a1_name = os.path.join(self.get_dir(), 'a1.c')
-    open(a1_name, 'w').write(a1)
-    a2 = "void x() {}"
-    a2_name = os.path.join(self.get_dir(), 'a2.c')
-    open(a2_name, 'w').write(a2)
-    b1 = "int f() { return 2; }"
-    b1_name = os.path.join(self.get_dir(), 'b1.c')
-    open(b1_name, 'w').write(b1)
-    b2 = "void y() {}"
-    b2_name = os.path.join(self.get_dir(), 'b2.c')
-    open(b2_name, 'w').write(b2)
-    main = r'''
+    create_test_file('a1.c', 'int f() { return 1; }')
+    create_test_file('a2.c', 'void x() {}')
+    create_test_file('b1.c', 'int f() { return 2; }')
+    create_test_file('b2.c', 'void y() {}')
+    create_test_file('main.c', r'''
       #include <stdio.h>
       int f();
       int main() {
         printf("result: %d\n", f());
         return 0;
       }
-    '''
-    main_name = os.path.join(self.get_dir(), 'main.c')
-    open(main_name, 'w').write(main)
+    ''')
 
-    Building.emcc(a1_name)
-    Building.emcc(a2_name)
-    Building.emcc(b1_name)
-    Building.emcc(b2_name)
-    Building.emcc(main_name)
+    Building.emcc('a1.c')
+    Building.emcc('a2.c')
+    Building.emcc('b1.c')
+    Building.emcc('b2.c')
+    Building.emcc('main.c')
 
-    liba_name = os.path.join(self.get_dir(), 'liba.a')
-    Building.emar('cr', liba_name, [a1_name + '.o', a2_name + '.o'])
-    libb_name = os.path.join(self.get_dir(), 'libb.a')
-    Building.emar('cr', libb_name, [b1_name + '.o', b2_name + '.o'])
+    Building.emar('cr', 'liba.a', ['a1.c.o', 'a2.c.o'])
+    Building.emar('cr', 'libb.a', ['b1.c.o', 'b2.c.o'])
 
-    all_name = os.path.join(self.get_dir(), 'all.bc')
-    Building.link([main_name + '.o', liba_name, libb_name], all_name)
+    Building.link(['main.c.o', 'liba.a', 'libb.a'], 'all.bc')
 
-    self.do_ll_run(all_name, 'result: 1')
+    self.do_ll_run('all.bc', 'result: 1')
 
   def test_if(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_if')
@@ -1512,7 +1499,7 @@ int main() {
   @no_wasm()
   def test_life(self):
     self.emcc_args += ['-std=c99']
-    src = open(path_from_root('tests', 'life.c'), 'r').read()
+    src = open(path_from_root('tests', 'life.c')).read()
     self.do_run(src, '''--------------------------------
 []                                    []                  [][][]
                     []  []    []    [][]  []            []  []  
@@ -1705,16 +1692,14 @@ int main(int argc, char **argv) {
   # This test is identical to test_em_asm_2, just search-replaces EM_ASM to MAIN_THREAD_EM_ASM on the test file. That way if new
   # test cases are added to test_em_asm_2.cpp for EM_ASM, they will also get tested in MAIN_THREAD_EM_ASM form.
   def test_main_thread_em_asm(self):
-    src = open(path_from_root('tests', 'core', 'test_em_asm_2.cpp'), 'r').read()
-    test_file = 'src.cpp'
-    open(test_file, 'w').write(src.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
+    src = open(path_from_root('tests', 'core', 'test_em_asm_2.cpp')).read()
+    create_test_file('src.cpp', src.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
 
-    expected_result = open(path_from_root('tests', 'core', 'test_em_asm_2.out'), 'r').read()
-    expected_result_file = 'result.out'
-    open(expected_result_file, 'w').write(expected_result.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
+    expected_result = open(path_from_root('tests', 'core', 'test_em_asm_2.out')).read()
+    create_test_file('result.out', expected_result.replace('EM_ASM', 'MAIN_THREAD_EM_ASM'))
 
-    self.do_run_from_file(test_file, expected_result_file)
-    self.do_run_from_file(test_file, expected_result_file, force_c=True)
+    self.do_run_from_file('src.cpp', 'result.out')
+    self.do_run_from_file('src.cpp', 'result.out', force_c=True)
 
   def test_main_thread_async_em_asm(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_main_thread_async_em_asm')
@@ -2052,7 +2037,7 @@ The current type of b is: 9
     self.do_run(src, 'pre:  54,2\ndump: 55,3\ndump: 55,3\npost: 54,2\ndump: 55,3\ndump: 56,4\nlast: 56,4')
 
     # Check for lack of warning in the generated code (they should appear in part 2)
-    generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
+    generated = open('src.cpp.o.js').read()
     assert 'Casting a function pointer type to another with a different number of arguments.' not in generated, 'Unexpected warning'
 
     # part 2: make sure we warn about mixing c and c++ calling conventions here
@@ -2061,16 +2046,14 @@ The current type of b is: 9
       # Optimized code is missing the warning comments
       return
 
-    header = r'''
+    create_test_file('header.h', r'''
       struct point
       {
         int x, y;
       };
+    ''')
 
-    '''
-    open(os.path.join(self.get_dir(), 'header.h'), 'w').write(header)
-
-    supp = r'''
+    create_test_file('supp.cpp', r'''
       #include <stdio.h>
       #include "header.h"
 
@@ -2079,11 +2062,9 @@ The current type of b is: 9
         p.y++; // anything in the caller!
         printf("dump: %d,%d\n", p.x, p.y);
       }
-    '''
-    supp_name = os.path.join(self.get_dir(), 'supp.c')
-    open(supp_name, 'w').write(supp)
+    ''')
 
-    main = r'''
+    create_test_file('main.cpp', r'''
       #include <stdio.h>
       #include "header.h"
 
@@ -2104,20 +2085,17 @@ The current type of b is: 9
         printf("post: %d,%d\n", p.x, p.y);
         return 0;
       }
-    '''
-    main_name = os.path.join(self.get_dir(), 'main.cpp')
-    open(main_name, 'w').write(main)
+    ''')
 
-    Building.emcc(supp_name)
-    Building.emcc(main_name)
-    all_name = os.path.join(self.get_dir(), 'all.bc')
-    Building.link([supp_name + '.o', main_name + '.o'], all_name)
+    Building.emcc('supp.cpp')
+    Building.emcc('main.cpp')
+    Building.link(['supp.cpp.o', 'main.cpp.o'], 'all.bc')
 
     # This will fail! See explanation near the warning we check for, in the compiler source code
-    run_process([PYTHON, EMCC, all_name] + self.emcc_args, check=False, stderr=PIPE)
+    run_process([PYTHON, EMCC, 'all.bc'] + self.emcc_args, check=False, stderr=PIPE)
 
     # Check for warning in the generated code
-    generated = open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read()
+    generated = open('src.cpp.o.js').read()
     print('skipping C/C++ conventions warning check, since not i386-pc-linux-gnu', file=sys.stderr)
 
   def test_stdlibs(self):
@@ -2181,20 +2159,20 @@ The current type of b is: 9
     self.do_run_in_out_file_test('tests', 'core', 'test_atexit')
 
   def test_pthread_specific(self):
-    src = open(path_from_root('tests', 'pthread', 'specific.c'), 'r').read()
-    expected = open(path_from_root('tests', 'pthread', 'specific.c.txt'), 'r').read()
+    src = open(path_from_root('tests', 'pthread', 'specific.c')).read()
+    expected = open(path_from_root('tests', 'pthread', 'specific.c.txt')).read()
     self.do_run(src, expected, force_c=True)
 
   def test_pthread_equal(self):
     self.do_run_in_out_file_test('tests', 'pthread', 'test_pthread_equal')
 
   def test_tcgetattr(self):
-    src = open(path_from_root('tests', 'termios', 'test_tcgetattr.c'), 'r').read()
+    src = open(path_from_root('tests', 'termios', 'test_tcgetattr.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_time(self):
-    src = open(path_from_root('tests', 'time', 'src.cpp'), 'r').read()
-    expected = open(path_from_root('tests', 'time', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'time', 'src.cpp')).read()
+    expected = open(path_from_root('tests', 'time', 'output.txt')).read()
     self.do_run(src, expected)
     if 'TZ' in os.environ:
       print('TZ set in environment, skipping extra time zone checks')
@@ -2239,7 +2217,7 @@ The current type of b is: 9
                    "It also doesn't segfault.")
   def test_intentional_fault(self):
     # Some programs intentionally segfault themselves, we should compile that into a throw
-    src = open(path_from_root('tests', 'core', 'test_intentional_fault.c'), 'r').read()
+    src = open(path_from_root('tests', 'core', 'test_intentional_fault.c')).read()
     self.do_run(src, 'abort()' if self.run_name != 'asm2g' else 'abort("segmentation fault')
 
   def test_trickystring(self):
@@ -2276,10 +2254,10 @@ The current type of b is: 9
     self.do_run_in_out_file_test('tests', 'core', 'test_memcpy3')
 
   def test_memcpy_alignment(self):
-    self.do_run(open(path_from_root('tests', 'test_memcpy_alignment.cpp'), 'r').read(), 'OK.')
+    self.do_run(open(path_from_root('tests', 'test_memcpy_alignment.cpp')).read(), 'OK.')
 
   def test_memset_alignment(self):
-    self.do_run(open(path_from_root('tests', 'test_memset_alignment.cpp'), 'r').read(), 'OK.')
+    self.do_run(open(path_from_root('tests', 'test_memset_alignment.cpp')).read(), 'OK.')
 
   def test_memset(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_memset')
@@ -2403,8 +2381,7 @@ The current type of b is: 9
     self.clear_setting('SIDE_MODULE')
     self.set_setting('EXPORT_ALL')
 
-    with open('lib_so_pre.js', 'w') as f:
-      f.write('''
+    create_test_file('lib_so_pre.js', '''
     if (!Module['preRun']) Module['preRun'] = [];
     Module['preRun'].push(function() { FS.createDataFile('/', 'liblib.so', %s, true, false, false); });
 ''' % str(list(bytearray(open('liblib.so', 'rb').read()))))
@@ -3357,7 +3334,7 @@ ok
     self.set_setting('EXPORT_ALL', 1)
 
     if header:
-      open('header.h', 'w').write(header)
+      create_test_file('header.h', header)
 
     old_args = self.emcc_args[:]
 
@@ -3392,7 +3369,7 @@ ok
     if isinstance(main, list):
       # main is just a library
       try_delete('src.cpp.o.js')
-      run_process([PYTHON, EMCC] + main + self.emcc_args + self.serialize_settings() + ['-o', os.path.join(self.get_dir(), 'src.cpp.o.js')])
+      run_process([PYTHON, EMCC] + main + self.emcc_args + self.serialize_settings() + ['-o', 'src.cpp.o.js'])
       self.do_run(None, expected, no_build=True)
     else:
       self.do_run(main, expected, force_c=force_c)
@@ -3772,7 +3749,7 @@ ok
   def test_dylink_jslib(self):
     # avoid using asm2wasm imports, which don't work in side modules yet (should they?)
     self.set_setting('BINARYEN_TRAP_MODE', 'clamp')
-    open('lib.js', 'w').write(r'''
+    create_test_file('lib.js', r'''
       mergeInto(LibraryManager.library, {
         test_lib_func: function(x) {
           return x + 17.2;
@@ -3807,7 +3784,7 @@ ok
 
   @needs_dlfcn
   def test_dylink_global_var_jslib(self):
-    open('lib.js', 'w').write(r'''
+    create_test_file('lib.js', r'''
       mergeInto(LibraryManager.library, {
         jslib_x: 'allocate(1, "i32*", ALLOC_STATIC)',
         jslib_x__postset: 'HEAP32[_jslib_x>>2] = 148;',
@@ -4044,7 +4021,7 @@ ok
       self.emcc_args += ['-s', 'ASSERTIONS=2']
 
     # test hyper-dynamic linking, and test duplicate warnings
-    open('third.cpp', 'w').write(r'''
+    create_test_file('third.cpp', r'''
       #include <stdio.h>
       int sidef() { return 36; }
       int sideg = 49;
@@ -4115,12 +4092,12 @@ ok
   @needs_dlfcn
   def test_dylink_dot_a(self):
     # .a linking must force all .o files inside it, when in a shared module
-    open('third.cpp', 'w').write(r'''
+    create_test_file('third.cpp', r'''
       int sidef() { return 36; }
     ''')
     run_process([PYTHON, EMCC, 'third.cpp'] + Building.COMPILER_TEST_OPTS + self.emcc_args + ['-o', 'third.o', '-c'])
 
-    open('fourth.cpp', 'w').write(r'''
+    create_test_file('fourth.cpp', r'''
       int sideg() { return 17; }
     ''')
     run_process([PYTHON, EMCC, 'fourth.cpp'] + Building.COMPILER_TEST_OPTS + self.emcc_args + ['-o', 'fourth.o', '-c'])
@@ -4181,20 +4158,20 @@ ok
     run_process([PYTHON, path_from_root('embuilder.py'), 'build', 'zlib'])
 
     zlib = shared.Cache.get_path(os.path.join('ports-builds', 'zlib', 'libz.a'))
-    self.dylink_test(main=open(path_from_root('tests', 'zlib', 'example.c'), 'r').read(),
+    self.dylink_test(main=open(path_from_root('tests', 'zlib', 'example.c')).read(),
                      side=[zlib],
-                     expected=open(path_from_root('tests', 'zlib', 'ref.txt'), 'r').read(),
+                     expected=open(path_from_root('tests', 'zlib', 'ref.txt')).read(),
                      force_c=True)
 
   # @needs_dlfcn
   # def test_dylink_bullet(self):
   #   Building.COMPILER_TEST_OPTS += ['-I' + path_from_root('tests', 'bullet', 'src')]
   #   side = get_bullet_library(self, True)
-  #   self.dylink_test(main=open(path_from_root('tests', 'bullet', 'Demos', 'HelloWorld', 'HelloWorld.cpp'), 'r').read(),
+  #   self.dylink_test(main=open(path_from_root('tests', 'bullet', 'Demos', 'HelloWorld', 'HelloWorld.cpp')).read(),
   #                    side=side,
-  #                    expected=[open(path_from_root('tests', 'bullet', 'output.txt'), 'r').read(), # different roundings
-  #                              open(path_from_root('tests', 'bullet', 'output2.txt'), 'r').read(),
-  #                              open(path_from_root('tests', 'bullet', 'output3.txt'), 'r').read()])
+  #                    expected=[open(path_from_root('tests', 'bullet', 'output.txt')).read(), # different roundings
+  #                              open(path_from_root('tests', 'bullet', 'output2.txt')).read(),
+  #                              open(path_from_root('tests', 'bullet', 'output3.txt')).read()])
 
   def test_random(self):
     src = r'''#include <stdlib.h>
@@ -4273,8 +4250,8 @@ Have even and odd!
     self.do_run(src, expected)
 
   def test_strtod(self):
-    src = open(path_from_root('tests', 'core', 'test_strtod.c'), 'r').read()
-    expected = open(path_from_root('tests', 'core', 'test_strtod.out'), 'r').read()
+    src = open(path_from_root('tests', 'core', 'test_strtod.c')).read()
+    expected = open(path_from_root('tests', 'core', 'test_strtod.out')).read()
     self.do_run(src, expected)
 
   def test_strtold(self):
@@ -4283,16 +4260,16 @@ Have even and odd!
       expected_file = 'test_strtod.out'
     else:
       expected_file = 'test_strtold.out'
-    src = open(path_from_root('tests', 'core', 'test_strtold.c'), 'r').read()
-    expected = open(path_from_root('tests', 'core', expected_file), 'r').read()
+    src = open(path_from_root('tests', 'core', 'test_strtold.c')).read()
+    expected = open(path_from_root('tests', 'core', expected_file)).read()
     self.do_run(src, expected)
 
   def test_strtok(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_strtok')
 
   def test_parseInt(self):
-    src = open(path_from_root('tests', 'parseInt', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'parseInt', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'parseInt', 'src.c')).read()
+    expected = open(path_from_root('tests', 'parseInt', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_transtrcase(self):
@@ -4302,8 +4279,8 @@ Have even and odd!
     self.banned_js_engines = [NODE_JS, V8_ENGINE] # SpiderMonkey and V8 do different things to float64 typed arrays, un-NaNing, etc.
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME', 1)
-    src = open(path_from_root('tests', 'printf', 'test.c'), 'r').read()
-    expected = open(path_from_root('tests', 'printf', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'printf', 'test.c')).read()
+    expected = open(path_from_root('tests', 'printf', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_printf_2(self):
@@ -4441,8 +4418,8 @@ Pass: 0.000012 0.000012''')
     self.do_run_in_out_file_test('tests', 'core', 'test_sscanf_float')
 
   def test_langinfo(self):
-    src = open(path_from_root('tests', 'langinfo', 'test.c'), 'r').read()
-    expected = open(path_from_root('tests', 'langinfo', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'langinfo', 'test.c')).read()
+    expected = open(path_from_root('tests', 'langinfo', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_files(self):
@@ -4457,8 +4434,7 @@ Pass: 0.000012 0.000012''')
 
     print('base', self.emcc_args)
 
-    with open('pre.js', 'w') as f:
-      f.write('''
+    create_test_file('pre.js', '''
 Module = {
   'noFSInit': true,
   'preRun': function() {
@@ -4474,10 +4450,9 @@ Module = {
 };
 ''')
 
-    with open('test.file', 'w') as f:
-      f.write('some data')
+    create_test_file('test.file', 'some data')
 
-    src = open(path_from_root('tests', 'files.cpp'), 'r').read()
+    src = open(path_from_root('tests', 'files.cpp')).read()
 
     mem_file = 'src.cpp.o.js.mem'
     orig_args = self.emcc_args
@@ -4499,8 +4474,7 @@ Module = {
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME', 1)
 
-    with open('pre.js', 'w') as f:
-      f.write('''
+    create_test_file('pre.js', '''
     Module = {
       data: [10, 20, 40, 30],
       stdin: function() { return Module.data.pop() || null },
@@ -4530,11 +4504,11 @@ Module = {
 
   def test_mount(self):
     self.set_setting('FORCE_FILESYSTEM', 1)
-    src = open(path_from_root('tests', 'fs', 'test_mount.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_mount.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_getdents64(self):
-    src = open(path_from_root('tests', 'fs', 'test_getdents64.cpp'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_getdents64.cpp')).read()
     self.do_run(src, '..')
 
   def test_getdents64_special_cases(self):
@@ -4567,7 +4541,7 @@ Module = {
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
     for fs in ['MEMFS', 'NODEFS']:
       print(fs)
-      src = open(path_from_root('tests', 'stdio', 'test_fgetc_ungetc.c'), 'r').read()
+      src = open(path_from_root('tests', 'stdio', 'test_fgetc_ungetc.c')).read()
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
 
@@ -4580,7 +4554,7 @@ Module = {
         printf("*%d\n", c);
       }
     '''
-    open('file_with_byte_234.txt', 'wb').write(b'\xea')
+    create_test_file('file_with_byte_234.txt', b'\xea', binary=True)
     self.emcc_args += ['--embed-file', 'file_with_byte_234.txt']
     self.do_run(src, '*234\n')
 
@@ -4608,7 +4582,7 @@ Module = {
     self.do_run(src, 'SUCCESS\n')
 
   def test_fscanf(self):
-    open(os.path.join(self.get_dir(), 'three_numbers.txt'), 'w').write('''-1 0.1 -.1''')
+    create_test_file('three_numbers.txt', '-1 0.1 -.1')
     src = r'''
       #include <stdio.h>
       #include <assert.h>
@@ -4632,7 +4606,7 @@ Module = {
     self.do_run(src, 'match = 3\nx = -1.0, y = 0.1, z = -0.1\n')
 
   def test_fscanf_2(self):
-    open('a.txt', 'w').write('''1/2/3 4/5/6 7/8/9
+    create_test_file('a.txt', '''1/2/3 4/5/6 7/8/9
 ''')
     self.emcc_args += ['--embed-file', 'a.txt']
     self.do_run(r'''#include <cstdio>
@@ -4659,7 +4633,7 @@ main( int argv, char ** argc ) {
 ''', 'fscanf test\n9\n')
 
   def test_fileno(self):
-    open(os.path.join(self.get_dir(), 'empty.txt'), 'w').write('')
+    create_test_file('empty.txt', '')
     src = r'''
       #include <stdio.h>
       #include <unistd.h>
@@ -4678,7 +4652,7 @@ main( int argv, char ** argc ) {
     self.do_run(src, '3\n')
 
   def test_readdir(self):
-    src = open(path_from_root('tests', 'dirent', 'test_readdir.c'), 'r').read()
+    src = open(path_from_root('tests', 'dirent', 'test_readdir.c')).read()
     self.do_run(src, '''SIGILL: Illegal instruction
 success
 n: 8
@@ -4693,46 +4667,44 @@ name: .
 ''', force_c=True)
 
   def test_readdir_empty(self):
-    src = open(path_from_root('tests', 'dirent', 'test_readdir_empty.c'), 'r').read()
+    src = open(path_from_root('tests', 'dirent', 'test_readdir_empty.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_stat(self):
-    src = open(path_from_root('tests', 'stat', 'test_stat.c'), 'r').read()
+    src = open(path_from_root('tests', 'stat', 'test_stat.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_stat_chmod(self):
-    src = open(path_from_root('tests', 'stat', 'test_chmod.c'), 'r').read()
+    src = open(path_from_root('tests', 'stat', 'test_chmod.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_stat_mknod(self):
-    src = open(path_from_root('tests', 'stat', 'test_mknod.c'), 'r').read()
+    src = open(path_from_root('tests', 'stat', 'test_mknod.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def add_pre_run(self, code):
-    with open('pre.js', 'w') as f:
-      f.write('Module.preRun = function() { %s }' % code)
+    create_test_file('pre.js', 'Module.preRun = function() { %s }' % code)
     self.emcc_args += ['--pre-js', 'pre.js']
 
   def add_post_run(self, code):
-    with open('pre.js', 'w') as f:
-      f.write('Module.postRun = function() { %s }' % code)
+    create_test_file('pre.js', 'Module.postRun = function() { %s }' % code)
     self.emcc_args += ['--pre-js', 'pre.js']
 
   def test_fcntl(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
-    src = open(path_from_root('tests', 'fcntl', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'fcntl', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'fcntl', 'src.c')).read()
+    expected = open(path_from_root('tests', 'fcntl', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_fcntl_open(self):
-    src = open(path_from_root('tests', 'fcntl-open', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'fcntl-open', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'fcntl-open', 'src.c')).read()
+    expected = open(path_from_root('tests', 'fcntl-open', 'output.txt')).read()
     self.do_run(src, expected, force_c=True)
 
   def test_fcntl_misc(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
-    src = open(path_from_root('tests', 'fcntl-misc', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'fcntl-misc', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'fcntl-misc', 'src.c')).read()
+    expected = open(path_from_root('tests', 'fcntl-misc', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_poll(self):
@@ -4754,7 +4726,7 @@ name: .
     self.do_run_in_out_file_test('tests', 'core', 'test_libgen')
 
   def test_utime(self):
-    src = open(path_from_root('tests', 'utime', 'test_utime.c'), 'r').read()
+    src = open(path_from_root('tests', 'utime', 'test_utime.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_utf(self):
@@ -4826,16 +4798,16 @@ name: .
     # undefined symbols at link time so perhaps have it imply this setting?
     self.set_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
     self.set_setting('INCLUDE_FULL_LIBRARY', 1)
-    self.add_pre_run(open(path_from_root('tests', 'filesystem', 'src.js'), 'r').read())
+    self.add_pre_run(open(path_from_root('tests', 'filesystem', 'src.js')).read())
     src = 'int main() {return 0;}\n'
-    expected = open(path_from_root('tests', 'filesystem', 'output.txt'), 'r').read()
+    expected = open(path_from_root('tests', 'filesystem', 'output.txt')).read()
     self.do_run(src, expected)
 
   @also_with_noderawfs
   @is_slow_test
   def test_fs_nodefs_rw(self, js_engines=[NODE_JS]):
     self.set_setting('SYSCALL_DEBUG', 1)
-    src = open(path_from_root('tests', 'fs', 'test_nodefs_rw.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_nodefs_rw.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
     print('closure')
     self.emcc_args += ['--closure', '1']
@@ -4843,12 +4815,12 @@ name: .
 
   @also_with_noderawfs
   def test_fs_nodefs_cloexec(self, js_engines=[NODE_JS]):
-    src = open(path_from_root('tests', 'fs', 'test_nodefs_cloexec.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_nodefs_cloexec.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
   def test_fs_nodefs_home(self):
     self.set_setting('FORCE_FILESYSTEM', 1)
-    src = open(path_from_root('tests', 'fs', 'test_nodefs_home.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_nodefs_home.c')).read()
     self.do_run(src, 'success', js_engines=[NODE_JS])
 
   def test_fs_trackingdelegate(self):
@@ -4878,7 +4850,7 @@ name: .
 
   @also_with_noderawfs
   def test_fs_append(self, js_engines=None):
-    src = open(path_from_root('tests', 'fs', 'test_append.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_append.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
   def test_fs_mmap(self):
@@ -4893,8 +4865,7 @@ name: .
   def test_fs_errorstack(self, js_engines=[NODE_JS]):
     # Enables strict mode, which may catch some strict-mode-only errors
     # so that users can safely work with strict JavaScript if enabled.
-    with open('pre.js', 'w') as f:
-      f.write('"use strict";')
+    create_test_file('pre.js', '"use strict";')
     self.emcc_args += ['--pre-js', 'pre.js']
 
     self.set_setting('FORCE_FILESYSTEM', 1)
@@ -4918,14 +4889,14 @@ name: .
   @also_with_noderawfs
   def test_fs_llseek(self, js_engines=None):
     self.set_setting('FORCE_FILESYSTEM', 1)
-    src = open(path_from_root('tests', 'fs', 'test_llseek.c'), 'r').read()
+    src = open(path_from_root('tests', 'fs', 'test_llseek.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
   def test_unistd_access(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
-    src = open(path_from_root('tests', 'unistd', 'access.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'access.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'access.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'access.out')).read()
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, expected, js_engines=[NODE_JS])
@@ -4936,47 +4907,47 @@ name: .
       self.do_run(src, expected, js_engines=[NODE_JS])
 
   def test_unistd_curdir(self):
-    src = open(path_from_root('tests', 'unistd', 'curdir.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'curdir.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'curdir.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'curdir.out')).read()
     self.do_run(src, expected)
 
   @also_with_noderawfs
   def test_unistd_close(self, js_engines=None):
-    src = open(path_from_root('tests', 'unistd', 'close.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'close.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'close.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'close.out')).read()
     self.do_run(src, expected, js_engines=js_engines)
 
   def test_unistd_confstr(self):
-    src = open(path_from_root('tests', 'unistd', 'confstr.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'confstr.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'confstr.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'confstr.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_ttyname(self):
-    src = open(path_from_root('tests', 'unistd', 'ttyname.c'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'ttyname.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   @also_with_noderawfs
   def test_unistd_pipe(self, js_engines=None):
-    src = open(path_from_root('tests', 'unistd', 'pipe.c'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'pipe.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
   @also_with_noderawfs
   def test_unistd_dup(self, js_engines=None):
-    src = open(path_from_root('tests', 'unistd', 'dup.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'dup.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'dup.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'dup.out')).read()
     self.do_run(src, expected, js_engines=js_engines)
 
   def test_unistd_pathconf(self):
-    src = open(path_from_root('tests', 'unistd', 'pathconf.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'pathconf.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'pathconf.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'pathconf.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_truncate(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
     for fs in ['MEMFS', 'NODEFS']:
-      src = open(path_from_root('tests', 'unistd', 'truncate.c'), 'r').read()
-      expected = open(path_from_root('tests', 'unistd', 'truncate.out'), 'r').read()
+      src = open(path_from_root('tests', 'unistd', 'truncate.c')).read()
+      expected = open(path_from_root('tests', 'unistd', 'truncate.out')).read()
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, expected, js_engines=[NODE_JS])
 
@@ -4989,21 +4960,21 @@ name: .
     self.do_run_from_file(src, output, js_engines=[NODE_JS])
 
   def test_unistd_swab(self):
-    src = open(path_from_root('tests', 'unistd', 'swab.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'swab.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'swab.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'swab.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_isatty(self):
-    src = open(path_from_root('tests', 'unistd', 'isatty.c'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'isatty.c')).read()
     self.do_run(src, 'success', force_c=True)
 
   def test_unistd_sysconf(self):
-    src = open(path_from_root('tests', 'unistd', 'sysconf.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'sysconf.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'sysconf.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'sysconf.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_sysconf_phys_pages(self):
-    src = open(path_from_root('tests', 'unistd', 'sysconf_phys_pages.c'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')).read()
     if self.get_setting('ALLOW_MEMORY_GROWTH'):
       expected = (2 * 1024 * 1024 * 1024 - 16777216) // 16384
     else:
@@ -5011,14 +4982,14 @@ name: .
     self.do_run(src, str(expected) + ', errno: 0')
 
   def test_unistd_login(self):
-    src = open(path_from_root('tests', 'unistd', 'login.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'login.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'login.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'login.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_unlink(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
-    src = open(path_from_root('tests', 'unistd', 'unlink.c'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'unlink.c')).read()
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       # symlinks on node.js on Windows require administrative privileges, so skip testing those bits on that combination.
@@ -5037,8 +5008,8 @@ name: .
   def test_unistd_links(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
-    src = open(path_from_root('tests', 'unistd', 'links.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'links.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'links.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'links.out')).read()
     for fs in ['MEMFS', 'NODEFS']:
       if WINDOWS and fs == 'NODEFS':
         print('Skipping NODEFS part of this test for test_unistd_links on Windows, since it would require administrative privileges.', file=sys.stderr)
@@ -5055,28 +5026,28 @@ name: .
     # test expects /, but Windows gives \ as path slashes.
     # Calling readlink() on a non-link gives error 22 EINVAL on Unix, but simply error 0 OK on Windows.
     self.clear()
-    src = open(path_from_root('tests', 'unistd', 'symlink_on_nodefs.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'symlink_on_nodefs.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'symlink_on_nodefs.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'symlink_on_nodefs.out')).read()
     self.do_run(src, expected, js_engines=[NODE_JS])
 
   def test_unistd_sleep(self):
-    src = open(path_from_root('tests', 'unistd', 'sleep.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'sleep.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'sleep.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'sleep.out')).read()
     self.do_run(src, expected)
 
   def test_unistd_io(self):
     self.clear()
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
-    src = open(path_from_root('tests', 'unistd', 'io.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'io.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'io.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'io.out')).read()
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, expected, js_engines=[NODE_JS])
 
   def test_unistd_misc(self):
     orig_compiler_opts = Building.COMPILER_TEST_OPTS[:]
-    src = open(path_from_root('tests', 'unistd', 'misc.c'), 'r').read()
-    expected = open(path_from_root('tests', 'unistd', 'misc.out'), 'r').read()
+    src = open(path_from_root('tests', 'unistd', 'misc.c')).read()
+    expected = open(path_from_root('tests', 'unistd', 'misc.out')).read()
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
       self.do_run(src, expected, js_engines=[NODE_JS])
@@ -5100,24 +5071,24 @@ name: .
     self.do_run_in_out_file_test('tests', 'core', 'test_unary_literal')
 
   def test_env(self):
-    src = open(path_from_root('tests', 'env', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'env', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'env', 'src.c')).read()
+    expected = open(path_from_root('tests', 'env', 'output.txt')).read()
     self.do_run(src, [
-      expected.replace('{{{ THIS_PROGRAM }}}', os.path.join(self.get_dir(), 'src.cpp.o.js').replace('\\', '/')), # node, can find itself properly
+      expected.replace('{{{ THIS_PROGRAM }}}', self.in_dir('src.cpp.o.js')).replace('\\', '/'), # node, can find itself properly
       expected.replace('{{{ THIS_PROGRAM }}}', './this.program') # spidermonkey, v8
     ])
 
   def test_environ(self):
-    src = open(path_from_root('tests', 'env', 'src-mini.c'), 'r').read()
-    expected = open(path_from_root('tests', 'env', 'output-mini.txt'), 'r').read()
+    src = open(path_from_root('tests', 'env', 'src-mini.c')).read()
+    expected = open(path_from_root('tests', 'env', 'output-mini.txt')).read()
     self.do_run(src, [
-      expected.replace('{{{ THIS_PROGRAM }}}', os.path.join(self.get_dir(), 'src.cpp.o.js').replace('\\', '/')), # node, can find itself properly
+      expected.replace('{{{ THIS_PROGRAM }}}', self.in_dir('src.cpp.o.js')).replace('\\', '/'), # node, can find itself properly
       expected.replace('{{{ THIS_PROGRAM }}}', './this.program') # spidermonkey, v8
     ])
 
   def test_systypes(self):
-    src = open(path_from_root('tests', 'systypes', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'systypes', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'systypes', 'src.c')).read()
+    expected = open(path_from_root('tests', 'systypes', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_getloadavg(self):
@@ -5127,15 +5098,15 @@ name: .
     self.do_run_in_out_file_test('tests', 'core', 'test_nl_types')
 
   def test_799(self):
-    src = open(path_from_root('tests', '799.cpp'), 'r').read()
+    src = open(path_from_root('tests', '799.cpp')).read()
     self.do_run(src, '''Set PORT family: 0, port: 3979
 Get PORT family: 0
 PORT: 3979
 ''')
 
   def test_ctype(self):
-    src = open(path_from_root('tests', 'ctype', 'src.c'), 'r').read()
-    expected = open(path_from_root('tests', 'ctype', 'output.txt'), 'r').read()
+    src = open(path_from_root('tests', 'ctype', 'src.c')).read()
+    expected = open(path_from_root('tests', 'ctype', 'output.txt')).read()
     self.do_run(src, expected)
 
   def test_strcasecmp(self):
@@ -5160,8 +5131,8 @@ PORT: 3979
     self.do_run_in_out_file_test('tests', 'core', 'test_phiundef')
 
   def test_netinet_in(self):
-    src = open(path_from_root('tests', 'netinet', 'in.cpp'), 'r').read()
-    expected = open(path_from_root('tests', 'netinet', 'in.out'), 'r').read()
+    src = open(path_from_root('tests', 'netinet', 'in.cpp')).read()
+    expected = open(path_from_root('tests', 'netinet', 'in.out')).read()
     self.do_run(src, expected)
 
   @no_wasm_backend('No dynamic linking support in wasm backend path')
@@ -5216,7 +5187,7 @@ PORT: 3979
     self.do_run_in_out_file_test('tests', 'core', 'test_reinterpreted_ptrs')
 
   def test_js_libraries(self):
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write('''
+    create_test_file('main.cpp', '''
       #include <stdio.h>
       extern "C" {
         extern void printey();
@@ -5228,14 +5199,14 @@ PORT: 3979
         return 0;
       }
     ''')
-    open(os.path.join(self.get_dir(), 'mylib1.js'), 'w').write('''
+    create_test_file('mylib1.js', '''
       mergeInto(LibraryManager.library, {
         printey: function() {
           out('hello from lib!');
         }
       });
     ''')
-    open(os.path.join(self.get_dir(), 'mylib2.js'), 'w').write('''
+    create_test_file('mylib2.js', '''
       mergeInto(LibraryManager.library, {
         calcey: function(x, y) {
           return x + y;
@@ -5243,11 +5214,11 @@ PORT: 3979
       });
     ''')
 
-    self.emcc_args += ['--js-library', os.path.join(self.get_dir(), 'mylib1.js'), '--js-library', os.path.join(self.get_dir(), 'mylib2.js')]
-    self.do_run(open(os.path.join(self.get_dir(), 'main.cpp'), 'r').read(), 'hello from lib!\n*32*\n')
+    self.emcc_args += ['--js-library', 'mylib1.js', '--js-library', 'mylib2.js']
+    self.do_run(open('main.cpp').read(), 'hello from lib!\n*32*\n')
 
   def test_unicode_js_library(self):
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write('''
+    create_test_file('main.cpp', '''
       #include <stdio.h>
       extern "C" {
         extern void printey();
@@ -5258,10 +5229,10 @@ PORT: 3979
       }
     ''')
     self.emcc_args += ['--js-library', path_from_root('tests', 'unicode_library.js')]
-    self.do_run(open(os.path.join(self.get_dir(), 'main.cpp'), 'r').read(), u'Unicode snowman \u2603 says hello!')
+    self.do_run(open('main.cpp').read(), u'Unicode snowman \u2603 says hello!')
 
   def test_js_lib_dep_memset(self):
-    open('lib.js', 'w').write(r'''
+    create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {
   depper__deps: ['memset'],
   depper: function(ptr) {
@@ -5338,15 +5309,15 @@ int main(void) {
   def test_fannkuch(self):
     results = [(1, 0), (2, 1), (3, 2), (4, 4), (5, 7), (6, 10), (7, 16), (8, 22)]
     for i, j in results:
-      src = open(path_from_root('tests', 'fannkuch.cpp'), 'r').read()
+      src = open(path_from_root('tests', 'fannkuch.cpp')).read()
       self.do_run(src, 'Pfannkuchen(%d) = %d.' % (i, j), [str(i)], no_build=i > 1)
 
   def test_raytrace(self):
     # TODO: Should we remove this test?
     self.skipTest('Relies on double value rounding, extremely sensitive')
 
-    src = open(path_from_root('tests', 'raytrace.cpp'), 'r').read().replace('double', 'float')
-    output = open(path_from_root('tests', 'raytrace.ppm'), 'r').read()
+    src = open(path_from_root('tests', 'raytrace.cpp')).read().replace('double', 'float')
+    output = open(path_from_root('tests', 'raytrace.ppm')).read()
     self.do_run(src, output, ['3', '16']) # , build_ll_hook=self.do_autodebug)
 
   def test_fasta(self):
@@ -5357,7 +5328,7 @@ int main(void) {
         self.set_setting('PRECISE_F32', precision)
         for t in ['float', 'double']:
           print(precision, t)
-          src = open(path_from_root('tests', 'fasta.cpp'), 'r').read().replace('double', t)
+          src = open(path_from_root('tests', 'fasta.cpp')).read().replace('double', t)
           for i, j in results:
             self.do_run(src, j, [str(i)], lambda x, err: x.replace('\n', '*'), no_build=i > 1)
           shutil.copyfile('src.cpp.o.js', '%d_%s.js' % (precision, t))
@@ -5372,12 +5343,12 @@ int main(void) {
     # needed with typed arrays
     self.set_setting('TOTAL_MEMORY', 128 * 1024 * 1024)
 
-    src = open(path_from_root('system', 'lib', 'dlmalloc.c'), 'r').read() + '\n\n\n' + open(path_from_root('tests', 'dlmalloc_test.c'), 'r').read()
+    src = open(path_from_root('system', 'lib', 'dlmalloc.c')).read() + '\n\n\n' + open(path_from_root('tests', 'dlmalloc_test.c')).read()
     self.do_run(src, '*1,0*', ['200', '1'])
     self.do_run(src, '*400,0*', ['400', '400'], no_build=True)
 
     # Linked version
-    src = open(path_from_root('tests', 'dlmalloc_test.c'), 'r').read()
+    src = open(path_from_root('tests', 'dlmalloc_test.c')).read()
     self.do_run(src, '*1,0*', ['200', '1'])
     self.do_run(src, '*400,0*', ['400', '400'], no_build=True)
 
@@ -5385,8 +5356,8 @@ int main(void) {
     if self.emcc_args == []:
       # emcc should build in dlmalloc automatically, and do all the sign correction etc. for it
 
-      try_delete(os.path.join(self.get_dir(), 'src.cpp.o.js'))
-      run_process([PYTHON, EMCC, path_from_root('tests', 'dlmalloc_test.c'), '-s', 'TOTAL_MEMORY=128MB', '-o', os.path.join(self.get_dir(), 'src.cpp.o.js')], stdout=PIPE, stderr=self.stderr_redirect)
+      try_delete('src.cpp.o.js')
+      run_process([PYTHON, EMCC, path_from_root('tests', 'dlmalloc_test.c'), '-s', 'TOTAL_MEMORY=128MB', '-o', 'src.cpp.o.js'], stdout=PIPE, stderr=self.stderr_redirect)
 
       self.do_run('x', '*1,0*', ['200', '1'], no_build=True)
       self.do_run('x', '*400,0*', ['400', '400'], no_build=True)
@@ -5470,7 +5441,7 @@ return malloc(size);
           continue
         s += '.'
       assert len(s) == 9000
-      open(self.in_dir('data.dat'), 'w').write(s)
+      create_test_file('data.dat', s)
       src = open(path_from_root('tests', 'mmap_file.c')).read()
       self.do_run(src, '*\n' + s[0:20] + '\n' + s[4096:4096 + 20] + '\n*\n')
 
@@ -5544,7 +5515,7 @@ return malloc(size);
       self.emcc_args = orig_args + mode + ['-msse']
       self.maybe_closure()
 
-      self.do_run(open(path_from_root('tests', 'test_sse1.cpp'), 'r').read(), 'Success!')
+      self.do_run(open(path_from_root('tests', 'test_sse1.cpp')).read(), 'Success!')
 
   # ignore nans in some simd tests due to an LLVM regression still being investigated,
   # https://github.com/kripken/emscripten/issues/4435
@@ -5566,7 +5537,7 @@ return malloc(size);
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse']
       self.maybe_closure()
 
-      self.do_run(open(path_from_root('tests', 'test_sse1_full.cpp'), 'r').read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
+      self.do_run(open(path_from_root('tests', 'test_sse1_full.cpp')).read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
 
   # Tests the full SSE2 API.
   @SIMD
@@ -5591,7 +5562,7 @@ return malloc(size);
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse2'] + args
       self.maybe_closure()
 
-      self.do_run(open(path_from_root('tests', 'test_sse2_full.cpp'), 'r').read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
+      self.do_run(open(path_from_root('tests', 'test_sse2_full.cpp')).read(), self.ignore_nans(native_result), output_nicerizer=self.ignore_nans)
 
   # Tests the full SSE3 API.
   @SIMD
@@ -5607,7 +5578,7 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse3'] + args
-      self.do_run(open(path_from_root('tests', 'test_sse3_full.cpp'), 'r').read(), native_result)
+      self.do_run(open(path_from_root('tests', 'test_sse3_full.cpp')).read(), native_result)
 
   @SIMD
   def test_ssse3_full(self):
@@ -5622,7 +5593,7 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-mssse3'] + args
-      self.do_run(open(path_from_root('tests', 'test_ssse3_full.cpp'), 'r').read(), native_result)
+      self.do_run(open(path_from_root('tests', 'test_ssse3_full.cpp')).read(), native_result)
 
   @SIMD
   def test_sse4_1_full(self):
@@ -5637,7 +5608,7 @@ return malloc(size);
     orig_args = self.emcc_args
     for mode in [[], ['-s', 'SIMD=1']]:
       self.emcc_args = orig_args + mode + ['-I' + path_from_root('tests'), '-msse4.1'] + args
-      self.do_run(open(path_from_root('tests', 'test_sse4_1_full.cpp'), 'r').read(), native_result)
+      self.do_run(open(path_from_root('tests', 'test_sse4_1_full.cpp')).read(), native_result)
 
   @SIMD
   def test_simd(self):
@@ -5837,14 +5808,14 @@ return malloc(size);
     ))
 
     # Not needed for js, but useful for debugging
-    shutil.copyfile(path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), os.path.join(self.get_dir(), 'font.ttf'))
+    shutil.copyfile(path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), 'font.ttf')
 
     # Main
     for outlining in [0, 5000]:
       self.set_setting('OUTLINING_LIMIT', outlining)
       print('outlining:', outlining, file=sys.stderr)
-      self.do_run(open(path_from_root('tests', 'freetype', 'main.c'), 'r').read(),
-                  open(path_from_root('tests', 'freetype', 'ref.txt'), 'r').read(),
+      self.do_run(open(path_from_root('tests', 'freetype', 'main.c')).read(),
+                  open(path_from_root('tests', 'freetype', 'ref.txt')).read(),
                   ['font.ttf', 'test!', '150', '120', '25'],
                   libraries=get_freetype_library(self),
                   includes=[path_from_root('tests', 'freetype', 'include')])
@@ -5852,22 +5823,22 @@ return malloc(size);
 
     # github issue 324
     print('[issue 324]')
-    self.do_run(open(path_from_root('tests', 'freetype', 'main_2.c'), 'r').read(),
-                open(path_from_root('tests', 'freetype', 'ref_2.txt'), 'r').read(),
+    self.do_run(open(path_from_root('tests', 'freetype', 'main_2.c')).read(),
+                open(path_from_root('tests', 'freetype', 'ref_2.txt')).read(),
                 ['font.ttf', 'w', '32', '32', '25'],
                 libraries=get_freetype_library(self),
                 includes=[path_from_root('tests', 'freetype', 'include')])
 
     print('[issue 324 case 2]')
-    self.do_run(open(path_from_root('tests', 'freetype', 'main_3.c'), 'r').read(),
-                open(path_from_root('tests', 'freetype', 'ref_3.txt'), 'r').read(),
+    self.do_run(open(path_from_root('tests', 'freetype', 'main_3.c')).read(),
+                open(path_from_root('tests', 'freetype', 'ref_3.txt')).read(),
                 ['font.ttf', 'W', '32', '32', '0'],
                 libraries=get_freetype_library(self),
                 includes=[path_from_root('tests', 'freetype', 'include')])
 
     print('[issue 324 case 3]')
     self.do_run('',
-                open(path_from_root('tests', 'freetype', 'ref_4.txt'), 'r').read(),
+                open(path_from_root('tests', 'freetype', 'ref_4.txt')).read(),
                 ['font.ttf', 'ea', '40', '32', '0'],
                 no_build=True)
 
@@ -5894,7 +5865,7 @@ return malloc(size);
     src += open(path_from_root('tests', 'sqlite', 'sqlite3.c')).read()
     src += open(path_from_root('tests', 'sqlite', 'benchmark.c')).read()
     self.do_run(src,
-                open(path_from_root('tests', 'sqlite', 'benchmark.txt'), 'r').read(),
+                open(path_from_root('tests', 'sqlite', 'benchmark.txt')).read(),
                 includes=[path_from_root('tests', 'sqlite')],
                 force_c=True)
 
@@ -5914,10 +5885,10 @@ return malloc(size);
       make_args = ['libz.a']
       configure = ['sh', './configure']
 
-    self.do_run(open(path_from_root('tests', 'zlib', 'example.c'), 'r').read(),
-                open(path_from_root('tests', 'zlib', 'ref.txt'), 'r').read(),
+    self.do_run(open(path_from_root('tests', 'zlib', 'example.c')).read(),
+                open(path_from_root('tests', 'zlib', 'ref.txt')).read(),
                 libraries=self.get_library('zlib', os.path.join('libz.a'), make_args=make_args, configure=configure),
-                includes=[path_from_root('tests', 'zlib'), os.path.join(self.get_dir(), 'building', 'zlib')],
+                includes=[path_from_root('tests', 'zlib'), 'building', 'zlib'],
                 force_c=True)
 
   @is_slow_test
@@ -5936,11 +5907,11 @@ return malloc(size);
       self.set_setting('ASSERTIONS', 2 if use_cmake else asserts)
 
       def test():
-        self.do_run(open(path_from_root('tests', 'bullet', 'Demos', 'HelloWorld', 'HelloWorld.cpp'), 'r').read(),
-                    [open(path_from_root('tests', 'bullet', 'output.txt'), 'r').read(), # different roundings
-                     open(path_from_root('tests', 'bullet', 'output2.txt'), 'r').read(),
-                     open(path_from_root('tests', 'bullet', 'output3.txt'), 'r').read(),
-                     open(path_from_root('tests', 'bullet', 'output4.txt'), 'r').read()],
+        self.do_run(open(path_from_root('tests', 'bullet', 'Demos', 'HelloWorld', 'HelloWorld.cpp')).read(),
+                    [open(path_from_root('tests', 'bullet', 'output.txt')).read(), # different roundings
+                     open(path_from_root('tests', 'bullet', 'output2.txt')).read(),
+                     open(path_from_root('tests', 'bullet', 'output3.txt')).read(),
+                     open(path_from_root('tests', 'bullet', 'output4.txt')).read()],
                     libraries=get_bullet_library(self, use_cmake),
                     includes=[path_from_root('tests', 'bullet', 'src')])
       test()
@@ -5962,11 +5933,10 @@ return malloc(size);
   @no_windows('depends on freetype, which uses a ./configure which donsnt run on windows.')
   def test_poppler(self):
     def test():
-      with open(os.path.join(self.get_dir(), 'paper.pdf.js'), 'w') as f:
-        f.write(str(list(bytearray(open(path_from_root('tests', 'poppler', 'paper.pdf'), 'rb').read()))))
+      pdf_data = open(path_from_root('tests', 'poppler', 'paper.pdf'), 'rb').read()
+      create_test_file('paper.pdf.js', str(list(bytearray(pdf_data))))
 
-      with open('pre.js', 'w') as f:
-        f.write('''
+      create_test_file('pre.js', '''
       Module.preRun = function() {
         FS.createDataFile('/', 'paper.pdf', eval(Module.read('paper.pdf.js')), true, false, false);
       };
@@ -5998,8 +5968,7 @@ return malloc(size);
 
     original_j2k = path_from_root('tests', 'openjpeg', 'syntensity_lobby_s.j2k')
     image_bytes = list(bytearray(open(original_j2k, 'rb').read()))
-    with open('pre.js', 'w') as f:
-      f.write("""
+    create_test_file('pre.js', """
       Module.preRun = function() { FS.createDataFile('/', 'image.j2k', %s, true, false, false); };
       Module.postRun = function() {
         out('Data: ' + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.analyzePath('image.raw').object)));
@@ -6055,7 +6024,7 @@ return malloc(size);
     self.emcc_args += ['--pre-js', 'pre.js']
 
     def do_test():
-      self.do_run(open(path_from_root('tests', 'openjpeg', 'codec', 'j2k_to_image.c'), 'r').read(),
+      self.do_run(open(path_from_root('tests', 'openjpeg', 'codec', 'j2k_to_image.c')).read(),
                   'Successfully generated', # The real test for valid output is in image_compare
                   '-i image.j2k -o image.raw'.split(' '),
                   libraries=lib,
@@ -6104,7 +6073,7 @@ return malloc(size);
   def test_lifetime(self):
     self.do_ll_run(path_from_root('tests', 'lifetime.ll'), 'hello, world!\n')
     if '-O1' in self.emcc_args or '-O2' in self.emcc_args:
-      assert 'a18' not in open(os.path.join(self.get_dir(), 'src.cpp.o.js')).read(), 'lifetime stuff and their vars must be culled'
+      assert 'a18' not in open('src.cpp.o.js').read(), 'lifetime stuff and their vars must be culled'
 
   # Test cases in separate files. Note that these files may contain invalid .ll!
   # They are only valid enough for us to read for test purposes, not for llvm-as
@@ -6197,7 +6166,7 @@ return malloc(size);
       print("Testing case '%s'..." % basename)
       output_file = path_from_root('tests', 'cases', shortname + '.txt')
       if os.path.exists(output_file):
-        output = open(output_file, 'r').read()
+        output = open(output_file).read()
       else:
         output = 'hello, world!'
 
@@ -6291,11 +6260,11 @@ return malloc(size);
     output = test_path + '.out'
     self.do_run_from_file(src, output, build_ll_hook=lambda x: False) # add an ll hook, to force ll generation
 
-    filename = os.path.join(self.get_dir(), 'src.cpp')
+    filename = 'src.cpp'
     self.do_autodebug(filename)
 
     # Compare to each other, and to expected output
-    self.do_ll_run(path_from_root('tests', filename + '.o.ll.ll'), 'AD:-1,1')
+    self.do_ll_run(filename + '.o.ll.ll', 'AD:-1,1')
 
     # Test using build_ll_hook
     src = '''
@@ -6321,8 +6290,7 @@ return malloc(size);
   def test_ccall(self):
     self.emcc_args.append('-Wno-return-stack-address')
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
-    with open('post.js', 'w') as f:
-      f.write('''
+    create_test_file('post.js', '''
       out('*');
       var ret;
       ret = Module['ccall']('get_int', 'number'); out([typeof ret, ret].join(','));
@@ -6471,7 +6439,7 @@ return malloc(size);
 
     def test(expected, args=[], no_build=False):
       self.do_run(src, expected, args=args, no_build=no_build)
-      return open(self.in_dir('src.cpp.o.js')).read()
+      return open('src.cpp.o.js').read()
 
     # Sanity check that it works and the dead function is emitted
     js = test('*1*', ['x'])
@@ -6499,7 +6467,7 @@ return malloc(size);
 
       def test(expected, args=[], no_build=False):
         self.do_run(src, expected, args=args, no_build=no_build)
-        return open(self.in_dir('src.cpp.o.js')).read()
+        return open('src.cpp.o.js').read()
 
       # Sanity check that it works and the dead function is emitted
       js = test('*9*')
@@ -6571,7 +6539,7 @@ return malloc(size);
     output = 'hello, world!'
 
     self.do_run(src, output)
-    shutil.move(self.in_dir('src.cpp.o.js'), self.in_dir('normal.js'))
+    shutil.move('src.cpp.o.js', 'normal.js')
 
     self.set_setting('ASM_JS', 0)
     self.set_setting('PGO', 1)
@@ -6579,16 +6547,16 @@ return malloc(size);
     self.set_setting('ASM_JS', 1)
     self.set_setting('PGO', 0)
 
-    shutil.move(self.in_dir('src.cpp.o.js'), self.in_dir('pgo.js'))
-    pgo_output = run_js(self.in_dir('pgo.js')).split('\n')[1]
-    open('pgo_data.rsp', 'w').write(pgo_output)
+    shutil.move('src.cpp.o.js', 'pgo.js')
+    pgo_output = run_js('pgo.js').split('\n')[1]
+    create_test_file('pgo_data.rsp', pgo_output)
 
     # with response file
 
     self.emcc_args += ['@pgo_data.rsp']
     self.do_run(src, output)
     self.emcc_args.pop()
-    shutil.move(self.in_dir('src.cpp.o.js'), self.in_dir('pgoed.js'))
+    shutil.move('src.cpp.o.js', 'pgoed.js')
 
     before = len(open('normal.js').read())
     after = len(open('pgoed.js').read())
@@ -6596,41 +6564,39 @@ return malloc(size);
 
     # with response in settings element itself
 
-    open('dead_funcs', 'w').write(pgo_output[pgo_output.find('['):-1])
-    self.emcc_args += ['-s', 'DEAD_FUNCTIONS=@' + self.in_dir('dead_funcs')]
-    self.do_run(src, output)
-    self.emcc_args.pop()
-    self.emcc_args.pop()
-    shutil.move(self.in_dir('src.cpp.o.js'), self.in_dir('pgoed2.js'))
-    assert open('pgoed.js').read() == open('pgoed2.js').read()
-
-    # with relative response in settings element itself
-
-    open('dead_funcs', 'w').write(pgo_output[pgo_output.find('['):-1])
+    create_test_file('dead_funcs', pgo_output[pgo_output.find('['):-1])
     self.emcc_args += ['-s', 'DEAD_FUNCTIONS=@dead_funcs']
     self.do_run(src, output)
     self.emcc_args.pop()
     self.emcc_args.pop()
-    shutil.move(self.in_dir('src.cpp.o.js'), self.in_dir('pgoed2.js'))
+    shutil.move('src.cpp.o.js', 'pgoed2.js')
+    assert open('pgoed.js').read() == open('pgoed2.js').read()
+
+    # with relative response in settings element itself
+
+    create_test_file('dead_funcs', pgo_output[pgo_output.find('['):-1])
+    self.emcc_args += ['-s', 'DEAD_FUNCTIONS=@dead_funcs']
+    self.do_run(src, output)
+    self.emcc_args.pop()
+    self.emcc_args.pop()
+    shutil.move('src.cpp.o.js', 'pgoed2.js')
     assert open('pgoed.js').read() == open('pgoed2.js').read()
 
   def test_response_file(self):
-    with open('rsp_file', 'w') as f:
-      response_data = '-o %s/response_file.o.js %s' % (self.get_dir(), path_from_root('tests', 'hello_world.cpp'))
-      f.write(response_data.replace('\\', '\\\\'))
+    response_data = '-o %s/response_file.o.js %s' % (self.get_dir(), path_from_root('tests', 'hello_world.cpp'))
+    create_test_file('rsp_file', response_data.replace('\\', '\\\\'))
     run_process([PYTHON, EMCC, "@rsp_file"] + self.emcc_args)
     self.do_run('', 'hello, world', basename='response_file', no_build=True)
 
   def test_linker_response_file(self):
-    objfile = os.path.join(self.get_dir(), 'response_file.o')
+    objfile = 'response_file.o'
     run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.cpp'), '-o', objfile] + self.emcc_args)
     # This should expand into -Wl,--export=foo which will then be ignored
     # by emscripten, except when using the wasm backend (lld) in which case it
     # should pass the original flag to the linker.
-    with open('rsp_file', 'w') as f:
-      response_data = objfile + ' --export=foo'
-      f.write(response_data.replace('\\', '\\\\'))
-    run_process([PYTHON, EMCC, "-Wl,@rsp_file", '-o', os.path.join(self.get_dir(), 'response_file.o.js')] + self.emcc_args)
+    response_data = objfile + ' --export=foo'
+    create_test_file('rsp_file', response_data.replace('\\', '\\\\'))
+    run_process([PYTHON, EMCC, "-Wl,@rsp_file", '-o', 'response_file.o.js'] + self.emcc_args)
     self.do_run('', 'hello, world', basename='response_file', no_build=True)
 
   def test_exported_response(self):
@@ -6650,7 +6616,7 @@ return malloc(size);
         return 0;
       }
     '''
-    open('exps', 'w').write('["_main","_other_function"]')
+    create_test_file('exps', '["_main","_other_function"]')
 
     self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=@exps']
     self.do_run(src, '''waka 5!''')
@@ -6685,8 +6651,8 @@ return malloc(size);
     '''
 
     js_funcs.append('_main')
-    exported_func_json_file = os.path.join(self.get_dir(), 'large_exported_response.json')
-    open(exported_func_json_file, 'w').write(json.dumps(js_funcs))
+    exported_func_json_file = 'large_exported_response.json'
+    create_test_file(exported_func_json_file, json.dumps(js_funcs))
 
     self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=@' + exported_func_json_file]
     self.do_run(src, '''waka 4999!''')
@@ -6958,7 +6924,7 @@ someweirdtext
 
   def test_embind_2(self):
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
-    open('post.js', 'w').write('''
+    create_test_file('post.js', '''
       function printLerp() {
           out('lerp ' + Module.lerp(100, 200, 66) + '.');
       }
@@ -6983,7 +6949,7 @@ someweirdtext
 
   def test_embind_3(self):
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
-    open('post.js', 'w').write('''
+    create_test_file('post.js', '''
       function ready() {
         try {
           Module.compute(new Uint8Array([1,2,3]));
@@ -7012,7 +6978,7 @@ someweirdtext
   @no_wasm_backend('long doubles are f128s in wasm backend')
   def test_embind_4(self):
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
-    open('post.js', 'w').write('''
+    create_test_file('post.js', '''
       function printFirstElement() {
         out(Module.getBufferView()[0]);
       }
@@ -7099,32 +7065,31 @@ someweirdtext
 
       # Export things on "TheModule". This matches the typical use pattern of the bound library
       # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
-      open('export.js', 'w').write('''
+      create_test_file('export.js', '''
 // test purposes: remove printErr output, whose order is unpredictable when compared to print
 err = err = function(){};
 ''')
       self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=["_malloc"]', '--post-js', 'glue.js', '--post-js', 'export.js']
       if allow_memory_growth:
         self.emcc_args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
-      shutil.copyfile(path_from_root('tests', 'webidl', 'test.h'), self.in_dir('test.h'))
-      shutil.copyfile(path_from_root('tests', 'webidl', 'test.cpp'), self.in_dir('test.cpp'))
+      shutil.copyfile(path_from_root('tests', 'webidl', 'test.h'), 'test.h')
+      shutil.copyfile(path_from_root('tests', 'webidl', 'test.cpp'), 'test.cpp')
       src = open('test.cpp').read()
 
       def post(filename):
-        src = open(filename, 'a')
-        src.write('\n\n')
-        if self.run_name == 'asm2':
-          src.write('var TheModule = Module();\n')
-        else:
-          src.write('var TheModule = Module;\n')
-        src.write('\n\n')
-        if allow_memory_growth:
-          src.write("var isMemoryGrowthAllowed = true;")
-        else:
-          src.write("var isMemoryGrowthAllowed = false;")
-        src.write(open(path_from_root('tests', 'webidl', 'post.js')).read())
-        src.write('\n\n')
-        src.close()
+        with open(filename, 'a') as f:
+          f.write('\n\n')
+          if self.run_name == 'asm2':
+            f.write('var TheModule = Module();\n')
+          else:
+            f.write('var TheModule = Module;\n')
+          f.write('\n\n')
+          if allow_memory_growth:
+            f.write("var isMemoryGrowthAllowed = true;")
+          else:
+            f.write("var isMemoryGrowthAllowed = false;")
+          f.write(open(path_from_root('tests', 'webidl', 'post.js')).read())
+          f.write('\n\n')
 
       output = open(path_from_root('tests', 'webidl', "output_%s.txt" % mode)).read()
       self.do_run(src, output, post_build=post, output_nicerizer=(lambda out, err: out))
@@ -7175,8 +7140,8 @@ err = err = function(){};
         printf("%f\\n", *y);
       }
     '''
-    module_name = os.path.join(self.get_dir(), 'module.cpp')
-    open(module_name, 'w').write(module)
+    module_name = 'module.cpp'
+    create_test_file(module_name, module)
 
     main = '''
       #include <stdio.h>
@@ -7191,12 +7156,12 @@ err = err = function(){};
         return 0;
       }
     '''
-    main_name = os.path.join(self.get_dir(), 'main.cpp')
-    open(main_name, 'w').write(main)
+    main_name = 'main.cpp'
+    create_test_file(main_name, main)
 
     Building.emcc(module_name, ['-g'])
     Building.emcc(main_name, ['-g'])
-    all_name = os.path.join(self.get_dir(), 'all.bc')
+    all_name = 'all.bc'
     Building.link([module_name + '.o', main_name + '.o'], all_name)
 
     try:
@@ -7226,17 +7191,14 @@ err = err = function(){};
         return 0; // line 12
       }
     '''
+    create_test_file('src.cpp', src)
 
-    dirname = self.get_dir()
-    src_filename = os.path.join(dirname, 'src.cpp')
-    out_filename = os.path.join(dirname, 'a.out.js')
-    wasm_filename = os.path.join(dirname, 'a.out.wasm')
-    no_maps_filename = os.path.join(dirname, 'no-maps.out.js')
+    out_filename = 'a.out.js'
+    wasm_filename = 'a.out.wasm'
+    no_maps_filename = 'no-maps.out.js'
 
-    with open(src_filename, 'w') as f:
-      f.write(src)
     assert '-g4' not in Building.COMPILER_TEST_OPTS
-    Building.emcc(src_filename,
+    Building.emcc('src.cpp',
                   self.serialize_settings() + self.emcc_args + Building.COMPILER_TEST_OPTS,
                   out_filename)
     # the file name may find its way into the generated code, so make sure we
@@ -7248,7 +7210,7 @@ err = err = function(){};
     Building.COMPILER_TEST_OPTS.append('-g4')
 
     def build_and_check():
-      Building.emcc(src_filename,
+      Building.emcc('src.cpp',
                     self.serialize_settings() + self.emcc_args + Building.COMPILER_TEST_OPTS,
                     out_filename,
                     stderr=PIPE)
@@ -7274,7 +7236,7 @@ err = err = function(){};
         else:
           return data
 
-      data = json.load(open(map_filename, 'r'))
+      data = json.load(open(map_filename))
       if str is bytes:
         # Python 2 compatibility
         data = encode_utf8(data)
@@ -7283,7 +7245,7 @@ err = err = function(){};
         # the output file.
         self.assertPathsIdentical(map_referent, data['file'])
       assert len(data['sources']) == 1, data['sources']
-      self.assertPathsIdentical(src_filename, data['sources'][0])
+      self.assertPathsIdentical('src.cpp', data['sources'][0])
       if hasattr(data, 'sourcesContent'):
         # the sourcesContent attribute is optional, but if it is present it
         # needs to containt valid source text.
@@ -7296,7 +7258,7 @@ err = err = function(){};
         mappings = encode_utf8(mappings)
       seen_lines = set()
       for m in mappings:
-        self.assertPathsIdentical(src_filename, m['source'])
+        self.assertPathsIdentical('src.cpp', m['source'])
         seen_lines.add(m['originalLine'])
       # ensure that all the 'meaningful' lines in the original code get mapped
       assert seen_lines.issuperset([6, 7, 11, 12])
@@ -7436,8 +7398,7 @@ Success!
         }
       }
     '''
-    with open('pre.js', 'w') as f:
-      f.write('''
+    create_test_file('pre.js', '''
       Module.preInit = function() {
         addOnExit(function () {
           out('I see exit status: ' + EXITSTATUS);
@@ -7522,7 +7483,7 @@ int main() {
 '''
       self.set_setting('ASSERTIONS', 1)
       self.set_setting('INVOKE_RUN', 0)
-      open('pre.js', 'w').write('''
+      create_test_file('pre.js', '''
 Module['onRuntimeInitialized'] = function() {
   try {
     ccall('main', 'number', ['number', 'string'], [2, 'waka']);
@@ -7546,7 +7507,7 @@ int main() {
   printf("World\n");
 }
 '''
-      open('pre.js', 'w').write('''
+      create_test_file('pre.js', '''
 Module['onRuntimeInitialized'] = function() {
   ccall('main', null, ['number', 'string'], [2, 'waka'], { async: true });
 };
@@ -7571,7 +7532,7 @@ extern "C" {
   }
 }
 '''
-      open('pre.js', 'w').write(r'''
+      create_test_file('pre.js', r'''
 Module['onRuntimeInitialized'] = function() {
   ccall('stringf', 'string', ['string'], ['first\n'], { async: true })
     .then(function(val) {
@@ -7594,7 +7555,7 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('EMTERPRETIFY_ASYNC', 1)
     self.banned_js_engines = [SPIDERMONKEY_ENGINE, V8_ENGINE] # needs setTimeout which only node has
 
-    open('lib.js', 'w').write(r'''
+    create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {
   sleep_with_return__deps: ['$EmterpreterAsync'],
   sleep_with_return: function(ms) {
@@ -7672,7 +7633,7 @@ int main() {
 
     self.set_setting('EMTERPRETIFY_ASYNC', 1)
 
-    open('lib.js', 'w').write(r'''
+    create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {
   sleep_with_abort__deps: ['$EmterpreterAsync'],
   sleep_with_abort: function() {
@@ -7726,7 +7687,7 @@ int main() {
     self.set_setting('EMTERPRETIFY_ASYNC', 1)
     self.set_setting('ASSERTIONS', 2)
 
-    open('post.js', 'w').write(r'''
+    create_test_file('post.js', r'''
 var AsyncOperation = {
   done: false,
 
@@ -7813,7 +7774,7 @@ extern "C" {
 
   def test_cxx_self_assign(self):
     # See https://github.com/kripken/emscripten/pull/2688 and http://llvm.org/bugs/show_bug.cgi?id=18735
-    open('src.cpp', 'w').write(r'''
+    create_test_file('src.cpp', r'''
       #include <map>
       #include <stdio.h>
 
@@ -7834,7 +7795,7 @@ extern "C" {
     # This test checks for the global variables required to run the memory
     # profiler.  It would fail if these variables were made no longer global
     # or if their identifiers were changed.
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write('''
+    create_test_file('main.cpp', '''
       extern "C" {
         void check_memprof_requirements();
       }
@@ -7843,7 +7804,7 @@ extern "C" {
         return 0;
       }
     ''')
-    open(os.path.join(self.get_dir(), 'lib.js'), 'w').write('''
+    create_test_file('lib.js', '''
       mergeInto(LibraryManager.library, {
         check_memprof_requirements: function() {
           if (typeof TOTAL_MEMORY === 'number' &&
@@ -7861,12 +7822,12 @@ extern "C" {
         }
       });
     ''')
-    self.emcc_args += ['--js-library', os.path.join(self.get_dir(), 'lib.js')]
-    self.do_run(open(os.path.join(self.get_dir(), 'main.cpp'), 'r').read(), 'able to run memprof')
+    self.emcc_args += ['--js-library', 'lib.js']
+    self.do_run(open('main.cpp').read(), 'able to run memprof')
 
   def test_fs_dict(self):
     self.set_setting('FORCE_FILESYSTEM', 1)
-    open(self.in_dir('pre.js'), 'w').write('''
+    create_test_file('pre.js', '''
       Module = {};
       Module['preRun'] = function() {
           out(typeof FS.filesystems['MEMFS']);
@@ -7882,13 +7843,13 @@ extern "C" {
   def test_stack_overflow_check(self):
     args = self.emcc_args + ['-s', 'TOTAL_STACK=1048576']
     self.emcc_args = args + ['-s', 'STACK_OVERFLOW_CHECK=1', '-s', 'ASSERTIONS=0']
-    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp'), 'r').read(), 'Stack overflow! Stack cookie has been overwritten' if not self.get_setting('SAFE_HEAP') else 'segmentation fault')
+    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp')).read(), 'Stack overflow! Stack cookie has been overwritten' if not self.get_setting('SAFE_HEAP') else 'segmentation fault')
 
     self.emcc_args = args + ['-s', 'STACK_OVERFLOW_CHECK=2', '-s', 'ASSERTIONS=0']
-    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp'), 'r').read(), 'Stack overflow! Attempted to allocate')
+    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp')).read(), 'Stack overflow! Attempted to allocate')
 
     self.emcc_args = args + ['-s', 'ASSERTIONS=1']
-    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp'), 'r').read(), 'Stack overflow! Attempted to allocate')
+    self.do_run(open(path_from_root('tests', 'stack_overflow.cpp')).read(), 'Stack overflow! Attempted to allocate')
 
   @no_wasm_backend('Wasm backend emits non-trapping float-to-int conversion')
   def test_binaryen_trap_mode(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7245,7 +7245,7 @@ err = err = function(){};
         # the output file.
         self.assertPathsIdentical(map_referent, data['file'])
       assert len(data['sources']) == 1, data['sources']
-      self.assertPathsIdentical('src.cpp', data['sources'][0])
+      self.assertPathsIdentical(os.path.abspath('src.cpp'), data['sources'][0])
       if hasattr(data, 'sourcesContent'):
         # the sourcesContent attribute is optional, but if it is present it
         # needs to containt valid source text.
@@ -7258,7 +7258,7 @@ err = err = function(){};
         mappings = encode_utf8(mappings)
       seen_lines = set()
       for m in mappings:
-        self.assertPathsIdentical('src.cpp', m['source'])
+        self.assertPathsIdentical(os.path.abspath('src.cpp'), m['source'])
         seen_lines.add(m['originalLine'])
       # ensure that all the 'meaningful' lines in the original code get mapped
       assert seen_lines.issuperset([6, 7, 11, 12])

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -246,9 +246,9 @@ class sockets(BrowserCore):
   @no_windows('This test uses Unix-specific build architecture.')
   def test_enet(self):
     # this is also a good test of raw usage of emconfigure and emmake
-    shared.try_delete(self.in_dir('enet'))
-    shutil.copytree(path_from_root('tests', 'enet'), self.in_dir('enet'))
-    with chdir(self.in_dir('enet')):
+    shared.try_delete('enet')
+    shutil.copytree(path_from_root('tests', 'enet'), 'enet')
+    with chdir('enet'):
       run_process([PYTHON, path_from_root('emconfigure'), './configure'])
       run_process([PYTHON, path_from_root('emmake'), 'make'])
       enet = [self.in_dir('enet', '.libs', 'libenet.a'), '-I' + path_from_root('tests', 'enet', 'include')]
@@ -264,10 +264,10 @@ class sockets(BrowserCore):
   # somewhat work, but those have been removed). However, with WebRTC it
   # should be able to resurect this test.
   # def test_enet_in_browser(self):
-  #   shared.try_delete(self.in_dir('enet'))
-  #   shutil.copytree(path_from_root('tests', 'enet'), self.in_dir('enet'))
+  #   shared.try_delete('enet')
+  #   shutil.copytree(path_from_root('tests', 'enet'), 'enet')
   #   pwd = os.getcwd()
-  #   os.chdir(self.in_dir('enet'))
+  #   os.chdir('enet')
   #   run_process([PYTHON, path_from_root('emconfigure'), './configure'])
   #   run_process([PYTHON, path_from_root('emmake'), 'make'])
   #   enet = [self.in_dir('enet', '.libs', 'libenet.a'), '-I' + path_from_root('tests', 'enet', 'include')]


### PR DESCRIPTION
- Remove single argument use of `self.in_dir()`.
  All tests run in their own directory, so `self.in_dir('foo')` is
  normally equivialent to just `'foo'`
- Same for os.path.join(self.get_dir(), ...)
- Use new utility function `create_test_file` in place of open('w')
  for consistency.