### PR TITLE
Make call to emscripten_sample_gamepad_data() explicit so that caller can control when it should be invoked

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -1689,9 +1689,21 @@ Functions
   :rtype: |EMSCRIPTEN_RESULT|
 
 
+.. c:function:: EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void)
+
+  This function samples a new state of connected Gamepad data, and returns either
+  EMSCRIPTEN_RESULT_SUCCESS if Gamepad API is supported by the current browser,
+  or EMSCRIPTEN_RESULT_NOT_SUPPORTED if Gamepad API is not supported. Note that
+  even if EMSCRIPTEN_RESULT_SUCCESS is returned, there may not be any gamepads
+  connected yet to the current browser tab.
+
+  Call this function before calling either of the functions
+  emscripten_get_num_gamepads() or emscripten_get_gamepad_status().
+
 .. c:function:: int emscripten_get_num_gamepads(void)
 
-  Returns the number of gamepads connected to the system or
+  After having called emscripten_sample_gamepad_data(), this function
+  returns the number of gamepads connected to the system or
   :c:type:`EMSCRIPTEN_RESULT_NOT_SUPPORTED` if the current browser does not
   support gamepads.
 
@@ -1707,16 +1719,18 @@ Functions
      for the count of connected gamepads, even though gamepad A is no longer
      present. To find the actual number of connected gamepads, listen for the
      gamepadconnected and gamepaddisconnected events.  Consider the return value
-     of this function as the largest value (-1) that can be passed to the
-     function emscripten_get_gamepad_status().
+     of function emscripten_get_num_gamepads() minus one to be the largest index
+     value that can be passed to the function emscripten_get_gamepad_status().
 
-  :returns: :c:data:`EMSCRIPTEN_RESULT_SUCCESS`, or one of the other result values.
+  :returns: The number of gamepads connected to the browser tab.
   :rtype: int
 
 
 .. c:function:: EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState)
 
