### PR TITLE
Add FORCE_TEXTDECODER option which means we assume it must exist

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1084,6 +1084,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
+    if shared.Settings.FORCE_TEXTDECODER:
+      shared.Settings.TEXTDECODER = 1
+
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
     if shared.Settings.WASM:
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
@@ -1186,6 +1189,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('MODULARIZE is not yet supported with pthreads')
       # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
       shared.Settings.TEXTDECODER = 0
+      shared.Settings.FORCE_TEXTDECODER = 0
       options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
       newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
       shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem

--- a/emcc.py
+++ b/emcc.py
@@ -1084,9 +1084,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
-    if shared.Settings.FORCE_TEXTDECODER:
-      shared.Settings.TEXTDECODER = 1
-
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
     if shared.Settings.WASM:
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
@@ -1189,7 +1186,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('MODULARIZE is not yet supported with pthreads')
       # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
       shared.Settings.TEXTDECODER = 0
-      shared.Settings.FORCE_TEXTDECODER = 0
       options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
       newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
       shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -439,13 +439,13 @@ function stringToAscii(str, outPtr) {
 // Given a pointer 'ptr' to a null-terminated UTF8-encoded string in the given array that contains uint8 values, returns
 // a copy of that string as a Javascript String object.
 
-#if FORCE_TEXTDECODER
+#if TEXTDECODER == 2
 var UTF8Decoder = new TextDecoder('utf8');
-#else // FORCE_TEXTDECODER
+#else // TEXTDECODER == 2
 #if TEXTDECODER
 var UTF8Decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined;
 #endif // TEXTDECODER
-#endif // FORCE_TEXTDECODER
+#endif // TEXTDECODER == 2
 
 function UTF8ArrayToString(u8Array, idx) {
 #if TEXTDECODER
@@ -455,11 +455,11 @@ function UTF8ArrayToString(u8Array, idx) {
   while (u8Array[endPtr]) ++endPtr;
 #endif // TEXTDECODER
 
-#if FORCE_TEXTDECODER
+#if TEXTDECODER == 2
   return UTF8Decoder.decode(
     u8Array.subarray ? u8Array.subarray(idx, endPtr) : new Uint8Array(u8Array.slice(idx, endPtr))
   );
-#else // FORCE_TEXTDECODER
+#else // TEXTDECODER == 2
 #if TEXTDECODER
   if (endPtr - idx > 16 && u8Array.subarray && UTF8Decoder) {
     return UTF8Decoder.decode(u8Array.subarray(idx, endPtr));
@@ -505,7 +505,7 @@ function UTF8ArrayToString(u8Array, idx) {
 #if TEXTDECODER
   }
 #endif // TEXTDECODER
-#endif // FORCE_TEXTDECODER
+#endif // TEXTDECODER == 2
 }
 
 // Given a pointer 'ptr' to a null-terminated UTF8-encoded string in the emscripten HEAP, returns
@@ -624,13 +624,13 @@ function lengthBytesUTF8(str) {
 // Given a pointer 'ptr' to a null-terminated UTF16LE-encoded string in the emscripten HEAP, returns
 // a copy of that string as a Javascript String object.
 
-#if FORCE_TEXTDECODER
+#if TEXTDECODER == 2
 var UTF16Decoder = new TextDecoder('utf-16le');
-#else // FORCE_TEXTDECODER
+#else // TEXTDECODER == 2
 #if TEXTDECODER
 var UTF16Decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-16le') : undefined;
 #endif // TEXTDECODER
-#endif // FORCE_TEXTDECODER
+#endif // TEXTDECODER == 2
 function UTF16ToString(ptr) {
 #if ASSERTIONS
   assert(ptr % 2 == 0, 'Pointer passed to UTF16ToString must be aligned to two bytes!');
@@ -643,13 +643,13 @@ function UTF16ToString(ptr) {
   while (HEAP16[idx]) ++idx;
   endPtr = idx << 1;
 
-#if !FORCE_TEXTDECODER
+#if TEXTDECODER != 2
   if (endPtr - ptr > 32 && UTF16Decoder) {
-#endif // !FORCE_TEXTDECODER
+#endif // TEXTDECODER != 2
     return UTF16Decoder.decode(HEAPU8.subarray(ptr, endPtr));
-#if !FORCE_TEXTDECODER
+#if TEXTDECODER != 2
   } else {
-#endif // FORCE_TEXTDECODER
+#endif // TEXTDECODER != 2
 #endif // TEXTDECODER
     var i = 0;
 
@@ -661,7 +661,7 @@ function UTF16ToString(ptr) {
       // fromCharCode constructs a character from a UTF-16 code unit, so we can pass the UTF16 string right through.
       str += String.fromCharCode(codeUnit);
     }
-#if TEXTDECODER && !FORCE_TEXTDECODER
+#if TEXTDECODER && TEXTDECODER != 2
   }
 #endif // TEXTDECODER
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1204,6 +1204,12 @@ var BUNDLED_CD_DEBUG_FILE = "";
 // Enabled by default, set this to 0 to disable.
 var TEXTDECODER = 1;
 
+// Is enabled, we assume TextDecoder is present and usable, and do not emit
+// any JS code to fall back if it is missing.
+// TODO: when all modern browsers support it, and also node.js, the fallback
+//       code can be in LEGACY_VM_SUPPORT
+var FORCE_TEXTDECODER = 0;
+
 // Embind specific: If enabled, assume UTF-8 encoded data in std::string binding.
 // Disable this to support binary data transfer.
 var EMBIND_STD_STRING_IS_UTF8 = 1;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1202,13 +1202,9 @@ var BUNDLED_CD_DEBUG_FILE = "";
 
 // Is enabled, use the JavaScript TextDecoder API for string marshalling.
 // Enabled by default, set this to 0 to disable.
-var TEXTDECODER = 1;
-
-// Is enabled, we assume TextDecoder is present and usable, and do not emit
+// If set to 2, we assume TextDecoder is present and usable, and do not emit
 // any JS code to fall back if it is missing.
-// TODO: when all modern browsers support it, and also node.js, the fallback
-//       code can be in LEGACY_VM_SUPPORT
-var FORCE_TEXTDECODER = 0;
+var TEXTDECODER = 1;
 
 // Embind specific: If enabled, assume UTF-8 encoded data in std::string binding.
 // Disable this to support binary data transfer.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3924,6 +3924,16 @@ window.close = function() {
   def test_utf16_textdecoder(self):
     self.btest('benchmark_utf16.cpp', expected='0', args=['--embed-file', path_from_root('tests/utf16_corpus.txt') + '@/utf16_corpus.txt', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","lengthBytesUTF16"]'])
 
+  def test_TextDecoder(self):
+    self.btest('browser_test_hello_world.c', '0', args=['-s', 'TEXTDECODER=0'])
+    just_fallback = os.path.getsize('test.js')
+    self.btest('browser_test_hello_world.c', '0')
+    td_with_fallback = os.path.getsize('test.js')
+    self.btest('browser_test_hello_world.c', '0', args=['-s', 'FORCE_TEXTDECODER=1'])
+    td_without_fallback = os.path.getsize('test.js')
+    self.assertLess(td_without_fallback, just_fallback)
+    self.assertLess(just_fallback, td_with_fallback)
+
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.
   @no_chrome('see #7374')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3929,7 +3929,7 @@ window.close = function() {
     just_fallback = os.path.getsize('test.js')
     self.btest('browser_test_hello_world.c', '0')
     td_with_fallback = os.path.getsize('test.js')
-    self.btest('browser_test_hello_world.c', '0', args=['-s', 'FORCE_TEXTDECODER=1'])
+    self.btest('browser_test_hello_world.c', '0', args=['-s', 'TEXTDECODER=2'])
     td_without_fallback = os.path.getsize('test.js')
     self.assertLess(td_without_fallback, just_fallback)
     self.assertLess(just_fallback, td_with_fallback)


### PR DESCRIPTION
This avoids emitting the fallback code, as suggested in #7802 . This shrinks hello world by around 5%.

However,  we can't do this by default, nor even when not `LEGACY_VM_SUPPORT`, since TextDecoder is not present in neither Edge (even the last version from a month or so ago) nor Node.js (at least not in 8.12). :anguished: