### PR TITLE
Use binaryen feature flags

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2556,6 +2556,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     else:
       cmd += ['-o', wasm_text_target, '-S']
       wrote_wasm_text = True
+    cmd += shared.Building.get_binaryen_feature_flags()
     logger.debug('asm2wasm (asm.js => WebAssembly): ' + ' '.join(cmd))
     TimeLogger.update()
     shared.check_call(cmd)

--- a/emcc.py
+++ b/emcc.py
@@ -2581,7 +2581,8 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       shared.safe_copy(wasm_binary_target, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(wasm_binary_target) + '.pre-byn'))
     # BINARYEN_PASSES is comma-separated, and we support both '-'-prefixed and unprefixed pass names
     passes = [('--' + p) if p[0] != '-' else p for p in shared.Settings.BINARYEN_PASSES.split(',')]
-    cmd = [os.path.join(binaryen_bin, 'wasm-opt'), '--mvp-features', wasm_binary_target, '-o', wasm_binary_target] + passes
+    cmd = [os.path.join(binaryen_bin, 'wasm-opt'), wasm_binary_target, '-o', wasm_binary_target] + passes
+    cmd += shared.Building.get_binaryen_feature_flags()
     if debug_info:
       cmd += ['-g'] # preserve the debug info
     logger.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -152,7 +152,7 @@ class NativeBenchmarker(Benchmarker):
 
 def run_binaryen_opts(filename, opts):
   run_process([
-    os.path.join(Building.get_binaryen_bin(), 'wasm-opt', '--mvp-features'),
+    os.path.join(Building.get_binaryen_bin(), 'wasm-opt', '--all-features'),
     filename,
     '-o', filename
   ] + opts)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2537,7 +2537,8 @@ class Building(object):
   def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, debug_info):
     logger.debug('minifying wasm imports and exports')
     # run the pass
-    cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm-opt'), '--mvp-features', '--minify-imports-and-exports', wasm_file, '-o', wasm_file]
+    cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm-opt'), '--minify-imports-and-exports', wasm_file, '-o', wasm_file]
+    cmd += Building.get_binaryen_feature_flags()
     if debug_info:
       cmd.append('-g')
     out = check_call(cmd, stdout=PIPE).stdout
@@ -2657,6 +2658,16 @@ class Building(object):
     if 'USE_SDL=2' in link_settings:
       system_js_libraries += ['library_egl.js', 'library_glut.js', 'library_gl.js']
     return [path_from_root('src', x) for x in system_js_libraries]
+
+  @staticmethod
+  def get_binaryen_feature_flags():
+    # start with the MVP features, add the rest as needed
+    ret = ['--mvp-features']
+    if Settings.USE_PTHREADS:
+      ret += ['--enable-threads']
+    if Settings.SIMD:
+      ret += ['--enable-simd']
+    return ret
 
   @staticmethod
   def get_binaryen():


### PR DESCRIPTION
Clean up our handling of feature flags, and pass the proper ones to asm2wasm and wasm-opt. This should fix current pthreads test breakage.

(in the benchmark script we use wasm-opt in a very specific way, and can just enable all the flags there)
