### PR TITLE
Do not emit FUNCTION_TABLE_X on the outside for wasm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1479,7 +1479,13 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
       receiving += table + '\n'
 
   if shared.Settings.EMULATED_FUNCTION_POINTERS:
-    receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '') + '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
+    # in asm.js emulated function tables, emit the table on the outside, where
+    # JS can manage it (for wasm, a native wasm Table is used directly, and we
+    # don't need this)
+    if not shared.Settings.WASM:
+      receiving += '\n' + function_tables_defs.replace('// EMSCRIPTEN_END_FUNCS\n', '')
+    # wasm still needs definitions for dyncalls on the outside, for JS
+    receiving += '\n' + ''.join(['Module["dynCall_%s"] = dynCall_%s\n' % (sig, sig) for sig in function_table_data])
     if not shared.Settings.WASM:
       for sig in function_table_data.keys():
         name = 'FUNCTION_TABLE_' + sig


### PR DESCRIPTION
Wasm doesn't need it - emulated function pointers in that mode mean we use a native wasm Table. (And having it can cause problems in some followup PRs I'll have, which will also test this.)