### PR TITLE
Add Emscripten WebSockets API

### DIFF
--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -1,0 +1,403 @@
+var LibraryWebSocket = {
+  $WS: {
+    sockets: [null],
+    socketEvent: null
+  },
+
+  emscripten_websocket_get_ready_state__proxy: 'sync',
+  emscripten_websocket_get_ready_state__sig: 'iii',
+  emscripten_websocket_get_ready_state: function(socketId, readyState) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_ready_state(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+    HEAPU16[readyState>>1] = socket.readyState;
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_buffered_amount__proxy: 'sync',
+  emscripten_websocket_get_buffered_amount__sig: 'iii',
+  emscripten_websocket_get_buffered_amount: function(socketId, bufferedAmount) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_buffered_amount(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+    {{{ makeSetValue('bufferedAmount', '0', 'socket.bufferedAmount', 'i64') }}};
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_extensions__proxy: 'sync',
+  emscripten_websocket_get_extensions__sig: 'iiii',
+  emscripten_websocket_get_extensions: function(socketId, extensions, extensionsLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_extensions(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_extensions_length__proxy: 'sync',
+  emscripten_websocket_get_extensions_length__sig: 'iii',
+  emscripten_websocket_get_extensions_length: function(socketId, extensionsLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_extensions_length(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_protocol__proxy: 'sync',
+  emscripten_websocket_get_protocol__sig: 'iiii',
+  emscripten_websocket_get_protocol: function(socketId, protocol, protocolLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_protocol(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_protocol_length__proxy: 'sync',
+  emscripten_websocket_get_protocol_length__sig: 'iii',
+  emscripten_websocket_get_protocol_length: function(socketId, protocolLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_protocol_length(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_url__proxy: 'sync',
+  emscripten_websocket_get_url__sig: 'iiii',
+  emscripten_websocket_get_url: function(socketId, url, urlLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_url(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_get_url_length__proxy: 'sync',
+  emscripten_websocket_get_url_length__sig: 'iii',
+  emscripten_websocket_get_url_length: function(socketId, urlLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_get_url_length(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_set_onopen_callback_on_thread__proxy: 'sync',
+  emscripten_websocket_set_onopen_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onopen_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
+// TODO:
+//    if (thread == {{{ cDefine('EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD') }}} ||
+//      (thread == _pthread_self()) return emscripten_websocket_set_onopen_callback_on_calling_thread(socketId, userData, callbackFunc);
+
+    if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
+
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_set_onopen_callback(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_set_onopen_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+    socket.onopen = function(e) {
+#if WEBSOCKET_DEBUG
+      console.error('websocket event "open": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+      HEAPU32[WS.socketEvent>>2] = socketId;
+      Module['dynCall_iiii'](callbackFunc, 0/*TODO*/, WS.socketEvent, userData);
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_set_onerror_callback_on_thread__proxy: 'sync',
+  emscripten_websocket_set_onerror_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onerror_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
+    if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
+
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_set_onerror_callback(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_set_onerror_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+    socket.onerror = function(e) {
+#if WEBSOCKET_DEBUG
+      console.error('websocket event "error": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+      HEAPU32[WS.socketEvent>>2] = socketId;
+      Module['dynCall_iiii'](callbackFunc, 0/*TODO*/, WS.socketEvent, userData);
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_set_onclose_callback_on_thread__proxy: 'sync',
+  emscripten_websocket_set_onclose_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onclose_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
+    if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
+
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_set_onclose_callback(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_set_onclose_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+    socket.onclose = function(e) {
+#if WEBSOCKET_DEBUG
+      console.error('websocket event "close": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+      HEAPU32[WS.socketEvent>>2] = socketId;
+      HEAPU32[(WS.socketEvent+4)>>2] = e.wasClean;
+      HEAPU32[(WS.socketEvent+8)>>2] = e.code;
+      stringToUTF8(e.reason, HEAPU32[(WS.socketEvent+10)>>2], 512);
+      Module['dynCall_iiii'](callbackFunc, 0/*TODO*/, WS.socketEvent, userData);
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_set_onmessage_callback_on_thread__proxy: 'sync',
+  emscripten_websocket_set_onmessage_callback_on_thread__sig: 'iiiii',
+  emscripten_websocket_set_onmessage_callback_on_thread: function(socketId, userData, callbackFunc, thread) {
+    if (!WS.socketEvent) WS.socketEvent = _malloc(1024); // TODO: sizeof(EmscriptenWebSocketCloseEvent), which is the largest event struct
+
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_set_onmessage_callback(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_set_onmessage_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+    socket.onmessage = function(e) {
+#if WEBSOCKET_DEBUG == 2
+      console.error('websocket event "message": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#endif
+      HEAPU32[WS.socketEvent>>2] = socketId;
+      if (typeof e.data === 'string') {
+        var len = lengthBytesUTF8(e.data)+1;
+        var buf = _malloc(len);
+        stringToUTF8(e.data, buf, len);
+#if WEBSOCKET_DEBUG
+        var s = (e.data.length < 256) ? e.data : (e.data.substr(0, 256) + ' (' + (e.data.length-256) + ' more characters)');
+        console.error('WebSocket onmessage, received data: "' + e.data + '", ' + e.data.length + ' chars, ' + len + ' bytes encoded as UTF-8: "' + s + '"');
+#endif
+        HEAPU32[(WS.socketEvent+12)>>2] = 1; // text data
+      } else {
+        var len = e.data.byteLength;
+        var buf = _malloc(len);
+        HEAP8.set(new Uint8Array(e.data), buf);
+#if WEBSOCKET_DEBUG
+        var s = 'WebSocket onmessage, received data: ' + len + ' bytes of binary:';
+        for(var i = 0; i < Math.min(len, 256); ++i) s += ' ' + HEAPU8[buf+i].toString(16);
+        s += ', "';
+        for(var i = 0; i < Math.min(len, 256); ++i) s += (HEAPU8[buf+i] >= 32 && HEAPU8[buf+i] <= 127) ? String.fromCharCode(HEAPU8[buf+i]) : '\uFFFD';
+        s += '"';
+        if (len > 256) s + ' ... (' + (len - 256) + ' more bytes)';
+
+        console.error(s);
+#endif
+        HEAPU32[(WS.socketEvent+12)>>2] = 0; // binary data
+      }
+      HEAPU32[(WS.socketEvent+4)>>2] = buf;
+      HEAPU32[(WS.socketEvent+8)>>2] = len;
+      Module['dynCall_iiii'](callbackFunc, 0/*TODO*/, WS.socketEvent, userData);
+      _free(buf);
+    }
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_new__deps: ['$WS'],
+  emscripten_websocket_new__proxy: 'sync',
+  emscripten_websocket_new__sig: 'ii',
+  emscripten_websocket_new: function(createAttributes) {
+    if (typeof WebSocket === 'undefined') {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_new(): WebSocket API is not supported by current browser)');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    }
+    if (!createAttributes) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_new(): Missing required "createAttributes" function parameter!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    }
+
+    var url = UTF8ToString(HEAP32[createAttributes>>2]);
+
+    // TODO: protocols
+    // TODO: createOnMainThread
+    var socket = new WebSocket(url);
+    socket.binaryType = 'arraybuffer';
+    // TODO: While strictly not necessary, this ID would be good to be unique across all threads to avoid confusion.
+    var socketId = WS.sockets.length;
+    WS.sockets[socketId] = socket;
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_new(url='+url+'): created socket ID ' + socketId + ')');
+#endif
+    return socketId;
+  },
+
+  emscripten_websocket_send_utf8_text__proxy: 'sync',
+  emscripten_websocket_send_utf8_text__sig: 'iii',
+  emscripten_websocket_send_utf8_text: function(socketId, textData) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_send_utf8_text(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+    var str = UTF8ToString(textData);
+#if WEBSOCKET_DEBUG == 2
+    console.error('emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + str +'")');
+#else
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + ((str.length > 8) ? (str.substring(0,8) + '...') : str) + '")');
+#endif
+#endif
+    socket.send(str);
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_send_binary__proxy: 'sync',
+  emscripten_websocket_send_binary__sig: 'iiii',
+  emscripten_websocket_send_binary: function(socketId, binaryData, dataLength) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_send_binary(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    var s = 'data: ' + dataLength + ' bytes of binary:';
+    for(var i = 0; i < Math.min(dataLength, 256); ++i) s += ' '+ HEAPU8[binaryData+i].toString(16);
+    s += ', "';
+    for(var i = 0; i < Math.min(dataLength, 256); ++i) s += (HEAPU8[binaryData+i] >= 32 && HEAPU8[binaryData+i] <= 127) ? String.fromCharCode(HEAPU8[binaryData+i]) : '\uFFFD';
+    s += '"';
+    if (dataLength > 256) s + ' ... (' + (dataLength - 256) + ' more bytes)';
+
+    console.error('emscripten_websocket_send_binary(socketId='+socketId+',binaryData='+binaryData+ ',dataLength='+dataLength+'), ' + s);
+#endif
+#if USE_PTHREADS
+    // TODO: This is temporary to cast a shared Uint8Array to a non-shared Uint8Array. This could be removed if WebSocket API is improved
+    // to allow passing in views to SharedArrayBuffers
+    socket.send(new Uint8Array({{{ makeHEAPView('U8', 'binaryData', 'binaryData+dataLength') }}}));
+#else
+    socket.send({{{ makeHEAPView('U8', 'binaryData', 'binaryData+dataLength') }}});
+#endif
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_close__proxy: 'sync',
+  emscripten_websocket_close__sig: 'iiii',
+  emscripten_websocket_close: function(socketId, code, reason) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_close(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+    var reasonStr = reason ? UTF8ToString(reason) : undefined;
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_close(socketId='+socketId+',code='+code+',reason='+reasonStr+')');
+#endif
+    if (!code) code = undefined;
+    socket.close(code, reasonStr);
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_delete__proxy: 'sync',
+  emscripten_websocket_delete__sig: 'ii',
+  emscripten_websocket_delete: function(socketId) {
+    var socket = WS.sockets[socketId];
+    if (!socket) {
+#if WEBSOCKET_DEBUG
+      console.error('emscripten_websocket_delete(): Invalid socket ID ' + socketId + ' specified!');
+#endif
+      return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    }
+
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_delete(socketId='+socketId+')');
+#endif
+    socket.onopen = socket.onerror = socket.onclose = socket.onmessage = null;
+    socket = null;
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_websocket_is_supported__proxy: 'sync',
+  emscripten_websocket_is_supported__sig: 'i',
+  emscripten_websocket_is_supported: function() {
+    return typeof WebSocket !== 'undefined';
+  },
+
+  emscripten_websocket_deinitialize__proxy: 'sync',
+  emscripten_websocket_deinitialize__sig: 'v',
+  emscripten_websocket_deinitialize__deps: ['emscripten_websocket_delete'],
+  emscripten_websocket_deinitialize: function() {
+#if WEBSOCKET_DEBUG
+    console.error('emscripten_websocket_deinitialize()');
+#endif
+    for(var i in WS.sockets) {
+      var socket = WS.sockets[i];
+      if (socket) {
+        socket.close();
+        _emscripten_websocket_delete(i);
+      }
+    }
+  }
+}
+
+mergeInto(LibraryManager.library, LibraryWebSocket);

--- a/src/settings.js
+++ b/src/settings.js
@@ -370,6 +370,11 @@ var WEBSOCKET_SUBPROTOCOL = 'binary';
 // Print out debugging information from our OpenAL implementation.
 var OPENAL_DEBUG = 0;
 
+// If 1, prints out debugging related to calls from emscripten_web_socket_* functions
+// in emscripten/websocket.h.
+// If 2, additionally traces bytes communicated via the sockets.
+var WEBSOCKET_DEBUG = 0;
+
 // Adds extra checks for error situations in the GL library. Can impact
 // performance.
 var GL_ASSERTIONS = 0;

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <stdint.h>
+#include <memory.h>
+
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EMSCRIPTEN_WEBSOCKET_T int
+
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions, int extensionsLength);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol, int protocolLength);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url, int urlLength);
+extern EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength);
+
+typedef struct EmscriptenWebSocketOpenEvent {
+  EMSCRIPTEN_WEBSOCKET_T socket;
+} EmscriptenWebSocketOpenEvent;
+
+typedef EM_BOOL (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent *websocketEvent, void *userData);
+extern EMSCRIPTEN_RESULT emscripten_websocket_set_onopen_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_open_callback_func callback, pthread_t targetThread);
+
+typedef struct EmscriptenWebSocketMessageEvent {
+  EMSCRIPTEN_WEBSOCKET_T socket;
+  uint8_t *data;
+  uint32_t numBytes;
+  EM_BOOL isText;
+} EmscriptenWebSocketMessageEvent;
+
+typedef EM_BOOL (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent, void *userData);
+extern EMSCRIPTEN_RESULT emscripten_websocket_set_onmessage_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_message_callback_func callback, pthread_t targetThread);
+
+typedef struct EmscriptenWebSocketErrorEvent {
+  EMSCRIPTEN_WEBSOCKET_T socket;
+} EmscriptenWebSocketErrorEvent;
+
+typedef EM_BOOL (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent *websocketEvent, void *userData);
+extern EMSCRIPTEN_RESULT emscripten_websocket_set_onerror_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_error_callback_func callback, pthread_t targetThread);
+
+typedef struct EmscriptenWebSocketCloseEvent {
+  EMSCRIPTEN_WEBSOCKET_T socket;
+  EM_BOOL wasClean;
+  unsigned short code;
+  char reason[512]; // WebSockets spec enforces this can be max 123 characters, so as UTF-8 at most 123*4 bytes < 512.
+} EmscriptenWebSocketCloseEvent;
+
+typedef EM_BOOL (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent, void *userData);
+extern EMSCRIPTEN_RESULT emscripten_websocket_set_onclose_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_close_callback_func callback, pthread_t targetThread);
+
+#define emscripten_websocket_set_onopen_callback(socket, userData, callback)    emscripten_websocket_set_onopen_callback_on_thread(   (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
+#define emscripten_websocket_set_onerror_callback(socket, userData, callback)   emscripten_websocket_set_onerror_callback_on_thread(  (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
+#define emscripten_websocket_set_onclose_callback(socket, userData, callback)   emscripten_websocket_set_onclose_callback_on_thread(  (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
+#define emscripten_websocket_set_onmessage_callback(socket, userData, callback) emscripten_websocket_set_onmessage_callback_on_thread((socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
+
+typedef struct EmscriptenWebSocketCreateAttributes {
+  const char *url;
+  const char **protocols;
+
+  // If true, the created socket will reside on the main browser thread. If false, the created socket is bound to the calling thread.
+  // If you want to share the created EMSCRIPTEN_WEBSOCKET_T structure across multiple threads, or are running your own main loop in the
+  // pthread that you create the socket, set createOnMainThread to true. If the created WebSocket only needs to be accessible on the thread
+  // that created it, and the creating thread is an event based thread (meaning it regularly yields back to the browser event loop), then
+  // it is more efficient to set this to false.
+  EM_BOOL createOnMainThread;
+} EmscriptenWebSocketCreateAttributes;
+
+//extern void emscripten_websocket_init_create_attributes(EmscriptenWebSocketCreateAttributes *attributes);
+#define emscripten_websocket_init_create_attributes(attributes) do { memset((attributes), 0, sizeof(EmscriptenWebSocketCreateAttributes)); } while(0)
+
+// Returns true if WebSockets are supported by the current browser
+EM_BOOL emscripten_websocket_is_supported(void);
+
+// Creates a new WebSocket and connects it to the given remote host.
+// If the return value of this function is > 0, the function has succeeded and the return value represents a handle to the WebSocket object.
+// If the return value of this function is < 0, then the function has failed, and the return value can be interpreted as a EMSCRIPTEN_RESULT code
+// representing the cause of the failure. If the function returns 0, then the call has failed with an unknown reason (build with -s WEBSOCKET_DEBUG=1 for more information)
+EMSCRIPTEN_WEBSOCKET_T emscripten_websocket_new(EmscriptenWebSocketCreateAttributes *createAttributes);
+
+// Sends the given string of null-delimited UTF8 encoded text data to the connected server.
+EMSCRIPTEN_RESULT emscripten_websocket_send_utf8_text(EMSCRIPTEN_WEBSOCKET_T socket, const char *textData);
+
+// Sends the given block of raw memory data out to the connected server.
+EMSCRIPTEN_RESULT emscripten_websocket_send_binary(EMSCRIPTEN_WEBSOCKET_T socket, void *binaryData, uint32_t dataLength);
+
+// Closes the specified WebSocket. N.B.: the meaning of "closing" a WebSocket means "eager read/lazy write"-closing the socket. That is, all still
+// pending untransferred outbound bytes will continue to transfer out, but after calling close on the socket, any pending bytes still in the process
+// of being received will never be available. See https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-sclose
+// After calling close(), it is no longer possible to send() on the WebSocket to send more bytes.
+EMSCRIPTEN_RESULT emscripten_websocket_close(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short code, const char *reason);
+
+// Releases the given WebSocket object and all associated allocated memory for garbage collection. This effectively frees the socket handle, after calling
+// this function the given handle no longer exists.
+EMSCRIPTEN_RESULT emscripten_websocket_delete(EMSCRIPTEN_WEBSOCKET_T socket);
+
+// This function close()s and releases all created WebSocket connections for the current thread. You can call this at application exit time to enforce
+// teardown of all active sockets, although it is optional. When a pthread terminates, it will call this function to delete all active connections bound to
+// that specific pthread (sockets created with createOnMainThread=false). Any WebSockets created by a pthread with createOnMainThread=true will remain alive
+// even after the pthread quits, although be warned that if the target thread that was registered to handle events for a given WebSocket quits, then those
+// events will stop from being delivered altogether.
+void emscripten_websocket_deinitialize(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/websocket/websocket.c
+++ b/tests/websocket/websocket.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <emscripten/websocket.h>
+
+EM_BOOL WebSocketOpen(int eventType, const EmscriptenWebSocketOpenEvent *e, void *userData)
+{
+	printf("open(eventType=%d, userData=%d)\n", eventType, (int)userData);
+
+	emscripten_websocket_send_utf8_text(e->socket, "hello on the other side");
+
+	char data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+	emscripten_websocket_send_binary(e->socket, data, sizeof(data));
+
+	emscripten_websocket_close(e->socket, 0, 0);
+	return 0;
+}
+
+EM_BOOL WebSocketClose(int eventType, const EmscriptenWebSocketCloseEvent *e, void *userData)
+{
+	printf("close(eventType=%d, wasClean=%d, code=%d, reason=%s, userData=%d)\n", eventType, e->wasClean, e->code, e->reason, (int)userData);
+	return 0;
+}
+
+EM_BOOL WebSocketError(int eventType, const EmscriptenWebSocketErrorEvent *e, void *userData)
+{
+	printf("error(eventType=%d, userData=%d)\n", eventType, (int)userData);
+	return 0;
+}
+
+EM_BOOL WebSocketMessage(int eventType, const EmscriptenWebSocketMessageEvent *e, void *userData)
+{
+	printf("message(eventType=%d, userData=%d, data=%p, numBytes=%d, isText=%d)\n", eventType, (int)userData, e->data, e->numBytes, e->isText);
+	if (e->isText)
+		printf("text data: \"%s\"\n", e->data);
+	else
+	{
+		printf("binary data:");
+		for(int i = 0; i < e->numBytes; ++i)
+			printf(" %02X", e->data[i]);
+		printf("\n");
+
+		emscripten_websocket_delete(e->socket);
+		exit(0);
+	}
+	return 0;
+}
+
+int main()
+{
+	if (!emscripten_websocket_is_supported())
+	{
+		printf("WebSockets are not supported, cannot continue!\n");
+		exit(1);
+	}
+
+	EmscriptenWebSocketCreateAttributes attr;
+	emscripten_websocket_init_create_attributes(&attr);
+
+	attr.url = "ws://localhost:8080";
+
+	EMSCRIPTEN_WEBSOCKET_T socket = emscripten_websocket_new(&attr);
+	if (socket <= 0)
+	{
+		printf("WebSocket creation failed, error code %d!\n", (EMSCRIPTEN_RESULT)socket);
+		exit(1);
+	}
+
+	emscripten_websocket_set_onopen_callback(socket, (void*)42, WebSocketOpen);
+	emscripten_websocket_set_onclose_callback(socket, (void*)43, WebSocketClose);
+	emscripten_websocket_set_onerror_callback(socket, (void*)44, WebSocketError);
+	emscripten_websocket_set_onmessage_callback(socket, (void*)45, WebSocketMessage);
+}


### PR DESCRIPTION
Adds Emscripten WebSockets API: direct bare WebSockets support exposed to C code in multithreading aware manner. A C integer handle represents the WebSocket connection, and it can be shared across threads. Still slightly experimental, a number of TODOs left, but may be useful to others.

(One TODO in particular is backproxying - currently WebSocket events will all be dispatched on the main browser thread, and not the requested thread)