### PR TITLE
Simplify emcc.py temp file handling

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -686,758 +686,764 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   use_cxx = True
 
-  try:
-    with ToolchainProfiler.profile_block('parse arguments and setup'):
-      ## Parse args
+  with ToolchainProfiler.profile_block('parse arguments and setup'):
+    ## Parse args
 
-      newargs = sys.argv[1:]
+    newargs = sys.argv[1:]
 
-      # Scan and strip emscripten specific cmdline warning flags
-      # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
-      newargs = shared.WarningManager.capture_warnings(newargs)
+    # Scan and strip emscripten specific cmdline warning flags
+    # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
+    newargs = shared.WarningManager.capture_warnings(newargs)
 
-      for i in range(len(newargs)):
-        if newargs[i] in ['-l', '-L', '-I']:
-          # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
-          newargs[i] += newargs[i + 1]
-          newargs[i + 1] = ''
+    for i in range(len(newargs)):
+      if newargs[i] in ['-l', '-L', '-I']:
+        # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
+        newargs[i] += newargs[i + 1]
+        newargs[i + 1] = ''
 
-      def detect_fixed_language_mode(args):
-        check_next = False
-        for item in args:
-          if check_next:
-            if item in ("c++", "c"):
-              return True
-            else:
-              check_next = False
-          if item.startswith("-x"):
-            lmode = item[2:] if len(item) > 2 else None
-            if lmode in ("c++", "c"):
-              return True
-            else:
-              check_next = True
-              continue
-        return False
-
-      has_fixed_language_mode = detect_fixed_language_mode(newargs)
-
-      options, settings_changes, newargs = parse_args(newargs)
-
-      for arg in newargs:
-        if arg == '-xc':
-          use_cxx = False
-          break
-        elif arg == '-xc++':
-          use_cxx = True
-          break
-        elif not arg.startswith('-'):
-          if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
-            use_cxx = False
-
-      if not use_cxx:
-        options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
-
-      call = CXX if use_cxx else CC
-
-      # If user did not specify a default -std for C++ code, specify the emscripten default.
-      if options.default_cxx_std:
-        newargs = newargs + [options.default_cxx_std]
-
-      if options.emrun:
-        options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
-        options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
-        # emrun mode waits on program exit
-        shared.Settings.EXIT_RUNTIME = 1
-
-      if options.cpu_profiler:
-        options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
-
-      if options.memory_profiler:
-        options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
-
-      if options.thread_profiler:
-        options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
-
-      if options.js_opts is None:
-        options.js_opts = options.opt_level >= 2
-
-      if options.llvm_opts is None:
-        options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
-      elif type(options.llvm_opts) == int:
-        options.llvm_opts = ['-O%d' % options.llvm_opts]
-
-      if options.memory_init_file is None:
-        options.memory_init_file = options.opt_level >= 2
-
-      # TODO: support source maps with js_transform
-      if options.js_transform and use_source_map(options):
-        logger.warning('disabling source maps because a js transform is being done')
-        options.debug_level = 3
-
-      if DEBUG:
-        start_time = time.time() # done after parsing arguments, which might affect debug state
-
-      for i in range(len(newargs)):
-        if newargs[i] == '-s':
-          if is_minus_s_for_emcc(newargs, i):
-            key = newargs[i + 1]
-            # If not = is specified default to 1
-            if '=' not in key:
-              key += '=1'
-            settings_changes.append(key)
-            newargs[i] = newargs[i + 1] = ''
-            if key == 'WASM_BACKEND=1':
-              exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
-      newargs = [arg for arg in newargs if arg is not '']
-
-      settings_key_changes = set()
-      for s in settings_changes:
-        key, value = s.split('=', 1)
-        settings_key_changes.add(key)
-
-      # Find input files
-
-      # These three arrays are used to store arguments of different types for
-      # type-specific processing. In order to shuffle the arguments back together
-      # after processing, all of these arrays hold tuples (original_index, value).
-      # Note that the index part of the tuple can have a fractional part for input
-      # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
-      input_files = []
-      libs = []
-      link_flags = []
-
-      # All of the above arg lists entries contain indexes into the full argument
-      # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
-      # counter for the next index that should be used.
-      next_arg_index = len(newargs)
-
-      has_source_inputs = False
-      has_header_inputs = False
-      lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
-                  shared.path_from_root('system', 'lib')]
-      for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
-                                    # right now we just assume that what is left contains no more |-x OPT| things
-        arg = newargs[i]
-
-        if i > 0:
-          prev = newargs[i - 1]
-          if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
-                      '-Xpreprocessor', '-include', '-imacros', '-idirafter',
-                      '-iprefix', '-iwithprefix', '-iwithprefixbefore',
-                      '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
-                      '-install_name', '-compatibility_version',
-                      '-current_version', '-I', '-L', '-include-pch'):
-            continue # ignore this gcc-style argument
-
-        if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
-          arg = os.path.realpath(arg)
-
-        if not arg.startswith('-'):
-          if not os.path.exists(arg):
-            exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
-
-          arg_ending = filename_type_ending(arg)
-          if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
-            newargs[i] = ''
-            if arg_ending.endswith(SOURCE_ENDINGS):
-              input_files.append((i, arg))
-              has_source_inputs = True
-            elif arg_ending.endswith(HEADER_ENDINGS):
-              input_files.append((i, arg))
-              has_header_inputs = True
-            elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
-              input_files.append((i, arg))
-            elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
-              # if it's not, and it's a library, just add it to libs to find later
-              l = unsuffixed_basename(arg)
-              for prefix in LIB_PREFIXES:
-                if not prefix:
-                  continue
-                if l.startswith(prefix):
-                  l = l[len(prefix):]
-                  break
-              libs.append((i, l))
-              newargs[i] = ''
-            elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
-              input_files.append((i, arg))
-            else:
-              logger.warning(arg + ' is not valid LLVM bitcode')
-          elif arg_ending.endswith(STATICLIB_ENDINGS):
-            if not shared.Building.is_ar(arg):
-              if shared.Building.is_bitcode(arg):
-                message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
-              else:
-                message = arg + ': Unknown format, not a static library!'
-              exit_with_error(message)
-          else:
-            if has_fixed_language_mode:
-              newargs[i] = ''
-              input_files.append((i, arg))
-              has_source_inputs = True
-            else:
-              exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
-        elif arg.startswith('-L'):
-          lib_dirs.append(arg[2:])
-          newargs[i] = ''
-        elif arg.startswith('-l'):
-          libs.append((i, arg[2:]))
-          newargs[i] = ''
-        elif arg.startswith('-Wl,'):
-          # Multiple comma separated link flags can be specified. Create fake
-          # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
-          # (4, a), (4.25, b), (4.5, c), (4.75, d)
-          link_flags_to_add = arg.split(',')[1:]
-          for flag_index, flag in enumerate(link_flags_to_add):
-            link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
-
-          newargs[i] = ''
-        elif arg == '-s':
-          # -s and some other compiler flags are normally passed onto the linker
-          # TODO(sbc): Pass this and other flags through when using lld
-          # link_flags.append((i, arg))
-          newargs[i] = ''
-
-      original_input_files = input_files[:]
-
-      newargs = [a for a in newargs if a is not '']
-
-      # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
-      has_dash_c = '-c' in newargs
-      if has_dash_c:
-        assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
-        target = target_basename + '.o'
-        final_suffix = 'o'
-      if '-E' in newargs:
-        final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
-      if '-M' in newargs or '-MM' in newargs:
-        final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
-      final_ending = ('.' + final_suffix) if len(final_suffix) else ''
-
-      # target is now finalized, can finalize other _target s
-      js_target = unsuffixed(target) + '.js'
-
-      asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
-      wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
-      wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
-
-      if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
-        options.separate_asm = True
-        logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
-      if options.separate_asm:
-        shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
-
-      if 'EMCC_STRICT' in os.environ:
-        shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
-
-      # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
-      # command line already now.
-
-      def get_last_setting_change(setting):
-        return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
-
-      strict_cmdline = get_last_setting_change('STRICT')
-      if strict_cmdline:
-        shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
-
-      if shared.Settings.STRICT:
-        shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
-
-      error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
-      if error_on_missing_libraries_cmdline:
-        shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
-
-      settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
-
-      # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
-      # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
-      if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
-        def check(input_file):
-          if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
-            if not options.ignore_dynamic_linking:
-              logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
-            return False
-          else:
+    def detect_fixed_language_mode(args):
+      check_next = False
+      for item in args:
+        if check_next:
+          if item in ("c++", "c"):
             return True
-        input_files = [f for f in input_files if check(f[1])]
+          else:
+            check_next = False
+        if item.startswith("-x"):
+          lmode = item[2:] if len(item) > 2 else None
+          if lmode in ("c++", "c"):
+            return True
+          else:
+            check_next = True
+            continue
+      return False
 
-      if len(input_files) == 0:
-        exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
+    has_fixed_language_mode = detect_fixed_language_mode(newargs)
 
-      newargs = CC_ADDITIONAL_ARGS + newargs
+    options, settings_changes, newargs = parse_args(newargs)
 
-      if options.separate_asm and final_suffix != 'html':
-        shared.WarningManager.warn('SEPARATE_ASM')
+    for arg in newargs:
+      if arg == '-xc':
+        use_cxx = False
+        break
+      elif arg == '-xc++':
+        use_cxx = True
+        break
+      elif not arg.startswith('-'):
+        if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
+          use_cxx = False
 
-      # Apply optimization level settings
-      shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
+    if not use_cxx:
+      options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
 
-      # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
-      # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
-      if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
-        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+    call = CXX if use_cxx else CC
 
-      # Set ASM_JS default here so that we can override it from the command line.
-      shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
+    # If user did not specify a default -std for C++ code, specify the emscripten default.
+    if options.default_cxx_std:
+      newargs = newargs + [options.default_cxx_std]
 
-      # Apply -s settings in newargs here (after optimization levels, so they can override them)
-      apply_settings(settings_changes)
+    if options.emrun:
+      options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
+      options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
+      # emrun mode waits on program exit
+      shared.Settings.EXIT_RUNTIME = 1
 
-      shared.verify_settings()
+    if options.cpu_profiler:
+      options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
 
-      # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
-      shared.reconfigure_cache()
+    if options.memory_profiler:
+      options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
 
-      # Note the exports the user requested
-      shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
+    if options.thread_profiler:
+      options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
 
-      if options.bind:
-        # If we are using embind and generating JS, now is the time to link in bind.cpp
-        if final_suffix in JS_CONTAINING_SUFFIXES:
-          input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
-          next_arg_index += 1
+    if options.js_opts is None:
+      options.js_opts = options.opt_level >= 2
 
-      # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
-      # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
-      if shared.Settings.ASSERTIONS:
-        shared.Settings.STACK_OVERFLOW_CHECK = 2
+    if options.llvm_opts is None:
+      options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
+    elif type(options.llvm_opts) == int:
+      options.llvm_opts = ['-O%d' % options.llvm_opts]
 
-      if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
-        logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
+    if options.memory_init_file is None:
+      options.memory_init_file = options.opt_level >= 2
+
+    # TODO: support source maps with js_transform
+    if options.js_transform and use_source_map(options):
+      logger.warning('disabling source maps because a js transform is being done')
+      options.debug_level = 3
+
+    if DEBUG:
+      start_time = time.time() # done after parsing arguments, which might affect debug state
+
+    for i in range(len(newargs)):
+      if newargs[i] == '-s':
+        if is_minus_s_for_emcc(newargs, i):
+          key = newargs[i + 1]
+          # If not = is specified default to 1
+          if '=' not in key:
+            key += '=1'
+          settings_changes.append(key)
+          newargs[i] = newargs[i + 1] = ''
+          if key == 'WASM_BACKEND=1':
+            exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
+    newargs = [arg for arg in newargs if arg is not '']
+
+    settings_key_changes = set()
+    for s in settings_changes:
+      key, value = s.split('=', 1)
+      settings_key_changes.add(key)
+
+    # Find input files
+
+    # These three arrays are used to store arguments of different types for
+    # type-specific processing. In order to shuffle the arguments back together
+    # after processing, all of these arrays hold tuples (original_index, value).
+    # Note that the index part of the tuple can have a fractional part for input
+    # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
+    input_files = []
+    libs = []
+    link_flags = []
+
+    # All of the above arg lists entries contain indexes into the full argument
+    # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
+    # counter for the next index that should be used.
+    next_arg_index = len(newargs)
+
+    has_source_inputs = False
+    has_header_inputs = False
+    lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
+                shared.path_from_root('system', 'lib')]
+    for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
+                                  # right now we just assume that what is left contains no more |-x OPT| things
+      arg = newargs[i]
+
+      if i > 0:
+        prev = newargs[i - 1]
+        if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
+                    '-Xpreprocessor', '-include', '-imacros', '-idirafter',
+                    '-iprefix', '-iwithprefix', '-iwithprefixbefore',
+                    '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
+                    '-install_name', '-compatibility_version',
+                    '-current_version', '-I', '-L', '-include-pch'):
+          continue # ignore this gcc-style argument
+
+      if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
+        arg = os.path.realpath(arg)
+
+      if not arg.startswith('-'):
+        if not os.path.exists(arg):
+          exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
+
+        arg_ending = filename_type_ending(arg)
+        if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
+          newargs[i] = ''
+          if arg_ending.endswith(SOURCE_ENDINGS):
+            input_files.append((i, arg))
+            has_source_inputs = True
+          elif arg_ending.endswith(HEADER_ENDINGS):
+            input_files.append((i, arg))
+            has_header_inputs = True
+          elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
+            input_files.append((i, arg))
+          elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
+            # if it's not, and it's a library, just add it to libs to find later
+            l = unsuffixed_basename(arg)
+            for prefix in LIB_PREFIXES:
+              if not prefix:
+                continue
+              if l.startswith(prefix):
+                l = l[len(prefix):]
+                break
+            libs.append((i, l))
+            newargs[i] = ''
+          elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
+            input_files.append((i, arg))
+          else:
+            logger.warning(arg + ' is not valid LLVM bitcode')
+        elif arg_ending.endswith(STATICLIB_ENDINGS):
+          if not shared.Building.is_ar(arg):
+            if shared.Building.is_bitcode(arg):
+              message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
+            else:
+              message = arg + ': Unknown format, not a static library!'
+            exit_with_error(message)
+        else:
+          if has_fixed_language_mode:
+            newargs[i] = ''
+            input_files.append((i, arg))
+            has_source_inputs = True
+          else:
+            exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
+      elif arg.startswith('-L'):
+        lib_dirs.append(arg[2:])
+        newargs[i] = ''
+      elif arg.startswith('-l'):
+        libs.append((i, arg[2:]))
+        newargs[i] = ''
+      elif arg.startswith('-Wl,'):
+        # Multiple comma separated link flags can be specified. Create fake
+        # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
+        # (4, a), (4.25, b), (4.5, c), (4.75, d)
+        link_flags_to_add = arg.split(',')[1:]
+        for flag_index, flag in enumerate(link_flags_to_add):
+          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+
+        newargs[i] = ''
+      elif arg == '-s':
+        # -s and some other compiler flags are normally passed onto the linker
+        # TODO(sbc): Pass this and other flags through when using lld
+        # link_flags.append((i, arg))
+        newargs[i] = ''
+
+    original_input_files = input_files[:]
+
+    newargs = [a for a in newargs if a is not '']
+
+    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+    has_dash_c = '-c' in newargs
+    if has_dash_c:
+      assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
+      target = target_basename + '.o'
+      final_suffix = 'o'
+    if '-E' in newargs:
+      final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
+    if '-M' in newargs or '-MM' in newargs:
+      final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
+    final_ending = ('.' + final_suffix) if len(final_suffix) else ''
+
+    # target is now finalized, can finalize other _target s
+    js_target = unsuffixed(target) + '.js'
+
+    asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
+    wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
+    wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
+
+    if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
+      options.separate_asm = True
+      logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
+    if options.separate_asm:
+      shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
+
+    if 'EMCC_STRICT' in os.environ:
+      shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
+
+    # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
+    # command line already now.
+
+    def get_last_setting_change(setting):
+      return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
+
+    strict_cmdline = get_last_setting_change('STRICT')
+    if strict_cmdline:
+      shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
+
+    if shared.Settings.STRICT:
+      shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
+
+    error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
+    if error_on_missing_libraries_cmdline:
+      shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
+
+    settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
+
+    # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
+    # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
+    if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
+      def check(input_file):
+        if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
+          if not options.ignore_dynamic_linking:
+            logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
+          return False
+        else:
+          return True
+      input_files = [f for f in input_files if check(f[1])]
+
+    if len(input_files) == 0:
+      exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
+
+    newargs = CC_ADDITIONAL_ARGS + newargs
+
+    if options.separate_asm and final_suffix != 'html':
+      shared.WarningManager.warn('SEPARATE_ASM')
+
+    # Apply optimization level settings
+    shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
+
+    # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
+    # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
+    if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
+      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+
+    # Set ASM_JS default here so that we can override it from the command line.
+    shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
+
+    # Apply -s settings in newargs here (after optimization levels, so they can override them)
+    apply_settings(settings_changes)
+
+    shared.verify_settings()
+
+    # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
+    shared.reconfigure_cache()
+
+    # Note the exports the user requested
+    shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
+
+    if options.bind:
+      # If we are using embind and generating JS, now is the time to link in bind.cpp
+      if final_suffix in JS_CONTAINING_SUFFIXES:
+        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
+        next_arg_index += 1
+
+    # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
+    # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
+    if shared.Settings.ASSERTIONS:
+      shared.Settings.STACK_OVERFLOW_CHECK = 2
+
+    if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
+      logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
+      return 1
+
+    if not shared.Settings.STRICT:
+      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
+
+      # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
+      # This path is not available in Emscripten strict mode.
+      if shared.USE_EMSDK:
+        shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
+
+    # Use settings
+
+    try:
+      assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
+      assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
+      assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
+      assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
+      assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
+      assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
+    except Exception as e:
+      logger.error('Compiler settings error: {}'.format(e))
+      exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
+
+    assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
+
+    if options.debug_level > 1 and options.use_closure_compiler:
+      logger.warning('disabling closure because debug info was requested')
+      options.use_closure_compiler = False
+
+    assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
+
+    assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
+
+    if options.emrun:
+      shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+
+    if options.use_closure_compiler:
+      shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
+      if not shared.check_closure_compiler():
+        exit_with_error('fatal: closure compiler is not configured correctly')
+      if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
+        shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
+        shared.Settings.ASM_JS = 2
+
+    if shared.Settings.MAIN_MODULE:
+      assert not shared.Settings.SIDE_MODULE
+      if shared.Settings.MAIN_MODULE != 2:
+        shared.Settings.INCLUDE_FULL_LIBRARY = 1
+    elif shared.Settings.SIDE_MODULE:
+      assert not shared.Settings.MAIN_MODULE
+      options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
+
+    if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
+      assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
+      if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
+        shared.Settings.LINKABLE = 1
+      shared.Settings.RELOCATABLE = 1
+      shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
+      assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
+      # shared modules need memory utilities to allocate their memory
+      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+        'allocate',
+        'getMemory',
+      ]
+    if shared.Settings.USE_PTHREADS:
+      # These runtime methods are called from worker.js
+      shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
+
+    if shared.Settings.MODULARIZE_INSTANCE:
+      shared.Settings.MODULARIZE = 1
+
+    if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+      shared.Settings.ALIASING_FUNCTION_POINTERS = 0
+
+    if shared.Settings.LEGACY_VM_SUPPORT:
+      # legacy vms don't have wasm
+      assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
+      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
+      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
+      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
+
+    # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
+    if shared.Settings.WASM:
+      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
+      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
+      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
+
+    if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
+      next_arg_index += 1
+      shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
+      # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
+      newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
+
+    if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
+      newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
+      next_arg_index += 1
+      shared.Settings.FILESYSTEM = 0
+      shared.Settings.FETCH = 1
+      if not shared.Settings.USE_PTHREADS:
+        exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
+
+    if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
+      next_arg_index += 1
+      options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
+
+    forced_stdlibs = []
+    if shared.Settings.DEMANGLE_SUPPORT:
+      shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
+      forced_stdlibs += ['libc++abi']
+
+    if not shared.Settings.ONLY_MY_CODE:
+      # Always need malloc and free to be kept alive and exported, for internal use and other modules
+      shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
+      if shared.Settings.WASM_BACKEND:
+        # setjmp/longjmp and exception handling JS code depends on this so we
+        # include it by default.  Should be elimiated by meta-DCE if unused.
+        shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
+
+    if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
+      exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
+
+    if shared.Settings.RELOCATABLE:
+      assert shared.Settings.GLOBAL_BASE < 1
+      if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
+        shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
+      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+      shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
+
+    if shared.Settings.EMTERPRETIFY:
+      shared.Settings.FINALIZE_ASM_JS = 0
+      # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
+      shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
+      shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
+      if not options.js_opts:
+        logger.debug('enabling js opts for EMTERPRETIFY')
+        options.js_opts = True
+      options.force_js_opts = True
+      if options.use_closure_compiler == 2:
+         exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
+      assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
+
+    if shared.Settings.DEAD_FUNCTIONS:
+      if not options.js_opts:
+        logger.debug('enabling js opts for DEAD_FUNCTIONS')
+        options.js_opts = True
+      options.force_js_opts = True
+
+    if options.proxy_to_worker:
+      shared.Settings.PROXY_TO_WORKER = 1
+
+    if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
+      if shared.Settings.NODERAWFS:
+        exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
+      # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
+      shared.Settings.FORCE_FILESYSTEM = 1
+
+    if options.proxy_to_worker or options.use_preload_plugins:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
+
+    if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
+      shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
+      # to flush streams on FS exit, we need to be able to call fflush
+      # we only include it if the runtime is exitable, or when ASSERTIONS
+      # (ASSERTIONS will check that streams do not need to be flushed,
+      # helping people see when they should have disabled NO_EXIT_RUNTIME)
+      if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
+        shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
+
+    if shared.Settings.USE_PTHREADS:
+      if shared.Settings.USE_PTHREADS == 2:
+        exit_with_error('USE_PTHREADS=2 is not longer supported')
+      if shared.Settings.ALLOW_MEMORY_GROWTH:
+        exit_with_error('Memory growth is not yet supported with pthreads')
+      if shared.Settings.MODULARIZE:
+        # currently worker.js uses the global namespace, so it's setting of
+        # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
+        # modifications it performs.
+        exit_with_error('MODULARIZE is not yet supported with pthreads')
+      # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
+      shared.Settings.TEXTDECODER = 0
+      options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
+      newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
+      shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
+      # set location of worker.js
+      shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
+    else:
+      options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
+
+    if shared.Settings.FORCE_FILESYSTEM:
+      # when the filesystem is forced, we export by default methods that filesystem usage
+      # may need, including filesystem usage from standalone file packager output (i.e.
+      # file packages not built together with emcc, but that are loaded at runtime
+      # separately, and they need emcc's output to contain the support they need)
+      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+        'FS_createFolder',
+        'FS_createPath',
+        'FS_createDataFile',
+        'FS_createPreloadedFile',
+        'FS_createLazyFile',
+        'FS_createLink',
+        'FS_createDevice',
+        'FS_unlink',
+        'getMemory',
+        'addRunDependency',
+        'removeRunDependency',
+      ]
+
+    if shared.Settings.USE_PTHREADS:
+      if shared.Settings.LINKABLE:
+        exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.SIDE_MODULE:
+        exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.MAIN_MODULE:
+        exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.EMTERPRETIFY:
+        exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.PROXY_TO_WORKER:
+        exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
+    else:
+      if shared.Settings.PROXY_TO_PTHREAD:
+        exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
+
+    if shared.Settings.OUTLINING_LIMIT:
+      if shared.Settings.WASM_BACKEND:
+        exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
+      if not options.js_opts:
+        logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
+        options.js_opts = True
+      options.force_js_opts = True
+
+    # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
+    if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
+      shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
+
+    if shared.Settings.WASM:
+      if not shared.Building.need_asm_js_file():
+        asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
+        misc_temp_files.note(asm_target)
+
+    if shared.Settings.WASM:
+      if shared.Settings.TOTAL_MEMORY % 65536 != 0:
+        exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
+    else:
+      if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
+        exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+      if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
+        exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+    if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
+      exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
+    if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
+      exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
+    if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
+      exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
+
+    if shared.Settings.WASM_BACKEND:
+      options.js_opts = None
+
+      # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
+      # we run the optimizer during asm2wasm itself). use it, if not overridden
+      if 'BINARYEN_PASSES' not in settings_key_changes:
+        passes = []
+        if not shared.Settings.EXIT_RUNTIME:
+          passes += ['--no-exit-runtime']
+        if options.opt_level > 0 or options.shrink_level > 0:
+          passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
+        if options.debug_level < 3:
+          passes += ['--strip']
+        if passes:
+          shared.Settings.BINARYEN_PASSES = ','.join(passes)
+
+      # to bootstrap struct_info, we need binaryen
+      os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
+
+    if shared.Settings.WASM:
+      if shared.Settings.SINGLE_FILE:
+        # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
+        shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
+        shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
+        shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
+      else:
+        # set file locations, so that JS glue can find what it needs
+        shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
+        shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
+        shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
+
+      shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
+      shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
+      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
+        logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
+        shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
+      if shared.Settings.OUTLINING_LIMIT:
+        logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
+      # default precise-f32 to on, since it works well in wasm
+      # also always use f32s when asm.js is not in the picture
+      if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        shared.Settings.PRECISE_F32 = 1
+      if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        options.js_opts = None
+        logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
+      if options.use_closure_compiler == 2:
+        exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
+      # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
+      #  * if we also supported js mem inits we'd have 4 modes
+      #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
+      if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
+        exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
+      options.memory_init_file = True
+      # async compilation requires not interpreting (the interpreter modes needs sync input)
+      if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
+        # async compilation requires a swappable module - we swap it in when it's ready
+        shared.Settings.SWAPPABLE_ASM_MODULE = 1
+      else:
+        # if not wasm-only, we can't do async compilation as the build can run in other
+        # modes than wasm (like asm.js) which may not support an async step
+        shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
+        warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
+        if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
+          logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
+        elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
+          logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
+      # run safe-heap as a binaryen pass
+      if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'safe-heap'
+      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+        # emulated function pointer casts is emulated in wasm using a binaryen pass
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
+        # we also need emulated function pointers for that, as we need a single flat
+        # table, as is standard in wasm, and not asm.js split ones.
+        shared.Settings.EMULATED_FUNCTION_POINTERS = 1
+
+      # we will include the mem init data in the wasm, when we don't need the
+      # mem init file to be loadable by itself
+      shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
+                                         'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
+                                         not shared.Settings.USE_PTHREADS
+
+      # wasm side modules have suffix .wasm
+      if shared.Settings.SIDE_MODULE and target.endswith('.js'):
+        logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
+
+      if options.separate_asm:
+        exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
+
+    # wasm outputs are only possible with a side wasm
+    if target.endswith(WASM_ENDINGS):
+      if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
+        logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
         return 1
 
-      if not shared.Settings.STRICT:
-        # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-        shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
-
-        # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
-        # This path is not available in Emscripten strict mode.
-        if shared.USE_EMSDK:
-          shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
-
-      # Use settings
-
-      try:
-        assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
-        assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
-        assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
-        assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
-        assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
-        assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
-      except Exception as e:
-        logger.error('Compiler settings error: {}'.format(e))
-        exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
-
-      assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
-
-      if options.debug_level > 1 and options.use_closure_compiler:
-        logger.warning('disabling closure because debug info was requested')
-        options.use_closure_compiler = False
-
-      assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
-
-      assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
-
-      if options.emrun:
-        shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
-
-      if options.use_closure_compiler:
-        shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
-        if not shared.check_closure_compiler():
-          exit_with_error('fatal: closure compiler is not configured correctly')
-        if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
-          shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
-          shared.Settings.ASM_JS = 2
-
-      if shared.Settings.MAIN_MODULE:
-        assert not shared.Settings.SIDE_MODULE
-        if shared.Settings.MAIN_MODULE != 2:
-          shared.Settings.INCLUDE_FULL_LIBRARY = 1
-      elif shared.Settings.SIDE_MODULE:
-        assert not shared.Settings.MAIN_MODULE
-        options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
-
-      if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
-        assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
-        if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
-          shared.Settings.LINKABLE = 1
-        shared.Settings.RELOCATABLE = 1
-        shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
-        assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
-        # shared modules need memory utilities to allocate their memory
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
-          'allocate',
-          'getMemory',
-        ]
-      if shared.Settings.USE_PTHREADS:
-        # These runtime methods are called from worker.js
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
-
-      if shared.Settings.MODULARIZE_INSTANCE:
-        shared.Settings.MODULARIZE = 1
-
-      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-        shared.Settings.ALIASING_FUNCTION_POINTERS = 0
-
-      if shared.Settings.LEGACY_VM_SUPPORT:
-        # legacy vms don't have wasm
-        assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
-        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
-        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
-        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
-
-      # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
-      if shared.Settings.WASM:
-        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
-        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
-        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
-
-      if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
-        next_arg_index += 1
-        shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
-        # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
-        newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
-
-      if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
-        newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
-        next_arg_index += 1
-        shared.Settings.FILESYSTEM = 0
-        shared.Settings.FETCH = 1
-        if not shared.Settings.USE_PTHREADS:
-          exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
-
-      if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
-        next_arg_index += 1
-        options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
-
-      forced_stdlibs = []
-      if shared.Settings.DEMANGLE_SUPPORT:
-        shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
-        forced_stdlibs += ['libc++abi']
-
-      if not shared.Settings.ONLY_MY_CODE:
-        # Always need malloc and free to be kept alive and exported, for internal use and other modules
-        shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
-        if shared.Settings.WASM_BACKEND:
-          # setjmp/longjmp and exception handling JS code depends on this so we
-          # include it by default.  Should be elimiated by meta-DCE if unused.
-          shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
-
-      if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
-        exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
-
-      if shared.Settings.RELOCATABLE:
-        assert shared.Settings.GLOBAL_BASE < 1
-        if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
-          shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
-        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-        shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
-
-      if shared.Settings.EMTERPRETIFY:
-        shared.Settings.FINALIZE_ASM_JS = 0
-        # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
-        shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
-        shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
-        if not options.js_opts:
-          logger.debug('enabling js opts for EMTERPRETIFY')
-          options.js_opts = True
-        options.force_js_opts = True
-        if options.use_closure_compiler == 2:
-           exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
-        assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
-
-      if shared.Settings.DEAD_FUNCTIONS:
-        if not options.js_opts:
-          logger.debug('enabling js opts for DEAD_FUNCTIONS')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      if options.proxy_to_worker:
-        shared.Settings.PROXY_TO_WORKER = 1
-
-      if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
-        if shared.Settings.NODERAWFS:
-          exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
-        # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
-        shared.Settings.FORCE_FILESYSTEM = 1
-
-      if options.proxy_to_worker or options.use_preload_plugins:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
-
-      if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
-        shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
-        # to flush streams on FS exit, we need to be able to call fflush
-        # we only include it if the runtime is exitable, or when ASSERTIONS
-        # (ASSERTIONS will check that streams do not need to be flushed,
-        # helping people see when they should have disabled NO_EXIT_RUNTIME)
-        if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
-          shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
-
-      if shared.Settings.USE_PTHREADS:
-        if shared.Settings.USE_PTHREADS == 2:
-          exit_with_error('USE_PTHREADS=2 is not longer supported')
-        if shared.Settings.ALLOW_MEMORY_GROWTH:
-          exit_with_error('Memory growth is not yet supported with pthreads')
-        if shared.Settings.MODULARIZE:
-          # currently worker.js uses the global namespace, so it's setting of
-          # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
-          # modifications it performs.
-          exit_with_error('MODULARIZE is not yet supported with pthreads')
-        # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
-        shared.Settings.TEXTDECODER = 0
-        options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
-        newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
-        shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
-        # set location of worker.js
-        shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
-      else:
-        options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
-
-      if shared.Settings.FORCE_FILESYSTEM:
-        # when the filesystem is forced, we export by default methods that filesystem usage
-        # may need, including filesystem usage from standalone file packager output (i.e.
-        # file packages not built together with emcc, but that are loaded at runtime
-        # separately, and they need emcc's output to contain the support they need)
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
-          'FS_createFolder',
-          'FS_createPath',
-          'FS_createDataFile',
-          'FS_createPreloadedFile',
-          'FS_createLazyFile',
-          'FS_createLink',
-          'FS_createDevice',
-          'FS_unlink',
-          'getMemory',
-          'addRunDependency',
-          'removeRunDependency',
-        ]
-
-      if shared.Settings.USE_PTHREADS:
-        if shared.Settings.LINKABLE:
-          exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.SIDE_MODULE:
-          exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.MAIN_MODULE:
-          exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.EMTERPRETIFY:
-          exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.PROXY_TO_WORKER:
-          exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
-      else:
-        if shared.Settings.PROXY_TO_PTHREAD:
-          exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
-
-      if shared.Settings.OUTLINING_LIMIT:
-        if shared.Settings.WASM_BACKEND:
-          exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
-        if not options.js_opts:
-          logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
-      if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
-        shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
-
-      if shared.Settings.WASM:
-        if not shared.Building.need_asm_js_file():
-          asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
-          misc_temp_files.note(asm_target)
-
-      if shared.Settings.WASM:
-        if shared.Settings.TOTAL_MEMORY % 65536 != 0:
-          exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
-      else:
-        if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
-          exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-        if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
-          exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-      if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
-        exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
-      if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
-        exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
-      if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
-        exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
-
-      if shared.Settings.WASM_BACKEND:
-        options.js_opts = None
-
-        # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
-        # we run the optimizer during asm2wasm itself). use it, if not overridden
-        if 'BINARYEN_PASSES' not in settings_key_changes:
-          passes = []
-          if not shared.Settings.EXIT_RUNTIME:
-            passes += ['--no-exit-runtime']
-          if options.opt_level > 0 or options.shrink_level > 0:
-            passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
-          if options.debug_level < 3:
-            passes += ['--strip']
-          if passes:
-            shared.Settings.BINARYEN_PASSES = ','.join(passes)
-
-        # to bootstrap struct_info, we need binaryen
-        os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
-
-      if shared.Settings.WASM:
-        if shared.Settings.SINGLE_FILE:
-          # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
-          shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
-          shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
-          shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
-        else:
-          # set file locations, so that JS glue can find what it needs
-          shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
-          shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
-          shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
-
-        shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
-        shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
-        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
-          logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
-          shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
-        if shared.Settings.OUTLINING_LIMIT:
-          logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
-        # default precise-f32 to on, since it works well in wasm
-        # also always use f32s when asm.js is not in the picture
-        if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-          shared.Settings.PRECISE_F32 = 1
-        if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-          options.js_opts = None
-          logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
-        if options.use_closure_compiler == 2:
-          exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
-        # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
-        #  * if we also supported js mem inits we'd have 4 modes
-        #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
-        if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
-          exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
-        options.memory_init_file = True
-        # async compilation requires not interpreting (the interpreter modes needs sync input)
-        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
-          # async compilation requires a swappable module - we swap it in when it's ready
-          shared.Settings.SWAPPABLE_ASM_MODULE = 1
-        else:
-          # if not wasm-only, we can't do async compilation as the build can run in other
-          # modes than wasm (like asm.js) which may not support an async step
-          shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
-          warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
-          if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
-            logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
-          elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
-            logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
-        # run safe-heap as a binaryen pass
-        if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
-          if shared.Settings.BINARYEN_PASSES:
-            shared.Settings.BINARYEN_PASSES += ','
-          shared.Settings.BINARYEN_PASSES += 'safe-heap'
-        if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-          # emulated function pointer casts is emulated in wasm using a binaryen pass
-          if shared.Settings.BINARYEN_PASSES:
-            shared.Settings.BINARYEN_PASSES += ','
-          shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
-          # we also need emulated function pointers for that, as we need a single flat
-          # table, as is standard in wasm, and not asm.js split ones.
-          shared.Settings.EMULATED_FUNCTION_POINTERS = 1
-
-        # we will include the mem init data in the wasm, when we don't need the
-        # mem init file to be loadable by itself
-        shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                           'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
-                                           not shared.Settings.USE_PTHREADS
-
-        # wasm side modules have suffix .wasm
-        if shared.Settings.SIDE_MODULE and target.endswith('.js'):
-          logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
-
-        if options.separate_asm:
-          exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
-
-      # wasm outputs are only possible with a side wasm
-      if target.endswith(WASM_ENDINGS):
-        if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-          logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
-          return 1
-
-      if shared.Settings.EVAL_CTORS:
-        if not shared.Settings.WASM:
-          # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
-          # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
-          shared.Settings.RUNNING_JS_OPTS = 1
-        else:
-          if 'interpret' in shared.Settings.BINARYEN_METHOD:
-            logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
-            shared.Settings.EVAL_CTORS = 0
-
-      # memory growth does not work in dynamic linking, except for wasm
-      if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
-        assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
-
-      if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
-        # this is an issue in asm.js, but not wasm
-        if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
-          shared.WarningManager.warn('ALMOST_ASM')
-          shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
-
-      # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
-      if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
-        if not options.js_opts:
-          logger.debug('enabling js opts for SAFE_HEAP')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      if options.js_opts:
+    if shared.Settings.EVAL_CTORS:
+      if not shared.Settings.WASM:
+        # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
+        # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
         shared.Settings.RUNNING_JS_OPTS = 1
-
-      if shared.Settings.CYBERDWARF:
-        newargs.append('-g')
-        options.debug_level = max(options.debug_level, 2)
-        shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
-        options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
-        options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
-
-      if options.tracing:
-        if shared.Settings.ALLOW_MEMORY_GROWTH:
-          shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
-
-      if shared.Settings.ONLY_MY_CODE:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
-        options.separate_asm = True
-        shared.Settings.FINALIZE_ASM_JS = False
-
-      if shared.Settings.GLOBAL_BASE < 0:
-        shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
-
-      if shared.Settings.WASM_BACKEND:
-        if shared.Settings.SIMD:
-          newargs.append('-msimd128')
       else:
-        # We leave the -O option in place so that the clang front-end runs in that
-        # optimization mode, but we disable the actual optimization passes, as we'll
-        # run them separately.
-        if options.opt_level > 0:
-          newargs.append('-mllvm')
-          newargs.append('-disable-llvm-optzns')
+        if 'interpret' in shared.Settings.BINARYEN_METHOD:
+          logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
+          shared.Settings.EVAL_CTORS = 0
 
-      if not shared.Settings.LEGALIZE_JS_FFI:
-        assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+    # memory growth does not work in dynamic linking, except for wasm
+    if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
+      assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
 
-      shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
-      shared.Settings.OPT_LEVEL = options.opt_level
-      shared.Settings.DEBUG_LEVEL = options.debug_level
-      shared.Settings.PROFILING_FUNCS = options.profiling_funcs
-      shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
+    if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
+      # this is an issue in asm.js, but not wasm
+      if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
+        shared.WarningManager.warn('ALMOST_ASM')
+        shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
 
-      ## Compile source code to bitcode
+    # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
+    if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
+      if not options.js_opts:
+        logger.debug('enabling js opts for SAFE_HEAP')
+        options.js_opts = True
+      options.force_js_opts = True
 
-      logger.debug('compiling to bitcode')
+    if options.js_opts:
+      shared.Settings.RUNNING_JS_OPTS = 1
 
-      temp_files = []
+    if shared.Settings.CYBERDWARF:
+      newargs.append('-g')
+      options.debug_level = max(options.debug_level, 2)
+      shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
+      options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
+      options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
 
-    # exit block 'parse arguments and setup'
-    log_time('parse arguments and setup')
+    if options.tracing:
+      if shared.Settings.ALLOW_MEMORY_GROWTH:
+        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
 
+    if shared.Settings.ONLY_MY_CODE:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+      options.separate_asm = True
+      shared.Settings.FINALIZE_ASM_JS = False
+
+    if shared.Settings.GLOBAL_BASE < 0:
+      shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
+
+    if shared.Settings.WASM_BACKEND:
+      if shared.Settings.SIMD:
+        newargs.append('-msimd128')
+    else:
+      # We leave the -O option in place so that the clang front-end runs in that
+      # optimization mode, but we disable the actual optimization passes, as we'll
+      # run them separately.
+      if options.opt_level > 0:
+        newargs.append('-mllvm')
+        newargs.append('-disable-llvm-optzns')
+
+    if not shared.Settings.LEGALIZE_JS_FFI:
+      assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+
+    shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
+    shared.Settings.OPT_LEVEL = options.opt_level
+    shared.Settings.DEBUG_LEVEL = options.debug_level
+    shared.Settings.PROFILING_FUNCS = options.profiling_funcs
+    shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
+
+    ## Compile source code to bitcode
+
+    logger.debug('compiling to bitcode')
+
+    temp_files = []
+
+  # exit block 'parse arguments and setup'
+  log_time('parse arguments and setup')
+
+  if DEBUG:
+    # we are about to start using temp dirs. serialize access to the temp dir
+    # when using EMCC_DEBUG, since then multiple processes would use the same
+    # location
+    shared.Cache.acquire_cache_lock()
+
+  try:
     with ToolchainProfiler.profile_block('bitcodeize inputs'):
       # Precompiled headers support
       if has_header_inputs:
@@ -2094,11 +2100,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # exit block 'final emitting'
 
   finally:
-    try:
-      if not DEBUG:
-        shutil.rmtree(temp_dir)
-    except:
-      pass
+    if DEBUG:
+      shared.Cache.release_cache_lock()
 
   if DEBUG:
     logger.debug('total time: %.2f seconds', (time.time() - start_time))

--- a/emcc.py
+++ b/emcc.py
@@ -664,28 +664,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   else:
     final_suffix = ''
 
-  # Temporary file handling: we ensure that TEMP_DIR exists, which is the general
-  # location for all temp files from us on this system. We then create a temp dir
-  # under that, and store our main files there. As we process the main js file,
-  # we update the variable `final`, giving it an extra suffix each time, and
-  # relying on the entire dir going away for cleanup. For other miscellaneous
-  # temporary files (like in the js optimizer) we need to note() them so they
-  # get removed.
-
-  temp_root = shared.TEMP_DIR
-  if not os.path.exists(temp_root):
-    try:
-      os.makedirs(temp_root)
-    except Exception as e:
-      if os.path.exists(temp_root):
-        pass # If running multiple emcc instances simultaneously, they may race to create the temp directory if it did not initially exist. In that case, we can proceed.
-      else:
-        raise
-
-  if not DEBUG:
-    temp_dir = tempfile.mkdtemp(dir=temp_root)
-  else:
-    temp_dir = shared.get_emscripten_temp_dir()
+  temp_dir = shared.get_emscripten_temp_dir()
 
   def in_temp(name):
     return os.path.join(temp_dir, os.path.basename(name))
@@ -708,1422 +687,1414 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   use_cxx = True
 
-  try:
-    with ToolchainProfiler.profile_block('parse arguments and setup'):
-      ## Parse args
+  with ToolchainProfiler.profile_block('parse arguments and setup'):
+    ## Parse args
 
-      newargs = sys.argv[1:]
+    newargs = sys.argv[1:]
 
-      # Scan and strip emscripten specific cmdline warning flags
-      # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
-      newargs = shared.WarningManager.capture_warnings(newargs)
+    # Scan and strip emscripten specific cmdline warning flags
+    # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
+    newargs = shared.WarningManager.capture_warnings(newargs)
 
-      for i in range(len(newargs)):
-        if newargs[i] in ['-l', '-L', '-I']:
-          # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
-          newargs[i] += newargs[i + 1]
-          newargs[i + 1] = ''
+    for i in range(len(newargs)):
+      if newargs[i] in ['-l', '-L', '-I']:
+        # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
+        newargs[i] += newargs[i + 1]
+        newargs[i + 1] = ''
 
-      def detect_fixed_language_mode(args):
-        check_next = False
-        for item in args:
-          if check_next:
-            if item in ("c++", "c"):
-              return True
-            else:
-              check_next = False
-          if item.startswith("-x"):
-            lmode = item[2:] if len(item) > 2 else None
-            if lmode in ("c++", "c"):
-              return True
-            else:
-              check_next = True
-              continue
-        return False
-
-      has_fixed_language_mode = detect_fixed_language_mode(newargs)
-
-      options, settings_changes, newargs = parse_args(newargs)
-
-      for arg in newargs:
-        if arg == '-xc':
-          use_cxx = False
-          break
-        elif arg == '-xc++':
-          use_cxx = True
-          break
-        elif not arg.startswith('-'):
-          if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
-            use_cxx = False
-
-      if not use_cxx:
-        options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
-
-      call = CXX if use_cxx else CC
-
-      # If user did not specify a default -std for C++ code, specify the emscripten default.
-      if options.default_cxx_std:
-        newargs = newargs + [options.default_cxx_std]
-
-      if options.emrun:
-        options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
-        options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
-        # emrun mode waits on program exit
-        shared.Settings.EXIT_RUNTIME = 1
-
-      if options.cpu_profiler:
-        options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
-
-      if options.memory_profiler:
-        options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
-
-      if options.thread_profiler:
-        options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
-
-      if options.js_opts is None:
-        options.js_opts = options.opt_level >= 2
-
-      if options.llvm_opts is None:
-        options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
-      elif type(options.llvm_opts) == int:
-        options.llvm_opts = ['-O%d' % options.llvm_opts]
-
-      if options.memory_init_file is None:
-        options.memory_init_file = options.opt_level >= 2
-
-      # TODO: support source maps with js_transform
-      if options.js_transform and use_source_map(options):
-        logger.warning('disabling source maps because a js transform is being done')
-        options.debug_level = 3
-
-      if DEBUG:
-        start_time = time.time() # done after parsing arguments, which might affect debug state
-
-      for i in range(len(newargs)):
-        if newargs[i] == '-s':
-          if is_minus_s_for_emcc(newargs, i):
-            key = newargs[i + 1]
-            # If not = is specified default to 1
-            if '=' not in key:
-              key += '=1'
-            settings_changes.append(key)
-            newargs[i] = newargs[i + 1] = ''
-            if key == 'WASM_BACKEND=1':
-              exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
-      newargs = [arg for arg in newargs if arg is not '']
-
-      settings_key_changes = set()
-      for s in settings_changes:
-        key, value = s.split('=', 1)
-        settings_key_changes.add(key)
-
-      # Find input files
-
-      # These three arrays are used to store arguments of different types for
-      # type-specific processing. In order to shuffle the arguments back together
-      # after processing, all of these arrays hold tuples (original_index, value).
-      # Note that the index part of the tuple can have a fractional part for input
-      # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
-      input_files = []
-      libs = []
-      link_flags = []
-
-      # All of the above arg lists entries contain indexes into the full argument
-      # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
-      # counter for the next index that should be used.
-      next_arg_index = len(newargs)
-
-      has_source_inputs = False
-      has_header_inputs = False
-      lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
-                  shared.path_from_root('system', 'lib')]
-      for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
-                                    # right now we just assume that what is left contains no more |-x OPT| things
-        arg = newargs[i]
-
-        if i > 0:
-          prev = newargs[i - 1]
-          if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
-                      '-Xpreprocessor', '-include', '-imacros', '-idirafter',
-                      '-iprefix', '-iwithprefix', '-iwithprefixbefore',
-                      '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
-                      '-install_name', '-compatibility_version',
-                      '-current_version', '-I', '-L', '-include-pch'):
-            continue # ignore this gcc-style argument
-
-        if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
-          arg = os.path.realpath(arg)
-
-        if not arg.startswith('-'):
-          if not os.path.exists(arg):
-            exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
-
-          arg_ending = filename_type_ending(arg)
-          if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
-            newargs[i] = ''
-            if arg_ending.endswith(SOURCE_ENDINGS):
-              input_files.append((i, arg))
-              has_source_inputs = True
-            elif arg_ending.endswith(HEADER_ENDINGS):
-              input_files.append((i, arg))
-              has_header_inputs = True
-            elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
-              input_files.append((i, arg))
-            elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
-              # if it's not, and it's a library, just add it to libs to find later
-              l = unsuffixed_basename(arg)
-              for prefix in LIB_PREFIXES:
-                if not prefix:
-                  continue
-                if l.startswith(prefix):
-                  l = l[len(prefix):]
-                  break
-              libs.append((i, l))
-              newargs[i] = ''
-            elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
-              input_files.append((i, arg))
-            else:
-              logger.warning(arg + ' is not valid LLVM bitcode')
-          elif arg_ending.endswith(STATICLIB_ENDINGS):
-            if not shared.Building.is_ar(arg):
-              if shared.Building.is_bitcode(arg):
-                message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
-              else:
-                message = arg + ': Unknown format, not a static library!'
-              exit_with_error(message)
-          else:
-            if has_fixed_language_mode:
-              newargs[i] = ''
-              input_files.append((i, arg))
-              has_source_inputs = True
-            else:
-              exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
-        elif arg.startswith('-L'):
-          lib_dirs.append(arg[2:])
-          newargs[i] = ''
-        elif arg.startswith('-l'):
-          libs.append((i, arg[2:]))
-          newargs[i] = ''
-        elif arg.startswith('-Wl,'):
-          # Multiple comma separated link flags can be specified. Create fake
-          # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
-          # (4, a), (4.25, b), (4.5, c), (4.75, d)
-          link_flags_to_add = arg.split(',')[1:]
-          for flag_index, flag in enumerate(link_flags_to_add):
-            link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
-
-          newargs[i] = ''
-        elif arg == '-s':
-          # -s and some other compiler flags are normally passed onto the linker
-          # TODO(sbc): Pass this and other flags through when using lld
-          # link_flags.append((i, arg))
-          newargs[i] = ''
-
-      original_input_files = input_files[:]
-
-      newargs = [a for a in newargs if a is not '']
-
-      # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
-      has_dash_c = '-c' in newargs
-      if has_dash_c:
-        assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
-        target = target_basename + '.o'
-        final_suffix = 'o'
-      if '-E' in newargs:
-        final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
-      if '-M' in newargs or '-MM' in newargs:
-        final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
-      final_ending = ('.' + final_suffix) if len(final_suffix) else ''
-
-      # target is now finalized, can finalize other _target s
-      js_target = unsuffixed(target) + '.js'
-
-      asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
-      wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
-      wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
-
-      if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
-        options.separate_asm = True
-        logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
-      if options.separate_asm:
-        shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
-
-      if 'EMCC_STRICT' in os.environ:
-        shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
-
-      # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
-      # command line already now.
-
-      def get_last_setting_change(setting):
-        return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
-
-      strict_cmdline = get_last_setting_change('STRICT')
-      if strict_cmdline:
-        shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
-
-      if shared.Settings.STRICT:
-        shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
-
-      error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
-      if error_on_missing_libraries_cmdline:
-        shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
-
-      settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
-
-      # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
-      # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
-      if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
-        def check(input_file):
-          if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
-            if not options.ignore_dynamic_linking:
-              logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
-            return False
-          else:
+    def detect_fixed_language_mode(args):
+      check_next = False
+      for item in args:
+        if check_next:
+          if item in ("c++", "c"):
             return True
-        input_files = [f for f in input_files if check(f[1])]
-
-      if len(input_files) == 0:
-        exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
-
-      newargs = CC_ADDITIONAL_ARGS + newargs
-
-      if options.separate_asm and final_suffix != 'html':
-        shared.WarningManager.warn('SEPARATE_ASM')
-
-      # Apply optimization level settings
-      shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
-
-      # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
-      # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
-      if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
-        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-
-      # Set ASM_JS default here so that we can override it from the command line.
-      shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
-
-      # Apply -s settings in newargs here (after optimization levels, so they can override them)
-      apply_settings(settings_changes)
-
-      shared.verify_settings()
-
-      # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
-      shared.reconfigure_cache()
-
-      # Note the exports the user requested
-      shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
-
-      if options.bind:
-        # If we are using embind and generating JS, now is the time to link in bind.cpp
-        if final_suffix in JS_CONTAINING_SUFFIXES:
-          input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
-          next_arg_index += 1
-
-      # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
-      # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
-      if shared.Settings.ASSERTIONS:
-        shared.Settings.STACK_OVERFLOW_CHECK = 2
-
-      if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
-        logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
-        return 1
-
-      if not shared.Settings.STRICT:
-        # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-        shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
-
-        # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
-        # This path is not available in Emscripten strict mode.
-        if shared.USE_EMSDK:
-          shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
-
-      # Use settings
-
-      try:
-        assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
-        assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
-        assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
-        assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
-        assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
-        assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
-      except Exception as e:
-        logger.error('Compiler settings error: {}'.format(e))
-        exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
-
-      assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
-
-      if options.debug_level > 1 and options.use_closure_compiler:
-        logger.warning('disabling closure because debug info was requested')
-        options.use_closure_compiler = False
-
-      assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
-
-      assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
-
-      if options.emrun:
-        shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
-
-      if options.use_closure_compiler:
-        shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
-        if not shared.check_closure_compiler():
-          exit_with_error('fatal: closure compiler is not configured correctly')
-        if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
-          shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
-          shared.Settings.ASM_JS = 2
-
-      if shared.Settings.MAIN_MODULE:
-        assert not shared.Settings.SIDE_MODULE
-        if shared.Settings.MAIN_MODULE != 2:
-          shared.Settings.INCLUDE_FULL_LIBRARY = 1
-      elif shared.Settings.SIDE_MODULE:
-        assert not shared.Settings.MAIN_MODULE
-        options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
-
-      if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
-        assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
-        if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
-          shared.Settings.LINKABLE = 1
-        shared.Settings.RELOCATABLE = 1
-        shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
-        assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
-        # shared modules need memory utilities to allocate their memory
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
-          'allocate',
-          'getMemory',
-        ]
-      if shared.Settings.USE_PTHREADS:
-        # These runtime methods are called from worker.js
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
-
-      if shared.Settings.MODULARIZE_INSTANCE:
-        shared.Settings.MODULARIZE = 1
-
-      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-        shared.Settings.ALIASING_FUNCTION_POINTERS = 0
-
-      if shared.Settings.LEGACY_VM_SUPPORT:
-        # legacy vms don't have wasm
-        assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
-        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
-        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
-        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
-
-      # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
-      if shared.Settings.WASM:
-        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
-        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
-        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
-
-      if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
-        next_arg_index += 1
-        shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
-        # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
-        newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
-
-      if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
-        newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
-        next_arg_index += 1
-        shared.Settings.FILESYSTEM = 0
-        shared.Settings.FETCH = 1
-        if not shared.Settings.USE_PTHREADS:
-          exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
-
-      if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
-        next_arg_index += 1
-        options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
-
-      forced_stdlibs = []
-      if shared.Settings.DEMANGLE_SUPPORT:
-        shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
-        forced_stdlibs += ['libc++abi']
-
-      if not shared.Settings.ONLY_MY_CODE:
-        # Always need malloc and free to be kept alive and exported, for internal use and other modules
-        shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
-        if shared.Settings.WASM_BACKEND:
-          # setjmp/longjmp and exception handling JS code depends on this so we
-          # include it by default.  Should be elimiated by meta-DCE if unused.
-          shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
-
-      if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
-        exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
-
-      if shared.Settings.RELOCATABLE:
-        assert shared.Settings.GLOBAL_BASE < 1
-        if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
-          shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
-        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-        shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
-
-      if shared.Settings.EMTERPRETIFY:
-        shared.Settings.FINALIZE_ASM_JS = 0
-        # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
-        shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
-        shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
-        if not options.js_opts:
-          logger.debug('enabling js opts for EMTERPRETIFY')
-          options.js_opts = True
-        options.force_js_opts = True
-        if options.use_closure_compiler == 2:
-           exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
-        assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
-
-      if shared.Settings.DEAD_FUNCTIONS:
-        if not options.js_opts:
-          logger.debug('enabling js opts for DEAD_FUNCTIONS')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      if options.proxy_to_worker:
-        shared.Settings.PROXY_TO_WORKER = 1
-
-      if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
-        if shared.Settings.NODERAWFS:
-          exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
-        # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
-        shared.Settings.FORCE_FILESYSTEM = 1
-
-      if options.proxy_to_worker or options.use_preload_plugins:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
-
-      if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
-        shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
-        # to flush streams on FS exit, we need to be able to call fflush
-        # we only include it if the runtime is exitable, or when ASSERTIONS
-        # (ASSERTIONS will check that streams do not need to be flushed,
-        # helping people see when they should have disabled NO_EXIT_RUNTIME)
-        if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
-          shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
-
-      if shared.Settings.USE_PTHREADS:
-        if shared.Settings.USE_PTHREADS == 2:
-          exit_with_error('USE_PTHREADS=2 is not longer supported')
-        if shared.Settings.ALLOW_MEMORY_GROWTH:
-          exit_with_error('Memory growth is not yet supported with pthreads')
-        if shared.Settings.MODULARIZE:
-          # currently worker.js uses the global namespace, so it's setting of
-          # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
-          # modifications it performs.
-          exit_with_error('MODULARIZE is not yet supported with pthreads')
-        # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
-        shared.Settings.TEXTDECODER = 0
-        options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
-        newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
-        shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
-        # set location of worker.js
-        shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
-      else:
-        options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
-
-      if shared.Settings.FORCE_FILESYSTEM:
-        # when the filesystem is forced, we export by default methods that filesystem usage
-        # may need, including filesystem usage from standalone file packager output (i.e.
-        # file packages not built together with emcc, but that are loaded at runtime
-        # separately, and they need emcc's output to contain the support they need)
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
-          'FS_createFolder',
-          'FS_createPath',
-          'FS_createDataFile',
-          'FS_createPreloadedFile',
-          'FS_createLazyFile',
-          'FS_createLink',
-          'FS_createDevice',
-          'FS_unlink',
-          'getMemory',
-          'addRunDependency',
-          'removeRunDependency',
-        ]
-
-      if shared.Settings.USE_PTHREADS:
-        if shared.Settings.LINKABLE:
-          exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.SIDE_MODULE:
-          exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.MAIN_MODULE:
-          exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.EMTERPRETIFY:
-          exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
-        if shared.Settings.PROXY_TO_WORKER:
-          exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
-      else:
-        if shared.Settings.PROXY_TO_PTHREAD:
-          exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
-
-      if shared.Settings.OUTLINING_LIMIT:
-        if shared.Settings.WASM_BACKEND:
-          exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
-        if not options.js_opts:
-          logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
-      if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
-        shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
-
-      if shared.Settings.WASM:
-        if not shared.Building.need_asm_js_file():
-          asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
-          misc_temp_files.note(asm_target)
-
-      if shared.Settings.WASM:
-        if shared.Settings.TOTAL_MEMORY % 65536 != 0:
-          exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
-      else:
-        if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
-          exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-        if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
-          exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-      if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
-        exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
-      if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
-        exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
-      if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
-        exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
-
-      if shared.Settings.WASM_BACKEND:
-        options.js_opts = None
-
-        # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
-        # we run the optimizer during asm2wasm itself). use it, if not overridden
-        if 'BINARYEN_PASSES' not in settings_key_changes:
-          passes = []
-          if not shared.Settings.EXIT_RUNTIME:
-            passes += ['--no-exit-runtime']
-          if options.opt_level > 0 or options.shrink_level > 0:
-            passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
-          if options.debug_level < 3:
-            passes += ['--strip']
-          if passes:
-            shared.Settings.BINARYEN_PASSES = ','.join(passes)
-
-        # to bootstrap struct_info, we need binaryen
-        os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
-
-      if shared.Settings.WASM:
-        if shared.Settings.SINGLE_FILE:
-          # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
-          shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
-          shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
-          shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
-        else:
-          # set file locations, so that JS glue can find what it needs
-          shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
-          shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
-          shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
-
-        shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
-        shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
-        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
-          logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
-          shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
-        if shared.Settings.OUTLINING_LIMIT:
-          logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
-        # default precise-f32 to on, since it works well in wasm
-        # also always use f32s when asm.js is not in the picture
-        if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-          shared.Settings.PRECISE_F32 = 1
-        if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-          options.js_opts = None
-          logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
-        if options.use_closure_compiler == 2:
-          exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
-        # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
-        #  * if we also supported js mem inits we'd have 4 modes
-        #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
-        if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
-          exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
-        options.memory_init_file = True
-        # async compilation requires not interpreting (the interpreter modes needs sync input)
-        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
-          # async compilation requires a swappable module - we swap it in when it's ready
-          shared.Settings.SWAPPABLE_ASM_MODULE = 1
-        else:
-          # if not wasm-only, we can't do async compilation as the build can run in other
-          # modes than wasm (like asm.js) which may not support an async step
-          shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
-          warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
-          if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
-            logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
-          elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
-            logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
-        # run safe-heap as a binaryen pass
-        if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
-          if shared.Settings.BINARYEN_PASSES:
-            shared.Settings.BINARYEN_PASSES += ','
-          shared.Settings.BINARYEN_PASSES += 'safe-heap'
-        if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-          # emulated function pointer casts is emulated in wasm using a binaryen pass
-          if shared.Settings.BINARYEN_PASSES:
-            shared.Settings.BINARYEN_PASSES += ','
-          shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
-          # we also need emulated function pointers for that, as we need a single flat
-          # table, as is standard in wasm, and not asm.js split ones.
-          shared.Settings.EMULATED_FUNCTION_POINTERS = 1
-
-        # we will include the mem init data in the wasm, when we don't need the
-        # mem init file to be loadable by itself
-        shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                           'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
-                                           not shared.Settings.USE_PTHREADS
-
-        # wasm side modules have suffix .wasm
-        if shared.Settings.SIDE_MODULE and target.endswith('.js'):
-          logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
-
-        if options.separate_asm:
-          exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
-
-      # wasm outputs are only possible with a side wasm
-      if target.endswith(WASM_ENDINGS):
-        if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-          logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
-          return 1
-
-      if shared.Settings.EVAL_CTORS:
-        if not shared.Settings.WASM:
-          # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
-          # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
-          shared.Settings.RUNNING_JS_OPTS = 1
-        else:
-          if 'interpret' in shared.Settings.BINARYEN_METHOD:
-            logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
-            shared.Settings.EVAL_CTORS = 0
-
-      # memory growth does not work in dynamic linking, except for wasm
-      if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
-        assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
-
-      if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
-        # this is an issue in asm.js, but not wasm
-        if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
-          shared.WarningManager.warn('ALMOST_ASM')
-          shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
-
-      # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
-      if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
-        if not options.js_opts:
-          logger.debug('enabling js opts for SAFE_HEAP')
-          options.js_opts = True
-        options.force_js_opts = True
-
-      if options.js_opts:
-        shared.Settings.RUNNING_JS_OPTS = 1
-
-      if shared.Settings.CYBERDWARF:
-        newargs.append('-g')
-        options.debug_level = max(options.debug_level, 2)
-        shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
-        options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
-        options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
-
-      if options.tracing:
-        if shared.Settings.ALLOW_MEMORY_GROWTH:
-          shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
-
-      if shared.Settings.ONLY_MY_CODE:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
-        options.separate_asm = True
-        shared.Settings.FINALIZE_ASM_JS = False
-
-      if shared.Settings.GLOBAL_BASE < 0:
-        shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
-
-      if shared.Settings.WASM_BACKEND:
-        if shared.Settings.SIMD:
-          newargs.append('-msimd128')
-      else:
-        # We leave the -O option in place so that the clang front-end runs in that
-        # optimization mode, but we disable the actual optimization passes, as we'll
-        # run them separately.
-        if options.opt_level > 0:
-          newargs.append('-mllvm')
-          newargs.append('-disable-llvm-optzns')
-
-      if not shared.Settings.LEGALIZE_JS_FFI:
-        assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
-
-      shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
-      shared.Settings.OPT_LEVEL = options.opt_level
-      shared.Settings.DEBUG_LEVEL = options.debug_level
-      shared.Settings.PROFILING_FUNCS = options.profiling_funcs
-      shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
-
-      ## Compile source code to bitcode
-
-      logger.debug('compiling to bitcode')
-
-      temp_files = []
-
-    # exit block 'parse arguments and setup'
-    log_time('parse arguments and setup')
-
-    with ToolchainProfiler.profile_block('bitcodeize inputs'):
-      # Precompiled headers support
-      if has_header_inputs:
-        headers = [header for _, header in input_files]
-        for header in headers:
-          assert header.endswith(HEADER_ENDINGS), 'if you have one header input, we assume you want to precompile headers, and cannot have source files or other inputs as well: ' + str(headers) + ' : ' + header
-        args = newargs + shared.EMSDK_CXX_OPTS + headers
-        if specified_target:
-          args += ['-o', specified_target]
-        args = system_libs.process_args(args, shared.Settings)
-        logger.debug("running (for precompiled headers): " + call + ' ' + ' '.join(args))
-        return run_process([call] + args, check=False).returncode
-
-      def get_bitcode_file(input_file):
-        if final_suffix not in JS_CONTAINING_SUFFIXES:
-          # no need for a temp file, just emit to the right place
-          if len(input_files) == 1:
-            # can just emit directly to the target
-            if specified_target:
-              if specified_target.endswith('/') or specified_target.endswith('\\') or os.path.isdir(specified_target):
-                return os.path.join(specified_target, os.path.basename(unsuffixed(input_file))) + options.default_object_extension
-              return specified_target
-            return unsuffixed(input_file) + final_ending
           else:
