### PR TITLE
fix_path_compare

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2274,7 +2274,7 @@ def parse_args(newargs):
       newargs[i] = ''
     elif newargs[i] == '--cache':
       check_bad_eq(newargs[i])
-      os.environ['EM_CACHE'] = newargs[i + 1]
+      os.environ['EM_CACHE'] = os.path.normpath(newargs[i + 1])
       shared.reconfigure_cache()
       newargs[i] = ''
       newargs[i + 1] = ''

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -25,6 +25,8 @@ class Cache(object):
     # figure out the root directory for all caching
     if dirname is None:
       dirname = os.environ.get('EM_CACHE')
+      if dirname:
+        dirname = os.path.normpath(dirname)
     if not dirname:
       dirname = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
     self.root_dirname = dirname
@@ -107,7 +109,7 @@ class Cache(object):
       logger.info(message)
       self.ensure()
       temp = creator()
-      if temp != cachename:
+      if os.path.normcase(temp) != os.path.normcase(cachename):
         shutil.copyfile(temp, cachename)
       logger.info(' - ok')
     finally:


### PR DESCRIPTION
Normalize access to EM_CACHE variable, and avoid tripping up when comparing paths in cache.get(), in case they are the same modulo back vs forward slashes or letter case.

On Windows if user e.g. hand-wrote `--em-cache C:/tmp` or `--em-cache c:/tmp` to a build on command line, that would cause a compilation error if the cache directory was `C:\tmp` or `C:\TMP`.