### PR TITLE
restore_closure_minification

### DIFF
--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -836,11 +836,6 @@ SIMD.Bool32x4.fromFloat64x2 = function() {};
 SIMD.Bool64x2.fromFloat64x2 = function() {};
 
 /**
- * @suppress {duplicate}
- */
-var GLctx = {};
-
-/**
  * @const
  */
 var WebAssembly = {};
@@ -1133,6 +1128,10 @@ var buffer;
 /**
  * @suppress {duplicate}
  */
+var global;
+/**
+ * @suppress {duplicate}
+ */
 var fs;
 /**
  * @suppress {undefinedVars}
@@ -1158,10 +1157,6 @@ var SDL;
  * @suppress {duplicate, undefinedVars}
  */
 var SDL2;
-/**
- * @suppress {duplicate, undefinedVars}
- */
-var JSEvents;
 /**
  * @suppress {undefinedVars}
  */
@@ -1286,14 +1281,6 @@ var _emscripten_glDisableVertexAttribArray;
  */
 var _emscripten_glVertexAttribPointer;
 
-/**
- * @suppress {duplicate, undefinedVars}
- */
-var _glDrawArrays;
-/**
- * @suppress {duplicate, undefinedVars}
- */
-var _glDrawElements;
 /**
  * @suppress {duplicate, undefinedVars}
  */


### PR DESCRIPTION
Remove Closure externs that are preventing Closure from performing important minification.

These variables are not currently being minified, which expands code size undesirably for all users. I suspect these have been added to ignore list to allow external JS code to access e.g. `GLctx` or `JSEvents`? If so, this is the wrong way to export access to them, because it unconditionally applies to all builds, even those that do not need the symbols exported. Instead, we should make sure these get minified by default, and that another mechanism is used to export/remove minification.