-            if has_dash_c:
-              return unsuffixed(input_file) + options.default_object_extension
-        return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
-
-      # Request LLVM debug info if explicitly specified, or building bitcode with -g, or if building a source all the way to JS with -g
-      if use_source_map(options) or ((final_suffix not in JS_CONTAINING_SUFFIXES or (has_source_inputs and final_suffix in JS_CONTAINING_SUFFIXES)) and options.requested_debug == '-g'):
-        # do not save llvm debug info if js optimizer will wipe it out anyhow (but if source maps are used, keep it)
-        if use_source_map(options) or not (final_suffix in JS_CONTAINING_SUFFIXES and options.js_opts):
-          newargs.append('-g') # preserve LLVM debug info
-          options.debug_level = 4
-          shared.Settings.DEBUG_LEVEL = 4
-
-      # Bitcode args generation code
-      def get_clang_args(input_files):
-        file_ending = filename_type_ending(input_files[0])
-        args = [call] + newargs + input_files
-        if file_ending.endswith(CXX_ENDINGS):
-          args += shared.EMSDK_CXX_OPTS
-        if not shared.Building.can_inline():
-          args.append('-fno-inline-functions')
-        # For fastcomp backend, no LLVM IR functions should ever be annotated
-        # 'optnone', because that would skip running the SimplifyCFG pass on
-        # them, which is required to always run to clean up LandingPadInst
-        # instructions that are not needed.
-        if not shared.Settings.WASM_BACKEND:
-          args += ['-Xclang', '-disable-O0-optnone']
-        args = system_libs.process_args(args, shared.Settings)
-        return args
-
-      # -E preprocessor-only support
-      if '-E' in newargs or '-M' in newargs or '-MM' in newargs:
-        input_files = [x[1] for x in input_files]
-        cmd = get_clang_args(input_files)
-        if specified_target:
-          cmd += ['-o', specified_target]
-        # Do not compile, but just output the result from preprocessing stage or
-        # output the dependency rule. Warning: clang and gcc behave differently
-        # with -MF! (clang seems to not recognize it)
-        logger.debug(('just preprocessor ' if '-E' in newargs else 'just dependencies: ') + ' '.join(cmd))
-        return run_process(cmd, check=False).returncode
-
-      def compile_source_file(i, input_file):
-        logger.debug('compiling source file: ' + input_file)
-        output_file = get_bitcode_file(input_file)
-        temp_files.append((i, output_file))
-        args = get_clang_args([input_file]) + ['-c', '-o', output_file]
-        if shared.Settings.WASM_OBJECT_FILES:
-          for a in shared.Building.llvm_backend_args():
-            args += ['-mllvm', a]
-        else:
-          args.append('-emit-llvm')
-        logger.debug("running: " + ' '.join(shared.Building.doublequote_spaces(args))) # NOTE: Printing this line here in this specific format is important, it is parsed to implement the "emcc --cflags" command
-        if run_process(args, check=False).returncode != 0:
-          exit_with_error('compiler frontend failed to generate LLVM bitcode, halting')
-        assert(os.path.exists(output_file))
-
-      # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
-      for i, input_file in input_files:
-        file_ending = filename_type_ending(input_file)
-        if file_ending.endswith(SOURCE_ENDINGS):
-          compile_source_file(i, input_file)
-        else: # bitcode
-          if file_ending.endswith(BITCODE_ENDINGS):
-            logger.debug('using bitcode file: ' + input_file)
-            temp_files.append((i, input_file))
-          elif file_ending.endswith(DYNAMICLIB_ENDINGS) or shared.Building.is_ar(input_file):
-            logger.debug('using library file: ' + input_file)
-            temp_files.append((i, input_file))
-          elif file_ending.endswith(ASSEMBLY_ENDINGS):
-            if not LEAVE_INPUTS_RAW:
-              logger.debug('assembling assembly file: ' + input_file)
-              temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
-              shared.Building.llvm_as(input_file, temp_file)
-              temp_files.append((i, temp_file))
+            check_next = False
+        if item.startswith("-x"):
+          lmode = item[2:] if len(item) > 2 else None
+          if lmode in ("c++", "c"):
+            return True
           else:
-            if has_fixed_language_mode:
-              compile_source_file(i, input_file)
-            else:
-              exit_with_error(input_file + ': Unknown file suffix when compiling to LLVM bitcode!')
-
-    # exit block 'bitcodeize inputs'
-    log_time('bitcodeize inputs')
-
-    with ToolchainProfiler.profile_block('process inputs'):
-      if not LEAVE_INPUTS_RAW and not shared.Settings.WASM_BACKEND:
-        assert len(temp_files) == len(input_files)
-
-        # Optimize source files
-        if optimizing(options.llvm_opts):
-          for pos, (_, input_file) in enumerate(input_files):
-            file_ending = filename_type_ending(input_file)
-            if file_ending.endswith(SOURCE_ENDINGS):
-              temp_file = temp_files[pos][1]
-              logger.debug('optimizing %s', input_file)
-              # if DEBUG:
-              #   shutil.copyfile(temp_file, os.path.join(shared.configuration.CANONICAL_TEMP_DIR, 'to_opt.bc')) # useful when LLVM opt aborts
-              new_temp_file = in_temp(unsuffixed(uniquename(temp_file)) + '.o')
-              # after optimizing, lower intrinsics to libc calls so that our linking code
-              # will find them (otherwise, llvm.cos.f32() will not link in cosf(), and
-              # we end up calling out to JS for Math.cos).
-              opts = options.llvm_opts + ['-lower-non-em-intrinsics']
-              shared.Building.llvm_opt(temp_file, opts, new_temp_file)
-              temp_files[pos] = (temp_files[pos][0], new_temp_file)
-
-      # Decide what we will link
-      stop_at_bitcode = final_suffix not in EXECUTABLE_SUFFIXES
-
-      if stop_at_bitcode or not shared.Settings.WASM_BACKEND:
-        # Filter link flags, keeping only those that shared.Building.link knows
-        # how to deal with.  We currently can't handle flags with options (like
-        # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
-        # flag).
-        link_flags = [f for f in link_flags if f[1] in SUPPORTED_LINKER_FLAGS]
-
-      linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
-
-      # If we were just asked to generate bitcode, stop there
-      if stop_at_bitcode:
-        if not specified_target:
-          assert len(temp_files) == len(input_files)
-          for tempf, inputf in zip(temp_files, input_files):
-            safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_ending)
-        else:
-          if len(input_files) == 1:
-            input_file = input_files[0][1]
-            temp_file = temp_files[0][1]
-            bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_ending
-            if temp_file != input_file:
-              safe_move(temp_file, bitcode_target)
-            else:
-              shutil.copyfile(temp_file, bitcode_target)
-            temp_output_base = unsuffixed(temp_file)
-            if os.path.exists(temp_output_base + '.d'):
-              # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
-              # adjusting the target name away from the temporary file name to the specified target.
-              # It will be deleted with the rest of the temporary directory.
-              deps = open(temp_output_base + '.d').read()
-              deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
-              with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
-                out_dep.write(deps)
-          else:
-            assert len(original_input_files) == 1 or not has_dash_c, 'fatal error: cannot specify -o with -c with multiple files' + str(sys.argv) + ':' + str(original_input_files)
-            # We have a specified target (-o <target>), which is not JavaScript or HTML, and
-            # we have multiple files: Link them
-            logger.debug('link: ' + str(linker_inputs) + specified_target)
-            # Sort arg tuples and pass the extracted values to link.
-            shared.Building.link(linker_inputs, specified_target)
-        logger.debug('stopping at bitcode')
-        if shared.Settings.SIDE_MODULE:
-          exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting LLVM bitcode. That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an LLVM bitcode file, which you should then compile to .wasm or .js with SIDE_MODULE.')
-        if final_suffix.lower() in ['so', 'dylib', 'dll']:
-          logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an LLVM bitcode file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a file with LLVM bitcode, \'.bc\', which would avoid this warning.)')
-        return 0
-
-    # exit block 'process inputs'
-    log_time('process inputs')
-
-    ## Continue on to create JavaScript
-
-    with ToolchainProfiler.profile_block('calculate system libraries'):
-      logger.debug('will generate JavaScript')
-
-      extra_files_to_link = []
-
-      # link in ports and system libraries, if necessary
-      if not LEAVE_INPUTS_RAW and \
-         not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
-         not shared.Settings.ONLY_MY_CODE and \
-         not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
-        extra_files_to_link = system_libs.get_ports(shared.Settings)
-        extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
-
-    # exit block 'calculate system libraries'
-    log_time('calculate system libraries')
-
-    def dedup_list(lst):
-      rtn = []
-      for item in lst:
-        if item not in rtn:
-          rtn.append(item)
-      return rtn
-
-    # Make a final pass over shared.Settings.EXPORTED_FUNCTIONS to remove any
-    # duplication between functions added by the driver/libraries and function
-    # specified by the user
-    shared.Settings.EXPORTED_FUNCTIONS = dedup_list(shared.Settings.EXPORTED_FUNCTIONS)
-
-    with ToolchainProfiler.profile_block('link'):
-      # final will be an array if linking is deferred, otherwise a normal string.
-      if shared.Settings.WASM_BACKEND:
-        DEFAULT_FINAL = in_temp(target_basename + '.wasm')
-      else:
-        DEFAULT_FINAL = in_temp(target_basename + '.bc')
-
-      def get_final():
-        global final
-        if isinstance(final, list):
-          final = DEFAULT_FINAL
-        return final
-
-      # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
-      linker_inputs += extra_files_to_link
-      perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
-      if not perform_link and not LEAVE_INPUTS_RAW:
-        is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
-        is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
-        is_ar = shared.Building.is_ar(temp_files[0][1])
-        perform_link = not (is_bc or is_dylib) and is_ar
-      if perform_link:
-        logger.debug('linking: ' + str(linker_inputs))
-        # force archive contents to all be included, if just archives, or if linking shared modules
-        force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
-
-        # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
-        # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
-        # TODO: we could check if this is a fastcomp build, and still speed things up here
-        just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
-        if shared.Settings.WASM_BACKEND:
-          # If LTO is enabled then use the -O opt level as the LTO level
-          if options.llvm_lto:
-            lto_level = options.opt_level
-          else:
-            lto_level = 0
-          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts, lto_level)
-        else:
-          final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
-      else:
-        logger.debug('skipping linking: ' + str(linker_inputs))
-        if not LEAVE_INPUTS_RAW:
-          _, temp_file = temp_files[0]
-          _, input_file = input_files[0]
-          final = in_temp(target_basename + '.bc')
-          if temp_file != input_file:
-            shutil.move(temp_file, final)
-          else:
-            shutil.copyfile(temp_file, final)
-        else:
-          _, input_file = input_files[0]
-          final = in_temp(input_file)
-          shutil.copyfile(input_file, final)
-
-    # exit block 'link'
-    log_time('link')
-
-    if not shared.Settings.WASM_BACKEND:
-      with ToolchainProfiler.profile_block('post-link'):
-        if DEBUG:
-          logger.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
-          if not LEAVE_INPUTS_RAW:
-            save_intermediate('basebc', 'bc')
-
-        # Optimize, if asked to
-        if not LEAVE_INPUTS_RAW:
-          # remove LLVM debug if we are not asked for it
-          link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
-          if not shared.Settings.ASSERTIONS:
-            link_opts += ['-disable-verify']
-          else:
-            # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
-            # disable the type map in that case. we added linking to opt, so we need to do
-            # something similar, which we can do with a param to opt
-            link_opts += ['-disable-debug-info-type-map']
-
-          if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
-            logger.debug('running LLVM opts as pre-LTO')
-            final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
-            save_intermediate('opt', 'bc')
-
-          # If we can LTO, do it before dce, since it opens up dce opportunities
-          if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
-            if not shared.Building.can_inline():
-              link_opts.append('-disable-inlining')
-            # add a manual internalize with the proper things we need to be kept alive during lto
-            link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
-            # execute it now, so it is done entirely before we get to the stage of legalization etc.
-            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-            save_intermediate('lto', 'bc')
-            link_opts = []
-          else:
-            # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
-            link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
-
-          if options.cfi:
-            if use_cxx:
-               link_opts.append("-wholeprogramdevirt")
-            link_opts.append("-lowertypetests")
-
-          if AUTODEBUG:
-            # let llvm opt directly emit ll, to skip writing and reading all the bitcode
-            link_opts += ['-S']
-            final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
-            save_intermediate('linktime', 'll')
-          else:
-            if len(link_opts) > 0:
-              final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-              save_intermediate('linktime', 'bc')
-            if options.save_bc:
-              shutil.copyfile(final, options.save_bc)
-
-        # Prepare .ll for Emscripten
-        if LEAVE_INPUTS_RAW:
-          assert len(input_files) == 1
-        if options.save_bc:
-          save_intermediate('ll', 'll')
-
-        if AUTODEBUG:
-          logger.debug('autodebug')
-          next = get_final() + '.ad.ll'
-          run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
-          final = next
-          save_intermediate('autodebug', 'll')
-
-        assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
-
-      # exit block 'post-link'
-      log_time('post-link')
-
-    with ToolchainProfiler.profile_block('emscript'):
-      # Emscripten
-      logger.debug('LLVM => JS')
-      js_libraries = None
-      if options.js_libraries:
-        js_libraries = [os.path.abspath(lib) for lib in options.js_libraries]
-      if options.memory_init_file:
-        shared.Settings.MEM_INIT_METHOD = 1
-      else:
-        assert shared.Settings.MEM_INIT_METHOD != 1
-
-      if embed_memfile(options):
-        shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
-
-      final = shared.Building.emscripten(final, target + '.mem', js_libraries)
-      save_intermediate('original')
-
-      if shared.Settings.WASM_BACKEND:
-        # we also received wast and wasm at this stage
-        temp_basename = unsuffixed(final)
-        wasm_temp = temp_basename + '.wasm'
-        shutil.move(wasm_temp, wasm_binary_target)
-        if use_source_map(options):
-          shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
-
-      if shared.Settings.CYBERDWARF:
-        cd_target = final + '.cd'
-        shutil.move(cd_target, target + '.cd')
-
-    # exit block 'emscript'
-    log_time('emscript (llvm => executable code)')
-
-    with ToolchainProfiler.profile_block('source transforms'):
-      # Embed and preload files
-      if len(options.preload_files) or len(options.embed_files):
-
-        # Also, MEMFS is not aware of heap resizing feature in wasm, so if MEMFS and memory growth are used together, force
-        # no_heap_copy to be enabled.
-        if shared.Settings.ALLOW_MEMORY_GROWTH and not options.no_heap_copy:
-          logger.info('Enabling --no-heap-copy because -s ALLOW_MEMORY_GROWTH=1 is being used with file_packager.py (pass --no-heap-copy to suppress this notification)')
-          options.no_heap_copy = True
-
-        logger.debug('setting up files')
-        file_args = ['--from-emcc', '--export-name=' + shared.Settings.EXPORT_NAME]
-        if len(options.preload_files):
-          file_args.append('--preload')
-          file_args += options.preload_files
-        if len(options.embed_files):
-          file_args.append('--embed')
-          file_args += options.embed_files
-        if len(options.exclude_files):
-          file_args.append('--exclude')
-          file_args += options.exclude_files
-        if options.use_preload_cache:
-          file_args.append('--use-preload-cache')
-        if options.no_heap_copy:
-          file_args.append('--no-heap-copy')
-        if shared.Settings.LZ4:
-          file_args.append('--lz4')
-        if options.use_preload_plugins:
-          file_args.append('--use-preload-plugins')
-        file_code = run_process([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
-        options.pre_js = file_code + options.pre_js
-
-      # Apply pre and postjs files
-      if options.pre_js or options.post_js:
-        logger.debug('applying pre/postjses')
-        src = open(final).read()
-        final += '.pp.js'
-        if WINDOWS: # Avoid duplicating \r\n to \r\r\n when writing out.
-          if options.pre_js:
-            options.pre_js = options.pre_js.replace('\r\n', '\n')
-          if options.post_js:
-            options.post_js = options.post_js.replace('\r\n', '\n')
-        outfile = open(final, 'w')
-        # pre-js code goes right after the Module integration code (so it
-        # can use Module), we have a marker for it
-        outfile.write(src.replace('// {{PRE_JSES}}', options.pre_js))
-        outfile.write(options.post_js)
-        outfile.close()
-        options.pre_js = src = options.post_js = None
-        save_intermediate('pre-post')
-
-      # Apply a source code transformation, if requested
-      if options.js_transform:
-        shutil.copyfile(final, final + '.tr.js')
-        final += '.tr.js'
-        posix = not shared.WINDOWS
-        logger.debug('applying transform: %s', options.js_transform)
-        shared.check_call(shared.Building.remove_quotes(shlex.split(options.js_transform, posix=posix) + [os.path.abspath(final)]))
-        save_intermediate('transformed')
-
-      js_transform_tempfiles = [final]
-
-    # exit block 'source transforms'
-    log_time('source transforms')
-
-    with ToolchainProfiler.profile_block('memory initializer'):
-      memfile = None
-      if shared.Settings.MEM_INIT_METHOD > 0 or embed_memfile(options):
-        memfile = target + '.mem'
-
-      if memfile and not shared.Settings.WASM_BACKEND:
-        # Strip the memory initializer out of the asmjs file
-        shared.try_delete(memfile)
-
-        def repl(m):
-          # handle chunking of the memory initializer
-          s = m.group(1)
-          if len(s) == 0:
-            return '' # don't emit 0-size ones
-          membytes = [int(x or '0') for x in s.split(',')]
-          while membytes and membytes[-1] == 0:
-            membytes.pop()
-          if not membytes:
-            return ''
-          if shared.Settings.MEM_INIT_METHOD == 2:
-            # memory initializer in a string literal
-            return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
-          open(memfile, 'wb').write(bytearray(membytes))
-          if DEBUG:
-            # Copy into temp dir as well, so can be run there too
-            shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-          if not shared.Settings.WASM or not shared.Settings.MEM_INIT_IN_WASM:
-            return 'memoryInitializer = "%s";' % shared.JS.get_subresource_location(memfile, embed_memfile(options))
-          else:
-            return ''
-
-        src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
-        open(final + '.mem.js', 'w').write(src)
-        final += '.mem.js'
-        src = None
-        js_transform_tempfiles[-1] = final # simple text substitution preserves comment line number mappings
-        if os.path.exists(memfile):
-          save_intermediate('meminit')
-          logger.debug('wrote memory initialization to %s', memfile)
-        else:
-          logger.debug('did not see memory initialization')
-
-      if shared.Settings.USE_PTHREADS:
-        target_dir = os.path.dirname(os.path.abspath(target))
-        shutil.copyfile(shared.path_from_root('src', 'worker.js'),
-                        os.path.join(target_dir, shared.Settings.PTHREAD_WORKER_FILE))
-
-      # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
-      if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
-        if shared.Settings.WASM:
-          # FIXME(https://github.com/kripken/emscripten/issues/7024)
-          logger.warning('Blocking calls the fetch API do not work under WASM')
-        else:
-          shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
-
-    # exit block 'memory initializer'
-    log_time('memory initializer')
-
-    optimizer = JSOptimizer(
-      target=target,
-      options=options,
-      js_transform_tempfiles=js_transform_tempfiles,
-      in_temp=in_temp,
-    )
-    with ToolchainProfiler.profile_block('js opts'):
-      # It is useful to run several js optimizer passes together, to save on unneeded unparsing/reparsing
-      if shared.Settings.DEAD_FUNCTIONS:
-        optimizer.queue += ['eliminateDeadFuncs']
-        optimizer.extra_info['dead_functions'] = shared.Settings.DEAD_FUNCTIONS
-
-      if options.opt_level >= 1 and options.js_opts:
-        logger.debug('running js post-opts')
-
-        if DEBUG == 2:
-          # Clean up the syntax a bit
-          optimizer.queue += ['noop']
-
-        def get_eliminate():
-          if shared.Settings.ALLOW_MEMORY_GROWTH:
-            return 'eliminateMemSafe'
-          else:
-            return 'eliminate'
-
-        if options.opt_level >= 2:
-          optimizer.queue += [get_eliminate()]
-
-          if shared.Settings.AGGRESSIVE_VARIABLE_ELIMINATION:
-            # note that this happens before registerize/minification, which can obfuscate the name of 'label', which is tricky
-            optimizer.queue += ['aggressiveVariableElimination']
-
-          optimizer.queue += ['simplifyExpressions']
-
-          if shared.Settings.EMTERPRETIFY:
-            # emterpreter code will not run through a JS optimizing JIT, do more work ourselves
-            optimizer.queue += ['localCSE']
-
-      if shared.Settings.EMTERPRETIFY:
-        # add explicit label setting, as we will run aggressiveVariableElimination late, *after* 'label' is no longer notable by name
-        optimizer.queue += ['safeLabelSetting']
-
-      if options.opt_level >= 1 and options.js_opts:
-        if options.opt_level >= 2:
-          # simplify ifs if it is ok to make the code somewhat unreadable, and unless outlining (simplified ifs
-          # with commaified code breaks late aggressive variable elimination)
-          # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
-          debugging = options.debug_level == 0 or options.profiling
-          if shared.Settings.SIMPLIFY_IFS and debugging and shared.Settings.OUTLINING_LIMIT == 0 and not shared.Settings.WASM:
-            optimizer.queue += ['simplifyIfs']
-
-          if shared.Settings.PRECISE_F32:
-            optimizer.queue += ['optimizeFrounds']
-
-      if options.js_opts:
-        if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
-          optimizer.queue += ['safeHeap']
-
-        if shared.Settings.OUTLINING_LIMIT > 0:
-          optimizer.queue += ['outline']
-          optimizer.extra_info['sizeToOutline'] = shared.Settings.OUTLINING_LIMIT
-
-        if options.opt_level >= 2 and options.debug_level < 3:
-          if options.opt_level >= 3 or options.shrink_level > 0:
-            optimizer.queue += ['registerizeHarder']
-          else:
-            optimizer.queue += ['registerize']
-
-        # NOTE: Important that this comes after registerize/registerizeHarder
-        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and options.opt_level >= 2:
-          optimizer.flush()
-          shared.Building.eliminate_duplicate_funcs(final)
-          save_intermediate('dfe', 'js')
-
-      if shared.Settings.EVAL_CTORS and options.memory_init_file and not use_source_map(options) and not shared.Settings.WASM:
-        optimizer.flush()
-        shared.Building.eval_ctors(final, memfile)
-        save_intermediate('eval-ctors', 'js')
-
-      if options.js_opts:
-        # some compilation modes require us to minify later or not at all
-        if not shared.Settings.EMTERPRETIFY and not shared.Settings.WASM:
-          optimizer.do_minify()
-
-        if options.opt_level >= 2:
-          optimizer.queue += ['asmLastOpts']
-
-        if shared.Settings.FINALIZE_ASM_JS:
-          optimizer.queue += ['last']
-
-        optimizer.flush()
-
-      if options.use_closure_compiler == 2:
-        optimizer.flush()
-
-        logger.debug('running closure')
-        # no need to add this to js_transform_tempfiles, because closure and
-        # debug_level > 0 are never simultaneously true
-        final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
-        save_intermediate('closure')
-
-    log_time('js opts')
-
-    with ToolchainProfiler.profile_block('final emitting'):
-      if shared.Settings.EMTERPRETIFY:
-        emterpretify(js_target, optimizer, options)
-
-      # Remove some trivial whitespace
-      # TODO: do not run when compress has already been done on all parts of the code
-      # src = open(final).read()
-      # src = re.sub(r'\n+[ \n]*\n+', '\n', src)
-      # open(final, 'w').write(src)
-
-      # Bundle symbol data in with the cyberdwarf file
-      if shared.Settings.CYBERDWARF:
-        run_process([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target + '.symbols'])
-
-      if use_source_map(options) and not shared.Settings.WASM:
-        emit_js_source_maps(target, optimizer.js_transform_tempfiles)
-
-      # track files that will need native eols
-      generated_text_files_with_native_eols = []
-
-      if (options.separate_asm or shared.Settings.WASM) and not shared.Settings.WASM_BACKEND:
-        separate_asm_js(final, asm_target)
-        generated_text_files_with_native_eols += [asm_target]
-
-      if shared.Settings.WASM:
-        binaryen_method_sanity_check()
-        do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
-                    wasm_text_target, misc_temp_files, optimizer)
-
-      if shared.Settings.MODULARIZE:
-        modularize()
-
-      module_export_name_substitution()
-
-      # The JS is now final. Move it to its final location
-      shutil.move(final, js_target)
-
-      generated_text_files_with_native_eols += [js_target]
-
-      # If we were asked to also generate HTML, do that
-      if final_suffix == 'html':
-        generate_html(target, options, js_target, target_basename,
-                      asm_target, wasm_binary_target,
-                      memfile, optimizer)
-      else:
-        if options.proxy_to_worker:
-          generate_worker_js(target, js_target, target_basename)
-
-      if embed_memfile(options):
-        shared.try_delete(memfile)
-
-      for f in generated_text_files_with_native_eols:
-        tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
-    log_time('final emitting')
-    # exit block 'final emitting'
+            check_next = True
+            continue
+      return False
+
+    has_fixed_language_mode = detect_fixed_language_mode(newargs)
+
+    options, settings_changes, newargs = parse_args(newargs)
+
+    for arg in newargs:
+      if arg == '-xc':
+        use_cxx = False
+        break
+      elif arg == '-xc++':
+        use_cxx = True
+        break
+      elif not arg.startswith('-'):
+        if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
+          use_cxx = False
+
+    if not use_cxx:
+      options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
+
+    call = CXX if use_cxx else CC
+
+    # If user did not specify a default -std for C++ code, specify the emscripten default.
+    if options.default_cxx_std:
+      newargs = newargs + [options.default_cxx_std]
+
+    if options.emrun:
+      options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
+      options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
+      # emrun mode waits on program exit
+      shared.Settings.EXIT_RUNTIME = 1
+
+    if options.cpu_profiler:
+      options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
+
+    if options.memory_profiler:
+      options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
+
+    if options.thread_profiler:
+      options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
+
+    if options.js_opts is None:
+      options.js_opts = options.opt_level >= 2
+
+    if options.llvm_opts is None:
+      options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
+    elif type(options.llvm_opts) == int:
+      options.llvm_opts = ['-O%d' % options.llvm_opts]
+
+    if options.memory_init_file is None:
+      options.memory_init_file = options.opt_level >= 2
+
+    # TODO: support source maps with js_transform
+    if options.js_transform and use_source_map(options):
+      logger.warning('disabling source maps because a js transform is being done')
+      options.debug_level = 3
 
     if DEBUG:
-      logger.debug('total time: %.2f seconds', (time.time() - start_time))
+      start_time = time.time() # done after parsing arguments, which might affect debug state
 
-  finally:
+    for i in range(len(newargs)):
+      if newargs[i] == '-s':
+        if is_minus_s_for_emcc(newargs, i):
+          key = newargs[i + 1]
+          # If not = is specified default to 1
+          if '=' not in key:
+            key += '=1'
+          settings_changes.append(key)
+          newargs[i] = newargs[i + 1] = ''
+          if key == 'WASM_BACKEND=1':
+            exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
+    newargs = [arg for arg in newargs if arg is not '']
+
+    settings_key_changes = set()
+    for s in settings_changes:
+      key, value = s.split('=', 1)
+      settings_key_changes.add(key)
+
+    # Find input files
+
+    # These three arrays are used to store arguments of different types for
+    # type-specific processing. In order to shuffle the arguments back together
+    # after processing, all of these arrays hold tuples (original_index, value).
+    # Note that the index part of the tuple can have a fractional part for input
+    # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
+    input_files = []
+    libs = []
+    link_flags = []
+
+    # All of the above arg lists entries contain indexes into the full argument
+    # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
+    # counter for the next index that should be used.
+    next_arg_index = len(newargs)
+
+    has_source_inputs = False
+    has_header_inputs = False
+    lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
+                shared.path_from_root('system', 'lib')]
+    for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
+                                  # right now we just assume that what is left contains no more |-x OPT| things
+      arg = newargs[i]
+
+      if i > 0:
+        prev = newargs[i - 1]
+        if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
+                    '-Xpreprocessor', '-include', '-imacros', '-idirafter',
+                    '-iprefix', '-iwithprefix', '-iwithprefixbefore',
+                    '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
+                    '-install_name', '-compatibility_version',
+                    '-current_version', '-I', '-L', '-include-pch'):
+          continue # ignore this gcc-style argument
+
+      if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
+        arg = os.path.realpath(arg)
+
+      if not arg.startswith('-'):
+        if not os.path.exists(arg):
+          exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
+
+        arg_ending = filename_type_ending(arg)
+        if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
+          newargs[i] = ''
+          if arg_ending.endswith(SOURCE_ENDINGS):
+            input_files.append((i, arg))
+            has_source_inputs = True
+          elif arg_ending.endswith(HEADER_ENDINGS):
+            input_files.append((i, arg))
+            has_header_inputs = True
+          elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
+            input_files.append((i, arg))
+          elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
+            # if it's not, and it's a library, just add it to libs to find later
+            l = unsuffixed_basename(arg)
+            for prefix in LIB_PREFIXES:
+              if not prefix:
+                continue
+              if l.startswith(prefix):
+                l = l[len(prefix):]
+                break
+            libs.append((i, l))
+            newargs[i] = ''
+          elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
+            input_files.append((i, arg))
+          else:
+            logger.warning(arg + ' is not valid LLVM bitcode')
+        elif arg_ending.endswith(STATICLIB_ENDINGS):
+          if not shared.Building.is_ar(arg):
+            if shared.Building.is_bitcode(arg):
+              message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
+            else:
+              message = arg + ': Unknown format, not a static library!'
+            exit_with_error(message)
+        else:
+          if has_fixed_language_mode:
+            newargs[i] = ''
+            input_files.append((i, arg))
+            has_source_inputs = True
+          else:
+            exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
+      elif arg.startswith('-L'):
+        lib_dirs.append(arg[2:])
+        newargs[i] = ''
+      elif arg.startswith('-l'):
+        libs.append((i, arg[2:]))
+        newargs[i] = ''
+      elif arg.startswith('-Wl,'):
+        # Multiple comma separated link flags can be specified. Create fake
+        # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
+        # (4, a), (4.25, b), (4.5, c), (4.75, d)
+        link_flags_to_add = arg.split(',')[1:]
+        for flag_index, flag in enumerate(link_flags_to_add):
+          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+
+        newargs[i] = ''
+      elif arg == '-s':
+        # -s and some other compiler flags are normally passed onto the linker
+        # TODO(sbc): Pass this and other flags through when using lld
+        # link_flags.append((i, arg))
+        newargs[i] = ''
+
+    original_input_files = input_files[:]
+
+    newargs = [a for a in newargs if a is not '']
+
+    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+    has_dash_c = '-c' in newargs
+    if has_dash_c:
+      assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
+      target = target_basename + '.o'
+      final_suffix = 'o'
+    if '-E' in newargs:
+      final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
+    if '-M' in newargs or '-MM' in newargs:
+      final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
+    final_ending = ('.' + final_suffix) if len(final_suffix) else ''
+
+    # target is now finalized, can finalize other _target s
+    js_target = unsuffixed(target) + '.js'
+
+    asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
+    wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
+    wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
+
+    if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
+      options.separate_asm = True
+      logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
+    if options.separate_asm:
+      shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
+
+    if 'EMCC_STRICT' in os.environ:
+      shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
+
+    # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
+    # command line already now.
+
+    def get_last_setting_change(setting):
+      return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
+
+    strict_cmdline = get_last_setting_change('STRICT')
+    if strict_cmdline:
+      shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
+
+    if shared.Settings.STRICT:
+      shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
+
+    error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
+    if error_on_missing_libraries_cmdline:
+      shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
+
+    settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
+
+    # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
+    # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
+    if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
+      def check(input_file):
+        if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
+          if not options.ignore_dynamic_linking:
+            logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
+          return False
+        else:
+          return True
+      input_files = [f for f in input_files if check(f[1])]
+
+    if len(input_files) == 0:
+      exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
+
+    newargs = CC_ADDITIONAL_ARGS + newargs
+
+    if options.separate_asm and final_suffix != 'html':
+      shared.WarningManager.warn('SEPARATE_ASM')
+
+    # Apply optimization level settings
+    shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
+
+    # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
+    # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
+    if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
+      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+
+    # Set ASM_JS default here so that we can override it from the command line.
+    shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
+
+    # Apply -s settings in newargs here (after optimization levels, so they can override them)
+    apply_settings(settings_changes)
+
+    shared.verify_settings()
+
+    # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
+    shared.reconfigure_cache()
+
+    # Note the exports the user requested
+    shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
+
+    if options.bind:
+      # If we are using embind and generating JS, now is the time to link in bind.cpp
+      if final_suffix in JS_CONTAINING_SUFFIXES:
+        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
+        next_arg_index += 1
+
+    # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
+    # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
+    if shared.Settings.ASSERTIONS:
+      shared.Settings.STACK_OVERFLOW_CHECK = 2
+
+    if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
+      logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
+      return 1
+
+    if not shared.Settings.STRICT:
+      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
+
+      # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
+      # This path is not available in Emscripten strict mode.
+      if shared.USE_EMSDK:
+        shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
+
+    # Use settings
+
     try:
