### PR TITLE
cpuprofiler_without_emscripten_set_main_loop

### DIFF
--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -260,6 +260,19 @@ var emscriptenCpuProfiler = {
 
   // Installs the startup hooks and periodic UI update timer.
   initialize: function initialize() {
+    // Hook into requestAnimationFrame function to grab animation even if application did not use emscripten_set_main_loop() to drive animation, but e.g. used its own function that performs requestAnimationFrame().
+    if (!window.realRequestAnimationFrame) {
+      window.realRequestAnimationFrame = window.requestAnimationFrame;
+      window.requestAnimationFrame = function(cb) {
+        function hookedCb(p) {
+          emscriptenCpuProfiler.frameStart();
+          cb(performance.now());
+          emscriptenCpuProfiler.frameEnd();
+        }
+        return window.realRequestAnimationFrame(hookedCb);
+      }
+    }
+
     // Create the UI display if it doesn't yet exist. If you want to customize the location/style of the cpuprofiler UI,
     // you can manually create this beforehand.
     cpuprofiler = document.getElementById('cpuprofiler');


### PR DESCRIPTION
Update cpuprofiler to work even if application is not using emscripten_set_main_loop() (but uses some other custom function to do rAFs)