### PR TITLE
Fix: THREAD_LOCAL_EM_ASM no longer exists

### DIFF
--- a/tests/emscripten_hide_mouse.c
+++ b/tests/emscripten_hide_mouse.c
@@ -18,5 +18,5 @@ int main()
 	emscripten_hide_mouse();
 	EMSCRIPTEN_RESULT ret = emscripten_set_click_callback("#canvas", 0, 1, mouse_callback);
 	assert(ret == 0);
-	THREAD_LOCAL_EM_ASM(Module['noExitRuntime'] = true);
+	EM_ASM(Module['noExitRuntime'] = true);
 }

--- a/tests/pthread/emscripten_thread_sleep.c
+++ b/tests/pthread/emscripten_thread_sleep.c
@@ -15,6 +15,8 @@ void Sleep(double msecs)
 
 void *thread_main(void *arg)
 {
+	EM_ASM(Module.print('hello from thread!'));
+
 	Sleep(1);
 	Sleep(10);
 	Sleep(100);


### PR DESCRIPTION
THREAD_LOCAL_EM_ASM was an old name, which got renamed to just EM_ASM, but wrangling many PRs, a use of old name slipped in - also restores a print in test that used to be THREAD_LOCAL_EM_ASM, but was deleted probably to remove the nonexistent name.