-      if not DEBUG:
-        shutil.rmtree(temp_dir)
-    except:
-      pass
+      assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
+      assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
+      assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
+      assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
+      assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
+      assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
+    except Exception as e:
+      logger.error('Compiler settings error: {}'.format(e))
+      exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
+
+    assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
+
+    if options.debug_level > 1 and options.use_closure_compiler:
+      logger.warning('disabling closure because debug info was requested')
+      options.use_closure_compiler = False
+
+    assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
+
+    assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
+
+    if options.emrun:
+      shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+
+    if options.use_closure_compiler:
+      shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
+      if not shared.check_closure_compiler():
+        exit_with_error('fatal: closure compiler is not configured correctly')
+      if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
+        shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
+        shared.Settings.ASM_JS = 2
+
+    if shared.Settings.MAIN_MODULE:
+      assert not shared.Settings.SIDE_MODULE
+      if shared.Settings.MAIN_MODULE != 2:
+        shared.Settings.INCLUDE_FULL_LIBRARY = 1
+    elif shared.Settings.SIDE_MODULE:
+      assert not shared.Settings.MAIN_MODULE
+      options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
+
+    if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
+      assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
+      if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
+        shared.Settings.LINKABLE = 1
+      shared.Settings.RELOCATABLE = 1
+      shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
+      assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
+      # shared modules need memory utilities to allocate their memory
+      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+        'allocate',
+        'getMemory',
+      ]
+    if shared.Settings.USE_PTHREADS:
+      # These runtime methods are called from worker.js
+      shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
+
+    if shared.Settings.MODULARIZE_INSTANCE:
+      shared.Settings.MODULARIZE = 1
+
+    if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+      shared.Settings.ALIASING_FUNCTION_POINTERS = 0
+
+    if shared.Settings.LEGACY_VM_SUPPORT:
+      # legacy vms don't have wasm
+      assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
+      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
+      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
+      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
+
+    # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
+    if shared.Settings.WASM:
+      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
+      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
+      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
+
+    if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
+      next_arg_index += 1
+      shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
+      # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
+      newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
+
+    if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
+      newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
+      next_arg_index += 1
+      shared.Settings.FILESYSTEM = 0
+      shared.Settings.FETCH = 1
+      if not shared.Settings.USE_PTHREADS:
+        exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
+
+    if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
+      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
+      next_arg_index += 1
+      options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
+
+    forced_stdlibs = []
+    if shared.Settings.DEMANGLE_SUPPORT:
+      shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
+      forced_stdlibs += ['libc++abi']
+
+    if not shared.Settings.ONLY_MY_CODE:
+      # Always need malloc and free to be kept alive and exported, for internal use and other modules
+      shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
+      if shared.Settings.WASM_BACKEND:
+        # setjmp/longjmp and exception handling JS code depends on this so we
+        # include it by default.  Should be elimiated by meta-DCE if unused.
+        shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
+
+    if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
+      exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
+
+    if shared.Settings.RELOCATABLE:
+      assert shared.Settings.GLOBAL_BASE < 1
+      if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
+        shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
+      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+      shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
+
+    if shared.Settings.EMTERPRETIFY:
+      shared.Settings.FINALIZE_ASM_JS = 0
+      # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
+      shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
+      shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
+      if not options.js_opts:
+        logger.debug('enabling js opts for EMTERPRETIFY')
+        options.js_opts = True
+      options.force_js_opts = True
+      if options.use_closure_compiler == 2:
+         exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
+      assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
+
+    if shared.Settings.DEAD_FUNCTIONS:
+      if not options.js_opts:
+        logger.debug('enabling js opts for DEAD_FUNCTIONS')
+        options.js_opts = True
+      options.force_js_opts = True
+
+    if options.proxy_to_worker:
+      shared.Settings.PROXY_TO_WORKER = 1
+
+    if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
+      if shared.Settings.NODERAWFS:
+        exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
+      # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
+      shared.Settings.FORCE_FILESYSTEM = 1
+
+    if options.proxy_to_worker or options.use_preload_plugins:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
+
+    if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
+      shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
+      # to flush streams on FS exit, we need to be able to call fflush
+      # we only include it if the runtime is exitable, or when ASSERTIONS
+      # (ASSERTIONS will check that streams do not need to be flushed,
+      # helping people see when they should have disabled NO_EXIT_RUNTIME)
+      if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
+        shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
+
+    if shared.Settings.USE_PTHREADS:
+      if shared.Settings.USE_PTHREADS == 2:
+        exit_with_error('USE_PTHREADS=2 is not longer supported')
+      if shared.Settings.ALLOW_MEMORY_GROWTH:
+        exit_with_error('Memory growth is not yet supported with pthreads')
+      if shared.Settings.MODULARIZE:
+        # currently worker.js uses the global namespace, so it's setting of
+        # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
+        # modifications it performs.
+        exit_with_error('MODULARIZE is not yet supported with pthreads')
+      # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
+      shared.Settings.TEXTDECODER = 0
+      options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
+      newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
+      shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
+      # set location of worker.js
+      shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
+    else:
+      options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
+
+    if shared.Settings.FORCE_FILESYSTEM:
+      # when the filesystem is forced, we export by default methods that filesystem usage
+      # may need, including filesystem usage from standalone file packager output (i.e.
+      # file packages not built together with emcc, but that are loaded at runtime
+      # separately, and they need emcc's output to contain the support they need)
+      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+        'FS_createFolder',
+        'FS_createPath',
+        'FS_createDataFile',
+        'FS_createPreloadedFile',
+        'FS_createLazyFile',
+        'FS_createLink',
+        'FS_createDevice',
+        'FS_unlink',
+        'getMemory',
+        'addRunDependency',
+        'removeRunDependency',
+      ]
+
+    if shared.Settings.USE_PTHREADS:
+      if shared.Settings.LINKABLE:
+        exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.SIDE_MODULE:
+        exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.MAIN_MODULE:
+        exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.EMTERPRETIFY:
+        exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
+      if shared.Settings.PROXY_TO_WORKER:
+        exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
+    else:
+      if shared.Settings.PROXY_TO_PTHREAD:
+        exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
+
+    if shared.Settings.OUTLINING_LIMIT:
+      if shared.Settings.WASM_BACKEND:
+        exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
+      if not options.js_opts:
+        logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
+        options.js_opts = True
+      options.force_js_opts = True
+
+    # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
+    if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
+      shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
+
+    if shared.Settings.WASM:
+      if not shared.Building.need_asm_js_file():
+        asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
+        misc_temp_files.note(asm_target)
+
+    if shared.Settings.WASM:
+      if shared.Settings.TOTAL_MEMORY % 65536 != 0:
+        exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
+    else:
+      if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
+        exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+      if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
+        exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+    if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
+      exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
+    if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
+      exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
+    if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
+      exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
+
+    if shared.Settings.WASM_BACKEND:
+      options.js_opts = None
+
+      # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
+      # we run the optimizer during asm2wasm itself). use it, if not overridden
+      if 'BINARYEN_PASSES' not in settings_key_changes:
+        passes = []
+        if not shared.Settings.EXIT_RUNTIME:
+          passes += ['--no-exit-runtime']
+        if options.opt_level > 0 or options.shrink_level > 0:
+          passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
+        if options.debug_level < 3:
+          passes += ['--strip']
+        if passes:
+          shared.Settings.BINARYEN_PASSES = ','.join(passes)
+
+      # to bootstrap struct_info, we need binaryen
+      os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
+
+    if shared.Settings.WASM:
+      if shared.Settings.SINGLE_FILE:
+        # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
+        shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
+        shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
+        shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
+      else:
+        # set file locations, so that JS glue can find what it needs
+        shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
+        shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
+        shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
+
+      shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
+      shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
+      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
+        logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
+        shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
+      if shared.Settings.OUTLINING_LIMIT:
+        logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
+      # default precise-f32 to on, since it works well in wasm
+      # also always use f32s when asm.js is not in the picture
+      if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        shared.Settings.PRECISE_F32 = 1
+      if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+        options.js_opts = None
+        logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
+      if options.use_closure_compiler == 2:
+        exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
+      # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
+      #  * if we also supported js mem inits we'd have 4 modes
+      #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
+      if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
+        exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
+      options.memory_init_file = True
+      # async compilation requires not interpreting (the interpreter modes needs sync input)
+      if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
+        # async compilation requires a swappable module - we swap it in when it's ready
+        shared.Settings.SWAPPABLE_ASM_MODULE = 1
+      else:
+        # if not wasm-only, we can't do async compilation as the build can run in other
+        # modes than wasm (like asm.js) which may not support an async step
+        shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
+        warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
+        if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
+          logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
+        elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
+          logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
+      # run safe-heap as a binaryen pass
+      if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'safe-heap'
+      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+        # emulated function pointer casts is emulated in wasm using a binaryen pass
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
+        # we also need emulated function pointers for that, as we need a single flat
+        # table, as is standard in wasm, and not asm.js split ones.
+        shared.Settings.EMULATED_FUNCTION_POINTERS = 1
+
+      # we will include the mem init data in the wasm, when we don't need the
+      # mem init file to be loadable by itself
+      shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
+                                         'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
+                                         not shared.Settings.USE_PTHREADS
+
+      # wasm side modules have suffix .wasm
+      if shared.Settings.SIDE_MODULE and target.endswith('.js'):
+        logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
+
+      if options.separate_asm:
+        exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
+
+    # wasm outputs are only possible with a side wasm
+    if target.endswith(WASM_ENDINGS):
+      if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
+        logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
+        return 1
+
+    if shared.Settings.EVAL_CTORS:
+      if not shared.Settings.WASM:
+        # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
+        # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
+        shared.Settings.RUNNING_JS_OPTS = 1
+      else:
+        if 'interpret' in shared.Settings.BINARYEN_METHOD:
+          logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
+          shared.Settings.EVAL_CTORS = 0
+
+    # memory growth does not work in dynamic linking, except for wasm
+    if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
+      assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
+
+    if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
+      # this is an issue in asm.js, but not wasm
+      if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
+        shared.WarningManager.warn('ALMOST_ASM')
+        shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
+
+    # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
+    if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
+      if not options.js_opts:
+        logger.debug('enabling js opts for SAFE_HEAP')
+        options.js_opts = True
+      options.force_js_opts = True
+
+    if options.js_opts:
+      shared.Settings.RUNNING_JS_OPTS = 1
+
+    if shared.Settings.CYBERDWARF:
+      newargs.append('-g')
+      options.debug_level = max(options.debug_level, 2)
+      shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
+      options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
+      options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
+
+    if options.tracing:
+      if shared.Settings.ALLOW_MEMORY_GROWTH:
+        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
+
+    if shared.Settings.ONLY_MY_CODE:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+      options.separate_asm = True
+      shared.Settings.FINALIZE_ASM_JS = False
+
+    if shared.Settings.GLOBAL_BASE < 0:
+      shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
+
+    if shared.Settings.WASM_BACKEND:
+      if shared.Settings.SIMD:
+        newargs.append('-msimd128')
+    else:
+      # We leave the -O option in place so that the clang front-end runs in that
+      # optimization mode, but we disable the actual optimization passes, as we'll
+      # run them separately.
+      if options.opt_level > 0:
+        newargs.append('-mllvm')
+        newargs.append('-disable-llvm-optzns')
+
+    if not shared.Settings.LEGALIZE_JS_FFI:
+      assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+
+    shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
+    shared.Settings.OPT_LEVEL = options.opt_level
+    shared.Settings.DEBUG_LEVEL = options.debug_level
+    shared.Settings.PROFILING_FUNCS = options.profiling_funcs
+    shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
+
+    ## Compile source code to bitcode
+
+    logger.debug('compiling to bitcode')
+
+    temp_files = []
+
+  # exit block 'parse arguments and setup'
+  log_time('parse arguments and setup')
+
+  with ToolchainProfiler.profile_block('bitcodeize inputs'):
+    # Precompiled headers support
+    if has_header_inputs:
+      headers = [header for _, header in input_files]
+      for header in headers:
+        assert header.endswith(HEADER_ENDINGS), 'if you have one header input, we assume you want to precompile headers, and cannot have source files or other inputs as well: ' + str(headers) + ' : ' + header
+      args = newargs + shared.EMSDK_CXX_OPTS + headers
+      if specified_target:
+        args += ['-o', specified_target]
+      args = system_libs.process_args(args, shared.Settings)
+      logger.debug("running (for precompiled headers): " + call + ' ' + ' '.join(args))
+      return run_process([call] + args, check=False).returncode
+
+    def get_bitcode_file(input_file):
+      if final_suffix not in JS_CONTAINING_SUFFIXES:
+        # no need for a temp file, just emit to the right place
+        if len(input_files) == 1:
+          # can just emit directly to the target
+          if specified_target:
+            if specified_target.endswith('/') or specified_target.endswith('\\') or os.path.isdir(specified_target):
+              return os.path.join(specified_target, os.path.basename(unsuffixed(input_file))) + options.default_object_extension
+            return specified_target
+          return unsuffixed(input_file) + final_ending
+        else:
+          if has_dash_c:
+            return unsuffixed(input_file) + options.default_object_extension
+      return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
+
+    # Request LLVM debug info if explicitly specified, or building bitcode with -g, or if building a source all the way to JS with -g
+    if use_source_map(options) or ((final_suffix not in JS_CONTAINING_SUFFIXES or (has_source_inputs and final_suffix in JS_CONTAINING_SUFFIXES)) and options.requested_debug == '-g'):
+      # do not save llvm debug info if js optimizer will wipe it out anyhow (but if source maps are used, keep it)
+      if use_source_map(options) or not (final_suffix in JS_CONTAINING_SUFFIXES and options.js_opts):
+        newargs.append('-g') # preserve LLVM debug info
+        options.debug_level = 4
+        shared.Settings.DEBUG_LEVEL = 4
+
+    # Bitcode args generation code
+    def get_clang_args(input_files):
+      file_ending = filename_type_ending(input_files[0])
+      args = [call] + newargs + input_files
+      if file_ending.endswith(CXX_ENDINGS):
+        args += shared.EMSDK_CXX_OPTS
+      if not shared.Building.can_inline():
+        args.append('-fno-inline-functions')
+      # For fastcomp backend, no LLVM IR functions should ever be annotated
+      # 'optnone', because that would skip running the SimplifyCFG pass on
+      # them, which is required to always run to clean up LandingPadInst
+      # instructions that are not needed.
+      if not shared.Settings.WASM_BACKEND:
+        args += ['-Xclang', '-disable-O0-optnone']
+      args = system_libs.process_args(args, shared.Settings)
+      return args
+
+    # -E preprocessor-only support
+    if '-E' in newargs or '-M' in newargs or '-MM' in newargs:
+      input_files = [x[1] for x in input_files]
+      cmd = get_clang_args(input_files)
+      if specified_target:
+        cmd += ['-o', specified_target]
+      # Do not compile, but just output the result from preprocessing stage or
+      # output the dependency rule. Warning: clang and gcc behave differently
+      # with -MF! (clang seems to not recognize it)
+      logger.debug(('just preprocessor ' if '-E' in newargs else 'just dependencies: ') + ' '.join(cmd))
+      return run_process(cmd, check=False).returncode
+
+    def compile_source_file(i, input_file):
+      logger.debug('compiling source file: ' + input_file)
+      output_file = get_bitcode_file(input_file)
+      temp_files.append((i, output_file))
+      args = get_clang_args([input_file]) + ['-c', '-o', output_file]
+      if shared.Settings.WASM_OBJECT_FILES:
+        for a in shared.Building.llvm_backend_args():
+          args += ['-mllvm', a]
+      else:
+        args.append('-emit-llvm')
+      logger.debug("running: " + ' '.join(shared.Building.doublequote_spaces(args))) # NOTE: Printing this line here in this specific format is important, it is parsed to implement the "emcc --cflags" command
+      if run_process(args, check=False).returncode != 0:
+        exit_with_error('compiler frontend failed to generate LLVM bitcode, halting')
+      assert(os.path.exists(output_file))
+
+    # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
+    for i, input_file in input_files:
+      file_ending = filename_type_ending(input_file)
+      if file_ending.endswith(SOURCE_ENDINGS):
+        compile_source_file(i, input_file)
+      else: # bitcode
+        if file_ending.endswith(BITCODE_ENDINGS):
+          logger.debug('using bitcode file: ' + input_file)
+          temp_files.append((i, input_file))
+        elif file_ending.endswith(DYNAMICLIB_ENDINGS) or shared.Building.is_ar(input_file):
+          logger.debug('using library file: ' + input_file)
+          temp_files.append((i, input_file))
+        elif file_ending.endswith(ASSEMBLY_ENDINGS):
+          if not LEAVE_INPUTS_RAW:
+            logger.debug('assembling assembly file: ' + input_file)
+            temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
+            shared.Building.llvm_as(input_file, temp_file)
+            temp_files.append((i, temp_file))
+        else:
+          if has_fixed_language_mode:
+            compile_source_file(i, input_file)
+          else:
+            exit_with_error(input_file + ': Unknown file suffix when compiling to LLVM bitcode!')
+
+  # exit block 'bitcodeize inputs'
+  log_time('bitcodeize inputs')
+
+  with ToolchainProfiler.profile_block('process inputs'):
+    if not LEAVE_INPUTS_RAW and not shared.Settings.WASM_BACKEND:
+      assert len(temp_files) == len(input_files)
+
+      # Optimize source files
+      if optimizing(options.llvm_opts):
+        for pos, (_, input_file) in enumerate(input_files):
+          file_ending = filename_type_ending(input_file)
+          if file_ending.endswith(SOURCE_ENDINGS):
+            temp_file = temp_files[pos][1]
+            logger.debug('optimizing %s', input_file)
+            # if DEBUG:
+            #   shutil.copyfile(temp_file, os.path.join(shared.configuration.CANONICAL_TEMP_DIR, 'to_opt.bc')) # useful when LLVM opt aborts
+            new_temp_file = in_temp(unsuffixed(uniquename(temp_file)) + '.o')
+            # after optimizing, lower intrinsics to libc calls so that our linking code
+            # will find them (otherwise, llvm.cos.f32() will not link in cosf(), and
+            # we end up calling out to JS for Math.cos).
+            opts = options.llvm_opts + ['-lower-non-em-intrinsics']
+            shared.Building.llvm_opt(temp_file, opts, new_temp_file)
+            temp_files[pos] = (temp_files[pos][0], new_temp_file)
+
+    # Decide what we will link
+    stop_at_bitcode = final_suffix not in EXECUTABLE_SUFFIXES
+
+    if stop_at_bitcode or not shared.Settings.WASM_BACKEND:
+      # Filter link flags, keeping only those that shared.Building.link knows
+      # how to deal with.  We currently can't handle flags with options (like
+      # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
+      # flag).
+      link_flags = [f for f in link_flags if f[1] in SUPPORTED_LINKER_FLAGS]
+
+    linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
+
+    # If we were just asked to generate bitcode, stop there
+    if stop_at_bitcode:
+      if not specified_target:
+        assert len(temp_files) == len(input_files)
+        for tempf, inputf in zip(temp_files, input_files):
+          safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_ending)
+      else:
+        if len(input_files) == 1:
+          input_file = input_files[0][1]
+          temp_file = temp_files[0][1]
+          bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_ending
+          if temp_file != input_file:
+            safe_move(temp_file, bitcode_target)
+          else:
+            shutil.copyfile(temp_file, bitcode_target)
+          temp_output_base = unsuffixed(temp_file)
+          if os.path.exists(temp_output_base + '.d'):
+            # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
+            # adjusting the target name away from the temporary file name to the specified target.
+            # It will be deleted with the rest of the temporary directory.
+            deps = open(temp_output_base + '.d').read()
+            deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
+            with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
+              out_dep.write(deps)
+        else:
+          assert len(original_input_files) == 1 or not has_dash_c, 'fatal error: cannot specify -o with -c with multiple files' + str(sys.argv) + ':' + str(original_input_files)
+          # We have a specified target (-o <target>), which is not JavaScript or HTML, and
+          # we have multiple files: Link them
+          logger.debug('link: ' + str(linker_inputs) + specified_target)
+          # Sort arg tuples and pass the extracted values to link.
+          shared.Building.link(linker_inputs, specified_target)
+      logger.debug('stopping at bitcode')
+      if shared.Settings.SIDE_MODULE:
+        exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting LLVM bitcode. That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an LLVM bitcode file, which you should then compile to .wasm or .js with SIDE_MODULE.')
+      if final_suffix.lower() in ['so', 'dylib', 'dll']:
+        logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an LLVM bitcode file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a file with LLVM bitcode, \'.bc\', which would avoid this warning.)')
+      return 0
+
+  # exit block 'process inputs'
+  log_time('process inputs')
+
+  ## Continue on to create JavaScript
+
+  with ToolchainProfiler.profile_block('calculate system libraries'):
+    logger.debug('will generate JavaScript')
+
+    extra_files_to_link = []
+
+    # link in ports and system libraries, if necessary
+    if not LEAVE_INPUTS_RAW and \
+       not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
+       not shared.Settings.ONLY_MY_CODE and \
+       not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
+      extra_files_to_link = system_libs.get_ports(shared.Settings)
+      extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
+
+  # exit block 'calculate system libraries'
+  log_time('calculate system libraries')
+
+  def dedup_list(lst):
+    rtn = []
+    for item in lst:
+      if item not in rtn:
+        rtn.append(item)
+    return rtn
+
+  # Make a final pass over shared.Settings.EXPORTED_FUNCTIONS to remove any
+  # duplication between functions added by the driver/libraries and function
+  # specified by the user
+  shared.Settings.EXPORTED_FUNCTIONS = dedup_list(shared.Settings.EXPORTED_FUNCTIONS)
+
+  with ToolchainProfiler.profile_block('link'):
+    # final will be an array if linking is deferred, otherwise a normal string.
+    if shared.Settings.WASM_BACKEND:
+      DEFAULT_FINAL = in_temp(target_basename + '.wasm')
+    else:
+      DEFAULT_FINAL = in_temp(target_basename + '.bc')
+
+    def get_final():
+      global final
+      if isinstance(final, list):
+        final = DEFAULT_FINAL
+      return final
+
+    # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
+    linker_inputs += extra_files_to_link
+    perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
+    if not perform_link and not LEAVE_INPUTS_RAW:
+      is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
+      is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
+      is_ar = shared.Building.is_ar(temp_files[0][1])
+      perform_link = not (is_bc or is_dylib) and is_ar
+    if perform_link:
+      logger.debug('linking: ' + str(linker_inputs))
+      # force archive contents to all be included, if just archives, or if linking shared modules
+      force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
+
+      # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
+      # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
+      # TODO: we could check if this is a fastcomp build, and still speed things up here
+      just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
+      if shared.Settings.WASM_BACKEND:
+        # If LTO is enabled then use the -O opt level as the LTO level
+        if options.llvm_lto:
+          lto_level = options.opt_level
+        else:
+          lto_level = 0
+        final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts, lto_level)
+      else:
+        final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
+    else:
+      logger.debug('skipping linking: ' + str(linker_inputs))
+      if not LEAVE_INPUTS_RAW:
+        _, temp_file = temp_files[0]
+        _, input_file = input_files[0]
+        final = in_temp(target_basename + '.bc')
+        if temp_file != input_file:
+          shutil.move(temp_file, final)
+        else:
+          shutil.copyfile(temp_file, final)
+      else:
+        _, input_file = input_files[0]
+        final = in_temp(input_file)
+        shutil.copyfile(input_file, final)
+
+  # exit block 'link'
+  log_time('link')
+
+  if not shared.Settings.WASM_BACKEND:
+    with ToolchainProfiler.profile_block('post-link'):
+      if DEBUG:
+        logger.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
+        if not LEAVE_INPUTS_RAW:
+          save_intermediate('basebc', 'bc')
+
+      # Optimize, if asked to
+      if not LEAVE_INPUTS_RAW:
+        # remove LLVM debug if we are not asked for it
+        link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
+        if not shared.Settings.ASSERTIONS:
+          link_opts += ['-disable-verify']
+        else:
+          # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
+          # disable the type map in that case. we added linking to opt, so we need to do
+          # something similar, which we can do with a param to opt
+          link_opts += ['-disable-debug-info-type-map']
+
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
+          logger.debug('running LLVM opts as pre-LTO')
+          final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
+          save_intermediate('opt', 'bc')
+
+        # If we can LTO, do it before dce, since it opens up dce opportunities
+        if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
+          if not shared.Building.can_inline():
+            link_opts.append('-disable-inlining')
+          # add a manual internalize with the proper things we need to be kept alive during lto
+          link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
+          # execute it now, so it is done entirely before we get to the stage of legalization etc.
+          final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+          save_intermediate('lto', 'bc')
+          link_opts = []
+        else:
+          # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
+          link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
+
+        if options.cfi:
+          if use_cxx:
+             link_opts.append("-wholeprogramdevirt")
+          link_opts.append("-lowertypetests")
+
+        if AUTODEBUG:
+          # let llvm opt directly emit ll, to skip writing and reading all the bitcode
+          link_opts += ['-S']
+          final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
+          save_intermediate('linktime', 'll')
+        else:
+          if len(link_opts) > 0:
+            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+            save_intermediate('linktime', 'bc')
+          if options.save_bc:
+            shutil.copyfile(final, options.save_bc)
+
+      # Prepare .ll for Emscripten
+      if LEAVE_INPUTS_RAW:
+        assert len(input_files) == 1
+      if options.save_bc:
+        save_intermediate('ll', 'll')
+
+      if AUTODEBUG:
+        logger.debug('autodebug')
+        next = get_final() + '.ad.ll'
+        run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
+        final = next
+        save_intermediate('autodebug', 'll')
+
+      assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
+
+    # exit block 'post-link'
+    log_time('post-link')
+
+  with ToolchainProfiler.profile_block('emscript'):
+    # Emscripten
+    logger.debug('LLVM => JS')
+    js_libraries = None
+    if options.js_libraries:
+      js_libraries = [os.path.abspath(lib) for lib in options.js_libraries]
+    if options.memory_init_file:
+      shared.Settings.MEM_INIT_METHOD = 1
+    else:
+      assert shared.Settings.MEM_INIT_METHOD != 1
+
+    if embed_memfile(options):
+      shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
+
+    final = shared.Building.emscripten(final, target + '.mem', js_libraries)
+    save_intermediate('original')
+
+    if shared.Settings.WASM_BACKEND:
+      # we also received wast and wasm at this stage
+      temp_basename = unsuffixed(final)
+      wasm_temp = temp_basename + '.wasm'
+      shutil.move(wasm_temp, wasm_binary_target)
+      if use_source_map(options):
+        shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
+
+    if shared.Settings.CYBERDWARF:
+      cd_target = final + '.cd'
+      shutil.move(cd_target, target + '.cd')
+
+  # exit block 'emscript'
+  log_time('emscript (llvm => executable code)')
+
+  with ToolchainProfiler.profile_block('source transforms'):
+    # Embed and preload files
+    if len(options.preload_files) or len(options.embed_files):
+
+      # Also, MEMFS is not aware of heap resizing feature in wasm, so if MEMFS and memory growth are used together, force
+      # no_heap_copy to be enabled.
+      if shared.Settings.ALLOW_MEMORY_GROWTH and not options.no_heap_copy:
+        logger.info('Enabling --no-heap-copy because -s ALLOW_MEMORY_GROWTH=1 is being used with file_packager.py (pass --no-heap-copy to suppress this notification)')
+        options.no_heap_copy = True
+
+      logger.debug('setting up files')
+      file_args = ['--from-emcc', '--export-name=' + shared.Settings.EXPORT_NAME]
+      if len(options.preload_files):
+        file_args.append('--preload')
+        file_args += options.preload_files
+      if len(options.embed_files):
+        file_args.append('--embed')
+        file_args += options.embed_files
+      if len(options.exclude_files):
+        file_args.append('--exclude')
+        file_args += options.exclude_files
+      if options.use_preload_cache:
+        file_args.append('--use-preload-cache')
+      if options.no_heap_copy:
+        file_args.append('--no-heap-copy')
+      if shared.Settings.LZ4:
+        file_args.append('--lz4')
+      if options.use_preload_plugins:
+        file_args.append('--use-preload-plugins')
+      file_code = run_process([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
+      options.pre_js = file_code + options.pre_js
+
+    # Apply pre and postjs files
+    if options.pre_js or options.post_js:
+      logger.debug('applying pre/postjses')
+      src = open(final).read()
+      final += '.pp.js'
+      if WINDOWS: # Avoid duplicating \r\n to \r\r\n when writing out.
+        if options.pre_js:
+          options.pre_js = options.pre_js.replace('\r\n', '\n')
+        if options.post_js:
+          options.post_js = options.post_js.replace('\r\n', '\n')
+      outfile = open(final, 'w')
+      # pre-js code goes right after the Module integration code (so it
+      # can use Module), we have a marker for it
+      outfile.write(src.replace('// {{PRE_JSES}}', options.pre_js))
+      outfile.write(options.post_js)
+      outfile.close()
+      options.pre_js = src = options.post_js = None
+      save_intermediate('pre-post')
+
+    # Apply a source code transformation, if requested
+    if options.js_transform:
+      shutil.copyfile(final, final + '.tr.js')
+      final += '.tr.js'
+      posix = not shared.WINDOWS
+      logger.debug('applying transform: %s', options.js_transform)
+      shared.check_call(shared.Building.remove_quotes(shlex.split(options.js_transform, posix=posix) + [os.path.abspath(final)]))
+      save_intermediate('transformed')
+
+    js_transform_tempfiles = [final]
+
+  # exit block 'source transforms'
+  log_time('source transforms')
+
+  with ToolchainProfiler.profile_block('memory initializer'):
+    memfile = None
+    if shared.Settings.MEM_INIT_METHOD > 0 or embed_memfile(options):
+      memfile = target + '.mem'
+
+    if memfile and not shared.Settings.WASM_BACKEND:
+      # Strip the memory initializer out of the asmjs file
+      shared.try_delete(memfile)
+
+      def repl(m):
+        # handle chunking of the memory initializer
+        s = m.group(1)
+        if len(s) == 0:
+          return '' # don't emit 0-size ones
+        membytes = [int(x or '0') for x in s.split(',')]
+        while membytes and membytes[-1] == 0:
+          membytes.pop()
+        if not membytes:
+          return ''
+        if shared.Settings.MEM_INIT_METHOD == 2:
+          # memory initializer in a string literal
+          return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
+        open(memfile, 'wb').write(bytearray(membytes))
+        if DEBUG:
+          # Copy into temp dir as well, so can be run there too
+          shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
+        if not shared.Settings.WASM or not shared.Settings.MEM_INIT_IN_WASM:
+          return 'memoryInitializer = "%s";' % shared.JS.get_subresource_location(memfile, embed_memfile(options))
+        else:
+          return ''
+
+      src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
+      open(final + '.mem.js', 'w').write(src)
+      final += '.mem.js'
+      src = None
+      js_transform_tempfiles[-1] = final # simple text substitution preserves comment line number mappings
+      if os.path.exists(memfile):
+        save_intermediate('meminit')
+        logger.debug('wrote memory initialization to %s', memfile)
+      else:
+        logger.debug('did not see memory initialization')
+
+    if shared.Settings.USE_PTHREADS:
+      target_dir = os.path.dirname(os.path.abspath(target))
+      shutil.copyfile(shared.path_from_root('src', 'worker.js'),
+                      os.path.join(target_dir, shared.Settings.PTHREAD_WORKER_FILE))
+
+    # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
+    if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
+      if shared.Settings.WASM:
+        # FIXME(https://github.com/kripken/emscripten/issues/7024)
+        logger.warning('Blocking calls the fetch API do not work under WASM')
+      else:
+        shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
+
+  # exit block 'memory initializer'
+  log_time('memory initializer')
+
+  optimizer = JSOptimizer(
+    target=target,
+    options=options,
+    js_transform_tempfiles=js_transform_tempfiles,
+    in_temp=in_temp,
+  )
+  with ToolchainProfiler.profile_block('js opts'):
+    # It is useful to run several js optimizer passes together, to save on unneeded unparsing/reparsing
+    if shared.Settings.DEAD_FUNCTIONS:
+      optimizer.queue += ['eliminateDeadFuncs']
+      optimizer.extra_info['dead_functions'] = shared.Settings.DEAD_FUNCTIONS
+
+    if options.opt_level >= 1 and options.js_opts:
+      logger.debug('running js post-opts')
+
+      if DEBUG == 2:
+        # Clean up the syntax a bit
+        optimizer.queue += ['noop']
+
+      def get_eliminate():
+        if shared.Settings.ALLOW_MEMORY_GROWTH:
+          return 'eliminateMemSafe'
+        else:
+          return 'eliminate'
+
+      if options.opt_level >= 2:
+        optimizer.queue += [get_eliminate()]
+
+        if shared.Settings.AGGRESSIVE_VARIABLE_ELIMINATION:
+          # note that this happens before registerize/minification, which can obfuscate the name of 'label', which is tricky
+          optimizer.queue += ['aggressiveVariableElimination']
+
+        optimizer.queue += ['simplifyExpressions']
+
+        if shared.Settings.EMTERPRETIFY:
+          # emterpreter code will not run through a JS optimizing JIT, do more work ourselves
+          optimizer.queue += ['localCSE']
+
+    if shared.Settings.EMTERPRETIFY:
+      # add explicit label setting, as we will run aggressiveVariableElimination late, *after* 'label' is no longer notable by name
+      optimizer.queue += ['safeLabelSetting']
+
+    if options.opt_level >= 1 and options.js_opts:
+      if options.opt_level >= 2:
+        # simplify ifs if it is ok to make the code somewhat unreadable, and unless outlining (simplified ifs
+        # with commaified code breaks late aggressive variable elimination)
+        # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
+        debugging = options.debug_level == 0 or options.profiling
+        if shared.Settings.SIMPLIFY_IFS and debugging and shared.Settings.OUTLINING_LIMIT == 0 and not shared.Settings.WASM:
+          optimizer.queue += ['simplifyIfs']
+
+        if shared.Settings.PRECISE_F32:
+          optimizer.queue += ['optimizeFrounds']
+
+    if options.js_opts:
+      if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
+        optimizer.queue += ['safeHeap']
+
+      if shared.Settings.OUTLINING_LIMIT > 0:
+        optimizer.queue += ['outline']
+        optimizer.extra_info['sizeToOutline'] = shared.Settings.OUTLINING_LIMIT
+
+      if options.opt_level >= 2 and options.debug_level < 3:
+        if options.opt_level >= 3 or options.shrink_level > 0:
+          optimizer.queue += ['registerizeHarder']
+        else:
+          optimizer.queue += ['registerize']
+
+      # NOTE: Important that this comes after registerize/registerizeHarder
+      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and options.opt_level >= 2:
+        optimizer.flush()
+        shared.Building.eliminate_duplicate_funcs(final)
+        save_intermediate('dfe', 'js')
+
+    if shared.Settings.EVAL_CTORS and options.memory_init_file and not use_source_map(options) and not shared.Settings.WASM:
+      optimizer.flush()
+      shared.Building.eval_ctors(final, memfile)
+      save_intermediate('eval-ctors', 'js')
+
+    if options.js_opts:
+      # some compilation modes require us to minify later or not at all
+      if not shared.Settings.EMTERPRETIFY and not shared.Settings.WASM:
+        optimizer.do_minify()
+
+      if options.opt_level >= 2:
+        optimizer.queue += ['asmLastOpts']
+
+      if shared.Settings.FINALIZE_ASM_JS:
+        optimizer.queue += ['last']
+
+      optimizer.flush()
+
+    if options.use_closure_compiler == 2:
+      optimizer.flush()
+
+      logger.debug('running closure')
+      # no need to add this to js_transform_tempfiles, because closure and
+      # debug_level > 0 are never simultaneously true
+      final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
+      save_intermediate('closure')
+
+  log_time('js opts')
+
+  with ToolchainProfiler.profile_block('final emitting'):
+    if shared.Settings.EMTERPRETIFY:
+      emterpretify(js_target, optimizer, options)
+
+    # Remove some trivial whitespace
+    # TODO: do not run when compress has already been done on all parts of the code
+    # src = open(final).read()
+    # src = re.sub(r'\n+[ \n]*\n+', '\n', src)
+    # open(final, 'w').write(src)
+
+    # Bundle symbol data in with the cyberdwarf file
+    if shared.Settings.CYBERDWARF:
+      run_process([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target + '.symbols'])
+
+    if use_source_map(options) and not shared.Settings.WASM:
+      emit_js_source_maps(target, optimizer.js_transform_tempfiles)
+
+    # track files that will need native eols
+    generated_text_files_with_native_eols = []
+
+    if (options.separate_asm or shared.Settings.WASM) and not shared.Settings.WASM_BACKEND:
+      separate_asm_js(final, asm_target)
+      generated_text_files_with_native_eols += [asm_target]
+
+    if shared.Settings.WASM:
+      binaryen_method_sanity_check()
+      do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
+                  wasm_text_target, misc_temp_files, optimizer)
+
+    if shared.Settings.MODULARIZE:
+      modularize()
+
+    module_export_name_substitution()
+
+    # The JS is now final. Move it to its final location
+    shutil.move(final, js_target)
+
+    generated_text_files_with_native_eols += [js_target]
+
+    # If we were asked to also generate HTML, do that
+    if final_suffix == 'html':
+      generate_html(target, options, js_target, target_basename,
+                    asm_target, wasm_binary_target,
+                    memfile, optimizer)
+    else:
+      if options.proxy_to_worker:
+        generate_worker_js(target, js_target, target_basename)
+
+    if embed_memfile(options):
+      shared.try_delete(memfile)
+
+    for f in generated_text_files_with_native_eols:
+      tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
+  log_time('final emitting')
+  # exit block 'final emitting'
+
+  if DEBUG:
+    logger.debug('total time: %.2f seconds', (time.time() - start_time))
 
   return 0
 

--- a/emcc.py
+++ b/emcc.py
@@ -35,7 +35,6 @@ import shlex
 import shutil
 import stat
 import sys
-import tempfile
 import time
 from subprocess import PIPE
 

--- a/emcc.py
+++ b/emcc.py
@@ -1439,8 +1439,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   if DEBUG:
     # we are about to start using temp dirs. serialize access to the temp dir
-    # when using EMCC_DEBUG, since then multiple processes would use the same
-    # location
+    # when using EMCC_DEBUG, since we don't want multiple processes would to
+    # use it at once, they might collide if they happen to use the same
+    # tempfile names
     shared.Cache.acquire_cache_lock()
 
   try:

--- a/emcc.py
+++ b/emcc.py
@@ -686,1411 +686,1419 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   use_cxx = True
 
-  with ToolchainProfiler.profile_block('parse arguments and setup'):
-    ## Parse args
+  try:
+    with ToolchainProfiler.profile_block('parse arguments and setup'):
+      ## Parse args
 
-    newargs = sys.argv[1:]
+      newargs = sys.argv[1:]
 
-    # Scan and strip emscripten specific cmdline warning flags
-    # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
-    newargs = shared.WarningManager.capture_warnings(newargs)
+      # Scan and strip emscripten specific cmdline warning flags
+      # This needs to run before other cmdline flags have been parsed, so that warnings are properly printed during arg parse
+      newargs = shared.WarningManager.capture_warnings(newargs)
 
-    for i in range(len(newargs)):
-      if newargs[i] in ['-l', '-L', '-I']:
-        # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
-        newargs[i] += newargs[i + 1]
-        newargs[i + 1] = ''
+      for i in range(len(newargs)):
+        if newargs[i] in ['-l', '-L', '-I']:
+          # Scan for individual -l/-L/-I arguments and concatenate the next arg on if there is no suffix
+          newargs[i] += newargs[i + 1]
+          newargs[i + 1] = ''
 
-    def detect_fixed_language_mode(args):
-      check_next = False
-      for item in args:
-        if check_next:
-          if item in ("c++", "c"):
-            return True
-          else:
-            check_next = False
-        if item.startswith("-x"):
-          lmode = item[2:] if len(item) > 2 else None
-          if lmode in ("c++", "c"):
-            return True
-          else:
-            check_next = True
-            continue
-      return False
-
-    has_fixed_language_mode = detect_fixed_language_mode(newargs)
-
-    options, settings_changes, newargs = parse_args(newargs)
-
-    for arg in newargs:
-      if arg == '-xc':
-        use_cxx = False
-        break
-      elif arg == '-xc++':
-        use_cxx = True
-        break
-      elif not arg.startswith('-'):
-        if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
-          use_cxx = False
-
-    if not use_cxx:
-      options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
-
-    call = CXX if use_cxx else CC
-
-    # If user did not specify a default -std for C++ code, specify the emscripten default.
-    if options.default_cxx_std:
-      newargs = newargs + [options.default_cxx_std]
-
-    if options.emrun:
-      options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
-      options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
-      # emrun mode waits on program exit
-      shared.Settings.EXIT_RUNTIME = 1
-
-    if options.cpu_profiler:
-      options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
-
-    if options.memory_profiler:
-      options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
-
-    if options.thread_profiler:
-      options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
-
-    if options.js_opts is None:
-      options.js_opts = options.opt_level >= 2
-
-    if options.llvm_opts is None:
-      options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
-    elif type(options.llvm_opts) == int:
-      options.llvm_opts = ['-O%d' % options.llvm_opts]
-
-    if options.memory_init_file is None:
-      options.memory_init_file = options.opt_level >= 2
-
-    # TODO: support source maps with js_transform
-    if options.js_transform and use_source_map(options):
-      logger.warning('disabling source maps because a js transform is being done')
-      options.debug_level = 3
-
-    if DEBUG:
-      start_time = time.time() # done after parsing arguments, which might affect debug state
-
-    for i in range(len(newargs)):
-      if newargs[i] == '-s':
-        if is_minus_s_for_emcc(newargs, i):
-          key = newargs[i + 1]
-          # If not = is specified default to 1
-          if '=' not in key:
-            key += '=1'
-          settings_changes.append(key)
-          newargs[i] = newargs[i + 1] = ''
-          if key == 'WASM_BACKEND=1':
-            exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
-    newargs = [arg for arg in newargs if arg is not '']
-
-    settings_key_changes = set()
-    for s in settings_changes:
-      key, value = s.split('=', 1)
-      settings_key_changes.add(key)
-
-    # Find input files
-
-    # These three arrays are used to store arguments of different types for
-    # type-specific processing. In order to shuffle the arguments back together
-    # after processing, all of these arrays hold tuples (original_index, value).
-    # Note that the index part of the tuple can have a fractional part for input
-    # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
-    input_files = []
-    libs = []
-    link_flags = []
-
-    # All of the above arg lists entries contain indexes into the full argument
-    # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
-    # counter for the next index that should be used.
-    next_arg_index = len(newargs)
-
-    has_source_inputs = False
-    has_header_inputs = False
-    lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
-                shared.path_from_root('system', 'lib')]
-    for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
-                                  # right now we just assume that what is left contains no more |-x OPT| things
-      arg = newargs[i]
-
-      if i > 0:
-        prev = newargs[i - 1]
-        if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
-                    '-Xpreprocessor', '-include', '-imacros', '-idirafter',
-                    '-iprefix', '-iwithprefix', '-iwithprefixbefore',
-                    '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
-                    '-install_name', '-compatibility_version',
-                    '-current_version', '-I', '-L', '-include-pch'):
-          continue # ignore this gcc-style argument
-
-      if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
-        arg = os.path.realpath(arg)
-
-      if not arg.startswith('-'):
-        if not os.path.exists(arg):
-          exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
-
-        arg_ending = filename_type_ending(arg)
-        if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
-          newargs[i] = ''
-          if arg_ending.endswith(SOURCE_ENDINGS):
-            input_files.append((i, arg))
-            has_source_inputs = True
-          elif arg_ending.endswith(HEADER_ENDINGS):
-            input_files.append((i, arg))
-            has_header_inputs = True
-          elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
-            input_files.append((i, arg))
-          elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
-            # if it's not, and it's a library, just add it to libs to find later
-            l = unsuffixed_basename(arg)
-            for prefix in LIB_PREFIXES:
-              if not prefix:
-                continue
-              if l.startswith(prefix):
-                l = l[len(prefix):]
-                break
-            libs.append((i, l))
-            newargs[i] = ''
-          elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
-            input_files.append((i, arg))
-          else:
-            logger.warning(arg + ' is not valid LLVM bitcode')
-        elif arg_ending.endswith(STATICLIB_ENDINGS):
-          if not shared.Building.is_ar(arg):
-            if shared.Building.is_bitcode(arg):
-              message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
+      def detect_fixed_language_mode(args):
+        check_next = False
+        for item in args:
+          if check_next:
+            if item in ("c++", "c"):
+              return True
             else:
