### PR TITLE
library_html5.js: only check for .commit() if OFFSCRENCANVAS_SUPPORT is on

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2272,7 +2272,7 @@ var LibraryJSEvents = {
 #if OFFSCREEN_FRAMEBUFFER
     if (GL.currentContext.defaultFbo) {
       GL.blitOffscreenFramebuffer(GL.currentContext);
-#if GL_DEBUG
+#if GL_DEBUG && OFFSCREENCANVAS_SUPPORT
       if (GL.currentContext.GLctx.commit) console.error('emscripten_webgl_commit_frame(): Offscreen framebuffer should never have gotten created when canvas is in OffscreenCanvas mode, since it is redundant and not necessary');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};


### PR DESCRIPTION
This suppresses some spurious error spam when OFFSCREEN_FRAMEBUFFER=1, OFFSCREENCANVAS_SUPPORT=0, and the browser is exposing support for OffscreenCanvas commit().