### PR TITLE
Add wasm-specific variant of `addFunction`: `addWasmFunction`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1728,6 +1728,7 @@ LibraryManager.library = {
     error: null,
     errorMsg: null,
   },
+
   // void* dlopen(const char* filename, int flag);
   dlopen__deps: ['$DLFCN', '$FS', '$ENV'],
   dlopen__proxy: 'sync',
@@ -1782,6 +1783,7 @@ LibraryManager.library = {
 
     return handle;
   },
+
   // int dlclose(void* handle);
   dlclose__deps: ['$DLFCN'],
   dlclose__proxy: 'sync',
@@ -1804,6 +1806,7 @@ LibraryManager.library = {
       return 0;
     }
   },
+
   // void* dlsym(void* handle, const char* symbol);
   dlsym__deps: ['$DLFCN'],
   dlsym__proxy: 'sync',
@@ -1846,11 +1849,20 @@ LibraryManager.library = {
 #endif // ASSERTIONS
     return result;
 #else // WASM && EMULATE_FUNCTION_POINTER_CASTS
+
+#if WASM
+    // Insert the function into the wasm table.  Since we know the function
+    // comes directly from the loaded wasm module we can insert it directly
+    // into the table, avoiding any JS interaction.
+    return addFunctionWasm(result);
+#else
     // convert the exported function into a function pointer using our generic
     // JS mechanism.
     return addFunction(result);
+#endif // WASM
 #endif // WASM && EMULATE_FUNCTION_POINTER_CASTS
   },
+
   // char* dlerror(void);
   dlerror__deps: ['$DLFCN'],
   dlerror__proxy: 'sync',

--- a/src/library.js
+++ b/src/library.js
@@ -1854,7 +1854,7 @@ LibraryManager.library = {
     // Insert the function into the wasm table.  Since we know the function
     // comes directly from the loaded wasm module we can insert it directly
     // into the table, avoiding any JS interaction.
-    return addFunctionWasm(result);
+    return addWasmFunction(result);
 #else
     // convert the exported function into a function pointer using our generic
     // JS mechanism.

--- a/src/support.js
+++ b/src/support.js
@@ -652,7 +652,10 @@ function addFunction(func, sig) {
   throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';
 #else
 #if WASM
-  // we can simply append to the wasm table
+  // assume we have been passed a wasm function and can add it to the table
+  // directly.
+  // TODO(sbc): This assumtion is most likely not valid.  Look into ways of
+  // creating wasm functions based on JS functions as input.
   return addWasmFunction(func);
 #else
   alignFunctionTables(); // XXX we should rely on this being an invariant

--- a/src/support.js
+++ b/src/support.js
@@ -616,7 +616,7 @@ var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 #if WASM
 // Add a wasm function to the table.
 // Attempting to call this with JS function will cause of table.set() to fail
-function addFunctionWasm(func) {
+function addWasmFunction(func) {
   var table = Module['wasmTable'];
   var ret = table.length;
   table.grow(1);
@@ -653,7 +653,7 @@ function addFunction(func, sig) {
 #else
 #if WASM
   // we can simply append to the wasm table
-  return addFunctionWasm(func);
+  return addWasmFunction(func);
 #else
   alignFunctionTables(); // XXX we should rely on this being an invariant
   var tables = getFunctionTables();

--- a/src/support.js
+++ b/src/support.js
@@ -613,6 +613,18 @@ var jsCallStartIndex = 1;
 var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 #endif // WASM_BACKEND && RESERVED_FUNCTION_POINTERS
 
+#if WASM
+// Add a wasm function to the table.
+// Attempting to call this with JS function will cause of table.set() to fail
+function addFunctionWasm(func) {
+  var table = Module['wasmTable'];
+  var ret = table.length;
+  table.grow(1);
+  table.set(ret, func);
+  return ret;
+}
+#endif
+
 // 'sig' parameter is only used on LLVM wasm backend
 function addFunction(func, sig) {
 #if WASM_BACKEND
@@ -641,11 +653,7 @@ function addFunction(func, sig) {
 #else
 #if WASM
   // we can simply append to the wasm table
-  var table = Module['wasmTable'];
-  var ret = table.length;
-  table.grow(1);
-  table.set(ret, func);
-  return ret;
+  return addFunctionWasm(func);
 #else
   alignFunctionTables(); // XXX we should rely on this being an invariant
   var tables = getFunctionTables();


### PR DESCRIPTION
This takes a wasm function and adds it directly to the table.

This is useful for `dlsym()` which knows that it has a native wasm
function but doesn't know its signature so cannot supply the second
argument to `addFunction()`.