-              message = arg + ': Unknown format, not a static library!'
-            exit_with_error(message)
-        else:
-          if has_fixed_language_mode:
+              check_next = False
+          if item.startswith("-x"):
+            lmode = item[2:] if len(item) > 2 else None
+            if lmode in ("c++", "c"):
+              return True
+            else:
+              check_next = True
+              continue
+        return False
+
+      has_fixed_language_mode = detect_fixed_language_mode(newargs)
+
+      options, settings_changes, newargs = parse_args(newargs)
+
+      for arg in newargs:
+        if arg == '-xc':
+          use_cxx = False
+          break
+        elif arg == '-xc++':
+          use_cxx = True
+          break
+        elif not arg.startswith('-'):
+          if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
+            use_cxx = False
+
+      if not use_cxx:
+        options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
+
+      call = CXX if use_cxx else CC
+
+      # If user did not specify a default -std for C++ code, specify the emscripten default.
+      if options.default_cxx_std:
+        newargs = newargs + [options.default_cxx_std]
+
+      if options.emrun:
+        options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
+        options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
+        # emrun mode waits on program exit
+        shared.Settings.EXIT_RUNTIME = 1
+
+      if options.cpu_profiler:
+        options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
+
+      if options.memory_profiler:
+        options.post_js += open(shared.path_from_root('src', 'memoryprofiler.js')).read() + '\n'
+
+      if options.thread_profiler:
+        options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
+
+      if options.js_opts is None:
+        options.js_opts = options.opt_level >= 2
+
+      if options.llvm_opts is None:
+        options.llvm_opts = LLVM_OPT_LEVEL[options.opt_level]
+      elif type(options.llvm_opts) == int:
+        options.llvm_opts = ['-O%d' % options.llvm_opts]
+
+      if options.memory_init_file is None:
+        options.memory_init_file = options.opt_level >= 2
+
+      # TODO: support source maps with js_transform
+      if options.js_transform and use_source_map(options):
+        logger.warning('disabling source maps because a js transform is being done')
+        options.debug_level = 3
+
+      if DEBUG:
+        start_time = time.time() # done after parsing arguments, which might affect debug state
+
+      for i in range(len(newargs)):
+        if newargs[i] == '-s':
+          if is_minus_s_for_emcc(newargs, i):
+            key = newargs[i + 1]
+            # If not = is specified default to 1
+            if '=' not in key:
+              key += '=1'
+            settings_changes.append(key)
+            newargs[i] = newargs[i + 1] = ''
+            if key == 'WASM_BACKEND=1':
+              exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
+      newargs = [arg for arg in newargs if arg is not '']
+
+      settings_key_changes = set()
+      for s in settings_changes:
+        key, value = s.split('=', 1)
+        settings_key_changes.add(key)
+
+      # Find input files
+
+      # These three arrays are used to store arguments of different types for
+      # type-specific processing. In order to shuffle the arguments back together
+      # after processing, all of these arrays hold tuples (original_index, value).
+      # Note that the index part of the tuple can have a fractional part for input
+      # arguments that expand into multiple processed arguments, as in -Wl,-f1,-f2.
+      input_files = []
+      libs = []
+      link_flags = []
+
+      # All of the above arg lists entries contain indexes into the full argument
+      # list. In order to add extra implicit args (embind.cc, etc) below, we keep a
+      # counter for the next index that should be used.
+      next_arg_index = len(newargs)
+
+      has_source_inputs = False
+      has_header_inputs = False
+      lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
+                  shared.path_from_root('system', 'lib')]
+      for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
+                                    # right now we just assume that what is left contains no more |-x OPT| things
+        arg = newargs[i]
+
+        if i > 0:
+          prev = newargs[i - 1]
+          if prev in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
+                      '-Xpreprocessor', '-include', '-imacros', '-idirafter',
+                      '-iprefix', '-iwithprefix', '-iwithprefixbefore',
+                      '-isysroot', '-imultilib', '-A', '-isystem', '-iquote',
+                      '-install_name', '-compatibility_version',
+                      '-current_version', '-I', '-L', '-include-pch'):
+            continue # ignore this gcc-style argument
+
+        if os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS):
+          arg = os.path.realpath(arg)
+
+        if not arg.startswith('-'):
+          if not os.path.exists(arg):
+            exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
+
+          arg_ending = filename_type_ending(arg)
+          if arg_ending.endswith(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS) or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
             newargs[i] = ''
-            input_files.append((i, arg))
-            has_source_inputs = True
+            if arg_ending.endswith(SOURCE_ENDINGS):
+              input_files.append((i, arg))
+              has_source_inputs = True
+            elif arg_ending.endswith(HEADER_ENDINGS):
+              input_files.append((i, arg))
+              has_header_inputs = True
+            elif arg_ending.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg): # this should be bitcode, make sure it is valid
+              input_files.append((i, arg))
+            elif arg_ending.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
+              # if it's not, and it's a library, just add it to libs to find later
+              l = unsuffixed_basename(arg)
+              for prefix in LIB_PREFIXES:
+                if not prefix:
+                  continue
+                if l.startswith(prefix):
+                  l = l[len(prefix):]
+                  break
+              libs.append((i, l))
+              newargs[i] = ''
+            elif 'WASM_OBJECT_FILES=1' in settings_changes and shared.Building.is_wasm(arg):
+              input_files.append((i, arg))
+            else:
+              logger.warning(arg + ' is not valid LLVM bitcode')
+          elif arg_ending.endswith(STATICLIB_ENDINGS):
+            if not shared.Building.is_ar(arg):
+              if shared.Building.is_bitcode(arg):
+                message = arg + ': File has a suffix of a static library ' + str(STATICLIB_ENDINGS) + ', but instead is an LLVM bitcode file! When linking LLVM bitcode files, use one of the suffixes ' + str(BITCODE_ENDINGS)
+              else:
+                message = arg + ': Unknown format, not a static library!'
+              exit_with_error(message)
           else:
