### PR TITLE
remove_uses_of_pointer_stringify

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -198,8 +198,8 @@ mergeInto(LibraryManager.library, {
 
   emscripten_wget__deps: ['emscripten_async_resume', '$PATH', '$Browser'],
   emscripten_wget: function(url, file) {
-    var _url = Pointer_stringify(url);
-    var _file = Pointer_stringify(file);
+    var _url = UTF8ToString(url);
+    var _file = UTF8ToString(file);
     _file = PATH.resolve(FS.cwd(), _file);
     Module['setAsync']();
     Module['noExitRuntime'] = true;
@@ -409,8 +409,8 @@ mergeInto(LibraryManager.library, {
   emscripten_wget__deps: ['$EmterpreterAsync', '$PATH', '$FS', '$Browser'],
   emscripten_wget: function(url, file) {
     EmterpreterAsync.handle(function(resume) {
-      var _url = Pointer_stringify(url);
-      var _file = Pointer_stringify(file);
+      var _url = UTF8ToString(url);
+      var _file = UTF8ToString(file);
       _file = PATH.resolve(FS.cwd(), _file);
       var destinationDirectory = PATH.dirname(_file);
       FS.createPreloadedFile(
@@ -432,7 +432,7 @@ mergeInto(LibraryManager.library, {
   emscripten_wget_data__deps: ['$EmterpreterAsync', '$Browser'],
   emscripten_wget_data: function(url, pbuffer, pnum, perror) {
     EmterpreterAsync.handle(function(resume) {
-      Browser.asyncLoad(Pointer_stringify(url), function(byteArray) {
+      Browser.asyncLoad(UTF8ToString(url), function(byteArray) {
         resume(function() {
           // can only allocate the buffer after the resume, not during an asyncing
           var buffer = _malloc(byteArray.length); // must be freed by caller!

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -780,8 +780,8 @@ var LibraryBrowser = {
   emscripten_async_wget: function(url, file, onload, onerror) {
     Module['noExitRuntime'] = true;
 
-    var _url = Pointer_stringify(url);
-    var _file = Pointer_stringify(file);
+    var _url = UTF8ToString(url);
+    var _file = UTF8ToString(file);
     _file = PATH.resolve(FS.cwd(), _file);
     function doCallback(callback) {
       if (callback) {
@@ -817,7 +817,7 @@ var LibraryBrowser = {
   emscripten_async_wget_data__proxy: 'sync',
   emscripten_async_wget_data__sig: 'viiii',
   emscripten_async_wget_data: function(url, arg, onload, onerror) {
-    Browser.asyncLoad(Pointer_stringify(url), function(byteArray) {
+    Browser.asyncLoad(UTF8ToString(url), function(byteArray) {
       var buffer = _malloc(byteArray.length);
       HEAPU8.set(byteArray, buffer);
       Module['dynCall_viii'](onload, arg, buffer, byteArray.length);
@@ -832,11 +832,11 @@ var LibraryBrowser = {
   emscripten_async_wget2: function(url, file, request, param, arg, onload, onerror, onprogress) {
     Module['noExitRuntime'] = true;
 
-    var _url = Pointer_stringify(url);
-    var _file = Pointer_stringify(file);
+    var _url = UTF8ToString(url);
+    var _file = UTF8ToString(file);
     _file = PATH.resolve(FS.cwd(), _file);
-    var _request = Pointer_stringify(request);
-    var _param = Pointer_stringify(param);
+    var _request = UTF8ToString(request);
+    var _param = UTF8ToString(param);
     var index = _file.lastIndexOf('/');
 
     var http = new XMLHttpRequest();
@@ -905,9 +905,9 @@ var LibraryBrowser = {
   emscripten_async_wget2_data__proxy: 'sync',
   emscripten_async_wget2_data__sig: 'iiiiiiiii',
   emscripten_async_wget2_data: function(url, request, param, arg, free, onload, onerror, onprogress) {
-    var _url = Pointer_stringify(url);
-    var _request = Pointer_stringify(request);
-    var _param = Pointer_stringify(param);
+    var _url = UTF8ToString(url);
+    var _request = UTF8ToString(request);
+    var _param = UTF8ToString(param);
 
     var http = new XMLHttpRequest();
     http.open(_request, _url, true);
@@ -975,7 +975,7 @@ var LibraryBrowser = {
   emscripten_run_preload_plugins: function(file, onload, onerror) {
     Module['noExitRuntime'] = true;
 
-    var _file = Pointer_stringify(file);
+    var _file = UTF8ToString(file);
     var data = FS.analyzePath(_file);
     if (!data.exists) return -1;
     FS.createPreloadedFile(
@@ -998,7 +998,7 @@ var LibraryBrowser = {
   emscripten_run_preload_plugins_data: function(data, size, suffix, arg, onload, onerror) {
     Module['noExitRuntime'] = true;
 
-    var _suffix = Pointer_stringify(suffix);
+    var _suffix = UTF8ToString(suffix);
     if (!Browser.asyncPrepareDataCounter) Browser.asyncPrepareDataCounter = 0;
     var name = 'prepare_data_' + (Browser.asyncPrepareDataCounter++) + '.' + _suffix;
     var lengthAsUTF8 = lengthBytesUTF8(name);
@@ -1037,7 +1037,7 @@ var LibraryBrowser = {
 
 #if USE_PTHREADS
     if (ENVIRONMENT_IS_PTHREAD) {
-      console.error('emscripten_async_load_script("' + Pointer_stringify(url) + '") failed, emscripten_async_load_script is currently not available in pthreads!');
+      console.error('emscripten_async_load_script("' + UTF8ToString(url) + '") failed, emscripten_async_load_script is currently not available in pthreads!');
       return onerror ? onerror() : undefined;
     }
 #endif
@@ -1055,7 +1055,7 @@ var LibraryBrowser = {
       };
     }
     if (onerror) script.onerror = onerror;
-    script.src = Pointer_stringify(url);
+    script.src = UTF8ToString(url);
     document.body.appendChild(script);
   },
 
@@ -1269,7 +1269,7 @@ var LibraryBrowser = {
   _emscripten_push_main_loop_blocker: function(func, arg, name) {
     Browser.mainLoop.queue.push({ func: function() {
       Module['dynCall_vi'](func, arg);
-    }, name: Pointer_stringify(name), counted: true });
+    }, name: UTF8ToString(name), counted: true });
     Browser.mainLoop.updateStatus();
   },
 
@@ -1277,7 +1277,7 @@ var LibraryBrowser = {
   _emscripten_push_uncounted_main_loop_blocker: function(func, arg, name) {
     Browser.mainLoop.queue.push({ func: function() {
       Module['dynCall_vi'](func, arg);
-    }, name: Pointer_stringify(name), counted: false });
+    }, name: UTF8ToString(name), counted: false });
     Browser.mainLoop.updateStatus();
   },
 
@@ -1360,7 +1360,7 @@ var LibraryBrowser = {
   emscripten_create_worker__proxy: 'sync',
   emscripten_create_worker__sig: 'ii',
   emscripten_create_worker: function(url) {
-    url = Pointer_stringify(url);
+    url = UTF8ToString(url);
     var id = Browser.workers.length;
     var info = {
       worker: new Worker(url),
@@ -1413,7 +1413,7 @@ var LibraryBrowser = {
   emscripten_call_worker: function(id, funcName, data, size, callback, arg) {
     Module['noExitRuntime'] = true; // should we only do this if there is a callback?
 
-    funcName = Pointer_stringify(funcName);
+    funcName = UTF8ToString(funcName);
     var info = Browser.workers[id];
     var callbackId = -1;
     if (callback) {
@@ -1481,9 +1481,7 @@ var LibraryBrowser = {
   emscripten_get_preloaded_image_data__proxy: 'sync',
   emscripten_get_preloaded_image_data__sig: 'iiii',
   emscripten_get_preloaded_image_data: function(path, w, h) {
-    if (typeof path === "number") {
-      path = Pointer_stringify(path);
-    }
+    if ((path | 0) === path) path = UTF8ToString(path);
 
     path = PATH.resolve(path);
 

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -452,7 +452,7 @@ mergeInto(LibraryManager.library, {
   },
   puts: function(s) {
     // extra effort to support puts, even without a filesystem. very partial, very hackish
-    var result = Pointer_stringify(s);
+    var result = UTF8ToString(s);
     var string = result.substr(0);
     if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
     out(string);

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -10,7 +10,7 @@
 
 var LibraryGLEmulation = {
   // GL emulation: provides misc. functionality not present in OpenGL ES 2.0 or WebGL
-  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture'],
+  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$stringToNewUTF8'],
   $GLEmulation__postset: 'GLEmulation.init();',
   $GLEmulation: {
     // Fog support. Partial, we assume shaders are used that implement fog. We just pass them uniforms
@@ -252,11 +252,11 @@ var LibraryGLEmulation = {
         if (GL.stringCache[name_]) return GL.stringCache[name_];
         switch(name_) {
           case 0x1F03 /* GL_EXTENSIONS */: // Add various extensions that we can support
-            var ret = allocate(intArrayFromString(GLctx.getSupportedExtensions().join(' ') +
+            var ret = stringToNewUTF8(GLctx.getSupportedExtensions().join(' ') +
                    ' GL_EXT_texture_env_combine GL_ARB_texture_env_crossbar GL_ATI_texture_env_combine3 GL_NV_texture_env_combine4 GL_EXT_texture_env_dot3 GL_ARB_multitexture GL_ARB_vertex_buffer_object GL_EXT_framebuffer_object GL_ARB_vertex_program GL_ARB_fragment_program GL_ARB_shading_language_100 GL_ARB_shader_objects GL_ARB_vertex_shader GL_ARB_fragment_shader GL_ARB_texture_cube_map GL_EXT_draw_range_elements' +
                    (GL.currentContext.compressionExt ? ' GL_ARB_texture_compression GL_EXT_texture_compression_s3tc' : '') +
                    (GL.currentContext.anisotropicExt ? ' GL_EXT_texture_filter_anisotropic' : '')
-            ), 'i8', ALLOC_NORMAL);
+            );
             GL.stringCache[name_] = ret;
             return ret;
         }

--- a/src/library_glew.js
+++ b/src/library_glew.js
@@ -99,7 +99,7 @@ var LibraryGLEW = {
 
     extensionIsSupported: function(name) {
       if (!GLEW.extensions) {
-        GLEW.extensions = Pointer_stringify(_glGetString(0x1F03)).split(' ');
+        GLEW.extensions = UTF8ToString(_glGetString(0x1F03)).split(' ');
       }
 
       if (GLEW.extensions.indexOf(name) != -1)
@@ -114,7 +114,7 @@ var LibraryGLEW = {
   glewInit: function() { return 0; },
 
   glewIsSupported: function(name) {
-    var exts = Pointer_stringify(name).split(' ');
+    var exts = UTF8ToString(name).split(' ');
     for (var i in exts) {
       if (!GLEW.extensionIsSupported(exts[i]))
         return 0;
@@ -123,7 +123,7 @@ var LibraryGLEW = {
   },
 
   glewGetExtension: function(name) {
-    return GLEW.extensionIsSupported(Pointer_stringify(name));
+    return GLEW.extensionIsSupported(UTF8ToString(name));
   },
 
   glewGetErrorString: function(error) {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -648,7 +648,7 @@ var LibraryGLFW = {
       var win = GLFW.WindowFromId(winid);
       if (!win) return;
 
-      win.title = Pointer_stringify(title);
+      win.title = UTF8ToString(title);
       if (GLFW.active.id == win.id) {
         document.title = win.title;
       }
@@ -1169,7 +1169,7 @@ var LibraryGLFW = {
 
   glfwExtensionSupported: function(extension) {
     if (!GLFW.extensions) {
-      GLFW.extensions = Pointer_stringify(_glGetString(0x1F03)).split(' ');
+      GLFW.extensions = UTF8ToString(_glGetString(0x1F03)).split(' ');
     }
 
     if (GLFW.extensions.indexOf(extension) != -1) return 1;

--- a/src/library_idbstore.js
+++ b/src/library_idbstore.js
@@ -14,7 +14,7 @@ var LibraryIDBStore = {
   ,
 
   emscripten_idb_async_load: function(db, id, arg, onload, onerror) {
-    IDBStore.getFile(Pointer_stringify(db), Pointer_stringify(id), function(error, byteArray) {
+    IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), function(error, byteArray) {
       if (error) {
         if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
@@ -27,7 +27,7 @@ var LibraryIDBStore = {
   },
   emscripten_idb_async_store: function(db, id, ptr, num, arg, onstore, onerror) {
     // note that we copy the data here, as these are async operatins - changes to HEAPU8 meanwhile should not affect us!
-    IDBStore.setFile(Pointer_stringify(db), Pointer_stringify(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), function(error) {
+    IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), function(error) {
       if (error) {
         if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
@@ -36,7 +36,7 @@ var LibraryIDBStore = {
     });
   },
   emscripten_idb_async_delete: function(db, id, arg, ondelete, onerror) {
-    IDBStore.deleteFile(Pointer_stringify(db), Pointer_stringify(id), function(error) {
+    IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), function(error) {
       if (error) {
         if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
@@ -45,7 +45,7 @@ var LibraryIDBStore = {
     });
   },
   emscripten_idb_async_exists: function(db, id, arg, oncheck, onerror) {
-    IDBStore.existsFile(Pointer_stringify(db), Pointer_stringify(id), function(error, exists) {
+    IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), function(error, exists) {
       if (error) {
         if (onerror) Module['dynCall_vi'](onerror, arg);
         return;
@@ -58,7 +58,7 @@ var LibraryIDBStore = {
   emscripten_idb_load__deps: ['$EmterpreterAsync'],
   emscripten_idb_load: function(db, id, pbuffer, pnum, perror) {
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.getFile(Pointer_stringify(db), Pointer_stringify(id), function(error, byteArray) {
+      IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), function(error, byteArray) {
         if (error) {
           {{{ makeSetValueAsm('perror', 0, '1', 'i32') }}};
           resume();
@@ -76,7 +76,7 @@ var LibraryIDBStore = {
   emscripten_idb_store__deps: ['$EmterpreterAsync'],
   emscripten_idb_store: function(db, id, ptr, num, perror) {
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.setFile(Pointer_stringify(db), Pointer_stringify(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), function(error) {
+      IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Uint8Array(HEAPU8.subarray(ptr, ptr+num)), function(error) {
         {{{ makeSetValueAsm('perror', 0, '!!error', 'i32') }}};
         resume();
       });
@@ -85,7 +85,7 @@ var LibraryIDBStore = {
   emscripten_idb_delete__deps: ['$EmterpreterAsync'],
   emscripten_idb_delete: function(db, id, perror) {
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.deleteFile(Pointer_stringify(db), Pointer_stringify(id), function(error) {
+      IDBStore.deleteFile(UTF8ToString(db), UTF8ToString(id), function(error) {
         {{{ makeSetValueAsm('perror', 0, '!!error', 'i32') }}};
         resume();
       });
@@ -94,7 +94,7 @@ var LibraryIDBStore = {
   emscripten_idb_exists__deps: ['$EmterpreterAsync'],
   emscripten_idb_exists: function(db, id, pexists, perror) {
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.existsFile(Pointer_stringify(db), Pointer_stringify(id), function(error, exists) {
+      IDBStore.existsFile(UTF8ToString(db), UTF8ToString(id), function(error, exists) {
         {{{ makeSetValueAsm('pexists', 0, '!!exists', 'i32') }}};
         {{{ makeSetValueAsm('perror',  0, '!!error', 'i32') }}};
         resume();
@@ -123,13 +123,13 @@ var LibraryIDBStore = {
       postMessage({
         target: 'IDBStore',
         method: 'loadBlob',
-        db: Pointer_stringify(db),
-        id: Pointer_stringify(id)
+        db: UTF8ToString(db),
+        id: UTF8ToString(id)
       });
     });
     /*
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.getFile(Pointer_stringify(db), Pointer_stringify(id), function(error, blob) {
+      IDBStore.getFile(UTF8ToString(db), UTF8ToString(id), function(error, blob) {
         if (error) {
           {{{ makeSetValueAsm('perror', 0, '1', 'i32') }}};
           resume();
@@ -156,14 +156,14 @@ var LibraryIDBStore = {
       postMessage({
         target: 'IDBStore',
         method: 'storeBlob',
-        db: Pointer_stringify(db),
-        id: Pointer_stringify(id),
+        db: UTF8ToString(db),
+        id: UTF8ToString(id),
         blob: new Blob([new Uint8Array(HEAPU8.subarray(ptr, ptr+num))])
       });
     });
     /*
     EmterpreterAsync.handle(function(resume) {
-      IDBStore.setFile(Pointer_stringify(db), Pointer_stringify(id), new Blob([new Uint8Array(HEAPU8.subarray(ptr, ptr+num))]), function(error) {
+      IDBStore.setFile(UTF8ToString(db), UTF8ToString(id), new Blob([new Uint8Array(HEAPU8.subarray(ptr, ptr+num))]), function(error) {
         {{{ makeSetValueAsm('perror', 0, '!!error', 'i32') }}};
         resume();
       });

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -1614,7 +1614,7 @@ var LibraryOpenAL = {
 
     // NULL is a valid device name here (resolves to default);
     if (pDeviceName !== 0) {
-      resolvedDeviceName = Pointer_stringify(pDeviceName);
+      resolvedDeviceName = UTF8ToString(pDeviceName);
       if (resolvedDeviceName !== AL.CAPTURE_DEVICE_NAME) {
 #if OPENAL_DEBUG
         console.error('alcCaptureOpenDevice() with invalid device name \''+resolvedDeviceName+'\'');
@@ -2054,7 +2054,7 @@ var LibraryOpenAL = {
   alcOpenDevice__sig: 'ii',
   alcOpenDevice: function(pDeviceName) {
     if (pDeviceName) {
-      var name = Pointer_stringify(pDeviceName);
+      var name = UTF8ToString(pDeviceName);
       if (name !== AL.DEVICE_NAME) {
         return 0;
       }
@@ -2306,7 +2306,7 @@ var LibraryOpenAL = {
   alcIsExtensionPresent__proxy: 'sync',
   alcIsExtensionPresent__sig: 'iii',
   alcIsExtensionPresent: function(deviceId, pExtName) {
-    name = Pointer_stringify(pExtName);
+    name = UTF8ToString(pExtName);
 
     return AL.ALC_EXTENSIONS[name] ? 1 : 0;
   },
@@ -2342,7 +2342,7 @@ var LibraryOpenAL = {
       AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
       return 0; /* ALC_NONE */
     }
-    name = Pointer_stringify(pEnumName);
+    name = UTF8ToString(pEnumName);
     // See alGetEnumValue(), but basically behave the same as OpenAL-Soft
     switch(name) {
     case 'ALC_NO_ERROR': return 0;
@@ -2924,7 +2924,7 @@ var LibraryOpenAL = {
   alIsExtensionPresent__proxy: 'sync',
   alIsExtensionPresent__sig: 'ii',
   alIsExtensionPresent: function(pExtName) {
-    name = Pointer_stringify(pExtName);
+    name = UTF8ToString(pExtName);
 
     return AL.AL_EXTENSIONS[name] ? 1 : 0;
   },
@@ -2966,7 +2966,7 @@ var LibraryOpenAL = {
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return 0 /* AL_NONE */;
     }
-    name = Pointer_stringify(pEnumName);
+    name = UTF8ToString(pEnumName);
 
     switch(name) {
     // Spec doesn't clearly state that alGetEnumValue() is required to

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -562,7 +562,7 @@ var LibraryPThread = {
     // Deduce which WebGL canvases (HTMLCanvasElements or OffscreenCanvases) should be passed over to the
     // Worker that hosts the spawned pthread.
     var transferredCanvasNames = attr ? {{{ makeGetValue('attr', 36, 'i32') }}} : 0; // Comma-delimited list of IDs "canvas1, canvas2, ..."
-    if (transferredCanvasNames) transferredCanvasNames = Pointer_stringify(transferredCanvasNames).trim();
+    if (transferredCanvasNames) transferredCanvasNames = UTF8ToString(transferredCanvasNames).trim();
     if (transferredCanvasNames) transferredCanvasNames = transferredCanvasNames.split(',');
 #if GL_DEBUG
     console.log('pthread_create: transferredCanvasNames="' + transferredCanvasNames + '"');

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1736,9 +1736,9 @@ var LibrarySDL = {
   SDL_WM_SetCaption__sig: 'vii',
   SDL_WM_SetCaption: function(title, icon) {
     if (title && typeof Module['setWindowTitle'] !== 'undefined') {
-      Module['setWindowTitle'](Pointer_stringify(title));
+      Module['setWindowTitle'](UTF8ToString(title));
     }
-    icon = icon && Pointer_stringify(icon);
+    icon = icon && UTF8ToString(icon);
   },
 
   SDL_EnableKeyRepeat: function(delay, interval) {
@@ -3166,7 +3166,7 @@ var LibrarySDL = {
   TTF_OpenFont__proxy: 'sync',
   TTF_OpenFont__sig: 'iii',
   TTF_OpenFont: function(filename, size) {
-    filename = PATH.normalize(Pointer_stringify(filename));
+    filename = PATH.normalize(UTF8ToString(filename));
     var id = SDL.fonts.length;
     SDL.fonts.push({
       name: filename, // but we don't actually do anything with it..
@@ -3185,7 +3185,7 @@ var LibrarySDL = {
   TTF_RenderText_Solid__sig: 'iiii',
   TTF_RenderText_Solid: function(font, text, color) {
     // XXX the font and color are ignored
-    text = Pointer_stringify(text) || ' '; // if given an empty string, still return a valid surface
+    text = UTF8ToString(text) || ' '; // if given an empty string, still return a valid surface
     var fontData = SDL.fonts[font];
     var w = SDL.estimateTextWidth(fontData, text);
     var h = fontData.size;
@@ -3214,7 +3214,7 @@ var LibrarySDL = {
   TTF_SizeText: function(font, text, w, h) {
     var fontData = SDL.fonts[font];
     if (w) {
-      {{{ makeSetValue('w', '0', 'SDL.estimateTextWidth(fontData, Pointer_stringify(text))', 'i32') }}};
+      {{{ makeSetValue('w', '0', 'SDL.estimateTextWidth(fontData, UTF8ToString(text))', 'i32') }}};
     }
     if (h) {
       {{{ makeSetValue('h', '0', 'fontData.size', 'i32') }}};
@@ -3468,7 +3468,7 @@ var LibrarySDL = {
   SDL_SetWindowTitle__proxy: 'sync',
   SDL_SetWindowTitle__sig: 'vii',
   SDL_SetWindowTitle: function(window, title) {
-    if (title) document.title = Pointer_stringify(title);
+    if (title) document.title = UTF8ToString(title);
   },
 
   SDL_GetWindowSize__proxy: 'sync',
@@ -3650,7 +3650,7 @@ var LibrarySDL = {
   SDL_RWFromFile__sig: 'iii',
   SDL_RWFromFile: function(_name, mode) {
     var id = SDL.rwops.length; // TODO: recycle ids when they are null
-    var name = Pointer_stringify(_name)
+    var name = UTF8ToString(_name)
     SDL.rwops.push({ filename: name, mimetype: Browser.getMimetype(name) });
     return id;
   },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -181,7 +181,7 @@ var SyscallsLibrary = {
       return ret;
     },
     getStr: function() {
-      var ret = Pointer_stringify(SYSCALLS.get());
+      var ret = UTF8ToString(SYSCALLS.get());
 #if SYSCALL_DEBUG
       err('    (str: "' + ret + '")');
 #endif

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -137,8 +137,8 @@ var LibraryTracing = {
   },
 
   emscripten_trace_configure: function(collector_url, application) {
-    EmscriptenTrace.configure(Pointer_stringify(collector_url),
-                              Pointer_stringify(application));
+    EmscriptenTrace.configure(UTF8ToString(collector_url),
+                              UTF8ToString(application));
   },
 
   emscripten_trace_configure_for_test: function() {
@@ -154,7 +154,7 @@ var LibraryTracing = {
   },
 
   emscripten_trace_set_session_username: function(username) {
-    EmscriptenTrace.post(EmscriptenTrace.EVENT_USER_NAME, Pointer_stringify(username));
+    EmscriptenTrace.post(EmscriptenTrace.EVENT_USER_NAME, UTF8ToString(username));
   },
 
   emscripten_trace_record_frame_start: function() {
@@ -183,8 +183,8 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_LOG_MESSAGE, now,
-                            Pointer_stringify(channel),
-                            Pointer_stringify(message)]);
+                            UTF8ToString(channel),
+                            UTF8ToString(message)]);
     }
   },
 
@@ -203,10 +203,10 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_LOG_MESSAGE, now,
-                            "MARK", Pointer_stringify(message)]);
+                            "MARK", UTF8ToString(message)]);
     }
     if (EmscriptenTrace.googleWTFEnabled) {
-      window.wtf.trace.mark(Pointer_stringify(message));
+      window.wtf.trace.mark(UTF8ToString(message));
     }
   },
 
@@ -214,7 +214,7 @@ var LibraryTracing = {
     var now = EmscriptenTrace.now();
     var callstack = (new Error).stack;
     EmscriptenTrace.post([EmscriptenTrace.EVENT_REPORT_ERROR, now,
-                          Pointer_stringify(error), callstack]);
+                          UTF8ToString(error), callstack]);
   },
 
   emscripten_trace_record_allocation: function(address, size) {
@@ -247,7 +247,7 @@ var LibraryTracing = {
   emscripten_trace_annotate_address_type: function(address, type_name) {
     if (EmscriptenTrace.postEnabled) {
       EmscriptenTrace.post([EmscriptenTrace.EVENT_ANNOTATE_TYPE, address,
-                            Pointer_stringify(type_name)]);
+                            UTF8ToString(type_name)]);
     }
   },
 
@@ -314,10 +314,10 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_ENTER_CONTEXT,
-                            now, Pointer_stringify(name)]);
+                            now, UTF8ToString(name)]);
     }
     if (EmscriptenTrace.googleWTFEnabled) {
-      EmscriptenTrace.googleWTFEnterScope(Pointer_stringify(name));
+      EmscriptenTrace.googleWTFEnterScope(UTF8ToString(name));
     }
   },
 
@@ -335,15 +335,15 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_TASK_START,
-                            now, task_id, Pointer_stringify(name)]);
+                            now, task_id, UTF8ToString(name)]);
     }
   },
 
   emscripten_trace_task_associate_data: function(key, value) {
     if (EmscriptenTrace.postEnabled) {
       EmscriptenTrace.post([EmscriptenTrace.EVENT_TASK_ASSOCIATE_DATA,
-                            Pointer_stringify(key),
-                            Pointer_stringify(value)]);
+                            UTF8ToString(key),
+                            UTF8ToString(value)]);
     }
   },
 
@@ -351,7 +351,7 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_TASK_SUSPEND,
-                            now, Pointer_stringify(explanation)]);
+                            now, UTF8ToString(explanation)]);
     }
   },
 
@@ -359,7 +359,7 @@ var LibraryTracing = {
     if (EmscriptenTrace.postEnabled) {
       var now = EmscriptenTrace.now();
       EmscriptenTrace.post([EmscriptenTrace.EVENT_TASK_RESUME,
-                            now, task_id, Pointer_stringify(explanation)]);
+                            now, task_id, UTF8ToString(explanation)]);
     }
   },
 

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -85,7 +85,7 @@ mergeInto(LibraryManager.library, {
   // pointed to by uu, otherwise -1 is returned.
   uuid_parse: function(inp, uu) {
     // int uuid_parse(const char *in, uuid_t uu);
-    var inp = Pointer_stringify(inp);
+    var inp = UTF8ToString(inp);
     if (inp.length === 36) {
       var i = 0;
       var uuid = new Array(16);

--- a/system/lib/al.c
+++ b/system/lib/al.c
@@ -52,7 +52,7 @@ void* emscripten_GetAlcProcAddress(ALCchar *name) {
   else if (!strcmp(name, "alcResetDeviceSOFT")) { return emscripten_alcResetDeviceSOFT; }
 
   EM_ASM_({
-    err("bad name in alcGetProcAddress: " + Pointer_stringify($0));
+    err("bad name in alcGetProcAddress: " + UTF8ToString($0));
   }, name);
   return 0;
 }
@@ -137,7 +137,7 @@ void* emscripten_GetAlProcAddress(ALchar *name) {
   // Extensions
 
   EM_ASM_({
-    err("bad name in alGetProcAddress: " + Pointer_stringify($0));
+    err("bad name in alGetProcAddress: " + UTF8ToString($0));
   }, name);
   return 0;
 }

--- a/system/lib/fetch/asmfs.cpp
+++ b/system/lib/fetch/asmfs.cpp
@@ -178,7 +178,7 @@ static void link_inode(inode *node, inode *parent)
 	char parentName[PATH_MAX];
 	inode_abspath(parent, parentName, PATH_MAX);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('link_inode: node "' + Pointer_stringify($0) + '" to parent "' + Pointer_stringify($1) + '".'), node->name, parentName);
+	EM_ASM(err('link_inode: node "' + UTF8ToString($0) + '" to parent "' + UTF8ToString($1) + '".'), node->name, parentName);
 #endif
 	// When linking a node, it can't be part of the filesystem tree (but it can have children of its own)
 	assert(!node->parent);
@@ -212,7 +212,7 @@ static inode *find_predecessor_sibling(inode *node, inode *parent)
 static void unlink_inode(inode *node)
 {
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('unlink_inode: node ' + Pointer_stringify($0) + ' from its parent ' + Pointer_stringify($1) + '.'), node->name, node->parent->name);
+	EM_ASM(err('unlink_inode: node ' + UTF8ToString($0) + ' from its parent ' + UTF8ToString($1) + '.'), node->name, node->parent->name);
 #endif
 	inode *parent = node->parent;
 	if (!parent) return;
@@ -326,7 +326,7 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 		bool is_directory = false;
 		const char *child_path = path_cmp(path_to_file, node->name, &is_directory);
 #ifdef ASMFS_DEBUG
-		EM_ASM_INT( { err('path_cmp ' + Pointer_stringify($0) + ', ' + Pointer_stringify($1) + ', ' + Pointer_stringify($2) + ' .') }, path_to_file, node->name, child_path);
+		EM_ASM_INT( { err('path_cmp ' + UTF8ToString($0) + ', ' + UTF8ToString($1) + ', ' + UTF8ToString($2) + ' .') }, path_to_file, node->name, child_path);
 #endif
 		if (child_path)
 		{
@@ -361,8 +361,8 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 	}
 	const char *basename_pos = basename_part(path_to_file);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('path_to_file ' + Pointer_stringify($0) + ' .'), path_to_file);
-	EM_ASM(err('basename_pos ' + Pointer_stringify($0) + ' .'), basename_pos);
+	EM_ASM(err('path_to_file ' + UTF8ToString($0) + ' .'), path_to_file);
+	EM_ASM(err('basename_pos ' + UTF8ToString($0) + ' .'), basename_pos);
 #endif
 	while(*path_to_file && path_to_file < basename_pos)
 	{
@@ -370,7 +370,7 @@ static inode *create_directory_hierarchy_for_file(inode *root, const char *path_
 		path_to_file += strcpy_inodename(node->name, path_to_file) + 1;
 		link_inode(node, root);
 #ifdef ASMFS_DEBUG
-		EM_ASM(out('create_directory_hierarchy_for_file: created directory ' + Pointer_stringify($0) + ' under parent ' + Pointer_stringify($1) + '.'), 
+		EM_ASM(out('create_directory_hierarchy_for_file: created directory ' + UTF8ToString($0) + ' under parent ' + UTF8ToString($1) + '.'), 
 			node->name, node->parent->name);
 #endif
 		root = node;
@@ -387,7 +387,7 @@ static inode *find_parent_inode(inode *root, const char *path, int *out_errno)
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('find_parent_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+	EM_ASM(err('find_parent_inode(root="' + UTF8ToString($0) + '", path="' + UTF8ToString($1) + '")'), rootName, path);
 #endif
 
 	assert(out_errno); // Passing in error is mandatory.
@@ -466,7 +466,7 @@ static inode *find_inode(inode *root, const char *path, int *out_errno)
 	char rootName[PATH_MAX];
 	inode_abspath(root, rootName, PATH_MAX);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('find_inode(root="' + Pointer_stringify($0) + '", path="' + Pointer_stringify($1) + '")'), rootName, path);
+	EM_ASM(err('find_inode(root="' + UTF8ToString($0) + '", path="' + UTF8ToString($1) + '")'), rootName, path);
 #endif
 
 	assert(out_errno); // Passing in error is mandatory.
@@ -686,14 +686,14 @@ void emscripten_dump_fs_tree(inode *root, char *path)
 			child->size ? child->size : (child->fetch ? (int)child->fetch->numBytes : 0),
 			child->name,
 			child->type == INODE_DIR ? '/' : ' ');
-		EM_ASM(out(Pointer_stringify($0)), str);
+		EM_ASM(out(UTF8ToString($0)), str);
 
 		totalSize += child->size;
 		child = child->sibling;
 	}
 
 	sprintf(str, "total %llu bytes\n", totalSize);
-	EM_ASM(out(Pointer_stringify($0)), str);
+	EM_ASM(out(UTF8ToString($0)), str);
 
 	child = root->child;
 	char *path_end = path + strlen(path);
@@ -737,7 +737,7 @@ void EMSCRIPTEN_KEEPALIVE emscripten_asmfs_discard_tree(const char *path)
 
 #ifdef ASMFS_DEBUG
 #define RETURN_ERRNO(errno, error_reason) do { \
-		EM_ASM(err(Pointer_stringify($0) + '() returned errno ' + #errno + '(' + $1 + '): ' + error_reason + '!'), __FUNCTION__, errno); \
+		EM_ASM(err(UTF8ToString($0) + '() returned errno ' + #errno + '(' + $1 + '): ' + error_reason + '!'), __FUNCTION__, errno); \
 		return -errno; \
 	} while(0)
 #else
@@ -762,7 +762,7 @@ static void print_stream(void *bytes, int numBytes, bool stdout)
 		if (buffer[i] == '\n')
 		{
 			buffer[i] = 0;
-			EM_ASM_INT( { out(Pointer_stringify($0)) }, buffer+new_buffer_start);
+			EM_ASM_INT( { out(UTF8ToString($0)) }, buffer+new_buffer_start);
 			new_buffer_start = i+1;
 		}
 	}
@@ -842,7 +842,7 @@ static long open(const char *pathname, int flags, int mode)
 	// However existing earlier unit tests in Emscripten expect that O_EXCL is simply ignored when O_CREAT was not passed. So do that for now.
 	if ((flags & O_EXCL) && !(flags & O_CREAT)) {
 #ifdef ASMFS_DEBUG
-		EM_ASM(err('warning: open(pathname="' + Pointer_stringify($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ': flag O_EXCL should always be paired with O_CREAT. Ignoring O_EXCL)'), pathname, flags, mode);
+		EM_ASM(err('warning: open(pathname="' + UTF8ToString($0) + '", flags=0x' + ($1).toString(16) + ', mode=0' + ($2).toString(8) + ': flag O_EXCL should always be paired with O_CREAT. Ignoring O_EXCL)'), pathname, flags, mode);
 #endif
 		flags &= ~O_EXCL;
 	}
@@ -1169,7 +1169,7 @@ long __syscall9(int which, ...) // link
 	const char *newpath = va_arg(vl, const char *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('link(oldpath="' + Pointer_stringify($0) + '", newpath="' + Pointer_stringify($1) + '")'), oldpath, newpath);
+	EM_ASM(err('link(oldpath="' + UTF8ToString($0) + '", newpath="' + UTF8ToString($1) + '")'), oldpath, newpath);
 #endif
 	((void)oldpath);
 	((void)newpath);
@@ -1184,7 +1184,7 @@ long __syscall10(int which, ...) // unlink
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('unlink(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('unlink(pathname="' + UTF8ToString($0) + '")'), pathname);
 #endif
 
 	int len = strlen(pathname);
@@ -1229,7 +1229,7 @@ long __syscall12(int which, ...) // chdir
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('chdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('chdir(pathname="' + UTF8ToString($0) + '")'), pathname);
 #endif
 
 	int len = strlen(pathname);
@@ -1259,7 +1259,7 @@ long __syscall14(int which, ...) // mknod
 	int dev = va_arg(vl, int);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('mknod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ', dev=' + $2 + ')'), pathname, mode, dev);
+	EM_ASM(err('mknod(pathname="' + UTF8ToString($0) + '", mode=0' + ($1).toString(8) + ', dev=' + $2 + ')'), pathname, mode, dev);
 #endif
 	(void)pathname;
 	(void)mode;
@@ -1276,7 +1276,7 @@ long __syscall15(int which, ...) // chmod
 	int mode = va_arg(vl, int);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('chmod(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('chmod(pathname="' + UTF8ToString($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 #endif
 
 	int len = strlen(pathname);
@@ -1307,7 +1307,7 @@ long __syscall33(int which, ...) // access
 	int mode = va_arg(vl, int);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('access(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('access(pathname="' + UTF8ToString($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 #endif
 
 	int len = strlen(pathname);
@@ -1353,7 +1353,7 @@ long __syscall36(int which, ...) // sync
 long EMSCRIPTEN_KEEPALIVE emscripten_asmfs_mkdir(const char *pathname, mode_t mode)
 {
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('mkdir(pathname="' + Pointer_stringify($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
+	EM_ASM(err('mkdir(pathname="' + UTF8ToString($0) + '", mode=0' + ($1).toString(8) + ')'), pathname, mode);
 #endif
 
 	int len = strlen(pathname);
@@ -1431,7 +1431,7 @@ long __syscall40(int which, ...) // rmdir
 	const char *pathname = va_arg(vl, const char *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('rmdir(pathname="' + Pointer_stringify($0) + '")'), pathname);
+	EM_ASM(err('rmdir(pathname="' + UTF8ToString($0) + '")'), pathname);
 #endif
 
 	int len = strlen(pathname);
@@ -1793,7 +1793,7 @@ long __syscall195(int which, ...) // SYS_stat64
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('SYS_stat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+	EM_ASM(err('SYS_stat64(pathname="' + UTF8ToString($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
 #endif
 
 	int len = strlen(pathname);
@@ -1832,7 +1832,7 @@ long __syscall196(int which, ...) // SYS_lstat64
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('SYS_lstat64(pathname="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
+	EM_ASM(err('SYS_lstat64(pathname="' + UTF8ToString($0) + '", buf=0x' + ($1).toString(16) + ')'), pathname, buf);
 #endif
 
 	int len = strlen(pathname);
@@ -1863,7 +1863,7 @@ long __syscall197(int which, ...) // SYS_fstat64
 	struct stat *buf = va_arg(vl, struct stat *);
 	va_end(vl);
 #ifdef ASMFS_DEBUG
-	EM_ASM(err('SYS_fstat64(fd="' + Pointer_stringify($0) + '", buf=0x' + ($1).toString(16) + ')'), fd, buf);
+	EM_ASM(err('SYS_fstat64(fd="' + UTF8ToString($0) + '", buf=0x' + ($1).toString(16) + ')'), fd, buf);
 #endif
 
 	FileDescriptor *desc = (FileDescriptor*)fd;

--- a/tests/core/test_em_asm.cpp
+++ b/tests/core/test_em_asm.cpp
@@ -20,9 +20,9 @@ int main() {
 #define TEST() \
   FUNC({ out("  takes ints: " + $0);}, 5); \
   FUNC({ out("  takes doubles: " + $0);}, 5.0675); \
-  FUNC({ out("  takes strings: " + Pointer_stringify($0)); return 7.75; }, "string arg"); \
+  FUNC({ out("  takes strings: " + UTF8ToString($0)); return 7.75; }, "string arg"); \
   FUNC({ out("  takes multiple ints: " + $0 + ", " + $1); return 6; }, 5, 7); \
-  FUNC({ out("  mixed arg types: " + $0 + ", " + Pointer_stringify($1) + ", " + $2); return 8.125; }, 3, "hello", 4.75); \
+  FUNC({ out("  mixed arg types: " + $0 + ", " + UTF8ToString($1) + ", " + $2); return 8.125; }, 3, "hello", 4.75); \
   FUNC({ out("  ignores unused args"); return 5.5; }, 0);     \
   FUNC({ out("  skips unused args: " + $1); return 6; }, 5, 7); \
   FUNC({ out("  " + $0 + " + " + $2); return $0 + $2; }, 5.5, 7.0, 14.375);

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -18,7 +18,7 @@ EM_JS(double, noarg_double, (void), {
 EM_JS(void, intarg, (int x), { out("  takes ints: " + x);});
 EM_JS(void, doublearg, (double d), { out("  takes doubles: " + d);});
 EM_JS(double, stringarg, (char* str), {
-  out("  takes strings: " + Pointer_stringify(str));
+  out("  takes strings: " + UTF8ToString(str));
   return 7.75;
 });
 EM_JS(int, multi_intarg, (int x, int y), {
@@ -26,7 +26,7 @@ EM_JS(int, multi_intarg, (int x, int y), {
   return 6;
 });
 EM_JS(double, multi_mixedarg, (int x, const char* str, double d), {
-  out("  mixed arg types: " + x + ", " + Pointer_stringify(str) + ", " + d);
+  out("  mixed arg types: " + x + ", " + UTF8ToString(str) + ", " + d);
   return 8.125;
 });
 EM_JS(int, unused_args, (int unused), {

--- a/tests/core/test_emmalloc.cpp
+++ b/tests/core/test_emmalloc.cpp
@@ -33,7 +33,7 @@ void check_where_we_would_malloc(size_t size, void* expected) {
 
 void stage(const char* name) {
   EM_ASM({
-    out('\n>> ' + Pointer_stringify($0) + '\n');
+    out('\n>> ' + UTF8ToString($0) + '\n');
   }, name);
 }
 

--- a/tests/core/test_utf.c
+++ b/tests/core/test_utf.c
@@ -15,7 +15,7 @@ int main() {
   emscripten_run_script(
       "cheez = _malloc(100);"
       "Module.stringToUTF8(\"μ†ℱ ╋ℯ╳╋ 😇\", cheez, 100);"
-      "out([Pointer_stringify(cheez), Module.getValue(cheez, "
+      "out([UTF8ToString(cheez), Module.getValue(cheez, "
       "'i8')&0xff, Module.getValue(cheez+1, 'i8')&0xff, "
       "Module.getValue(cheez+2, 'i8')&0xff, Module.getValue(cheez+3, "
       "'i8')&0xff].join(','));");

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -45,7 +45,7 @@ void ensure_js(string js_code)
   js_code.append(";");
   const char* js_code_pointer = js_code.c_str();
   ensure(EM_ASM_({
-    var js_code = Pointer_stringify($0);
+    var js_code = UTF8ToString($0);
     return eval(js_code);
   }, js_code_pointer));
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7848,7 +7848,7 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1506, [],         [],      226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1507, [],         [],      226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')


### PR DESCRIPTION
Remove uses of Pointer_stringify() in favor of UTF8ToString(). We can eventually deprecate Pointer_stringify() in favor of UTF8ToString(), to clean up code size.