### PR TITLE
Fix SDL2_Mixer documentation and add a unit test for SDL2_Mixer playing WAV files.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -377,3 +377,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Nicolas Allemand <contact@nicolasallemand.com>
 * Gabriel Cuvillier <contact@gabrielcuvillier.pro>
 * Thomas Lively <tlively@google.com> (copyright owned by Google, Inc.)
+* Brandon Surmanski <b.surmanski@gmail.com>

--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -178,7 +178,7 @@ Emscripten has partial support for SDL1 and 2 audio, and OpenAL.
 
 To use SDL1 audio, include it as ``#include <SDL/SDL_mixer.h>``. You can use it that way alongside SDL1, SDL2, or another library for platform integration.
 
-To use SDL2 audio, include it as ``#include <SDL2/SDL_mixer.h>`` and use `-s USE_SDL_MIXER=2`. Format support is currently limited to OGG.
+To use SDL2 audio, include it as ``#include <SDL2/SDL_mixer.h>`` and use `-s USE_SDL_MIXER=2`. Format support is currently limited to OGG and WAV.
 
 How can my compiled program access files?
 =========================================

--- a/tests/sdl2_mixer_wav.c
+++ b/tests/sdl2_mixer_wav.c
@@ -1,0 +1,43 @@
+#include <emscripten.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+
+#define WAV_PATH "/sound.wav"
+
+Mix_Chunk *wave = NULL;
+
+void sound_loop_then_quit() {
+    if (Mix_Playing(-1))
+        return;
+    printf("Done audio\n");
+    Mix_FreeChunk(wave);
+    Mix_CloseAudio();
+
+    emscripten_cancel_main_loop();
+    printf("Shutting down\n");
+    REPORT_RESULT(1);
+}
+
+int main(int argc, char* argv[]){
+    if (SDL_Init(SDL_INIT_AUDIO) < 0)
+        return -1;
+    int const frequency = EM_ASM_INT_V({
+        var context;
+        try {
+            context = new AudioContext();
+        } catch (e) {
+            context = new webkitAudioContext(); // safari only
+        }
+        return context.sampleRate;
+    });
+    if(Mix_OpenAudio(frequency, MIX_DEFAULT_FORMAT, 2, 1024) == -1)
+        return -1;
+    wave = Mix_LoadWAV(WAV_PATH);
+    if (wave == NULL)
+        return -1;
+    if (Mix_PlayChannel(-1, wave, 0) == -1)
+        return -1;
+    printf("Starting sound play loop\n");
+    emscripten_set_main_loop(sound_loop_then_quit, 0, 1);
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3068,6 +3068,11 @@ window.close = function() {
     shutil.copyfile(path_from_root('tests', 'sounds', 'alarmvictory_1.ogg'), 'sound.ogg')
     self.btest('sdl2_mixer.c', expected='1', args=['--preload-file', 'sound.ogg', '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'TOTAL_MEMORY=33554432'])
 
+  @requires_sound_hardware
+  def test_sdl2_mixer_wav(self):
+    shutil.copyfile(path_from_root('tests', 'sounds', 'the_entertainer.wav'), 'sound.wav')
+    self.btest('sdl2_mixer_wav.c', expected='1', args=['--preload-file', 'sound.wav', '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'TOTAL_MEMORY=33554432'])
+
   @requires_graphics_hardware
   def test_cocos2d_hello(self):
     cocos2d_root = os.path.join(system_libs.Ports.get_build_dir(), 'Cocos2d')

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -106,6 +106,13 @@ class interactive(BrowserCore):
     Popen([PYTHON, EMCC, '-O2', '--minify', '0', os.path.join(self.get_dir(), 'sdl2_mixer.c'), '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'TOTAL_MEMORY=33554432', '--preload-file', 'sound.ogg', '-o', 'page.html']).communicate()
     self.run_browser('page.html', '', '/report_result?1')
 
+  def test_sdl2_mixer_wav(self):
+    shutil.copyfile(path_from_root('tests', 'sounds', 'the_entertainer.wav'), os.path.join(self.get_dir(), 'sound.wav'))
+    open(os.path.join(self.get_dir(), 'sdl2_mixer_wav.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_mixer_wav.c')).read()))
+
+    Popen([PYTHON, EMCC, '-O2', '--minify', '0', os.path.join(self.get_dir(), 'sdl2_mixer_wav.c'), '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'TOTAL_MEMORY=33554432', '--preload-file', 'sound.wav', '-o', 'page.html']).communicate()
+    self.run_browser('page.html', '', '/report_result?1')
+
   def zzztest_sdl2_audio_beeps(self):
     open(os.path.join(self.get_dir(), 'sdl2_audio_beep.cpp'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl2_audio_beep.cpp')).read()))
 

--- a/tools/ports/sdl_mixer.py
+++ b/tools/ports/sdl_mixer.py
@@ -11,7 +11,7 @@ def get(ports, settings, shared):
     def create():
       cwd = os.getcwd()
       commonflags = ['--disable-shared', '--disable-music-cmd', '--enable-sdltest', '--disable-smpegtest']
-      formatflags = ['--disable-music-wave', '--disable-music-mod', '--disable-music-midi', '--enable-music-ogg', '--disable-music-ogg-shared', '--disable-music-flac', '--disable-music-mp3']
+      formatflags = ['--enable-music-wave', '--disable-music-mod', '--disable-music-midi', '--enable-music-ogg', '--disable-music-ogg-shared', '--disable-music-flac', '--disable-music-mp3']
       configure = os.path.join(ports.get_dir(), 'sdl2-mixer', 'SDL2_mixer-' + TAG, 'configure')
       build_dir = os.path.join(ports.get_build_dir(), 'sdl2-mixer')
       dist_dir = os.path.join(ports.get_build_dir(), 'sdl2-mixer', 'dist')


### PR DESCRIPTION
The correct flag is "-s USE_SDL_MIXER=2", not "-s SDL_MIXER=2".

USE_SDL_MIXER is consistent with the other emscripten port flags, and is also consistent with the code in the SDL2_Mixer PR. (here: https://github.com/kripken/emscripten/pull/7599)