-            exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
-      elif arg.startswith('-L'):
-        lib_dirs.append(arg[2:])
-        newargs[i] = ''
-      elif arg.startswith('-l'):
-        libs.append((i, arg[2:]))
-        newargs[i] = ''
-      elif arg.startswith('-Wl,'):
-        # Multiple comma separated link flags can be specified. Create fake
-        # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
-        # (4, a), (4.25, b), (4.5, c), (4.75, d)
-        link_flags_to_add = arg.split(',')[1:]
-        for flag_index, flag in enumerate(link_flags_to_add):
-          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
-
-        newargs[i] = ''
-      elif arg == '-s':
-        # -s and some other compiler flags are normally passed onto the linker
-        # TODO(sbc): Pass this and other flags through when using lld
-        # link_flags.append((i, arg))
-        newargs[i] = ''
-
-    original_input_files = input_files[:]
-
-    newargs = [a for a in newargs if a is not '']
-
-    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
-    has_dash_c = '-c' in newargs
-    if has_dash_c:
-      assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
-      target = target_basename + '.o'
-      final_suffix = 'o'
-    if '-E' in newargs:
-      final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
-    if '-M' in newargs or '-MM' in newargs:
-      final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
-    final_ending = ('.' + final_suffix) if len(final_suffix) else ''
-
-    # target is now finalized, can finalize other _target s
-    js_target = unsuffixed(target) + '.js'
-
-    asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
-    wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
-    wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
-
-    if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
-      options.separate_asm = True
-      logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
-    if options.separate_asm:
-      shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
-
-    if 'EMCC_STRICT' in os.environ:
-      shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
-
-    # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
-    # command line already now.
-
-    def get_last_setting_change(setting):
-      return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
-
-    strict_cmdline = get_last_setting_change('STRICT')
-    if strict_cmdline:
-      shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
-
-    if shared.Settings.STRICT:
-      shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
-
-    error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
-    if error_on_missing_libraries_cmdline:
-      shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
-
-    settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
-
-    # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
-    # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
-    if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
-      def check(input_file):
-        if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
-          if not options.ignore_dynamic_linking:
-            logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
-          return False
-        else:
-          return True
-      input_files = [f for f in input_files if check(f[1])]
-
-    if len(input_files) == 0:
-      exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
-
-    newargs = CC_ADDITIONAL_ARGS + newargs
-
-    if options.separate_asm and final_suffix != 'html':
-      shared.WarningManager.warn('SEPARATE_ASM')
-
-    # Apply optimization level settings
-    shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
-
-    # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
-    # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
-    if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
-      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-
-    # Set ASM_JS default here so that we can override it from the command line.
-    shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
-
-    # Apply -s settings in newargs here (after optimization levels, so they can override them)
-    apply_settings(settings_changes)
-
-    shared.verify_settings()
-
-    # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
-    shared.reconfigure_cache()
-
-    # Note the exports the user requested
-    shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
-
-    if options.bind:
-      # If we are using embind and generating JS, now is the time to link in bind.cpp
-      if final_suffix in JS_CONTAINING_SUFFIXES:
-        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
-        next_arg_index += 1
-
-    # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
-    # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
-    if shared.Settings.ASSERTIONS:
-      shared.Settings.STACK_OVERFLOW_CHECK = 2
-
-    if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
-      logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
-      return 1
-
-    if not shared.Settings.STRICT:
-      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
-
-      # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
-      # This path is not available in Emscripten strict mode.
-      if shared.USE_EMSDK:
-        shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
-
-    # Use settings
-
-    try:
-      assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
-      assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
-      assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
-      assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
-      assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
-      assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
-    except Exception as e:
-      logger.error('Compiler settings error: {}'.format(e))
-      exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
-
-    assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
-
-    if options.debug_level > 1 and options.use_closure_compiler:
-      logger.warning('disabling closure because debug info was requested')
-      options.use_closure_compiler = False
-
-    assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
-
-    assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
-
-    if options.emrun:
-      shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
-
-    if options.use_closure_compiler:
-      shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
-      if not shared.check_closure_compiler():
-        exit_with_error('fatal: closure compiler is not configured correctly')
-      if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
-        shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
-        shared.Settings.ASM_JS = 2
-
-    if shared.Settings.MAIN_MODULE:
-      assert not shared.Settings.SIDE_MODULE
-      if shared.Settings.MAIN_MODULE != 2:
-        shared.Settings.INCLUDE_FULL_LIBRARY = 1
-    elif shared.Settings.SIDE_MODULE:
-      assert not shared.Settings.MAIN_MODULE
-      options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
-
-    if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
-      assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
-      if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
-        shared.Settings.LINKABLE = 1
-      shared.Settings.RELOCATABLE = 1
-      shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
-      assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
-      # shared modules need memory utilities to allocate their memory
-      shared.Settings.EXPORTED_RUNTIME_METHODS += [
-        'allocate',
-        'getMemory',
-      ]
-    if shared.Settings.USE_PTHREADS:
-      # These runtime methods are called from worker.js
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
-
-    if shared.Settings.MODULARIZE_INSTANCE:
-      shared.Settings.MODULARIZE = 1
-
-    if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-      shared.Settings.ALIASING_FUNCTION_POINTERS = 0
-
-    if shared.Settings.LEGACY_VM_SUPPORT:
-      # legacy vms don't have wasm
-      assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
-      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
-      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
-      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
-
-    # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
-    if shared.Settings.WASM:
-      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
-      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
-      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
-
-    if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
-      input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
-      next_arg_index += 1
-      shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
-      # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
-      newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
-
-    if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
-      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
-      newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
-      next_arg_index += 1
-      shared.Settings.FILESYSTEM = 0
-      shared.Settings.FETCH = 1
-      if not shared.Settings.USE_PTHREADS:
-        exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
-
-    if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
-      input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
-      next_arg_index += 1
-      options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
-
-    forced_stdlibs = []
-    if shared.Settings.DEMANGLE_SUPPORT:
-      shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
-      forced_stdlibs += ['libc++abi']
-
-    if not shared.Settings.ONLY_MY_CODE:
-      # Always need malloc and free to be kept alive and exported, for internal use and other modules
-      shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
-      if shared.Settings.WASM_BACKEND:
-        # setjmp/longjmp and exception handling JS code depends on this so we
-        # include it by default.  Should be elimiated by meta-DCE if unused.
-        shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
-
-    if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
-      exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
-
-    if shared.Settings.RELOCATABLE:
-      assert shared.Settings.GLOBAL_BASE < 1
-      if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
-        shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
-      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-      shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
-
-    if shared.Settings.EMTERPRETIFY:
-      shared.Settings.FINALIZE_ASM_JS = 0
-      # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
-      shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
-      shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
-      if not options.js_opts:
-        logger.debug('enabling js opts for EMTERPRETIFY')
-        options.js_opts = True
-      options.force_js_opts = True
-      if options.use_closure_compiler == 2:
-         exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
-      assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
-
-    if shared.Settings.DEAD_FUNCTIONS:
-      if not options.js_opts:
-        logger.debug('enabling js opts for DEAD_FUNCTIONS')
-        options.js_opts = True
-      options.force_js_opts = True
-
-    if options.proxy_to_worker:
-      shared.Settings.PROXY_TO_WORKER = 1
-
-    if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
-      if shared.Settings.NODERAWFS:
-        exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
-      # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
-      shared.Settings.FORCE_FILESYSTEM = 1
-
-    if options.proxy_to_worker or options.use_preload_plugins:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
-
-    if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
-      shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
-      # to flush streams on FS exit, we need to be able to call fflush
-      # we only include it if the runtime is exitable, or when ASSERTIONS
-      # (ASSERTIONS will check that streams do not need to be flushed,
-      # helping people see when they should have disabled NO_EXIT_RUNTIME)
-      if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
-
-    if shared.Settings.USE_PTHREADS:
-      if shared.Settings.USE_PTHREADS == 2:
-        exit_with_error('USE_PTHREADS=2 is not longer supported')
-      if shared.Settings.ALLOW_MEMORY_GROWTH:
-        exit_with_error('Memory growth is not yet supported with pthreads')
-      if shared.Settings.MODULARIZE:
-        # currently worker.js uses the global namespace, so it's setting of
-        # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
-        # modifications it performs.
-        exit_with_error('MODULARIZE is not yet supported with pthreads')
-      # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
-      shared.Settings.TEXTDECODER = 0
-      options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
-      newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
-      shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
-      # set location of worker.js
-      shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
-    else:
-      options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
-
-    if shared.Settings.FORCE_FILESYSTEM:
-      # when the filesystem is forced, we export by default methods that filesystem usage
-      # may need, including filesystem usage from standalone file packager output (i.e.
-      # file packages not built together with emcc, but that are loaded at runtime
-      # separately, and they need emcc's output to contain the support they need)
-      shared.Settings.EXPORTED_RUNTIME_METHODS += [
-        'FS_createFolder',
-        'FS_createPath',
-        'FS_createDataFile',
-        'FS_createPreloadedFile',
-        'FS_createLazyFile',
-        'FS_createLink',
-        'FS_createDevice',
-        'FS_unlink',
-        'getMemory',
-        'addRunDependency',
-        'removeRunDependency',
-      ]
-
-    if shared.Settings.USE_PTHREADS:
-      if shared.Settings.LINKABLE:
-        exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
-      if shared.Settings.SIDE_MODULE:
-        exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-      if shared.Settings.MAIN_MODULE:
-        exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-      if shared.Settings.EMTERPRETIFY:
-        exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
-      if shared.Settings.PROXY_TO_WORKER:
-        exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
-    else:
-      if shared.Settings.PROXY_TO_PTHREAD:
-        exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
-
-    if shared.Settings.OUTLINING_LIMIT:
-      if shared.Settings.WASM_BACKEND:
-        exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
-      if not options.js_opts:
-        logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
-        options.js_opts = True
-      options.force_js_opts = True
-
-    # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
-    if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
-      shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
-
-    if shared.Settings.WASM:
-      if not shared.Building.need_asm_js_file():
-        asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
-        misc_temp_files.note(asm_target)
-
-    if shared.Settings.WASM:
-      if shared.Settings.TOTAL_MEMORY % 65536 != 0:
-        exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
-    else:
-      if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
-        exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-      if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
-        exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
-    if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
-      exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
-    if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
-      exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
-    if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
-      exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
-
-    if shared.Settings.WASM_BACKEND:
-      options.js_opts = None
-
-      # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
-      # we run the optimizer during asm2wasm itself). use it, if not overridden
-      if 'BINARYEN_PASSES' not in settings_key_changes:
-        passes = []
-        if not shared.Settings.EXIT_RUNTIME:
-          passes += ['--no-exit-runtime']
-        if options.opt_level > 0 or options.shrink_level > 0:
-          passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
-        if options.debug_level < 3:
-          passes += ['--strip']
-        if passes:
-          shared.Settings.BINARYEN_PASSES = ','.join(passes)
-
-      # to bootstrap struct_info, we need binaryen
-      os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
-
-    if shared.Settings.WASM:
-      if shared.Settings.SINGLE_FILE:
-        # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
-        shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
-        shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
-        shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
-      else:
-        # set file locations, so that JS glue can find what it needs
-        shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
-        shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
-        shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
-
-      shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
-      shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
-      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
-        logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
-        shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
-      if shared.Settings.OUTLINING_LIMIT:
-        logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
-      # default precise-f32 to on, since it works well in wasm
-      # also always use f32s when asm.js is not in the picture
-      if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-        shared.Settings.PRECISE_F32 = 1
-      if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-        options.js_opts = None
-        logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
-      if options.use_closure_compiler == 2:
-        exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
-      # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
-      #  * if we also supported js mem inits we'd have 4 modes
-      #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
-      if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
-        exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
-      options.memory_init_file = True
-      # async compilation requires not interpreting (the interpreter modes needs sync input)
-      if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
-        # async compilation requires a swappable module - we swap it in when it's ready
-        shared.Settings.SWAPPABLE_ASM_MODULE = 1
-      else:
-        # if not wasm-only, we can't do async compilation as the build can run in other
-        # modes than wasm (like asm.js) which may not support an async step
-        shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
-        warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
-        if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
-          logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
-        elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
-          logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
-      # run safe-heap as a binaryen pass
-      if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
-        if shared.Settings.BINARYEN_PASSES:
-          shared.Settings.BINARYEN_PASSES += ','
-        shared.Settings.BINARYEN_PASSES += 'safe-heap'
-      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-        # emulated function pointer casts is emulated in wasm using a binaryen pass
-        if shared.Settings.BINARYEN_PASSES:
-          shared.Settings.BINARYEN_PASSES += ','
-        shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
-        # we also need emulated function pointers for that, as we need a single flat
-        # table, as is standard in wasm, and not asm.js split ones.
-        shared.Settings.EMULATED_FUNCTION_POINTERS = 1
-
-      # we will include the mem init data in the wasm, when we don't need the
-      # mem init file to be loadable by itself
-      shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                         'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
-                                         not shared.Settings.USE_PTHREADS
-
-      # wasm side modules have suffix .wasm
-      if shared.Settings.SIDE_MODULE and target.endswith('.js'):
-        logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
-
+            if has_fixed_language_mode:
+              newargs[i] = ''
+              input_files.append((i, arg))
+              has_source_inputs = True
+            else:
+              exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
+        elif arg.startswith('-L'):
+          lib_dirs.append(arg[2:])
+          newargs[i] = ''
+        elif arg.startswith('-l'):
+          libs.append((i, arg[2:]))
+          newargs[i] = ''
+        elif arg.startswith('-Wl,'):
+          # Multiple comma separated link flags can be specified. Create fake
+          # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
+          # (4, a), (4.25, b), (4.5, c), (4.75, d)
+          link_flags_to_add = arg.split(',')[1:]
+          for flag_index, flag in enumerate(link_flags_to_add):
+            link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+
+          newargs[i] = ''
+        elif arg == '-s':
+          # -s and some other compiler flags are normally passed onto the linker
+          # TODO(sbc): Pass this and other flags through when using lld
+          # link_flags.append((i, arg))
+          newargs[i] = ''
+
+      original_input_files = input_files[:]
+
+      newargs = [a for a in newargs if a is not '']
+
+      # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+      has_dash_c = '-c' in newargs
+      if has_dash_c:
+        assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
+        target = target_basename + '.o'
+        final_suffix = 'o'
+      if '-E' in newargs:
+        final_suffix = 'eout' # not bitcode, not js; but just result from preprocessing stage of the input file
+      if '-M' in newargs or '-MM' in newargs:
+        final_suffix = 'mout' # not bitcode, not js; but just dependency rule of the input file
+      final_ending = ('.' + final_suffix) if len(final_suffix) else ''
+
+      # target is now finalized, can finalize other _target s
+      js_target = unsuffixed(target) + '.js'
+
+      asm_target = unsuffixed(js_target) + '.asm.js' # might not be used, but if it is, this is the name
+      wasm_text_target = asm_target.replace('.asm.js', '.wast') # ditto, might not be used
+      wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
+
+      if final_suffix == 'html' and not options.separate_asm and 'PRECISE_F32=2' in settings_changes:
+        options.separate_asm = True
+        logger.warning('forcing separate asm output (--separate-asm), because -s PRECISE_F32=2 was passed.')
       if options.separate_asm:
-        exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
+        shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
 
-    # wasm outputs are only possible with a side wasm
-    if target.endswith(WASM_ENDINGS):
-      if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-        logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
+      if 'EMCC_STRICT' in os.environ:
+        shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
+
+      # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
+      # command line already now.
+
+      def get_last_setting_change(setting):
+        return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
+
+      strict_cmdline = get_last_setting_change('STRICT')
+      if strict_cmdline:
+        shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
+
+      if shared.Settings.STRICT:
+        shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
+
+      error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
+      if error_on_missing_libraries_cmdline:
+        shared.Settings.ERROR_ON_MISSING_LIBRARIES = int(error_on_missing_libraries_cmdline[len('ERROR_ON_MISSING_LIBRARIES='):])
+
+      settings_changes.append(system_js_libraries_setting_str(libs, lib_dirs, settings_changes, input_files))
+
+      # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
+      # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
+      if filename_type_suffix(target) not in JS_CONTAINING_SUFFIXES or options.ignore_dynamic_linking:
+        def check(input_file):
+          if filename_type_ending(input_file) in DYNAMICLIB_ENDINGS:
+            if not options.ignore_dynamic_linking:
+              logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
+            return False
+          else:
+            return True
+        input_files = [f for f in input_files if check(f[1])]
+
+      if len(input_files) == 0:
+        exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
+
+      newargs = CC_ADDITIONAL_ARGS + newargs
+
+      if options.separate_asm and final_suffix != 'html':
+        shared.WarningManager.warn('SEPARATE_ASM')
+
+      # Apply optimization level settings
+      shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
+
+      # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
+      # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
+      if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
+        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+
+      # Set ASM_JS default here so that we can override it from the command line.
+      shared.Settings.ASM_JS = 1 if options.opt_level > 0 else 2
+
+      # Apply -s settings in newargs here (after optimization levels, so they can override them)
+      apply_settings(settings_changes)
+
+      shared.verify_settings()
+
+      # Reconfigure the cache now that settings have been applied (e.g. WASM_OBJECT_FILES)
+      shared.reconfigure_cache()
+
+      # Note the exports the user requested
+      shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
+
+      if options.bind:
+        # If we are using embind and generating JS, now is the time to link in bind.cpp
+        if final_suffix in JS_CONTAINING_SUFFIXES:
+          input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))
+          next_arg_index += 1
+
+      # -s ASSERTIONS=1 implies the heaviest stack overflow check mode. Set the implication here explicitly to avoid having to
+      # do preprocessor "#if defined(ASSERTIONS) || defined(STACK_OVERFLOW_CHECK)" in .js files, which is not supported.
+      if shared.Settings.ASSERTIONS:
+        shared.Settings.STACK_OVERFLOW_CHECK = 2
+
+      if shared.Settings.WASM_OBJECT_FILES and not shared.Settings.WASM_BACKEND:
+        logger.error('WASM_OBJECT_FILES can only be used with wasm backend')
         return 1
 
-    if shared.Settings.EVAL_CTORS:
-      if not shared.Settings.WASM:
-        # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
-        # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
-        shared.Settings.RUNNING_JS_OPTS = 1
+      if not shared.Settings.STRICT:
+        # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+        shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
+
+        # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
+        # This path is not available in Emscripten strict mode.
+        if shared.USE_EMSDK:
+          shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
+
+      # Use settings
+
+      try:
+        assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
+        assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
+        assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
+        assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
+        assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
+        assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
+      except Exception as e:
+        logger.error('Compiler settings error: {}'.format(e))
+        exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
+
+      assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
+
+      if options.debug_level > 1 and options.use_closure_compiler:
+        logger.warning('disabling closure because debug info was requested')
+        options.use_closure_compiler = False
+
+      assert not (shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE), 'cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time'
+
+      assert not (not shared.Settings.DYNAMIC_EXECUTION and options.use_closure_compiler), 'cannot have both NO_DYNAMIC_EXECUTION and closure compiler enabled at the same time'
+
+      if options.emrun:
+        shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+
+      if options.use_closure_compiler:
+        shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
+        if not shared.check_closure_compiler():
+          exit_with_error('fatal: closure compiler is not configured correctly')
+        if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1:
+          shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
+          shared.Settings.ASM_JS = 2
+
+      if shared.Settings.MAIN_MODULE:
+        assert not shared.Settings.SIDE_MODULE
+        if shared.Settings.MAIN_MODULE != 2:
+          shared.Settings.INCLUDE_FULL_LIBRARY = 1
+      elif shared.Settings.SIDE_MODULE:
+        assert not shared.Settings.MAIN_MODULE
+        options.memory_init_file = False # memory init file is not supported with asm.js side modules, must be executable synchronously (for dlopen)
+
+      if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
+        assert shared.Settings.ASM_JS, 'module linking requires asm.js output (-s ASM_JS=1)'
+        if shared.Settings.MAIN_MODULE != 2 and shared.Settings.SIDE_MODULE != 2:
+          shared.Settings.LINKABLE = 1
+        shared.Settings.RELOCATABLE = 1
+        shared.Settings.PRECISE_I64_MATH = 1 # other might use precise math, we need to be able to print it
+        assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
+        # shared modules need memory utilities to allocate their memory
+        shared.Settings.EXPORTED_RUNTIME_METHODS += [
+          'allocate',
+          'getMemory',
+        ]
+      if shared.Settings.USE_PTHREADS:
+        # These runtime methods are called from worker.js
+        shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
+
+      if shared.Settings.MODULARIZE_INSTANCE:
+        shared.Settings.MODULARIZE = 1
+
+      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+        shared.Settings.ALIASING_FUNCTION_POINTERS = 0
+
+      if shared.Settings.LEGACY_VM_SUPPORT:
+        # legacy vms don't have wasm
+        assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
+        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
+        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
+        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
+
+      # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
+      if shared.Settings.WASM:
+        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
+        shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
+        shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
+
+      if shared.Settings.STB_IMAGE and final_suffix in JS_CONTAINING_SUFFIXES:
+        input_files.append((next_arg_index, shared.path_from_root('third_party', 'stb_image.c')))
+        next_arg_index += 1
+        shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
+        # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
+        newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
+
+      if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_SUFFIXES:
+        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'asmfs.cpp')))
+        newargs.append('-D__EMSCRIPTEN_ASMFS__=1')
+        next_arg_index += 1
+        shared.Settings.FILESYSTEM = 0
+        shared.Settings.FETCH = 1
+        if not shared.Settings.USE_PTHREADS:
+          exit_with_error('-s ASMFS=1 requires -s USE_PTHREADS=1 to be set!')
+
+      if shared.Settings.FETCH and final_suffix in JS_CONTAINING_SUFFIXES:
+        input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
+        next_arg_index += 1
+        options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
+
+      forced_stdlibs = []
+      if shared.Settings.DEMANGLE_SUPPORT:
+        shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
+        forced_stdlibs += ['libc++abi']
+
+      if not shared.Settings.ONLY_MY_CODE:
+        # Always need malloc and free to be kept alive and exported, for internal use and other modules
+        shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
+        if shared.Settings.WASM_BACKEND:
+          # setjmp/longjmp and exception handling JS code depends on this so we
+          # include it by default.  Should be elimiated by meta-DCE if unused.
+          shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
+
+      if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
+        exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
+
+      if shared.Settings.RELOCATABLE:
+        assert shared.Settings.GLOBAL_BASE < 1
+        if 'EMULATED_FUNCTION_POINTERS' not in settings_key_changes:
+          shared.Settings.EMULATED_FUNCTION_POINTERS = 2 # by default, use optimized function pointer emulation
+        shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+        shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
+
+      if shared.Settings.EMTERPRETIFY:
+        shared.Settings.FINALIZE_ASM_JS = 0
+        # shared.Settings.GLOBAL_BASE = 8*256 # keep enough space at the bottom for a full stack frame, for z-interpreter
+        shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting
+        shared.Settings.EXPORTED_FUNCTIONS += ['emterpret']
+        if not options.js_opts:
+          logger.debug('enabling js opts for EMTERPRETIFY')
+          options.js_opts = True
+        options.force_js_opts = True
+        if options.use_closure_compiler == 2:
+           exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
+        assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
+
+      if shared.Settings.DEAD_FUNCTIONS:
+        if not options.js_opts:
+          logger.debug('enabling js opts for DEAD_FUNCTIONS')
+          options.js_opts = True
+        options.force_js_opts = True
+
+      if options.proxy_to_worker:
+        shared.Settings.PROXY_TO_WORKER = 1
+
+      if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
+        if shared.Settings.NODERAWFS:
+          exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
+        # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
+        shared.Settings.FORCE_FILESYSTEM = 1
+
+      if options.proxy_to_worker or options.use_preload_plugins:
+        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
+
+      if shared.Settings.FILESYSTEM and not shared.Settings.ONLY_MY_CODE:
+        shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
+        # to flush streams on FS exit, we need to be able to call fflush
+        # we only include it if the runtime is exitable, or when ASSERTIONS
+        # (ASSERTIONS will check that streams do not need to be flushed,
+        # helping people see when they should have disabled NO_EXIT_RUNTIME)
+        if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
+          shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
+
+      if shared.Settings.USE_PTHREADS:
+        if shared.Settings.USE_PTHREADS == 2:
+          exit_with_error('USE_PTHREADS=2 is not longer supported')
+        if shared.Settings.ALLOW_MEMORY_GROWTH:
+          exit_with_error('Memory growth is not yet supported with pthreads')
+        if shared.Settings.MODULARIZE:
+          # currently worker.js uses the global namespace, so it's setting of
+          # ENVIRONMENT_IS_PTHREAD is not picked up, in addition to all the other
+          # modifications it performs.
+          exit_with_error('MODULARIZE is not yet supported with pthreads')
+        # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
+        shared.Settings.TEXTDECODER = 0
+        options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
+        newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
+        shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
+        # set location of worker.js
+        shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
       else:
-        if 'interpret' in shared.Settings.BINARYEN_METHOD:
-          logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
-          shared.Settings.EVAL_CTORS = 0
+        options.js_libraries.append(shared.path_from_root('src', 'library_pthread_stub.js'))
 
-    # memory growth does not work in dynamic linking, except for wasm
-    if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
-      assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
+      if shared.Settings.FORCE_FILESYSTEM:
+        # when the filesystem is forced, we export by default methods that filesystem usage
+        # may need, including filesystem usage from standalone file packager output (i.e.
+        # file packages not built together with emcc, but that are loaded at runtime
+        # separately, and they need emcc's output to contain the support they need)
+        shared.Settings.EXPORTED_RUNTIME_METHODS += [
+          'FS_createFolder',
+          'FS_createPath',
+          'FS_createDataFile',
+          'FS_createPreloadedFile',
+          'FS_createLazyFile',
+          'FS_createLink',
+          'FS_createDevice',
+          'FS_unlink',
+          'getMemory',
+          'addRunDependency',
+          'removeRunDependency',
+        ]
 
-    if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
-      # this is an issue in asm.js, but not wasm
-      if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
-        shared.WarningManager.warn('ALMOST_ASM')
-        shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
-
-    # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
-    if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
-      if not options.js_opts:
-        logger.debug('enabling js opts for SAFE_HEAP')
-        options.js_opts = True
-      options.force_js_opts = True
-
-    if options.js_opts:
-      shared.Settings.RUNNING_JS_OPTS = 1
-
-    if shared.Settings.CYBERDWARF:
-      newargs.append('-g')
-      options.debug_level = max(options.debug_level, 2)
-      shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
-      options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
-      options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
-
-    if options.tracing:
-      if shared.Settings.ALLOW_MEMORY_GROWTH:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
-
-    if shared.Settings.ONLY_MY_CODE:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
-      options.separate_asm = True
-      shared.Settings.FINALIZE_ASM_JS = False
-
-    if shared.Settings.GLOBAL_BASE < 0:
-      shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
-
-    if shared.Settings.WASM_BACKEND:
-      if shared.Settings.SIMD:
-        newargs.append('-msimd128')
-    else:
-      # We leave the -O option in place so that the clang front-end runs in that
-      # optimization mode, but we disable the actual optimization passes, as we'll
-      # run them separately.
-      if options.opt_level > 0:
-        newargs.append('-mllvm')
-        newargs.append('-disable-llvm-optzns')
-
-    if not shared.Settings.LEGALIZE_JS_FFI:
-      assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
-
-    shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
-    shared.Settings.OPT_LEVEL = options.opt_level
-    shared.Settings.DEBUG_LEVEL = options.debug_level
-    shared.Settings.PROFILING_FUNCS = options.profiling_funcs
-    shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
-
-    ## Compile source code to bitcode
-
-    logger.debug('compiling to bitcode')
-
-    temp_files = []
-
-  # exit block 'parse arguments and setup'
-  log_time('parse arguments and setup')
-
-  with ToolchainProfiler.profile_block('bitcodeize inputs'):
-    # Precompiled headers support
-    if has_header_inputs:
-      headers = [header for _, header in input_files]
-      for header in headers:
-        assert header.endswith(HEADER_ENDINGS), 'if you have one header input, we assume you want to precompile headers, and cannot have source files or other inputs as well: ' + str(headers) + ' : ' + header
-      args = newargs + shared.EMSDK_CXX_OPTS + headers
-      if specified_target:
-        args += ['-o', specified_target]
-      args = system_libs.process_args(args, shared.Settings)
-      logger.debug("running (for precompiled headers): " + call + ' ' + ' '.join(args))
-      return run_process([call] + args, check=False).returncode
-
-    def get_bitcode_file(input_file):
-      if final_suffix not in JS_CONTAINING_SUFFIXES:
-        # no need for a temp file, just emit to the right place
-        if len(input_files) == 1:
-          # can just emit directly to the target
-          if specified_target:
-            if specified_target.endswith('/') or specified_target.endswith('\\') or os.path.isdir(specified_target):
-              return os.path.join(specified_target, os.path.basename(unsuffixed(input_file))) + options.default_object_extension
-            return specified_target
-          return unsuffixed(input_file) + final_ending
-        else:
-          if has_dash_c:
-            return unsuffixed(input_file) + options.default_object_extension
-      return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
-
-    # Request LLVM debug info if explicitly specified, or building bitcode with -g, or if building a source all the way to JS with -g
-    if use_source_map(options) or ((final_suffix not in JS_CONTAINING_SUFFIXES or (has_source_inputs and final_suffix in JS_CONTAINING_SUFFIXES)) and options.requested_debug == '-g'):
-      # do not save llvm debug info if js optimizer will wipe it out anyhow (but if source maps are used, keep it)
-      if use_source_map(options) or not (final_suffix in JS_CONTAINING_SUFFIXES and options.js_opts):
-        newargs.append('-g') # preserve LLVM debug info
-        options.debug_level = 4
-        shared.Settings.DEBUG_LEVEL = 4
-
-    # Bitcode args generation code
-    def get_clang_args(input_files):
-      file_ending = filename_type_ending(input_files[0])
-      args = [call] + newargs + input_files
-      if file_ending.endswith(CXX_ENDINGS):
-        args += shared.EMSDK_CXX_OPTS
-      if not shared.Building.can_inline():
-        args.append('-fno-inline-functions')
-      # For fastcomp backend, no LLVM IR functions should ever be annotated
-      # 'optnone', because that would skip running the SimplifyCFG pass on
-      # them, which is required to always run to clean up LandingPadInst
-      # instructions that are not needed.
-      if not shared.Settings.WASM_BACKEND:
-        args += ['-Xclang', '-disable-O0-optnone']
-      args = system_libs.process_args(args, shared.Settings)
-      return args
-
-    # -E preprocessor-only support
-    if '-E' in newargs or '-M' in newargs or '-MM' in newargs:
-      input_files = [x[1] for x in input_files]
-      cmd = get_clang_args(input_files)
-      if specified_target:
-        cmd += ['-o', specified_target]
-      # Do not compile, but just output the result from preprocessing stage or
-      # output the dependency rule. Warning: clang and gcc behave differently
-      # with -MF! (clang seems to not recognize it)
-      logger.debug(('just preprocessor ' if '-E' in newargs else 'just dependencies: ') + ' '.join(cmd))
-      return run_process(cmd, check=False).returncode
-
-    def compile_source_file(i, input_file):
-      logger.debug('compiling source file: ' + input_file)
-      output_file = get_bitcode_file(input_file)
-      temp_files.append((i, output_file))
-      args = get_clang_args([input_file]) + ['-c', '-o', output_file]
-      if shared.Settings.WASM_OBJECT_FILES:
-        for a in shared.Building.llvm_backend_args():
-          args += ['-mllvm', a]
+      if shared.Settings.USE_PTHREADS:
+        if shared.Settings.LINKABLE:
+          exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
+        if shared.Settings.SIDE_MODULE:
+          exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+        if shared.Settings.MAIN_MODULE:
+          exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+        if shared.Settings.EMTERPRETIFY:
+          exit_with_error('-s EMTERPRETIFY=1 is not supported with -s USE_PTHREADS>0!')
+        if shared.Settings.PROXY_TO_WORKER:
+          exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
       else:
-        args.append('-emit-llvm')
-      logger.debug("running: " + ' '.join(shared.Building.doublequote_spaces(args))) # NOTE: Printing this line here in this specific format is important, it is parsed to implement the "emcc --cflags" command
-      if run_process(args, check=False).returncode != 0:
-        exit_with_error('compiler frontend failed to generate LLVM bitcode, halting')
-      assert(os.path.exists(output_file))
+        if shared.Settings.PROXY_TO_PTHREAD:
+          exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
-    # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
-    for i, input_file in input_files:
-      file_ending = filename_type_ending(input_file)
-      if file_ending.endswith(SOURCE_ENDINGS):
-        compile_source_file(i, input_file)
-      else: # bitcode
-        if file_ending.endswith(BITCODE_ENDINGS):
-          logger.debug('using bitcode file: ' + input_file)
-          temp_files.append((i, input_file))
-        elif file_ending.endswith(DYNAMICLIB_ENDINGS) or shared.Building.is_ar(input_file):
-          logger.debug('using library file: ' + input_file)
-          temp_files.append((i, input_file))
-        elif file_ending.endswith(ASSEMBLY_ENDINGS):
-          if not LEAVE_INPUTS_RAW:
-            logger.debug('assembling assembly file: ' + input_file)
-            temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
-            shared.Building.llvm_as(input_file, temp_file)
-            temp_files.append((i, temp_file))
-        else:
-          if has_fixed_language_mode:
-            compile_source_file(i, input_file)
-          else:
-            exit_with_error(input_file + ': Unknown file suffix when compiling to LLVM bitcode!')
+      if shared.Settings.OUTLINING_LIMIT:
+        if shared.Settings.WASM_BACKEND:
+          exit_with_error('OUTLINING_LIMIT is not compatible with the LLVM wasm backend')
+        if not options.js_opts:
+          logger.debug('enabling js opts as optional functionality implemented as a js opt was requested')
+          options.js_opts = True
+        options.force_js_opts = True
 
-  # exit block 'bitcodeize inputs'
-  log_time('bitcodeize inputs')
+      # Enable minification of asm.js imports on -O1 and higher if -g1 or lower is used.
+      if options.opt_level >= 1 and options.debug_level < 2 and not shared.Settings.WASM:
+        shared.Settings.MINIFY_ASMJS_IMPORT_NAMES = 1
 
-  with ToolchainProfiler.profile_block('process inputs'):
-    if not LEAVE_INPUTS_RAW and not shared.Settings.WASM_BACKEND:
-      assert len(temp_files) == len(input_files)
+      if shared.Settings.WASM:
+        if not shared.Building.need_asm_js_file():
+          asm_target = asm_target.replace('.asm.js', '.temp.asm.js')
+          misc_temp_files.note(asm_target)
 
-      # Optimize source files
-      if optimizing(options.llvm_opts):
-        for pos, (_, input_file) in enumerate(input_files):
-          file_ending = filename_type_ending(input_file)
-          if file_ending.endswith(SOURCE_ENDINGS):
-            temp_file = temp_files[pos][1]
-            logger.debug('optimizing %s', input_file)
-            # if DEBUG:
-            #   shutil.copyfile(temp_file, os.path.join(shared.configuration.CANONICAL_TEMP_DIR, 'to_opt.bc')) # useful when LLVM opt aborts
-            new_temp_file = in_temp(unsuffixed(uniquename(temp_file)) + '.o')
-            # after optimizing, lower intrinsics to libc calls so that our linking code
-            # will find them (otherwise, llvm.cos.f32() will not link in cosf(), and
-            # we end up calling out to JS for Math.cos).
-            opts = options.llvm_opts + ['-lower-non-em-intrinsics']
-            shared.Building.llvm_opt(temp_file, opts, new_temp_file)
-            temp_files[pos] = (temp_files[pos][0], new_temp_file)
-
-    # Decide what we will link
-    stop_at_bitcode = final_suffix not in EXECUTABLE_SUFFIXES
-
-    if stop_at_bitcode or not shared.Settings.WASM_BACKEND:
-      # Filter link flags, keeping only those that shared.Building.link knows
-      # how to deal with.  We currently can't handle flags with options (like
-      # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
-      # flag).
-      link_flags = [f for f in link_flags if f[1] in SUPPORTED_LINKER_FLAGS]
-
-    linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
-
-    # If we were just asked to generate bitcode, stop there
-    if stop_at_bitcode:
-      if not specified_target:
-        assert len(temp_files) == len(input_files)
-        for tempf, inputf in zip(temp_files, input_files):
-          safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_ending)
+      if shared.Settings.WASM:
+        if shared.Settings.TOTAL_MEMORY % 65536 != 0:
+          exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
       else:
-        if len(input_files) == 1:
-          input_file = input_files[0][1]
-          temp_file = temp_files[0][1]
-          bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_ending
-          if temp_file != input_file:
-            safe_move(temp_file, bitcode_target)
-          else:
-            shutil.copyfile(temp_file, bitcode_target)
-          temp_output_base = unsuffixed(temp_file)
-          if os.path.exists(temp_output_base + '.d'):
-            # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
-            # adjusting the target name away from the temporary file name to the specified target.
-            # It will be deleted with the rest of the temporary directory.
-            deps = open(temp_output_base + '.d').read()
-            deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
-            with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
-              out_dep.write(deps)
-        else:
-          assert len(original_input_files) == 1 or not has_dash_c, 'fatal error: cannot specify -o with -c with multiple files' + str(sys.argv) + ':' + str(original_input_files)
-          # We have a specified target (-o <target>), which is not JavaScript or HTML, and
-          # we have multiple files: Link them
-          logger.debug('link: ' + str(linker_inputs) + specified_target)
-          # Sort arg tuples and pass the extracted values to link.
-          shared.Building.link(linker_inputs, specified_target)
-      logger.debug('stopping at bitcode')
-      if shared.Settings.SIDE_MODULE:
-        exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting LLVM bitcode. That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an LLVM bitcode file, which you should then compile to .wasm or .js with SIDE_MODULE.')
-      if final_suffix.lower() in ['so', 'dylib', 'dll']:
-        logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an LLVM bitcode file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a file with LLVM bitcode, \'.bc\', which would avoid this warning.)')
-      return 0
+        if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
+          exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+        if shared.Settings.TOTAL_MEMORY % (16 * 1024 * 1024) != 0:
+          exit_with_error('For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))
+      if shared.Settings.TOTAL_MEMORY < shared.Settings.TOTAL_STACK:
+        exit_with_error('TOTAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.TOTAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
+      if shared.Settings.WASM_MEM_MAX != -1 and shared.Settings.WASM_MEM_MAX % 65536 != 0:
+        exit_with_error('WASM_MEM_MAX must be a multiple of 64KB, was ' + str(shared.Settings.WASM_MEM_MAX))
+      if shared.Settings.USE_PTHREADS and shared.Settings.WASM and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.WASM_MEM_MAX == -1:
+        exit_with_error('If pthreads and memory growth are enabled, WASM_MEM_MAX must be set')
 
-  # exit block 'process inputs'
-  log_time('process inputs')
-
-  ## Continue on to create JavaScript
-
-  with ToolchainProfiler.profile_block('calculate system libraries'):
-    logger.debug('will generate JavaScript')
-
-    extra_files_to_link = []
-
-    # link in ports and system libraries, if necessary
-    if not LEAVE_INPUTS_RAW and \
-       not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
-       not shared.Settings.ONLY_MY_CODE and \
-       not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
-      extra_files_to_link = system_libs.get_ports(shared.Settings)
-      extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
-
-  # exit block 'calculate system libraries'
-  log_time('calculate system libraries')
-
-  def dedup_list(lst):
-    rtn = []
-    for item in lst:
-      if item not in rtn:
-        rtn.append(item)
-    return rtn
-
-  # Make a final pass over shared.Settings.EXPORTED_FUNCTIONS to remove any
-  # duplication between functions added by the driver/libraries and function
-  # specified by the user
-  shared.Settings.EXPORTED_FUNCTIONS = dedup_list(shared.Settings.EXPORTED_FUNCTIONS)
-
-  with ToolchainProfiler.profile_block('link'):
-    # final will be an array if linking is deferred, otherwise a normal string.
-    if shared.Settings.WASM_BACKEND:
-      DEFAULT_FINAL = in_temp(target_basename + '.wasm')
-    else:
-      DEFAULT_FINAL = in_temp(target_basename + '.bc')
-
-    def get_final():
-      global final
-      if isinstance(final, list):
-        final = DEFAULT_FINAL
-      return final
-
-    # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
-    linker_inputs += extra_files_to_link
-    perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
-    if not perform_link and not LEAVE_INPUTS_RAW:
-      is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
-      is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
-      is_ar = shared.Building.is_ar(temp_files[0][1])
-      perform_link = not (is_bc or is_dylib) and is_ar
-    if perform_link:
-      logger.debug('linking: ' + str(linker_inputs))
-      # force archive contents to all be included, if just archives, or if linking shared modules
-      force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
-
-      # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
-      # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
-      # TODO: we could check if this is a fastcomp build, and still speed things up here
-      just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
       if shared.Settings.WASM_BACKEND:
-        # If LTO is enabled then use the -O opt level as the LTO level
-        if options.llvm_lto:
-          lto_level = options.opt_level
-        else:
-          lto_level = 0
-        final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts, lto_level)
-      else:
-        final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
-    else:
-      logger.debug('skipping linking: ' + str(linker_inputs))
-      if not LEAVE_INPUTS_RAW:
-        _, temp_file = temp_files[0]
-        _, input_file = input_files[0]
-        final = in_temp(target_basename + '.bc')
-        if temp_file != input_file:
-          shutil.move(temp_file, final)
-        else:
-          shutil.copyfile(temp_file, final)
-      else:
-        _, input_file = input_files[0]
-        final = in_temp(input_file)
-        shutil.copyfile(input_file, final)
+        options.js_opts = None
 
-  # exit block 'link'
-  log_time('link')
+        # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
+        # we run the optimizer during asm2wasm itself). use it, if not overridden
+        if 'BINARYEN_PASSES' not in settings_key_changes:
+          passes = []
+          if not shared.Settings.EXIT_RUNTIME:
+            passes += ['--no-exit-runtime']
+          if options.opt_level > 0 or options.shrink_level > 0:
+            passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
+          if options.debug_level < 3:
+            passes += ['--strip']
+          if passes:
+            shared.Settings.BINARYEN_PASSES = ','.join(passes)
 
-  if not shared.Settings.WASM_BACKEND:
-    with ToolchainProfiler.profile_block('post-link'):
-      if DEBUG:
-        logger.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
+        # to bootstrap struct_info, we need binaryen
+        os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
+
+      if shared.Settings.WASM:
+        if shared.Settings.SINGLE_FILE:
+          # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
+          shared.Settings.WASM_TEXT_FILE = shared.FilenameReplacementStrings.WASM_TEXT_FILE
+          shared.Settings.WASM_BINARY_FILE = shared.FilenameReplacementStrings.WASM_BINARY_FILE
+          shared.Settings.ASMJS_CODE_FILE = shared.FilenameReplacementStrings.ASMJS_CODE_FILE
+        else:
+          # set file locations, so that JS glue can find what it needs
+          shared.Settings.WASM_TEXT_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_text_target))
+          shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(wasm_binary_target))
+          shared.Settings.ASMJS_CODE_FILE = shared.JS.escape_for_js_string(os.path.basename(asm_target))
+
+        shared.Settings.ASM_JS = 2 # when targeting wasm, we use a wasm Memory, but that is not compatible with asm.js opts
+        shared.Settings.GLOBAL_BASE = 1024 # leave some room for mapping global vars
+        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS:
+          logger.warning('for wasm there is no need to set ELIMINATE_DUPLICATE_FUNCTIONS, the binaryen optimizer does it automatically')
+          shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS = 0
+        if shared.Settings.OUTLINING_LIMIT:
+          logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
+        # default precise-f32 to on, since it works well in wasm
+        # also always use f32s when asm.js is not in the picture
+        if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+          shared.Settings.PRECISE_F32 = 1
+        if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+          options.js_opts = None
+          logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
+        if options.use_closure_compiler == 2:
+          exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
+        # for simplicity, we always have a mem init file, which may also be imported into the wasm module.
+        #  * if we also supported js mem inits we'd have 4 modes
+        #  * and js mem inits are useful for avoiding a side file, but the wasm module avoids that anyhow
+        if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
+          exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
+        options.memory_init_file = True
+        # async compilation requires not interpreting (the interpreter modes needs sync input)
+        if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
+          # async compilation requires a swappable module - we swap it in when it's ready
+          shared.Settings.SWAPPABLE_ASM_MODULE = 1
+        else:
+          # if not wasm-only, we can't do async compilation as the build can run in other
+          # modes than wasm (like asm.js) which may not support an async step
+          shared.Settings.BINARYEN_ASYNC_COMPILATION = 0
+          warning = 'This will reduce performance and compatibility (some browsers limit synchronous compilation), see http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#codegen-effects'
+          if 'BINARYEN_ASYNC_COMPILATION=1' in settings_changes:
+            logger.warning('BINARYEN_ASYNC_COMPILATION requested, but disabled because of user options. ' + warning)
+          elif 'BINARYEN_ASYNC_COMPILATION=0' not in settings_changes:
+            logger.warning('BINARYEN_ASYNC_COMPILATION disabled due to user options. ' + warning)
+        # run safe-heap as a binaryen pass
+        if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
+          if shared.Settings.BINARYEN_PASSES:
+            shared.Settings.BINARYEN_PASSES += ','
+          shared.Settings.BINARYEN_PASSES += 'safe-heap'
+        if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+          # emulated function pointer casts is emulated in wasm using a binaryen pass
+          if shared.Settings.BINARYEN_PASSES:
+            shared.Settings.BINARYEN_PASSES += ','
+          shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
+          # we also need emulated function pointers for that, as we need a single flat
+          # table, as is standard in wasm, and not asm.js split ones.
+          shared.Settings.EMULATED_FUNCTION_POINTERS = 1
+
+        # we will include the mem init data in the wasm, when we don't need the
+        # mem init file to be loadable by itself
+        shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
+                                           'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
+                                           not shared.Settings.USE_PTHREADS
+
+        # wasm side modules have suffix .wasm
+        if shared.Settings.SIDE_MODULE and target.endswith('.js'):
+          logger.warning('output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
+
+        if options.separate_asm:
+          exit_with_error('cannot --separate-asm when emitting wasm, since not emitting asm.js')
+
+      # wasm outputs are only possible with a side wasm
+      if target.endswith(WASM_ENDINGS):
+        if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
+          logger.warning('output file "%s" has a wasm suffix, but we cannot emit wasm by itself, except as a dynamic library (see SIDE_MODULE option). specify an output file with suffix .js or .html, and a wasm file will be created on the side' % target)
+          return 1
+
+      if shared.Settings.EVAL_CTORS:
+        if not shared.Settings.WASM:
+          # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
+          # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
+          shared.Settings.RUNNING_JS_OPTS = 1
+        else:
+          if 'interpret' in shared.Settings.BINARYEN_METHOD:
+            logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
+            shared.Settings.EVAL_CTORS = 0
+
+      # memory growth does not work in dynamic linking, except for wasm
+      if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
+        assert not shared.Settings.ALLOW_MEMORY_GROWTH, 'memory growth is not supported with shared asm.js modules'
+
+      if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
+        # this is an issue in asm.js, but not wasm
+        if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
+          shared.WarningManager.warn('ALMOST_ASM')
+          shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
+
+      # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
+      if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
+        if not options.js_opts:
+          logger.debug('enabling js opts for SAFE_HEAP')
+          options.js_opts = True
+        options.force_js_opts = True
+
+      if options.js_opts:
+        shared.Settings.RUNNING_JS_OPTS = 1
+
+      if shared.Settings.CYBERDWARF:
+        newargs.append('-g')
+        options.debug_level = max(options.debug_level, 2)
+        shared.Settings.BUNDLED_CD_DEBUG_FILE = target + ".cd"
+        options.js_libraries.append(shared.path_from_root('src', 'library_cyberdwarf.js'))
+        options.js_libraries.append(shared.path_from_root('src', 'library_debugger_toolkit.js'))
+
+      if options.tracing:
+        if shared.Settings.ALLOW_MEMORY_GROWTH:
+          shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
+
+      if shared.Settings.ONLY_MY_CODE:
+        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+        options.separate_asm = True
+        shared.Settings.FINALIZE_ASM_JS = False
+
+      if shared.Settings.GLOBAL_BASE < 0:
+        shared.Settings.GLOBAL_BASE = 8 # default if nothing else sets it
+
+      if shared.Settings.WASM_BACKEND:
+        if shared.Settings.SIMD:
+          newargs.append('-msimd128')
+      else:
+        # We leave the -O option in place so that the clang front-end runs in that
+        # optimization mode, but we disable the actual optimization passes, as we'll
+        # run them separately.
+        if options.opt_level > 0:
+          newargs.append('-mllvm')
+          newargs.append('-disable-llvm-optzns')
+
+      if not shared.Settings.LEGALIZE_JS_FFI:
+        assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+
+      shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
+      shared.Settings.OPT_LEVEL = options.opt_level
+      shared.Settings.DEBUG_LEVEL = options.debug_level
+      shared.Settings.PROFILING_FUNCS = options.profiling_funcs
+      shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
+
+      ## Compile source code to bitcode
+
+      logger.debug('compiling to bitcode')
+
+      temp_files = []
+
+    # exit block 'parse arguments and setup'
+    log_time('parse arguments and setup')
+
+    with ToolchainProfiler.profile_block('bitcodeize inputs'):
+      # Precompiled headers support
+      if has_header_inputs:
+        headers = [header for _, header in input_files]
+        for header in headers:
+          assert header.endswith(HEADER_ENDINGS), 'if you have one header input, we assume you want to precompile headers, and cannot have source files or other inputs as well: ' + str(headers) + ' : ' + header
+        args = newargs + shared.EMSDK_CXX_OPTS + headers
+        if specified_target:
+          args += ['-o', specified_target]
+        args = system_libs.process_args(args, shared.Settings)
+        logger.debug("running (for precompiled headers): " + call + ' ' + ' '.join(args))
+        return run_process([call] + args, check=False).returncode
+
+      def get_bitcode_file(input_file):
+        if final_suffix not in JS_CONTAINING_SUFFIXES:
+          # no need for a temp file, just emit to the right place
+          if len(input_files) == 1:
+            # can just emit directly to the target
+            if specified_target:
+              if specified_target.endswith('/') or specified_target.endswith('\\') or os.path.isdir(specified_target):
+                return os.path.join(specified_target, os.path.basename(unsuffixed(input_file))) + options.default_object_extension
+              return specified_target
+            return unsuffixed(input_file) + final_ending
+          else:
+            if has_dash_c:
+              return unsuffixed(input_file) + options.default_object_extension
+        return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
+
+      # Request LLVM debug info if explicitly specified, or building bitcode with -g, or if building a source all the way to JS with -g
+      if use_source_map(options) or ((final_suffix not in JS_CONTAINING_SUFFIXES or (has_source_inputs and final_suffix in JS_CONTAINING_SUFFIXES)) and options.requested_debug == '-g'):
+        # do not save llvm debug info if js optimizer will wipe it out anyhow (but if source maps are used, keep it)
+        if use_source_map(options) or not (final_suffix in JS_CONTAINING_SUFFIXES and options.js_opts):
+          newargs.append('-g') # preserve LLVM debug info
+          options.debug_level = 4
+          shared.Settings.DEBUG_LEVEL = 4
+
+      # Bitcode args generation code
+      def get_clang_args(input_files):
+        file_ending = filename_type_ending(input_files[0])
+        args = [call] + newargs + input_files
+        if file_ending.endswith(CXX_ENDINGS):
+          args += shared.EMSDK_CXX_OPTS
+        if not shared.Building.can_inline():
+          args.append('-fno-inline-functions')
+        # For fastcomp backend, no LLVM IR functions should ever be annotated
+        # 'optnone', because that would skip running the SimplifyCFG pass on
+        # them, which is required to always run to clean up LandingPadInst
+        # instructions that are not needed.
+        if not shared.Settings.WASM_BACKEND:
+          args += ['-Xclang', '-disable-O0-optnone']
+        args = system_libs.process_args(args, shared.Settings)
+        return args
+
+      # -E preprocessor-only support
+      if '-E' in newargs or '-M' in newargs or '-MM' in newargs:
+        input_files = [x[1] for x in input_files]
+        cmd = get_clang_args(input_files)
+        if specified_target:
+          cmd += ['-o', specified_target]
+        # Do not compile, but just output the result from preprocessing stage or
+        # output the dependency rule. Warning: clang and gcc behave differently
+        # with -MF! (clang seems to not recognize it)
+        logger.debug(('just preprocessor ' if '-E' in newargs else 'just dependencies: ') + ' '.join(cmd))
+        return run_process(cmd, check=False).returncode
+
+      def compile_source_file(i, input_file):
+        logger.debug('compiling source file: ' + input_file)
+        output_file = get_bitcode_file(input_file)
+        temp_files.append((i, output_file))
+        args = get_clang_args([input_file]) + ['-c', '-o', output_file]
+        if shared.Settings.WASM_OBJECT_FILES:
+          for a in shared.Building.llvm_backend_args():
+            args += ['-mllvm', a]
+        else:
+          args.append('-emit-llvm')
+        logger.debug("running: " + ' '.join(shared.Building.doublequote_spaces(args))) # NOTE: Printing this line here in this specific format is important, it is parsed to implement the "emcc --cflags" command
+        if run_process(args, check=False).returncode != 0:
+          exit_with_error('compiler frontend failed to generate LLVM bitcode, halting')
+        assert(os.path.exists(output_file))
+
+      # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
+      for i, input_file in input_files:
+        file_ending = filename_type_ending(input_file)
+        if file_ending.endswith(SOURCE_ENDINGS):
+          compile_source_file(i, input_file)
+        else: # bitcode
+          if file_ending.endswith(BITCODE_ENDINGS):
+            logger.debug('using bitcode file: ' + input_file)
+            temp_files.append((i, input_file))
+          elif file_ending.endswith(DYNAMICLIB_ENDINGS) or shared.Building.is_ar(input_file):
+            logger.debug('using library file: ' + input_file)
+            temp_files.append((i, input_file))
+          elif file_ending.endswith(ASSEMBLY_ENDINGS):
+            if not LEAVE_INPUTS_RAW:
+              logger.debug('assembling assembly file: ' + input_file)
+              temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
+              shared.Building.llvm_as(input_file, temp_file)
+              temp_files.append((i, temp_file))
+          else:
+            if has_fixed_language_mode:
+              compile_source_file(i, input_file)
+            else:
+              exit_with_error(input_file + ': Unknown file suffix when compiling to LLVM bitcode!')
+
+    # exit block 'bitcodeize inputs'
+    log_time('bitcodeize inputs')
+
+    with ToolchainProfiler.profile_block('process inputs'):
+      if not LEAVE_INPUTS_RAW and not shared.Settings.WASM_BACKEND:
+        assert len(temp_files) == len(input_files)
+
+        # Optimize source files
+        if optimizing(options.llvm_opts):
+          for pos, (_, input_file) in enumerate(input_files):
+            file_ending = filename_type_ending(input_file)
+            if file_ending.endswith(SOURCE_ENDINGS):
+              temp_file = temp_files[pos][1]
+              logger.debug('optimizing %s', input_file)
+              # if DEBUG:
+              #   shutil.copyfile(temp_file, os.path.join(shared.configuration.CANONICAL_TEMP_DIR, 'to_opt.bc')) # useful when LLVM opt aborts
+              new_temp_file = in_temp(unsuffixed(uniquename(temp_file)) + '.o')
+              # after optimizing, lower intrinsics to libc calls so that our linking code
+              # will find them (otherwise, llvm.cos.f32() will not link in cosf(), and
+              # we end up calling out to JS for Math.cos).
+              opts = options.llvm_opts + ['-lower-non-em-intrinsics']
+              shared.Building.llvm_opt(temp_file, opts, new_temp_file)
+              temp_files[pos] = (temp_files[pos][0], new_temp_file)
+
+      # Decide what we will link
+      stop_at_bitcode = final_suffix not in EXECUTABLE_SUFFIXES
+
+      if stop_at_bitcode or not shared.Settings.WASM_BACKEND:
+        # Filter link flags, keeping only those that shared.Building.link knows
+        # how to deal with.  We currently can't handle flags with options (like
+        # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
+        # flag).
+        link_flags = [f for f in link_flags if f[1] in SUPPORTED_LINKER_FLAGS]
+
+      linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
+
+      # If we were just asked to generate bitcode, stop there
+      if stop_at_bitcode:
+        if not specified_target:
+          assert len(temp_files) == len(input_files)
+          for tempf, inputf in zip(temp_files, input_files):
+            safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_ending)
+        else:
+          if len(input_files) == 1:
+            input_file = input_files[0][1]
+            temp_file = temp_files[0][1]
+            bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_ending
+            if temp_file != input_file:
+              safe_move(temp_file, bitcode_target)
+            else:
+              shutil.copyfile(temp_file, bitcode_target)
+            temp_output_base = unsuffixed(temp_file)
+            if os.path.exists(temp_output_base + '.d'):
+              # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
+              # adjusting the target name away from the temporary file name to the specified target.
+              # It will be deleted with the rest of the temporary directory.
+              deps = open(temp_output_base + '.d').read()
+              deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
+              with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
+                out_dep.write(deps)
+          else:
+            assert len(original_input_files) == 1 or not has_dash_c, 'fatal error: cannot specify -o with -c with multiple files' + str(sys.argv) + ':' + str(original_input_files)
+            # We have a specified target (-o <target>), which is not JavaScript or HTML, and
+            # we have multiple files: Link them
+            logger.debug('link: ' + str(linker_inputs) + specified_target)
+            # Sort arg tuples and pass the extracted values to link.
+            shared.Building.link(linker_inputs, specified_target)
+        logger.debug('stopping at bitcode')
+        if shared.Settings.SIDE_MODULE:
+          exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting LLVM bitcode. That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an LLVM bitcode file, which you should then compile to .wasm or .js with SIDE_MODULE.')
+        if final_suffix.lower() in ['so', 'dylib', 'dll']:
+          logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an LLVM bitcode file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a file with LLVM bitcode, \'.bc\', which would avoid this warning.)')
+        return 0
+
+    # exit block 'process inputs'
+    log_time('process inputs')
+
+    ## Continue on to create JavaScript
+
+    with ToolchainProfiler.profile_block('calculate system libraries'):
+      logger.debug('will generate JavaScript')
+
+      extra_files_to_link = []
+
+      # link in ports and system libraries, if necessary
+      if not LEAVE_INPUTS_RAW and \
+         not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
+         not shared.Settings.ONLY_MY_CODE and \
+         not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
+        extra_files_to_link = system_libs.get_ports(shared.Settings)
+        extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
+
+    # exit block 'calculate system libraries'
+    log_time('calculate system libraries')
+
+    def dedup_list(lst):
+      rtn = []
+      for item in lst:
+        if item not in rtn:
+          rtn.append(item)
+      return rtn
+
+    # Make a final pass over shared.Settings.EXPORTED_FUNCTIONS to remove any
+    # duplication between functions added by the driver/libraries and function
+    # specified by the user
+    shared.Settings.EXPORTED_FUNCTIONS = dedup_list(shared.Settings.EXPORTED_FUNCTIONS)
+
+    with ToolchainProfiler.profile_block('link'):
+      # final will be an array if linking is deferred, otherwise a normal string.
+      if shared.Settings.WASM_BACKEND:
+        DEFAULT_FINAL = in_temp(target_basename + '.wasm')
+      else:
+        DEFAULT_FINAL = in_temp(target_basename + '.bc')
+
+      def get_final():
+        global final
+        if isinstance(final, list):
+          final = DEFAULT_FINAL
+        return final
+
+      # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
+      linker_inputs += extra_files_to_link
+      perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
+      if not perform_link and not LEAVE_INPUTS_RAW:
+        is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
+        is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
+        is_ar = shared.Building.is_ar(temp_files[0][1])
+        perform_link = not (is_bc or is_dylib) and is_ar
+      if perform_link:
+        logger.debug('linking: ' + str(linker_inputs))
+        # force archive contents to all be included, if just archives, or if linking shared modules
+        force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
+
+        # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
+        # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
+        # TODO: we could check if this is a fastcomp build, and still speed things up here
+        just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
+        if shared.Settings.WASM_BACKEND:
+          # If LTO is enabled then use the -O opt level as the LTO level
+          if options.llvm_lto:
+            lto_level = options.opt_level
+          else:
+            lto_level = 0
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, options.llvm_opts, lto_level)
+        else:
+          final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, temp_files=misc_temp_files, just_calculate=just_calculate)
+      else:
+        logger.debug('skipping linking: ' + str(linker_inputs))
         if not LEAVE_INPUTS_RAW:
-          save_intermediate('basebc', 'bc')
-
-      # Optimize, if asked to
-      if not LEAVE_INPUTS_RAW:
-        # remove LLVM debug if we are not asked for it
-        link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
-        if not shared.Settings.ASSERTIONS:
-          link_opts += ['-disable-verify']
+          _, temp_file = temp_files[0]
+          _, input_file = input_files[0]
+          final = in_temp(target_basename + '.bc')
+          if temp_file != input_file:
+            shutil.move(temp_file, final)
+          else:
+            shutil.copyfile(temp_file, final)
         else:
-          # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
-          # disable the type map in that case. we added linking to opt, so we need to do
-          # something similar, which we can do with a param to opt
-          link_opts += ['-disable-debug-info-type-map']
+          _, input_file = input_files[0]
+          final = in_temp(input_file)
+          shutil.copyfile(input_file, final)
 
-        if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
-          logger.debug('running LLVM opts as pre-LTO')
-          final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
-          save_intermediate('opt', 'bc')
+    # exit block 'link'
+    log_time('link')
 
