### PR TITLE
Refactor ERRNO usage in JS library code

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -74,7 +74,7 @@ LibraryManager.library = {
   // utime.h
   // ==========================================================================
 
-  utime__deps: ['$FS', '__setErrNo', '$ERRNO_CODES'],
+  utime__deps: ['$FS', '__setErrNo'],
   utime__proxy: 'sync',
   utime__sig: 'iii',
   utime: function(path, times) {
@@ -99,7 +99,7 @@ LibraryManager.library = {
     }
   },
 
-  utimes__deps: ['$FS', '__setErrNo', '$ERRNO_CODES'],
+  utimes__deps: ['$FS', '__setErrNo'],
   utimes__proxy: 'sync',
   utimes__sig: 'iii',
   utimes: function(path, times) {
@@ -132,17 +132,17 @@ LibraryManager.library = {
     return 0;
   },
 
-  chroot__deps: ['__setErrNo', '$ERRNO_CODES'],
+  chroot__deps: ['__setErrNo'],
   chroot__proxy: 'sync',
   chroot__sig: 'ii',
   chroot: function(path) {
     // int chroot(const char *path);
     // http://pubs.opengroup.org/onlinepubs/7908799/xsh/chroot.html
-    ___setErrNo(ERRNO_CODES.EACCES);
+    ___setErrNo({{{ cDefine('EACCES') }}});
     return -1;
   },
 
-  fpathconf__deps: ['__setErrNo', '$ERRNO_CODES'],
+  fpathconf__deps: ['__setErrNo'],
   fpathconf__proxy: 'sync',
   fpathconf__sig: 'iii',
   fpathconf: function(fildes, name) {
@@ -180,12 +180,12 @@ LibraryManager.library = {
       case {{{ cDefine('_PC_FILESIZEBITS') }}}:
         return 64;
     }
-    ___setErrNo(ERRNO_CODES.EINVAL);
+    ___setErrNo({{{ cDefine('EINVAL') }}});
     return -1;
   },
   pathconf: 'fpathconf',
 
-  confstr__deps: ['__setErrNo', '$ERRNO_CODES', '$ENV'],
+  confstr__deps: ['__setErrNo', '$ENV'],
   confstr__proxy: 'sync',
   confstr__sig: 'iiii',
   confstr: function(name, buf, len) {
@@ -227,7 +227,7 @@ LibraryManager.library = {
         value = '-m32 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64';
         break;
       default:
-        ___setErrNo(ERRNO_CODES.EINVAL);
+        ___setErrNo({{{ cDefine('EINVAL') }}});
         return 0;
     }
     if (len == 0 || buf == 0) {
@@ -242,12 +242,12 @@ LibraryManager.library = {
     }
   },
 
-  execl__deps: ['__setErrNo', '$ERRNO_CODES'],
+  execl__deps: ['__setErrNo'],
   execl: function(/* ... */) {
     // int execl(const char *path, const char *arg0, ... /*, (char *)0 */);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
     // We don't support executing external code.
-    ___setErrNo(ERRNO_CODES.ENOEXEC);
+    ___setErrNo({{{ cDefine('ENOEXEC') }}});
     return -1;
   },
   execle: 'execl',
@@ -264,28 +264,28 @@ LibraryManager.library = {
     exit(status);
   },
 
-  fork__deps: ['__setErrNo', '$ERRNO_CODES'],
+  fork__deps: ['__setErrNo'],
   fork: function() {
     // pid_t fork(void);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
     // We don't support multiple processes.
-    ___setErrNo(ERRNO_CODES.EAGAIN);
+    ___setErrNo({{{ cDefine('EAGAIN') }}});
     return -1;
   },
   vfork: 'fork',
   posix_spawn: 'fork',
   posix_spawnp: 'fork',
 
-  setgroups__deps: ['__setErrNo', '$ERRNO_CODES', 'sysconf'],
+  setgroups__deps: ['__setErrNo', 'sysconf'],
   setgroups: function(ngroups, gidset) {
     // int setgroups(int ngroups, const gid_t *gidset);
     // https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man2/setgroups.2.html
     if (ngroups < 1 || ngroups > _sysconf({{{ cDefine('_SC_NGROUPS_MAX') }}})) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     } else {
       // We have just one process/user/group, so it makes no sense to set groups.
-      ___setErrNo(ERRNO_CODES.EPERM);
+      ___setErrNo({{{ cDefine('EPERM') }}});
       return -1;
     }
   },
@@ -294,7 +294,7 @@ LibraryManager.library = {
     return PAGE_SIZE;
   },
 
-  sysconf__deps: ['__setErrNo', '$ERRNO_CODES'],
+  sysconf__deps: ['__setErrNo'],
   sysconf__proxy: 'sync',
   sysconf__sig: 'ii',
   sysconf: function(name) {
@@ -450,7 +450,7 @@ LibraryManager.library = {
         return 1;
       }
     }
-    ___setErrNo(ERRNO_CODES.EINVAL);
+    ___setErrNo({{{ cDefine('EINVAL') }}});
     return -1;
   },
 
@@ -559,12 +559,12 @@ LibraryManager.library = {
     return 0;
   },
 
-  system__deps: ['__setErrNo', '$ERRNO_CODES'],
+  system__deps: ['__setErrNo'],
   system: function(command) {
     // int system(const char *command);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/system.html
     // Can't call external programs.
-    ___setErrNo(ERRNO_CODES.EAGAIN);
+    ___setErrNo({{{ cDefine('EAGAIN') }}});
     return -1;
   },
 
@@ -708,20 +708,20 @@ LibraryManager.library = {
     ___buildEnvironment(__get_environ());
     return 0;
   },
-  setenv__deps: ['$ENV', '__buildEnvironment', '$ERRNO_CODES', '__setErrNo'],
+  setenv__deps: ['$ENV', '__buildEnvironment', '__setErrNo'],
   setenv__proxy: 'sync',
   setenv__sig: 'iiii',
   setenv: function(envname, envval, overwrite) {
     // int setenv(const char *envname, const char *envval, int overwrite);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/setenv.html
     if (envname === 0) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     var name = Pointer_stringify(envname);
     var val = Pointer_stringify(envval);
     if (name === '' || name.indexOf('=') !== -1) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     if (ENV.hasOwnProperty(name) && !overwrite) return 0;
@@ -729,19 +729,19 @@ LibraryManager.library = {
     ___buildEnvironment(__get_environ());
     return 0;
   },
-  unsetenv__deps: ['$ENV', '__buildEnvironment', '$ERRNO_CODES', '__setErrNo'],
+  unsetenv__deps: ['$ENV', '__buildEnvironment', '__setErrNo'],
   unsetenv__proxy: 'sync',
   unsetenv__sig: 'ii',
   unsetenv: function(name) {
     // int unsetenv(const char *name);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/unsetenv.html
     if (name === 0) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     name = Pointer_stringify(name);
     if (name === '' || name.indexOf('=') !== -1) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     if (ENV.hasOwnProperty(name)) {
@@ -750,7 +750,7 @@ LibraryManager.library = {
     }
     return 0;
   },
-  putenv__deps: ['$ENV', '__buildEnvironment', '$ERRNO_CODES', '__setErrNo'],
+  putenv__deps: ['$ENV', '__buildEnvironment', '__setErrNo'],
   putenv__proxy: 'sync',
   putenv__sig: 'ii',
   putenv: function(string) {
@@ -760,13 +760,13 @@ LibraryManager.library = {
     //          string is taken by reference so future changes are reflected.
     //          We copy it instead, possibly breaking some uses.
     if (string === 0) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     string = Pointer_stringify(string);
     var splitPoint = string.indexOf('=')
     if (string === '' || string.indexOf('=') === -1) {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     var name = string.slice(0, splitPoint);
@@ -2144,15 +2144,15 @@ LibraryManager.library = {
     }
   },
 
-  stime__deps: ['$ERRNO_CODES', '__setErrNo'],
+  stime__deps: ['__setErrNo'],
   stime: function(when) {
-    ___setErrNo(ERRNO_CODES.EPERM);
+    ___setErrNo({{{ cDefine('EPERM') }}});
     return -1;
   },
 
-  __map_file__deps: ['$ERRNO_CODES', '__setErrNo'],
+  __map_file__deps: ['__setErrNo'],
   __map_file: function(pathname, size) {
-    ___setErrNo(ERRNO_CODES.EPERM);
+    ___setErrNo({{{ cDefine('EPERM') }}});
     return -1;
   },
 
@@ -2755,12 +2755,12 @@ LibraryManager.library = {
     return 0;
   },
 
-  timespec_get__deps: ['clock_gettime', '$ERRNO_CODES', '__setErrNo'],
+  timespec_get__deps: ['clock_gettime', '__setErrNo'],
   timespec_get: function(ts, base) {
     //int timespec_get(struct timespec *ts, int base);
     if (base !== {{{ cDefine('TIME_UTC') }}}) {
       // There is no other implemented value than TIME_UTC; all other values are considered erroneous.
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return 0;
     }
     var ret = _clock_gettime({{{ cDefine('CLOCK_REALTIME') }}}, ts);
@@ -2771,7 +2771,7 @@ LibraryManager.library = {
   // sys/time.h
   // ==========================================================================
 
-  clock_gettime__deps: ['emscripten_get_now', 'emscripten_get_now_is_monotonic', '$ERRNO_CODES', '__setErrNo'],
+  clock_gettime__deps: ['emscripten_get_now', 'emscripten_get_now_is_monotonic', '__setErrNo'],
   clock_gettime: function(clk_id, tp) {
     // int clock_gettime(clockid_t clk_id, struct timespec *tp);
     var now;
@@ -2780,7 +2780,7 @@ LibraryManager.library = {
     } else if (clk_id === {{{ cDefine('CLOCK_MONOTONIC') }}} && _emscripten_get_now_is_monotonic()) {
       now = _emscripten_get_now();
     } else {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     {{{ makeSetValue('tp', C_STRUCTS.timespec.tv_sec, '(now/1000)|0', 'i32') }}}; // seconds
@@ -2788,15 +2788,15 @@ LibraryManager.library = {
     return 0;
   },
   __clock_gettime: 'clock_gettime', // musl internal alias
-  clock_settime__deps: ['$ERRNO_CODES', '__setErrNo'],
+  clock_settime__deps: ['__setErrNo'],
   clock_settime: function(clk_id, tp) {
     // int clock_settime(clockid_t clk_id, const struct timespec *tp);
     // Nothing.
-    ___setErrNo(clk_id === {{{ cDefine('CLOCK_REALTIME') }}} ? ERRNO_CODES.EPERM
-                                                             : ERRNO_CODES.EINVAL);
+    ___setErrNo(clk_id === {{{ cDefine('CLOCK_REALTIME') }}} ? {{{ cDefine('EPERM') }}}
+                                                             : {{{ cDefine('EINVAL') }}});
     return -1;
   },
-  clock_getres__deps: ['emscripten_get_now_res', 'emscripten_get_now_is_monotonic', '$ERRNO_CODES', '__setErrNo'],
+  clock_getres__deps: ['emscripten_get_now_res', 'emscripten_get_now_is_monotonic', '__setErrNo'],
   clock_getres: function(clk_id, res) {
     // int clock_getres(clockid_t clk_id, struct timespec *res);
     var nsec;
@@ -2805,7 +2805,7 @@ LibraryManager.library = {
     } else if (clk_id === {{{ cDefine('CLOCK_MONOTONIC') }}} && _emscripten_get_now_is_monotonic()) {
       nsec = _emscripten_get_now_res();
     } else {
-      ___setErrNo(ERRNO_CODES.EINVAL);
+      ___setErrNo({{{ cDefine('EINVAL') }}});
       return -1;
     }
     {{{ makeSetValue('res', C_STRUCTS.timespec.tv_sec, '(nsec/1000000000)|0', 'i32') }}};
@@ -2814,8 +2814,8 @@ LibraryManager.library = {
   },
   clock_getcpuclockid__deps: ['$PROCINFO'],
   clock_getcpuclockid: function(pid, clk_id) {
-    if (pid < 0) return ERRNO_CODES.ESRCH;
-    if (pid !== 0 && pid !== PROCINFO.pid) return ERRNO_CODES.ENOSYS;
+    if (pid < 0) return {{{ cDefine('ESRCH') }}};
+    if (pid !== 0 && pid !== PROCINFO.pid) return {{{ cDefine('ENOSYS') }}};
     if (clk_id) {{{ makeSetValue('clk_id', 0, 2/*CLOCK_PROCESS_CPUTIME_ID*/, 'i32') }}};
     return 0;
   },
@@ -2961,12 +2961,12 @@ LibraryManager.library = {
   // sys/wait.h
   // ==========================================================================
 
-  wait__deps: ['$ERRNO_CODES', '__setErrNo'],
+  wait__deps: ['__setErrNo'],
   wait: function(stat_loc) {
     // pid_t wait(int *stat_loc);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/wait.html
     // Makes no sense in a single-process environment.
-    ___setErrNo(ERRNO_CODES.ECHILD);
+    ___setErrNo({{{ cDefine('ECHILD') }}});
     return -1;
   },
   // NOTE: These aren't really the same, but we use the same stub for them all.
@@ -3459,14 +3459,14 @@ LibraryManager.library = {
     switch (family) {
       case {{{ cDefine('AF_INET') }}}:
         if (salen !== {{{ C_STRUCTS.sockaddr_in.__size__ }}}) {
-          return { errno: ERRNO_CODES.EINVAL };
+          return { errno: {{{ cDefine('EINVAL') }}} };
         }
         addr = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_addr.s_addr, 'i32') }}};
         addr = __inet_ntop4_raw(addr);
         break;
       case {{{ cDefine('AF_INET6') }}}:
         if (salen !== {{{ C_STRUCTS.sockaddr_in6.__size__ }}}) {
-          return { errno: ERRNO_CODES.EINVAL };
+          return { errno: {{{ cDefine('EINVAL') }}} };
         }
         addr = [
           {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in6.sin6_addr.__in6_union.__s6_addr+0, 'i32') }}},
@@ -3477,7 +3477,7 @@ LibraryManager.library = {
         addr = __inet_ntop6_raw(addr);
         break;
       default:
-        return { errno: ERRNO_CODES.EAFNOSUPPORT };
+        return { errno: {{{ cDefine('EAFNOSUPPORT') }}} };
     }
 
     return { family: family, addr: addr, port: port };
@@ -3503,7 +3503,7 @@ LibraryManager.library = {
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in6.sin6_scope_id, '0', 'i32') }}};
         break;
       default:
-        return { errno: ERRNO_CODES.EAFNOSUPPORT };
+        return { errno: {{{ cDefine('EAFNOSUPPORT') }}} };
     }
     // kind of lame, but let's match _read_sockaddr's interface
     return {};
@@ -3565,7 +3565,7 @@ LibraryManager.library = {
   gethostbyaddr__sig: 'iiii',
   gethostbyaddr: function (addr, addrlen, type) {
     if (type !== {{{ cDefine('AF_INET') }}}) {
-      ___setErrNo(ERRNO_CODES.EAFNOSUPPORT);
+      ___setErrNo({{{ cDefine('EAFNOSUPPORT') }}});
       // TODO: set h_errno
       return null;
     }
@@ -3963,11 +3963,11 @@ LibraryManager.library = {
   // nonblocking
   // ==========================================================================
 #if SOCKET_WEBRTC
-  $Sockets__deps: ['__setErrNo', '$ERRNO_CODES',
+  $Sockets__deps: ['__setErrNo',
     function() { return 'var SocketIO = ' + read('socket.io.js') + ';\n' },
     function() { return 'var Peer = ' + read('wrtcp.js') + ';\n' }],
 #else
-  $Sockets__deps: ['__setErrNo', '$ERRNO_CODES'],
+  $Sockets__deps: ['__setErrNo'],
 #endif
   $Sockets: {
     BUFFER_SIZE: 10*1024, // initial size

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 mergeInto(LibraryManager.library, {
-  $FS__deps: ['$ERRNO_CODES', '$ERRNO_MESSAGES', '__setErrNo', '$PATH', '$TTY', '$MEMFS',
+  $FS__deps: ['__setErrNo', '$PATH', '$TTY', '$MEMFS',
 #if LibraryManager.has('library_idbfs.js')
     '$IDBFS',
 #endif
@@ -16,6 +16,9 @@ mergeInto(LibraryManager.library, {
 #endif
 #if LibraryManager.has('library_noderawfs.js')
     '$NODERAWFS',
+#endif
+#if ASSERTIONS
+    '$ERRNO_MESSAGES', '$ERRNO_CODES',
 #endif
     'stdin', 'stdout', 'stderr'],
   $FS__postset: 'FS.staticInit();' +
@@ -75,7 +78,7 @@ mergeInto(LibraryManager.library, {
       }
 
       if (opts.recurse_count > 8) {  // max recursive lookup of 8
-        throw new FS.ErrnoError(ERRNO_CODES.ELOOP);
+        throw new FS.ErrnoError({{{ cDefine('ELOOP') }}});
       }
 
       // split the path
@@ -116,7 +119,7 @@ mergeInto(LibraryManager.library, {
             current = lookup.node;
 
             if (count++ > 40) {  // limit max consecutive symlinks to 40 (SYMLOOP_MAX).
-              throw new FS.ErrnoError(ERRNO_CODES.ELOOP);
+              throw new FS.ErrnoError({{{ cDefine('ELOOP') }}});
             }
           }
         }
@@ -315,24 +318,24 @@ mergeInto(LibraryManager.library, {
       }
       // return 0 if any user, group or owner bits are set.
       if (perms.indexOf('r') !== -1 && !(node.mode & {{{ cDefine('S_IRUGO') }}})) {
-        return ERRNO_CODES.EACCES;
+        return {{{ cDefine('EACCES') }}};
       } else if (perms.indexOf('w') !== -1 && !(node.mode & {{{ cDefine('S_IWUGO') }}})) {
-        return ERRNO_CODES.EACCES;
+        return {{{ cDefine('EACCES') }}};
       } else if (perms.indexOf('x') !== -1 && !(node.mode & {{{ cDefine('S_IXUGO') }}})) {
-        return ERRNO_CODES.EACCES;
+        return {{{ cDefine('EACCES') }}};
       }
       return 0;
     },
     mayLookup: function(dir) {
       var err = FS.nodePermissions(dir, 'x');
       if (err) return err;
-      if (!dir.node_ops.lookup) return ERRNO_CODES.EACCES;
+      if (!dir.node_ops.lookup) return {{{ cDefine('EACCES') }}};
       return 0;
     },
     mayCreate: function(dir, name) {
       try {
         var node = FS.lookupNode(dir, name);
-        return ERRNO_CODES.EEXIST;
+        return {{{ cDefine('EEXIST') }}};
       } catch (e) {
       }
       return FS.nodePermissions(dir, 'wx');
@@ -350,28 +353,28 @@ mergeInto(LibraryManager.library, {
       }
       if (isdir) {
         if (!FS.isDir(node.mode)) {
-          return ERRNO_CODES.ENOTDIR;
+          return {{{ cDefine('ENOTDIR') }}};
         }
         if (FS.isRoot(node) || FS.getPath(node) === FS.cwd()) {
-          return ERRNO_CODES.EBUSY;
+          return {{{ cDefine('EBUSY') }}};
         }
       } else {
         if (FS.isDir(node.mode)) {
-          return ERRNO_CODES.EISDIR;
+          return {{{ cDefine('EISDIR') }}};
         }
       }
       return 0;
     },
     mayOpen: function(node, flags) {
       if (!node) {
-        return ERRNO_CODES.ENOENT;
+        return {{{ cDefine('ENOENT') }}};
       }
       if (FS.isLink(node.mode)) {
-        return ERRNO_CODES.ELOOP;
+        return {{{ cDefine('ELOOP') }}};
       } else if (FS.isDir(node.mode)) {
         if (FS.flagsToPermissionString(flags) !== 'r' || // opening for write
             (flags & {{{ cDefine('O_TRUNC') }}})) { // TODO: check for O_SEARCH? (== search for dir only)
-          return ERRNO_CODES.EISDIR;
+          return {{{ cDefine('EISDIR') }}};
         }
       }
       return FS.nodePermissions(node, FS.flagsToPermissionString(flags));
@@ -389,7 +392,7 @@ mergeInto(LibraryManager.library, {
           return fd;
         }
       }
-      throw new FS.ErrnoError(ERRNO_CODES.EMFILE);
+      throw new FS.ErrnoError({{{ cDefine('EMFILE') }}});
     },
     getStream: function(fd) {
       return FS.streams[fd];
@@ -453,7 +456,7 @@ mergeInto(LibraryManager.library, {
         }
       },
       llseek: function() {
-        throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
+        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
     },
     major: function(dev) {
@@ -537,7 +540,7 @@ mergeInto(LibraryManager.library, {
       var node;
 
       if (root && FS.root) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       } else if (!root && !pseudo) {
         var lookup = FS.lookupPath(mountpoint, { follow_mount: false });
 
@@ -545,11 +548,11 @@ mergeInto(LibraryManager.library, {
         node = lookup.node;
 
         if (FS.isMountpoint(node)) {
-          throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+          throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
         }
 
         if (!FS.isDir(node.mode)) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
+          throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
         }
       }
 
@@ -583,7 +586,7 @@ mergeInto(LibraryManager.library, {
       var lookup = FS.lookupPath(mountpoint, { follow_mount: false });
 
       if (!FS.isMountpoint(lookup.node)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
 
       // destroy the nodes for this mount, and all its child mounts
@@ -622,14 +625,14 @@ mergeInto(LibraryManager.library, {
       var parent = lookup.node;
       var name = PATH.basename(path);
       if (!name || name === '.' || name === '..') {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       var err = FS.mayCreate(parent, name);
       if (err) {
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.mknod) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       return parent.node_ops.mknod(parent, name, mode, dev);
     },
@@ -656,7 +659,7 @@ mergeInto(LibraryManager.library, {
         try {
           FS.mkdir(d, mode);
         } catch(e) {
-          if (e.errno != ERRNO_CODES.EEXIST) throw e;
+          if (e.errno != {{{ cDefine('EEXIST') }}}) throw e;
         }
       }
     },
@@ -670,12 +673,12 @@ mergeInto(LibraryManager.library, {
     },
     symlink: function(oldpath, newpath) {
       if (!PATH.resolve(oldpath)) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       var lookup = FS.lookupPath(newpath, { parent: true });
       var parent = lookup.node;
       if (!parent) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       var newname = PATH.basename(newpath);
       var err = FS.mayCreate(parent, newname);
@@ -683,7 +686,7 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.symlink) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       return parent.node_ops.symlink(parent, newname, oldpath);
     },
@@ -700,24 +703,24 @@ mergeInto(LibraryManager.library, {
         lookup = FS.lookupPath(new_path, { parent: true });
         new_dir = lookup.node;
       } catch (e) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
-      if (!old_dir || !new_dir) throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+      if (!old_dir || !new_dir) throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       // need to be part of the same mount
       if (old_dir.mount !== new_dir.mount) {
-        throw new FS.ErrnoError(ERRNO_CODES.EXDEV);
+        throw new FS.ErrnoError({{{ cDefine('EXDEV') }}});
       }
       // source must exist
       var old_node = FS.lookupNode(old_dir, old_name);
       // old path should not be an ancestor of the new path
       var relative = PATH.relative(old_path, new_dirname);
       if (relative.charAt(0) !== '.') {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       // new path should not be an ancestor of the old path
       relative = PATH.relative(new_path, old_dirname);
       if (relative.charAt(0) !== '.') {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTEMPTY);
+        throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
       }
       // see if the new path already exists
       var new_node;
@@ -745,10 +748,10 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(err);
       }
       if (!old_dir.node_ops.rename) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       if (FS.isMountpoint(old_node) || (new_node && FS.isMountpoint(new_node))) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
       // if we are going to change the parent, check write permissions
       if (new_dir !== old_dir) {
@@ -792,10 +795,10 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.rmdir) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       if (FS.isMountpoint(node)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
       try {
         if (FS.trackingDelegate['willDeletePath']) {
@@ -816,7 +819,7 @@ mergeInto(LibraryManager.library, {
       var lookup = FS.lookupPath(path, { follow: true });
       var node = lookup.node;
       if (!node.node_ops.readdir) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
+        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
       }
       return node.node_ops.readdir(node);
     },
@@ -833,10 +836,10 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(err);
       }
       if (!parent.node_ops.unlink) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       if (FS.isMountpoint(node)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBUSY);
+        throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
       try {
         if (FS.trackingDelegate['willDeletePath']) {
@@ -857,10 +860,10 @@ mergeInto(LibraryManager.library, {
       var lookup = FS.lookupPath(path);
       var link = lookup.node;
       if (!link) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       if (!link.node_ops.readlink) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       return PATH.resolve(FS.getPath(link.parent), link.node_ops.readlink(link));
     },
@@ -868,10 +871,10 @@ mergeInto(LibraryManager.library, {
       var lookup = FS.lookupPath(path, { follow: !dontFollow });
       var node = lookup.node;
       if (!node) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       if (!node.node_ops.getattr) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       return node.node_ops.getattr(node);
     },
@@ -887,7 +890,7 @@ mergeInto(LibraryManager.library, {
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       node.node_ops.setattr(node, {
         mode: (mode & {{{ cDefine('S_IALLUGO') }}}) | (node.mode & ~{{{ cDefine('S_IALLUGO') }}}),
@@ -900,7 +903,7 @@ mergeInto(LibraryManager.library, {
     fchmod: function(fd, mode) {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       FS.chmod(stream.node, mode);
     },
@@ -913,7 +916,7 @@ mergeInto(LibraryManager.library, {
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       node.node_ops.setattr(node, {
         timestamp: Date.now()
@@ -926,13 +929,13 @@ mergeInto(LibraryManager.library, {
     fchown: function(fd, uid, gid) {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       FS.chown(stream.node, uid, gid);
     },
     truncate: function(path, len) {
       if (len < 0) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       var node;
       if (typeof path === 'string') {
@@ -942,13 +945,13 @@ mergeInto(LibraryManager.library, {
         node = path;
       }
       if (!node.node_ops.setattr) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       if (FS.isDir(node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EISDIR);
+        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
       }
       if (!FS.isFile(node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       var err = FS.nodePermissions(node, 'w');
       if (err) {
@@ -962,10 +965,10 @@ mergeInto(LibraryManager.library, {
     ftruncate: function(fd, len) {
       var stream = FS.getStream(fd);
       if (!stream) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       FS.truncate(stream.node, len);
     },
@@ -978,7 +981,7 @@ mergeInto(LibraryManager.library, {
     },
     open: function(path, flags, mode, fd_start, fd_end) {
       if (path === "") {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       flags = typeof flags === 'string' ? FS.modeStringToFlags(flags) : flags;
       mode = typeof mode === 'undefined' ? 438 /* 0666 */ : mode;
@@ -1007,7 +1010,7 @@ mergeInto(LibraryManager.library, {
         if (node) {
           // if O_CREAT and O_EXCL are set, error out if the node already exists
           if ((flags & {{{ cDefine('O_EXCL') }}})) {
-            throw new FS.ErrnoError(ERRNO_CODES.EEXIST);
+            throw new FS.ErrnoError({{{ cDefine('EEXIST') }}});
           }
         } else {
           // node doesn't exist, try to create it
@@ -1016,7 +1019,7 @@ mergeInto(LibraryManager.library, {
         }
       }
       if (!node) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       // can't truncate a device
       if (FS.isChrdev(node.mode)) {
@@ -1024,7 +1027,7 @@ mergeInto(LibraryManager.library, {
       }
       // if asked only for a directory, then this must be one
       if ((flags & {{{ cDefine('O_DIRECTORY') }}}) && !FS.isDir(node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
+        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
       }
       // check permissions, if this is not a file we just created now (it is ok to
       // create and write to a file with read-only permissions; it is read-only
@@ -1083,7 +1086,7 @@ mergeInto(LibraryManager.library, {
     },
     close: function(stream) {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (stream.getdents) stream.getdents = null; // free readdir state
       try {
@@ -1102,10 +1105,10 @@ mergeInto(LibraryManager.library, {
     },
     llseek: function(stream, offset, whence) {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (!stream.seekable || !stream.stream_ops.llseek) {
-        throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
+        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
       stream.position = stream.stream_ops.llseek(stream, offset, whence);
       stream.ungotten = [];
@@ -1113,25 +1116,25 @@ mergeInto(LibraryManager.library, {
     },
     read: function(stream, buffer, offset, length, position) {
       if (length < 0 || position < 0) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY')}}}) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EISDIR);
+        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
       }
       if (!stream.stream_ops.read) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       var seeking = typeof position !== 'undefined';
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
-        throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
+        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
       var bytesRead = stream.stream_ops.read(stream, buffer, offset, length, position);
       if (!seeking) stream.position += bytesRead;
@@ -1139,19 +1142,19 @@ mergeInto(LibraryManager.library, {
     },
     write: function(stream, buffer, offset, length, position, canOwn) {
       if (length < 0 || position < 0) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EISDIR);
+        throw new FS.ErrnoError({{{ cDefine('EISDIR') }}});
       }
       if (!stream.stream_ops.write) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       if (stream.flags & {{{ cDefine('O_APPEND') }}}) {
         // seek to the end before writing in append mode
@@ -1161,7 +1164,7 @@ mergeInto(LibraryManager.library, {
       if (!seeking) {
         position = stream.position;
       } else if (!stream.seekable) {
-        throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
+        throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
       var bytesWritten = stream.stream_ops.write(stream, buffer, offset, length, position, canOwn);
       if (!seeking) stream.position += bytesWritten;
@@ -1174,29 +1177,29 @@ mergeInto(LibraryManager.library, {
     },
     allocate: function(stream, offset, length) {
       if (FS.isClosed(stream)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (offset < 0 || length <= 0) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_RDONLY')}}}) {
-        throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+        throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
       }
       if (!FS.isFile(stream.node.mode) && !FS.isDir(stream.node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
+        throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
       }
       if (!stream.stream_ops.allocate) {
-        throw new FS.ErrnoError(ERRNO_CODES.EOPNOTSUPP);
+        throw new FS.ErrnoError({{{ cDefine('EOPNOTSUPP') }}});
       }
       stream.stream_ops.allocate(stream, offset, length);
     },
     mmap: function(stream, buffer, offset, length, position, prot, flags) {
       // TODO if PROT is PROT_WRITE, make sure we have write access
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY')}}}) {
-        throw new FS.ErrnoError(ERRNO_CODES.EACCES);
+        throw new FS.ErrnoError({{{ cDefine('EACCES') }}});
       }
       if (!stream.stream_ops.mmap) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
+        throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
       }
       return stream.stream_ops.mmap(stream, buffer, offset, length, position, prot, flags);
     },
@@ -1211,7 +1214,7 @@ mergeInto(LibraryManager.library, {
     },
     ioctl: function(stream, cmd, arg) {
       if (!stream.stream_ops.ioctl) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTTY);
+        throw new FS.ErrnoError({{{ cDefine('ENOTTY') }}});
       }
       return stream.stream_ops.ioctl(stream, cmd, arg);
     },
@@ -1261,10 +1264,10 @@ mergeInto(LibraryManager.library, {
     chdir: function(path) {
       var lookup = FS.lookupPath(path, { follow: true });
       if (lookup.node === null) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       }
       if (!FS.isDir(lookup.node.mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
+        throw new FS.ErrnoError({{{ cDefine('ENOTDIR') }}});
       }
       var err = FS.nodePermissions(lookup.node, 'x');
       if (err) {
@@ -1327,7 +1330,7 @@ mergeInto(LibraryManager.library, {
             lookup: function(parent, name) {
               var fd = +name;
               var stream = FS.getStream(fd);
-              if (!stream) throw new FS.ErrnoError(ERRNO_CODES.EBADF);
+              if (!stream) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
               var ret = {
                 parent: null,
                 mount: { mountpoint: 'fake' },
@@ -1382,15 +1385,21 @@ mergeInto(LibraryManager.library, {
         this.node = node;
         this.setErrno = function(errno) {
           this.errno = errno;
+#if ASSERTIONS
           for (var key in ERRNO_CODES) {
             if (ERRNO_CODES[key] === errno) {
               this.code = key;
               break;
             }
           }
+#endif
         };
         this.setErrno(errno);
+#if ASSERTIONS
         this.message = ERRNO_MESSAGES[errno];
+#else
+        this.message = 'FS error';
+#endif
         // Node.js compatibility: assigning on this.stack fails on Node 4 (but fixed on Node 8)
         if (this.stack) Object.defineProperty(this, "stack", { value: (new Error).stack, writable: true });
 #if ASSERTIONS
@@ -1400,7 +1409,7 @@ mergeInto(LibraryManager.library, {
       FS.ErrnoError.prototype = new Error();
       FS.ErrnoError.prototype.constructor = FS.ErrnoError;
       // Some errors may happen quite a bit, to avoid overhead we reuse them (and suffer a lack of stack info)
-      [ERRNO_CODES.ENOENT].forEach(function(code) {
+      [{{{ cDefine('ENOENT') }}}].forEach(function(code) {
         FS.genericErrors[code] = new FS.ErrnoError(code);
         FS.genericErrors[code].stack = '<generic error, no stack>';
       });
@@ -1583,10 +1592,10 @@ mergeInto(LibraryManager.library, {
             try {
               result = input();
             } catch (e) {
-              throw new FS.ErrnoError(ERRNO_CODES.EIO);
+              throw new FS.ErrnoError({{{ cDefine('EIO') }}});
             }
             if (result === undefined && bytesRead === 0) {
-              throw new FS.ErrnoError(ERRNO_CODES.EAGAIN);
+              throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
             }
             if (result === null || result === undefined) break;
             bytesRead++;
@@ -1602,7 +1611,7 @@ mergeInto(LibraryManager.library, {
             try {
               output(buffer[offset+i]);
             } catch (e) {
-              throw new FS.ErrnoError(ERRNO_CODES.EIO);
+              throw new FS.ErrnoError({{{ cDefine('EIO') }}});
             }
           }
           if (length) {
@@ -1637,7 +1646,7 @@ mergeInto(LibraryManager.library, {
       } else {
         throw new Error('Cannot load without read() or XMLHttpRequest.');
       }
-      if (!success) ___setErrNo(ERRNO_CODES.EIO);
+      if (!success) ___setErrNo({{{ cDefine('EIO') }}});
       return success;
     },
     // Creates a file record for lazy-loading from a URL. XXX This requires a synchronous
@@ -1777,7 +1786,7 @@ mergeInto(LibraryManager.library, {
         var fn = node.stream_ops[key];
         stream_ops[key] = function forceLoadLazyFile() {
           if (!FS.forceLoadFile(node)) {
-            throw new FS.ErrnoError(ERRNO_CODES.EIO);
+            throw new FS.ErrnoError({{{ cDefine('EIO') }}});
           }
           return fn.apply(null, arguments);
         };
@@ -1785,7 +1794,7 @@ mergeInto(LibraryManager.library, {
       // use a custom read function
       stream_ops.read = function stream_ops_read(stream, buffer, offset, length, position) {
         if (!FS.forceLoadFile(node)) {
-          throw new FS.ErrnoError(ERRNO_CODES.EIO);
+          throw new FS.ErrnoError({{{ cDefine('EIO') }}});
         }
         var contents = stream.node.contents;
         if (position >= contents.length)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2399,6 +2399,7 @@ The current type of b is: 9
   @needs_dlfcn
   def test_dlfcn_missing(self):
     self.set_setting('MAIN_MODULE', 1)
+    self.set_setting('ASSERTIONS', 1)
     src = r'''
       #include <dlfcn.h>
       #include <stdio.h>
@@ -2412,6 +2413,9 @@ The current type of b is: 9
       }
       '''
     self.do_run(src, 'error: Could not load dynamic lib: libfoo.so\nError: No such file or directory')
+    print('without assertions, the error is less clear')
+    self.set_setting('ASSERTIONS', 0)
+    self.do_run(src, 'error: Could not load dynamic lib: libfoo.so\nError: FS error')
 
   @needs_dlfcn
   def test_dlfcn_basic(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6143,7 +6143,7 @@ int main(int argc, char** argv) {
 
     self.assertGreater(vector, 1000)
     # we can strip out almost all of libcxx when just using vector
-    self.assertLess(2.4 * vector, iostream)
+    self.assertLess(2.25 * vector, iostream)
 
   @no_wasm_backend('relies on EMULATED_FUNCTION_POINTERS')
   def test_emulated_function_pointers(self):


### PR DESCRIPTION
Avoid `ERRNO_MESSAGES` and `ERRNO_CODES` at runtime. This avoids linking them in and including them in the JS glue.

To enable that

 * Replace e.g. `ERRNO_CODES.EACCES` with `{{{ cDefine('EACCES') }}}`, that is, compute the numeric code at compile time.
 * Avoid including the code and message in FS Error objects (which does dynamic lookups on those objects), except when ASSERTIONS are enabled.

This saves 4% of code size on hello world with c++ iostreams.
