### PR TITLE
Error when trying to do OUTLINING_LIMIT with the LLVM wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1249,6 +1249,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
       if shared.Settings.OUTLINING_LIMIT:
+        if shared.Settings.WASM_BACKEND:
+          exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
         if not options.js_opts:
           logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
           options.js_opts = True

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -650,7 +650,7 @@ align 32: 0
 base align: 0, 0, 0, 0'''])
 
     test()
-    if '-O' in str(self.emcc_args):
+    if '-O' in str(self.emcc_args) and not self.is_wasm_backend():
       print('outlining')
       self.set_setting('OUTLINING_LIMIT', 60)
       test()
@@ -5812,6 +5812,8 @@ return malloc(size);
 
     # Main
     for outlining in [0, 5000]:
+      if outlining and self.is_wasm_backend():
+        continue
       self.set_setting('OUTLINING_LIMIT', outlining)
       print('outlining:', outlining, file=sys.stderr)
       self.do_run(open(path_from_root('tests', 'freetype', 'main.c')).read(),
@@ -5853,8 +5855,6 @@ return malloc(size);
     if self.get_setting('ASM_JS') == 1 and '-g' in self.emcc_args:
       print("disabling inlining") # without registerize (which -g disables), we generate huge amounts of code
       self.set_setting('INLINING_LIMIT', 50)
-
-    # self.set_setting('OUTLINING_LIMIT', 60000)
 
     src = '''
        #define SQLITE_DISABLE_LFS

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1052,6 +1052,7 @@ int main() {
            expected_ranges,
            args=['-I' + path_from_root('tests', 'zlib')], suffix='c')
 
+  @no_wasm_backend('outlining is an asmjs only feature')
   def test_outline_stack(self):
     create_test_file('src.c', r'''
 #include <stdio.h>


### PR DESCRIPTION
This also prevents some wasted time on CI.