-        # If we can LTO, do it before dce, since it opens up dce opportunities
-        if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
-          if not shared.Building.can_inline():
-            link_opts.append('-disable-inlining')
-          # add a manual internalize with the proper things we need to be kept alive during lto
-          link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
-          # execute it now, so it is done entirely before we get to the stage of legalization etc.
-          final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-          save_intermediate('lto', 'bc')
-          link_opts = []
-        else:
-          # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
-          link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
+    if not shared.Settings.WASM_BACKEND:
+      with ToolchainProfiler.profile_block('post-link'):
+        if DEBUG:
+          logger.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
+          if not LEAVE_INPUTS_RAW:
+            save_intermediate('basebc', 'bc')
 
-        if options.cfi:
-          if use_cxx:
-             link_opts.append("-wholeprogramdevirt")
-          link_opts.append("-lowertypetests")
+        # Optimize, if asked to
+        if not LEAVE_INPUTS_RAW:
+          # remove LLVM debug if we are not asked for it
+          link_opts = [] if use_source_map(options) or shared.Settings.CYBERDWARF else ['-strip-debug']
+          if not shared.Settings.ASSERTIONS:
+            link_opts += ['-disable-verify']
+          else:
+            # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
+            # disable the type map in that case. we added linking to opt, so we need to do
+            # something similar, which we can do with a param to opt
+            link_opts += ['-disable-debug-info-type-map']
+
+          if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
+            logger.debug('running LLVM opts as pre-LTO')
+            final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
+            save_intermediate('opt', 'bc')
+
+          # If we can LTO, do it before dce, since it opens up dce opportunities
+          if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
+            if not shared.Building.can_inline():
+              link_opts.append('-disable-inlining')
+            # add a manual internalize with the proper things we need to be kept alive during lto
+            link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
+            # execute it now, so it is done entirely before we get to the stage of legalization etc.
+            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+            save_intermediate('lto', 'bc')
+            link_opts = []
+          else:
+            # At minimum remove dead functions etc., this potentially saves a lot in the size of the generated code (and the time to compile it)
+            link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
+
+          if options.cfi:
+            if use_cxx:
+               link_opts.append("-wholeprogramdevirt")
+            link_opts.append("-lowertypetests")
+
+          if AUTODEBUG:
+            # let llvm opt directly emit ll, to skip writing and reading all the bitcode
+            link_opts += ['-S']
+            final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
+            save_intermediate('linktime', 'll')
+          else:
+            if len(link_opts) > 0:
+              final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+              save_intermediate('linktime', 'bc')
+            if options.save_bc:
+              shutil.copyfile(final, options.save_bc)
+
+        # Prepare .ll for Emscripten
+        if LEAVE_INPUTS_RAW:
+          assert len(input_files) == 1
+        if options.save_bc:
+          save_intermediate('ll', 'll')
 
         if AUTODEBUG:
-          # let llvm opt directly emit ll, to skip writing and reading all the bitcode
-          link_opts += ['-S']
-          final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
-          save_intermediate('linktime', 'll')
-        else:
-          if len(link_opts) > 0:
-            final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-            save_intermediate('linktime', 'bc')
-          if options.save_bc:
-            shutil.copyfile(final, options.save_bc)
+          logger.debug('autodebug')
+          next = get_final() + '.ad.ll'
+          run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
+          final = next
+          save_intermediate('autodebug', 'll')
 
-      # Prepare .ll for Emscripten
-      if LEAVE_INPUTS_RAW:
-        assert len(input_files) == 1
-      if options.save_bc:
-        save_intermediate('ll', 'll')
+        assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
 
-      if AUTODEBUG:
-        logger.debug('autodebug')
-        next = get_final() + '.ad.ll'
-        run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])
-        final = next
-        save_intermediate('autodebug', 'll')
+      # exit block 'post-link'
+      log_time('post-link')
 
-      assert not isinstance(final, list), 'we must have linked the final files, if linking was deferred, by this point'
-
-    # exit block 'post-link'
-    log_time('post-link')
-
-  with ToolchainProfiler.profile_block('emscript'):
-    # Emscripten
-    logger.debug('LLVM => JS')
-    js_libraries = None
-    if options.js_libraries:
-      js_libraries = [os.path.abspath(lib) for lib in options.js_libraries]
-    if options.memory_init_file:
-      shared.Settings.MEM_INIT_METHOD = 1
-    else:
-      assert shared.Settings.MEM_INIT_METHOD != 1
-
-    if embed_memfile(options):
-      shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
-
-    final = shared.Building.emscripten(final, target + '.mem', js_libraries)
-    save_intermediate('original')
-
-    if shared.Settings.WASM_BACKEND:
-      # we also received wast and wasm at this stage
-      temp_basename = unsuffixed(final)
-      wasm_temp = temp_basename + '.wasm'
-      shutil.move(wasm_temp, wasm_binary_target)
-      if use_source_map(options):
-        shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
-
-    if shared.Settings.CYBERDWARF:
-      cd_target = final + '.cd'
-      shutil.move(cd_target, target + '.cd')
-
-  # exit block 'emscript'
-  log_time('emscript (llvm => executable code)')
-
-  with ToolchainProfiler.profile_block('source transforms'):
-    # Embed and preload files
-    if len(options.preload_files) or len(options.embed_files):
-
-      # Also, MEMFS is not aware of heap resizing feature in wasm, so if MEMFS and memory growth are used together, force
-      # no_heap_copy to be enabled.
-      if shared.Settings.ALLOW_MEMORY_GROWTH and not options.no_heap_copy:
-        logger.info('Enabling --no-heap-copy because -s ALLOW_MEMORY_GROWTH=1 is being used with file_packager.py (pass --no-heap-copy to suppress this notification)')
-        options.no_heap_copy = True
-
-      logger.debug('setting up files')
-      file_args = ['--from-emcc', '--export-name=' + shared.Settings.EXPORT_NAME]
-      if len(options.preload_files):
-        file_args.append('--preload')
-        file_args += options.preload_files
-      if len(options.embed_files):
-        file_args.append('--embed')
-        file_args += options.embed_files
-      if len(options.exclude_files):
-        file_args.append('--exclude')
-        file_args += options.exclude_files
-      if options.use_preload_cache:
-        file_args.append('--use-preload-cache')
-      if options.no_heap_copy:
-        file_args.append('--no-heap-copy')
-      if shared.Settings.LZ4:
-        file_args.append('--lz4')
-      if options.use_preload_plugins:
-        file_args.append('--use-preload-plugins')
-      file_code = run_process([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
-      options.pre_js = file_code + options.pre_js
-
-    # Apply pre and postjs files
-    if options.pre_js or options.post_js:
-      logger.debug('applying pre/postjses')
-      src = open(final).read()
-      final += '.pp.js'
-      if WINDOWS: # Avoid duplicating \r\n to \r\r\n when writing out.
-        if options.pre_js:
-          options.pre_js = options.pre_js.replace('\r\n', '\n')
-        if options.post_js:
-          options.post_js = options.post_js.replace('\r\n', '\n')
-      outfile = open(final, 'w')
-      # pre-js code goes right after the Module integration code (so it
-      # can use Module), we have a marker for it
-      outfile.write(src.replace('// {{PRE_JSES}}', options.pre_js))
-      outfile.write(options.post_js)
-      outfile.close()
-      options.pre_js = src = options.post_js = None
-      save_intermediate('pre-post')
-
-    # Apply a source code transformation, if requested
-    if options.js_transform:
-      shutil.copyfile(final, final + '.tr.js')
-      final += '.tr.js'
-      posix = not shared.WINDOWS
-      logger.debug('applying transform: %s', options.js_transform)
-      shared.check_call(shared.Building.remove_quotes(shlex.split(options.js_transform, posix=posix) + [os.path.abspath(final)]))
-      save_intermediate('transformed')
-
-    js_transform_tempfiles = [final]
-
-  # exit block 'source transforms'
-  log_time('source transforms')
-
-  with ToolchainProfiler.profile_block('memory initializer'):
-    memfile = None
-    if shared.Settings.MEM_INIT_METHOD > 0 or embed_memfile(options):
-      memfile = target + '.mem'
-
-    if memfile and not shared.Settings.WASM_BACKEND:
-      # Strip the memory initializer out of the asmjs file
-      shared.try_delete(memfile)
-
-      def repl(m):
-        # handle chunking of the memory initializer
-        s = m.group(1)
-        if len(s) == 0:
-          return '' # don't emit 0-size ones
-        membytes = [int(x or '0') for x in s.split(',')]
-        while membytes and membytes[-1] == 0:
-          membytes.pop()
-        if not membytes:
-          return ''
-        if shared.Settings.MEM_INIT_METHOD == 2:
-          # memory initializer in a string literal
-          return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
-        open(memfile, 'wb').write(bytearray(membytes))
-        if DEBUG:
-          # Copy into temp dir as well, so can be run there too
-          shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
-        if not shared.Settings.WASM or not shared.Settings.MEM_INIT_IN_WASM:
-          return 'memoryInitializer = "%s";' % shared.JS.get_subresource_location(memfile, embed_memfile(options))
-        else:
-          return ''
-
-      src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
-      open(final + '.mem.js', 'w').write(src)
-      final += '.mem.js'
-      src = None
-      js_transform_tempfiles[-1] = final # simple text substitution preserves comment line number mappings
-      if os.path.exists(memfile):
-        save_intermediate('meminit')
-        logger.debug('wrote memory initialization to %s', memfile)
+    with ToolchainProfiler.profile_block('emscript'):
+      # Emscripten
+      logger.debug('LLVM => JS')
+      js_libraries = None
+      if options.js_libraries:
+        js_libraries = [os.path.abspath(lib) for lib in options.js_libraries]
+      if options.memory_init_file:
+        shared.Settings.MEM_INIT_METHOD = 1
       else:
-        logger.debug('did not see memory initialization')
+        assert shared.Settings.MEM_INIT_METHOD != 1
 
-    if shared.Settings.USE_PTHREADS:
-      target_dir = os.path.dirname(os.path.abspath(target))
-      shutil.copyfile(shared.path_from_root('src', 'worker.js'),
-                      os.path.join(target_dir, shared.Settings.PTHREAD_WORKER_FILE))
+      if embed_memfile(options):
+        shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
 
-    # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
-    if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
-      if shared.Settings.WASM:
-        # FIXME(https://github.com/kripken/emscripten/issues/7024)
-        logger.warning('Blocking calls the fetch API do not work under WASM')
-      else:
-        shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
+      final = shared.Building.emscripten(final, target + '.mem', js_libraries)
+      save_intermediate('original')
 
-  # exit block 'memory initializer'
-  log_time('memory initializer')
+      if shared.Settings.WASM_BACKEND:
+        # we also received wast and wasm at this stage
+        temp_basename = unsuffixed(final)
+        wasm_temp = temp_basename + '.wasm'
+        shutil.move(wasm_temp, wasm_binary_target)
+        if use_source_map(options):
+          shutil.move(wasm_temp + '.map', wasm_binary_target + '.map')
 
-  optimizer = JSOptimizer(
-    target=target,
-    options=options,
-    js_transform_tempfiles=js_transform_tempfiles,
-    in_temp=in_temp,
-  )
-  with ToolchainProfiler.profile_block('js opts'):
-    # It is useful to run several js optimizer passes together, to save on unneeded unparsing/reparsing
-    if shared.Settings.DEAD_FUNCTIONS:
-      optimizer.queue += ['eliminateDeadFuncs']
-      optimizer.extra_info['dead_functions'] = shared.Settings.DEAD_FUNCTIONS
+      if shared.Settings.CYBERDWARF:
+        cd_target = final + '.cd'
+        shutil.move(cd_target, target + '.cd')
 
-    if options.opt_level >= 1 and options.js_opts:
-      logger.debug('running js post-opts')
+    # exit block 'emscript'
+    log_time('emscript (llvm => executable code)')
 
-      if DEBUG == 2:
-        # Clean up the syntax a bit
-        optimizer.queue += ['noop']
+    with ToolchainProfiler.profile_block('source transforms'):
+      # Embed and preload files
+      if len(options.preload_files) or len(options.embed_files):
 
-      def get_eliminate():
-        if shared.Settings.ALLOW_MEMORY_GROWTH:
-          return 'eliminateMemSafe'
+        # Also, MEMFS is not aware of heap resizing feature in wasm, so if MEMFS and memory growth are used together, force
+        # no_heap_copy to be enabled.
+        if shared.Settings.ALLOW_MEMORY_GROWTH and not options.no_heap_copy:
+          logger.info('Enabling --no-heap-copy because -s ALLOW_MEMORY_GROWTH=1 is being used with file_packager.py (pass --no-heap-copy to suppress this notification)')
+          options.no_heap_copy = True
+
+        logger.debug('setting up files')
+        file_args = ['--from-emcc', '--export-name=' + shared.Settings.EXPORT_NAME]
+        if len(options.preload_files):
+          file_args.append('--preload')
+          file_args += options.preload_files
+        if len(options.embed_files):
+          file_args.append('--embed')
+          file_args += options.embed_files
+        if len(options.exclude_files):
+          file_args.append('--exclude')
+          file_args += options.exclude_files
+        if options.use_preload_cache:
+          file_args.append('--use-preload-cache')
+        if options.no_heap_copy:
+          file_args.append('--no-heap-copy')
+        if shared.Settings.LZ4:
+          file_args.append('--lz4')
+        if options.use_preload_plugins:
+          file_args.append('--use-preload-plugins')
+        file_code = run_process([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
+        options.pre_js = file_code + options.pre_js
+
+      # Apply pre and postjs files
+      if options.pre_js or options.post_js:
+        logger.debug('applying pre/postjses')
+        src = open(final).read()
+        final += '.pp.js'
+        if WINDOWS: # Avoid duplicating \r\n to \r\r\n when writing out.
+          if options.pre_js:
+            options.pre_js = options.pre_js.replace('\r\n', '\n')
+          if options.post_js:
+            options.post_js = options.post_js.replace('\r\n', '\n')
+        outfile = open(final, 'w')
+        # pre-js code goes right after the Module integration code (so it
+        # can use Module), we have a marker for it
+        outfile.write(src.replace('// {{PRE_JSES}}', options.pre_js))
+        outfile.write(options.post_js)
+        outfile.close()
+        options.pre_js = src = options.post_js = None
+        save_intermediate('pre-post')
+
+      # Apply a source code transformation, if requested
+      if options.js_transform:
+        shutil.copyfile(final, final + '.tr.js')
+        final += '.tr.js'
+        posix = not shared.WINDOWS
+        logger.debug('applying transform: %s', options.js_transform)
+        shared.check_call(shared.Building.remove_quotes(shlex.split(options.js_transform, posix=posix) + [os.path.abspath(final)]))
+        save_intermediate('transformed')
+
+      js_transform_tempfiles = [final]
+
+    # exit block 'source transforms'
+    log_time('source transforms')
+
+    with ToolchainProfiler.profile_block('memory initializer'):
+      memfile = None
+      if shared.Settings.MEM_INIT_METHOD > 0 or embed_memfile(options):
+        memfile = target + '.mem'
+
+      if memfile and not shared.Settings.WASM_BACKEND:
+        # Strip the memory initializer out of the asmjs file
+        shared.try_delete(memfile)
+
+        def repl(m):
+          # handle chunking of the memory initializer
+          s = m.group(1)
+          if len(s) == 0:
+            return '' # don't emit 0-size ones
+          membytes = [int(x or '0') for x in s.split(',')]
+          while membytes and membytes[-1] == 0:
+            membytes.pop()
+          if not membytes:
+            return ''
+          if shared.Settings.MEM_INIT_METHOD == 2:
+            # memory initializer in a string literal
+            return "memoryInitializer = '%s';" % shared.JS.generate_string_initializer(membytes)
+          open(memfile, 'wb').write(bytearray(membytes))
+          if DEBUG:
+            # Copy into temp dir as well, so can be run there too
+            shared.safe_copy(memfile, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(memfile)))
+          if not shared.Settings.WASM or not shared.Settings.MEM_INIT_IN_WASM:
+            return 'memoryInitializer = "%s";' % shared.JS.get_subresource_location(memfile, embed_memfile(options))
+          else:
+            return ''
+
+        src = re.sub(shared.JS.memory_initializer_pattern, repl, open(final).read(), count=1)
+        open(final + '.mem.js', 'w').write(src)
+        final += '.mem.js'
+        src = None
+        js_transform_tempfiles[-1] = final # simple text substitution preserves comment line number mappings
+        if os.path.exists(memfile):
+          save_intermediate('meminit')
+          logger.debug('wrote memory initialization to %s', memfile)
         else:
-          return 'eliminate'
+          logger.debug('did not see memory initialization')
 
-      if options.opt_level >= 2:
-        optimizer.queue += [get_eliminate()]
+      if shared.Settings.USE_PTHREADS:
+        target_dir = os.path.dirname(os.path.abspath(target))
+        shutil.copyfile(shared.path_from_root('src', 'worker.js'),
+                        os.path.join(target_dir, shared.Settings.PTHREAD_WORKER_FILE))
 
-        if shared.Settings.AGGRESSIVE_VARIABLE_ELIMINATION:
-          # note that this happens before registerize/minification, which can obfuscate the name of 'label', which is tricky
-          optimizer.queue += ['aggressiveVariableElimination']
-
-        optimizer.queue += ['simplifyExpressions']
-
-        if shared.Settings.EMTERPRETIFY:
-          # emterpreter code will not run through a JS optimizing JIT, do more work ourselves
-          optimizer.queue += ['localCSE']
-
-    if shared.Settings.EMTERPRETIFY:
-      # add explicit label setting, as we will run aggressiveVariableElimination late, *after* 'label' is no longer notable by name
-      optimizer.queue += ['safeLabelSetting']
-
-    if options.opt_level >= 1 and options.js_opts:
-      if options.opt_level >= 2:
-        # simplify ifs if it is ok to make the code somewhat unreadable, and unless outlining (simplified ifs
-        # with commaified code breaks late aggressive variable elimination)
-        # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
-        debugging = options.debug_level == 0 or options.profiling
-        if shared.Settings.SIMPLIFY_IFS and debugging and shared.Settings.OUTLINING_LIMIT == 0 and not shared.Settings.WASM:
-          optimizer.queue += ['simplifyIfs']
-
-        if shared.Settings.PRECISE_F32:
-          optimizer.queue += ['optimizeFrounds']
-
-    if options.js_opts:
-      if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
-        optimizer.queue += ['safeHeap']
-
-      if shared.Settings.OUTLINING_LIMIT > 0:
-        optimizer.queue += ['outline']
-        optimizer.extra_info['sizeToOutline'] = shared.Settings.OUTLINING_LIMIT
-
-      if options.opt_level >= 2 and options.debug_level < 3:
-        if options.opt_level >= 3 or options.shrink_level > 0:
-          optimizer.queue += ['registerizeHarder']
+      # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
+      if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
+        if shared.Settings.WASM:
+          # FIXME(https://github.com/kripken/emscripten/issues/7024)
+          logger.warning('Blocking calls the fetch API do not work under WASM')
         else:
-          optimizer.queue += ['registerize']
+          shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
 
-      # NOTE: Important that this comes after registerize/registerizeHarder
-      if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and options.opt_level >= 2:
+    # exit block 'memory initializer'
+    log_time('memory initializer')
+
+    optimizer = JSOptimizer(
+      target=target,
+      options=options,
+      js_transform_tempfiles=js_transform_tempfiles,
+      in_temp=in_temp,
+    )
+    with ToolchainProfiler.profile_block('js opts'):
+      # It is useful to run several js optimizer passes together, to save on unneeded unparsing/reparsing
+      if shared.Settings.DEAD_FUNCTIONS:
+        optimizer.queue += ['eliminateDeadFuncs']
+        optimizer.extra_info['dead_functions'] = shared.Settings.DEAD_FUNCTIONS
+
+      if options.opt_level >= 1 and options.js_opts:
+        logger.debug('running js post-opts')
+
+        if DEBUG == 2:
+          # Clean up the syntax a bit
+          optimizer.queue += ['noop']
+
+        def get_eliminate():
+          if shared.Settings.ALLOW_MEMORY_GROWTH:
+            return 'eliminateMemSafe'
+          else:
+            return 'eliminate'
+
+        if options.opt_level >= 2:
+          optimizer.queue += [get_eliminate()]
+
+          if shared.Settings.AGGRESSIVE_VARIABLE_ELIMINATION:
+            # note that this happens before registerize/minification, which can obfuscate the name of 'label', which is tricky
+            optimizer.queue += ['aggressiveVariableElimination']
+
+          optimizer.queue += ['simplifyExpressions']
+
+          if shared.Settings.EMTERPRETIFY:
+            # emterpreter code will not run through a JS optimizing JIT, do more work ourselves
+            optimizer.queue += ['localCSE']
+
+      if shared.Settings.EMTERPRETIFY:
+        # add explicit label setting, as we will run aggressiveVariableElimination late, *after* 'label' is no longer notable by name
+        optimizer.queue += ['safeLabelSetting']
+
+      if options.opt_level >= 1 and options.js_opts:
+        if options.opt_level >= 2:
+          # simplify ifs if it is ok to make the code somewhat unreadable, and unless outlining (simplified ifs
+          # with commaified code breaks late aggressive variable elimination)
+          # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
+          debugging = options.debug_level == 0 or options.profiling
+          if shared.Settings.SIMPLIFY_IFS and debugging and shared.Settings.OUTLINING_LIMIT == 0 and not shared.Settings.WASM:
+            optimizer.queue += ['simplifyIfs']
+
+          if shared.Settings.PRECISE_F32:
+            optimizer.queue += ['optimizeFrounds']
+
+      if options.js_opts:
+        if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():
+          optimizer.queue += ['safeHeap']
+
+        if shared.Settings.OUTLINING_LIMIT > 0:
+          optimizer.queue += ['outline']
+          optimizer.extra_info['sizeToOutline'] = shared.Settings.OUTLINING_LIMIT
+
+        if options.opt_level >= 2 and options.debug_level < 3:
+          if options.opt_level >= 3 or options.shrink_level > 0:
+            optimizer.queue += ['registerizeHarder']
+          else:
+            optimizer.queue += ['registerize']
+
+        # NOTE: Important that this comes after registerize/registerizeHarder
+        if shared.Settings.ELIMINATE_DUPLICATE_FUNCTIONS and options.opt_level >= 2:
+          optimizer.flush()
+          shared.Building.eliminate_duplicate_funcs(final)
+          save_intermediate('dfe', 'js')
+
+      if shared.Settings.EVAL_CTORS and options.memory_init_file and not use_source_map(options) and not shared.Settings.WASM:
         optimizer.flush()
-        shared.Building.eliminate_duplicate_funcs(final)
-        save_intermediate('dfe', 'js')
+        shared.Building.eval_ctors(final, memfile)
+        save_intermediate('eval-ctors', 'js')
 
-    if shared.Settings.EVAL_CTORS and options.memory_init_file and not use_source_map(options) and not shared.Settings.WASM:
-      optimizer.flush()
-      shared.Building.eval_ctors(final, memfile)
-      save_intermediate('eval-ctors', 'js')
+      if options.js_opts:
+        # some compilation modes require us to minify later or not at all
+        if not shared.Settings.EMTERPRETIFY and not shared.Settings.WASM:
+          optimizer.do_minify()
 
-    if options.js_opts:
-      # some compilation modes require us to minify later or not at all
-      if not shared.Settings.EMTERPRETIFY and not shared.Settings.WASM:
-        optimizer.do_minify()
+        if options.opt_level >= 2:
+          optimizer.queue += ['asmLastOpts']
 
-      if options.opt_level >= 2:
-        optimizer.queue += ['asmLastOpts']
+        if shared.Settings.FINALIZE_ASM_JS:
+          optimizer.queue += ['last']
 
-      if shared.Settings.FINALIZE_ASM_JS:
-        optimizer.queue += ['last']
+        optimizer.flush()
 
-      optimizer.flush()
+      if options.use_closure_compiler == 2:
+        optimizer.flush()
 
-    if options.use_closure_compiler == 2:
-      optimizer.flush()
+        logger.debug('running closure')
+        # no need to add this to js_transform_tempfiles, because closure and
+        # debug_level > 0 are never simultaneously true
+        final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
+        save_intermediate('closure')
 
-      logger.debug('running closure')
-      # no need to add this to js_transform_tempfiles, because closure and
-      # debug_level > 0 are never simultaneously true
-      final = shared.Building.closure_compiler(final, pretty=options.debug_level >= 1)
-      save_intermediate('closure')
+    log_time('js opts')
 
-  log_time('js opts')
+    with ToolchainProfiler.profile_block('final emitting'):
+      if shared.Settings.EMTERPRETIFY:
+        emterpretify(js_target, optimizer, options)
 
-  with ToolchainProfiler.profile_block('final emitting'):
-    if shared.Settings.EMTERPRETIFY:
-      emterpretify(js_target, optimizer, options)
+      # Remove some trivial whitespace
+      # TODO: do not run when compress has already been done on all parts of the code
+      # src = open(final).read()
+      # src = re.sub(r'\n+[ \n]*\n+', '\n', src)
+      # open(final, 'w').write(src)
 
-    # Remove some trivial whitespace
-    # TODO: do not run when compress has already been done on all parts of the code
-    # src = open(final).read()
-    # src = re.sub(r'\n+[ \n]*\n+', '\n', src)
-    # open(final, 'w').write(src)
+      # Bundle symbol data in with the cyberdwarf file
+      if shared.Settings.CYBERDWARF:
+        run_process([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target + '.symbols'])
 
-    # Bundle symbol data in with the cyberdwarf file
-    if shared.Settings.CYBERDWARF:
-      run_process([shared.PYTHON, shared.path_from_root('tools', 'emdebug_cd_merger.py'), target + '.cd', target + '.symbols'])
+      if use_source_map(options) and not shared.Settings.WASM:
+        emit_js_source_maps(target, optimizer.js_transform_tempfiles)
 
-    if use_source_map(options) and not shared.Settings.WASM:
-      emit_js_source_maps(target, optimizer.js_transform_tempfiles)
+      # track files that will need native eols
+      generated_text_files_with_native_eols = []
 
-    # track files that will need native eols
-    generated_text_files_with_native_eols = []
+      if (options.separate_asm or shared.Settings.WASM) and not shared.Settings.WASM_BACKEND:
+        separate_asm_js(final, asm_target)
+        generated_text_files_with_native_eols += [asm_target]
 
-    if (options.separate_asm or shared.Settings.WASM) and not shared.Settings.WASM_BACKEND:
-      separate_asm_js(final, asm_target)
-      generated_text_files_with_native_eols += [asm_target]
+      if shared.Settings.WASM:
+        binaryen_method_sanity_check()
+        do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
+                    wasm_text_target, misc_temp_files, optimizer)
 
-    if shared.Settings.WASM:
-      binaryen_method_sanity_check()
-      do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
-                  wasm_text_target, misc_temp_files, optimizer)
+      if shared.Settings.MODULARIZE:
+        modularize()
 
-    if shared.Settings.MODULARIZE:
-      modularize()
+      module_export_name_substitution()
 
-    module_export_name_substitution()
+      # The JS is now final. Move it to its final location
+      shutil.move(final, js_target)
 
-    # The JS is now final. Move it to its final location
-    shutil.move(final, js_target)
+      generated_text_files_with_native_eols += [js_target]
 
-    generated_text_files_with_native_eols += [js_target]
+      # If we were asked to also generate HTML, do that
+      if final_suffix == 'html':
+        generate_html(target, options, js_target, target_basename,
+                      asm_target, wasm_binary_target,
+                      memfile, optimizer)
+      else:
+        if options.proxy_to_worker:
+          generate_worker_js(target, js_target, target_basename)
 
-    # If we were asked to also generate HTML, do that
-    if final_suffix == 'html':
-      generate_html(target, options, js_target, target_basename,
-                    asm_target, wasm_binary_target,
-                    memfile, optimizer)
-    else:
-      if options.proxy_to_worker:
-        generate_worker_js(target, js_target, target_basename)
+      if embed_memfile(options):
+        shared.try_delete(memfile)
 
-    if embed_memfile(options):
-      shared.try_delete(memfile)
+      for f in generated_text_files_with_native_eols:
+        tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
+    log_time('final emitting')
+    # exit block 'final emitting'
 
-    for f in generated_text_files_with_native_eols:
-      tools.line_endings.convert_line_endings_in_file(f, os.linesep, options.output_eol)
-  log_time('final emitting')
-  # exit block 'final emitting'
+  finally:
+    try:
+      if not DEBUG:
+        shutil.rmtree(temp_dir)
+    except:
+      pass
 
   if DEBUG:
     logger.debug('total time: %.2f seconds', (time.time() - start_time))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1408,17 +1408,21 @@ class Building(object):
             for t in tasks:
               results += [func(t)]
             return results
+
           def map_async(self, func, tasks, **kwargs):
             class Result:
               def __init__(self, func, tasks):
                 self.func = func
                 self.tasks = tasks
+
               def get(self, timeout):
                 results = []
                 for t in tasks:
                   results += [func(t)]
                 return results
+
             return Result(func, tasks)
+
         Building.multiprocessing_pool = FakeMultiprocessor()
       else:
         child_env = [

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1394,6 +1394,10 @@ class Building(object):
   def get_multiprocessing_pool():
     if not Building.multiprocessing_pool:
       cores = Building.get_num_cores()
+      if DEBUG:
+        # When in EMCC_DEBUG mode, only use a single core in the pool, so that
+        # logging is not all jumbled up.
+        cores = 1
 
       # If running with one core only, create a mock instance of a pool that does not
       # actually spawn any new subprocesses. Very useful for internal debugging.
@@ -1404,6 +1408,17 @@ class Building(object):
             for t in tasks:
               results += [func(t)]
             return results
+          def map_async(self, func, tasks, **kwargs):
+            class Result:
+              def __init__(self, func, tasks):
+                self.func = func
+                self.tasks = tasks
+              def get(self, timeout):
+                results = []
+                for t in tasks:
+                  results += [func(t)]
+                return results
+            return Result(func, tasks)
         Building.multiprocessing_pool = FakeMultiprocessor()
       else:
         child_env = [


### PR DESCRIPTION
Followup to #7710: we don't need to special-case the EMCC_DEBUG case in emcc.py, as shared.py already does that. So we can just use the temp dir it gives us, and remove a bunch of logic.

(best viewed with `?w=1` to ignore whitespace, as this removed an indentation block for a try-catch we no longer need)