-  Returns a snapshot of the current gamepad state.
+  After having called emscripten_sample_gamepad_data(), this function returns a
+  snapshot of the current gamepad state for the gamepad controller located at
+  given index of the controllers array.
 
   :param int index: The index of the gamepad to check (in the `array of connected gamepads <https://developer.mozilla.org/en-US/docs/Web/API/Navigator.getGamepads>`_).
   :param EmscriptenGamepadEvent* gamepadState: The most recently received gamepad state.

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -4,7 +4,6 @@
 // found in the LICENSE file.
 
 var LibraryJSEvents = {
-  $JSEvents__postset: 'JSEvents.staticInit();',
   $JSEvents__deps: ['_get_canvas_element_size', '_set_canvas_element_size'],
   $JSEvents: {
     // pointers to structs malloc()ed to Emscripten HEAP for JS->C interop.
@@ -20,14 +19,6 @@ var LibraryJSEvents = {
     visibilityChangeEvent: 0,
     touchEvent: 0,
 
-    // In order to ensure most coherent Gamepad API state as possible (https://github.com/w3c/gamepad/issues/22) and
-    // to minimize the amount of garbage created, we sample the gamepad state at most once per frame, and not e.g. once per
-    // each controller or similar. To implement that, the following variables retain a cache of the most recent polled gamepad
-    // state.
-    lastGamepadState: null,
-    lastGamepadStateFrame: null, // The integer value of Browser.mainLoop.currentFrameNumber of when the last gamepad state was produced.
-    numGamepadsConnected: 0, // Keep track of how many gamepads are connected, to optimize to not poll gamepads when none are connected.
-
     // When we transition from fullscreen to windowed mode, we remember here the element that was just in fullscreen mode
     // so that we can report information about that element in the event message.
     previousFullscreenElement: null,
@@ -41,33 +32,12 @@ var LibraryJSEvents = {
     // Track in this field whether we have yet registered that __ATEXIT__ handler.
     removeEventListenersRegistered: false, 
 
-    _onGamepadConnected: function() { ++JSEvents.numGamepadsConnected; },
-    _onGamepadDisconnected: function() { --JSEvents.numGamepadsConnected; },
-
-    staticInit: function() {
-      if (typeof window !== 'undefined') {
-        window.addEventListener("gamepadconnected", JSEvents._onGamepadConnected);
-        window.addEventListener("gamepaddisconnected", JSEvents._onGamepadDisconnected);
-        
-        // Chromium does not fire the gamepadconnected event on reload, so we need to get the number of gamepads here as a workaround.
-        // See https://bugs.chromium.org/p/chromium/issues/detail?id=502824
-        var firstState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null);
-        if (firstState) {
-          JSEvents.numGamepadsConnected = firstState.length;
-        }
-      }
-    },
-
     removeAllEventListeners: function() {
       for(var i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
         JSEvents._removeHandler(i);
       }
       JSEvents.eventHandlers = [];
       JSEvents.deferredCalls = [];
-      if (typeof window !== 'undefined') {
-        window.removeEventListener("gamepadconnected", JSEvents._onGamepadConnected);
-        window.removeEventListener("gamepaddisconnected", JSEvents._onGamepadDisconnected);
-      }
     },
 
     registerRemoveEventListeners: function() {
@@ -2015,37 +1985,32 @@ var LibraryJSEvents = {
     if (!navigator.getGamepads && !navigator.webkitGetGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     JSEvents.registerGamepadEventCallback(window, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_GAMEPADDISCONNECTED') }}}, "gamepaddisconnected", targetThread);
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
- },
+  },
   
-  _emscripten_sample_gamepad_data: function() {
-    // Polling gamepads generates garbage, so don't do it when we know there are no gamepads connected.
-    if (!JSEvents.numGamepadsConnected) return;
-
-    // Produce a new Gamepad API sample if we are ticking a new game frame, or if not using emscripten_set_main_loop() at all to drive animation.
-    if (Browser.mainLoop.currentFrameNumber !== JSEvents.lastGamepadStateFrame || !Browser.mainLoop.currentFrameNumber) {
-      JSEvents.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : null);
-      JSEvents.lastGamepadStateFrame = Browser.mainLoop.currentFrameNumber;
-    }
+  emscripten_sample_gamepad_data__proxy: 'sync',
+  emscripten_sample_gamepad_data__sig: 'i',
+  emscripten_sample_gamepad_data: function() {
+    return (JSEvents.lastGamepadState = (navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null)))
+      ? {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
   },
 
-  emscripten_get_num_gamepads__deps: ['_emscripten_sample_gamepad_data'],
   emscripten_get_num_gamepads__proxy: 'sync',
   emscripten_get_num_gamepads__sig: 'i',
   emscripten_get_num_gamepads: function() {
-    // Polling gamepads generates garbage, so don't do it when we know there are no gamepads connected.
-    if (!JSEvents.numGamepadsConnected) return 0;
-
-    __emscripten_sample_gamepad_data();
-    if (!JSEvents.lastGamepadState) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+#if ASSERTIONS
+    if (!JSEvents.lastGamepadState) throw 'emscripten_get_num_gamepads() can only be called after having first called emscripten_sample_gamepad_data() and that function has returned EMSCRIPTEN_RESULT_SUCCESS!';
+#endif
+    // N.B. Do not call emscripten_get_num_gamepads() unless having first called emscripten_sample_gamepad_data(), and that has returned EMSCRIPTEN_RESULT_SUCCESS.
+    // Otherwise the following line will throw an exception.
     return JSEvents.lastGamepadState.length;
   },
   
-  emscripten_get_gamepad_status__deps: ['_emscripten_sample_gamepad_data'],
   emscripten_get_gamepad_status__proxy: 'sync',
   emscripten_get_gamepad_status__sig: 'iii',
   emscripten_get_gamepad_status: function(index, gamepadState) {
-    __emscripten_sample_gamepad_data();
-    if (!JSEvents.lastGamepadState) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+#if ASSERTIONS
+    if (!JSEvents.lastGamepadState) throw 'emscripten_get_gamepad_status() can only be called after having first called emscripten_sample_gamepad_data() and that function has returned EMSCRIPTEN_RESULT_SUCCESS!';
+#endif
 
     // INVALID_PARAM is returned on a Gamepad index that never was there.
     if (index < 0 || index >= JSEvents.lastGamepadState.length) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -395,6 +395,7 @@ typedef EM_BOOL (*em_gamepad_callback_func)(int eventType, const EmscriptenGamep
 extern EMSCRIPTEN_RESULT emscripten_set_gamepadconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 extern EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 
+extern EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void);
 extern int emscripten_get_num_gamepads(void);
 extern EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState);
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2456,6 +2456,11 @@ Module["preRun"].push(function () {
       print(opts)
       self.btest(path_from_root('tests', 'test_html5.c'), args=opts, expected='0', timeout=20)
 
+  def test_html5_gamepad(self):
+    for opts in [[], ['-O2', '-g1', '--closure', '1'], ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1']]:
+      print(opts)
+      self.btest(path_from_root('tests', 'test_gamepad.c'), args=opts, expected='0', timeout=20)
+
   @requires_graphics_hardware
   def test_html5_webgl_create_context_no_antialias(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1'], ['-s', 'FULL_ES2=1']]:

--- a/tests/test_gamepad.c
+++ b/tests/test_gamepad.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <emscripten.h>
+#include <string.h>
+#include <emscripten/html5.h>
+
+static inline const char *emscripten_event_type_to_string(int eventType) {
+  const char *events[] = { "(invalid)", "(none)", "keypress", "keydown", "keyup", "click", "mousedown", "mouseup", "dblclick", "mousemove", "wheel", "resize", 
+    "scroll", "blur", "focus", "focusin", "focusout", "deviceorientation", "devicemotion", "orientationchange", "fullscreenchange", "pointerlockchange", 
+    "visibilitychange", "touchstart", "touchend", "touchmove", "touchcancel", "gamepadconnected", "gamepaddisconnected", "beforeunload", 
+    "batterychargingchange", "batterylevelchange", "webglcontextlost", "webglcontextrestored", "mouseenter", "mouseleave", "mouseover", "mouseout", "(invalid)" };
+  ++eventType;
+  if (eventType < 0) eventType = 0;
+  if (eventType >= sizeof(events)/sizeof(events[0])) eventType = sizeof(events)/sizeof(events[0])-1;
+  return events[eventType];
+}
+
+const char *emscripten_result_to_string(EMSCRIPTEN_RESULT result) {
+  if (result == EMSCRIPTEN_RESULT_SUCCESS) return "EMSCRIPTEN_RESULT_SUCCESS";
+  if (result == EMSCRIPTEN_RESULT_DEFERRED) return "EMSCRIPTEN_RESULT_DEFERRED";
+  if (result == EMSCRIPTEN_RESULT_NOT_SUPPORTED) return "EMSCRIPTEN_RESULT_NOT_SUPPORTED";
+  if (result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED) return "EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED";
+  if (result == EMSCRIPTEN_RESULT_INVALID_TARGET) return "EMSCRIPTEN_RESULT_INVALID_TARGET";
+  if (result == EMSCRIPTEN_RESULT_UNKNOWN_TARGET) return "EMSCRIPTEN_RESULT_UNKNOWN_TARGET";
+  if (result == EMSCRIPTEN_RESULT_INVALID_PARAM) return "EMSCRIPTEN_RESULT_INVALID_PARAM";
+  if (result == EMSCRIPTEN_RESULT_FAILED) return "EMSCRIPTEN_RESULT_FAILED";
+  if (result == EMSCRIPTEN_RESULT_NO_DATA) return "EMSCRIPTEN_RESULT_NO_DATA";
+  return "Unknown EMSCRIPTEN_RESULT!";
+}
+
+#define TEST_RESULT(x) if (ret != EMSCRIPTEN_RESULT_SUCCESS) printf("%s returned %s.\n", #x, emscripten_result_to_string(ret));
+
+EM_BOOL gamepad_callback(int eventType, const EmscriptenGamepadEvent *e, void *userData)
+{
+  printf("%s: timeStamp: %g, connected: %d, index: %ld, numAxes: %d, numButtons: %d, id: \"%s\", mapping: \"%s\"\n",
+    eventType != 0 ? emscripten_event_type_to_string(eventType) : "Gamepad state", e->timestamp, e->connected, e->index, 
+    e->numAxes, e->numButtons, e->id, e->mapping);
+
+  if (e->connected)
+  {
+    for(int i = 0; i < e->numAxes; ++i)
+      printf("Axis %d: %g\n", i, e->axis[i]);
+
+    for(int i = 0; i < e->numButtons; ++i)
+      printf("Button %d: Digital: %d, Analog: %g\n", i, e->digitalButton[i], e->analogButton[i]);
+  }
+
+  return 0;
+}
+
+EmscriptenGamepadEvent prevState[32];
+int prevNumGamepads = 0;
+
+void mainloop()
+{
+  EMSCRIPTEN_RESULT res = emscripten_sample_gamepad_data();
+  if (res != EMSCRIPTEN_RESULT_SUCCESS)
+  {
+    printf("emscripten_sample_gamepad_data returned EMSCRIPTEN_RESULT_NOT_SUPPORTED.\n");
+    emscripten_cancel_main_loop();
+    return;
+  }
+
+  int numGamepads = emscripten_get_num_gamepads();
+  if (numGamepads != prevNumGamepads)
+  {
+    printf("Number of connected gamepads: %d\n", numGamepads);
+    prevNumGamepads = numGamepads;
+  }
+
+  for(int i = 0; i < numGamepads && i < 32; ++i)
+  {
+    EmscriptenGamepadEvent ge;
+    int ret = emscripten_get_gamepad_status(i, &ge);
+    if (ret == EMSCRIPTEN_RESULT_SUCCESS)
+    {
+      int g = ge.index;
+      for(int j = 0; j < ge.numAxes; ++j)
+      {
+        if (ge.axis[j] != prevState[g].axis[j])
+          printf("Gamepad %d, axis %d: %g\n", g, j, ge.axis[j]);
+      }
+
+      for(int j = 0; j < ge.numButtons; ++j)
+      {
+        if (ge.analogButton[j] != prevState[g].analogButton[j] || ge.digitalButton[j] != prevState[g].digitalButton[j])
+          printf("Gamepad %d, button %d: Digital: %d, Analog: %g\n", g, j, ge.digitalButton[j], ge.analogButton[j]);
+      }
+      prevState[g] = ge;
+    }
+  }
+}
+
+#ifdef REPORT_RESULT
+void report_result(void *arg)
+{
+  emscripten_html5_remove_all_event_listeners();
+  REPORT_RESULT(0);
+}
+#endif
+
+int main()
+{
+  EMSCRIPTEN_RESULT ret = emscripten_set_gamepadconnected_callback(0, 1, gamepad_callback);
+  TEST_RESULT(emscripten_set_gamepadconnected_callback);
+  ret = emscripten_set_gamepaddisconnected_callback(0, 1, gamepad_callback);
+  TEST_RESULT(emscripten_set_gamepaddisconnected_callback);
+
+  emscripten_set_main_loop(mainloop, 10, 0);
+
+  /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means. 
+     Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
+  EM_ASM(Module['noExitRuntime'] = true);
+
+#ifdef REPORT_RESULT
+  // Keep the page running for a moment.
+  emscripten_async_call(report_result, 0, 5000);
+#endif
+  return 0;
+}

--- a/tests/test_html5.c
+++ b/tests/test_html5.c
@@ -188,24 +188,6 @@ EM_BOOL touch_callback(int eventType, const EmscriptenTouchEvent *e, void *userD
   return 0;
 }
 
-EM_BOOL gamepad_callback(int eventType, const EmscriptenGamepadEvent *e, void *userData)
-{
-  printf("%s: timeStamp: %g, connected: %d, index: %ld, numAxes: %d, numButtons: %d, id: \"%s\", mapping: \"%s\"\n",
-    eventType != 0 ? emscripten_event_type_to_string(eventType) : "Gamepad state", e->timestamp, e->connected, e->index, 
-    e->numAxes, e->numButtons, e->id, e->mapping);
-
-  if (e->connected)
-  {
-    for(int i = 0; i < e->numAxes; ++i)
-      printf("Axis %d: %g\n", i, e->axis[i]);
-
-    for(int i = 0; i < e->numButtons; ++i)
-      printf("Button %d: Digital: %d, Analog: %g\n", i, e->digitalButton[i], e->analogButton[i]);
-  }
-
-  return 0;
-}
-
 const char *beforeunload_callback(int eventType, const void *reserved, void *userData)
 {
 #ifdef REPORT_RESULT
@@ -248,48 +230,6 @@ EM_BOOL webglcontext_callback(int eventType, const void *reserved, void *userDat
   printf("%s.\n", emscripten_event_type_to_string(eventType));
 
   return 0;
-}
-
-EmscriptenGamepadEvent prevState[32];
-int prevNumGamepads = 0;
-
-void mainloop()
-{
-  int numGamepads = emscripten_get_num_gamepads();
-  if (numGamepads != prevNumGamepads)
-  {
-    if (numGamepads == EMSCRIPTEN_RESULT_NOT_SUPPORTED) {
-      printf("emscripten_get_num_gamepads returned EMSCRIPTEN_RESULT_NOT_SUPPORTED.\n");
-      emscripten_cancel_main_loop();
-      return;
-    } else {
-      printf("Number of connected gamepads: %d\n", numGamepads);
-    }
-    prevNumGamepads = numGamepads;
-  }
-
-  for(int i = 0; i < numGamepads && i < 32; ++i)
-  {
-    EmscriptenGamepadEvent ge;
-    int ret = emscripten_get_gamepad_status(i, &ge);
-    if (ret == EMSCRIPTEN_RESULT_SUCCESS)
-    {
-      int g = ge.index;
-      for(int j = 0; j < ge.numAxes; ++j)
-      {
-        if (ge.axis[j] != prevState[g].axis[j])
-          printf("Gamepad %d, axis %d: %g\n", g, j, ge.axis[j]);
-      }
-
-      for(int j = 0; j < ge.numButtons; ++j)
-      {
-        if (ge.analogButton[j] != prevState[g].analogButton[j] || ge.digitalButton[j] != prevState[g].digitalButton[j])
-          printf("Gamepad %d, button %d: Digital: %d, Analog: %g\n", g, j, ge.digitalButton[j], ge.analogButton[j]);
-      }
-      prevState[g] = ge;
-    }
-  }
-
 }
 
 #ifdef REPORT_RESULT
@@ -448,13 +388,6 @@ int main()
   TEST_RESULT(emscripten_set_touchmove_callback);
   ret = emscripten_set_touchcancel_callback(0, 0, 1, touch_callback);
   TEST_RESULT(emscripten_set_touchcancel_callback);
-
-  ret = emscripten_set_gamepadconnected_callback(0, 1, gamepad_callback);
-  TEST_RESULT(emscripten_set_gamepadconnected_callback);
-  ret = emscripten_set_gamepaddisconnected_callback(0, 1, gamepad_callback);
-  TEST_RESULT(emscripten_set_gamepaddisconnected_callback);
-
-  emscripten_set_main_loop(mainloop, 10, 0);
 
   ret = emscripten_set_beforeunload_callback(0, beforeunload_callback);
   TEST_RESULT(emscripten_set_beforeunload_callback);


### PR DESCRIPTION
The `JSEvents.staticInit();` code path with unconditionally registered listeners to `gamepadConnected` and `gamepadDisconnected` was a pretty horrible thing for us to do - it is something that not even Closure is able to optimize, and all Emscripten compiled pages now start listening to gamepad from `JSEvents.staticInit();` if they use any of the html5.h functionality.

Use of Gamepad API is really rare, this moves the feature behind a `-s SUPPORT_GAMEPAD_API=1` linker flag. It is a breaking change, but a very visibly breaking change - one will get missing symbols if not setting that flag, so there is no danger of silent failure. After this, people will not get Gamepad API code polluting their builds.