### PR TITLE
Add macOS .DS_Store thumbnail file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ third_party/lzma.js/lzma-native
 third_party/lzma.js/lzma-native.exe
 
 tools/optimizer_build/
+
+.DS_Store


### PR DESCRIPTION
This keeps coming up when iterating on macOS when one opens Emscripten subdirectories in Finder.