### PR TITLE
Remove support for the binaryen interpreter / wasm.js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1313,8 +1313,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
         exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
       options.memory_init_file = True
-      # async compilation requires not interpreting (the interpreter modes needs sync input)
-      if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1 and 'interpret' not in shared.Settings.BINARYEN_METHOD:
+      if shared.Settings.BINARYEN_ASYNC_COMPILATION == 1:
         # async compilation requires a swappable module - we swap it in when it's ready
         shared.Settings.SWAPPABLE_ASM_MODULE = 1
       else:
@@ -1343,7 +1342,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # we will include the mem init data in the wasm, when we don't need the
       # mem init file to be loadable by itself
       shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                         'interpret-asm2wasm' not in shared.Settings.BINARYEN_METHOD and \
                                          not shared.Settings.USE_PTHREADS
 
       # wasm side modules have suffix .wasm
@@ -1364,10 +1362,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # for asm.js: this option is not a js optimizer pass, but does run the js optimizer internally, so
         # we need to generate proper code for that (for wasm, we run a binaryen tool for this)
         shared.Settings.RUNNING_JS_OPTS = 1
-      else:
-        if 'interpret' in shared.Settings.BINARYEN_METHOD:
-          logger.warning('disabling EVAL_CTORS as the bundled interpreter confuses the ctor tool')
-          shared.Settings.EVAL_CTORS = 0
 
     # memory growth does not work in dynamic linking, except for wasm
     if not shared.Settings.WASM and (shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE):
@@ -2466,7 +2460,7 @@ def separate_asm_js(final, asm_target):
 def binaryen_method_sanity_check():
   if shared.Settings.BINARYEN_METHOD:
     methods = shared.Settings.BINARYEN_METHOD.split(',')
-    valid_methods = ['asmjs', 'native-wasm', 'interpret-s-expr', 'interpret-binary', 'interpret-asm2wasm']
+    valid_methods = ['asmjs', 'native-wasm']
     for m in methods:
       if m.strip() not in valid_methods:
         exit_with_error('Unrecognized BINARYEN_METHOD "' + m.strip() + '" specified! Please pass a comma-delimited list containing one or more of: ' + ','.join(valid_methods))
@@ -2477,23 +2471,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
   global final
   logger.debug('using binaryen, with method: ' + shared.Settings.BINARYEN_METHOD)
   binaryen_bin = shared.Building.get_binaryen_bin()
-  binaryen_lib = shared.Building.get_binaryen_lib()
-  # Emit wasm.js at the top of the js. This is *not* optimized with the rest of the code, since
-  # (1) it contains asm.js, whose validation would be broken, and (2) it's very large so it would
-  # be slow in cleanup/JSDCE etc.
-  # TODO: for html, it could be a separate script tag
-  # We need wasm.js if there is a chance the polyfill will be used. If the user sets
-  # BINARYEN_METHOD with something that doesn't use the polyfill, then we don't need it.
-  if not shared.Settings.BINARYEN_METHOD or 'interpret' in shared.Settings.BINARYEN_METHOD:
-    logger.debug('integrating wasm.js polyfill interpreter')
-    wasm_js = open(os.path.join(binaryen_lib, 'wasm.js')).read()
-    wasm_js = wasm_js.replace('EMSCRIPTEN_', 'emscripten_') # do not confuse the markers
-    js = open(final).read()
-    combined = open(final, 'w')
-    combined.write(wasm_js)
-    combined.write('\n//^wasm.js\n')
-    combined.write(js)
-    combined.close()
   # normally we emit binary, but for debug info, we might emit text first
   wrote_wasm_text = False
   debug_info = options.debug_level >= 2 or options.profiling_funcs
@@ -2578,10 +2555,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['-g'] # preserve the debug info
     logger.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))
     shared.check_call(cmd)
-  if not wrote_wasm_text and 'interpret-s-expr' in shared.Settings.BINARYEN_METHOD:
-    cmd = [os.path.join(binaryen_bin, 'wasm-dis'), wasm_binary_target, '-o', wasm_text_target]
-    logger.debug('wasm-dis (binary => text): ' + ' '.join(cmd))
-    shared.check_call(cmd)
   if shared.Settings.BINARYEN_SCRIPTS:
     binaryen_scripts = os.path.join(shared.Settings.BINARYEN_ROOT, 'scripts')
     script_env = os.environ.copy()
@@ -2625,15 +2598,12 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     f.close()
     f = open(final, 'w')
     for target, replacement_string, should_embed in (
-        (wasm_text_target,
-         shared.FilenameReplacementStrings.WASM_TEXT_FILE,
-         'interpret-s-expr' in shared.Settings.BINARYEN_METHOD),
         (wasm_binary_target,
          shared.FilenameReplacementStrings.WASM_BINARY_FILE,
-         'native-wasm' in shared.Settings.BINARYEN_METHOD or 'interpret-binary' in shared.Settings.BINARYEN_METHOD),
+         'native-wasm' in shared.Settings.BINARYEN_METHOD),
         (asm_target,
          shared.FilenameReplacementStrings.ASMJS_CODE_FILE,
-         'asmjs' in shared.Settings.BINARYEN_METHOD or 'interpret-asm2wasm' in shared.Settings.BINARYEN_METHOD),
+         'asmjs' in shared.Settings.BINARYEN_METHOD),
       ):
       if should_embed and os.path.isfile(target):
         js = js.replace(replacement_string, shared.JS.get_subresource_location(target))

--- a/emcc.py
+++ b/emcc.py
@@ -2472,7 +2472,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
   logger.debug('using binaryen, with method: ' + shared.Settings.BINARYEN_METHOD)
   binaryen_bin = shared.Building.get_binaryen_bin()
   # normally we emit binary, but for debug info, we might emit text first
-  wrote_wasm_text = False
   debug_info = options.debug_level >= 2 or options.profiling_funcs
   emit_symbol_map = options.emit_symbol_map or shared.Settings.CYBERDWARF
   # finish compiling to WebAssembly, using asm2wasm, if we didn't already emit WebAssembly directly using the wasm backend.
@@ -2522,7 +2521,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['-o', wasm_binary_target]
     else:
       cmd += ['-o', wasm_text_target, '-S']
-      wrote_wasm_text = True
     cmd += shared.Building.get_binaryen_feature_flags()
     logger.debug('asm2wasm (asm.js => WebAssembly): ' + ' '.join(cmd))
     TimeLogger.update()

--- a/src/settings.js
+++ b/src/settings.js
@@ -975,7 +975,7 @@ var WASM_BACKEND = 0;
 var WASM_OBJECT_FILES = 0;
 
 // How we should run WebAssembly code. By default, we run it natively.
-// See binaryen's src/js/wasm.js-post.js for more details and options.
+// See binaryen's src/preamble.js for more details and options.
 var BINARYEN_METHOD = "native-wasm";
 
 // An optional comma-separated list of script hooks to run after binaryen,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3848,10 +3848,6 @@ window.close = function() {
       print('default html')
       self.btest('in_flight_memfile_request.c', expected='0' if o < 2 else '1', args=opts) # should happen when there is a mem init file (-O2+)
 
-  def test_binaryen_interpreter(self):
-    self.btest('browser_test_hello_world.c', expected='0', args=['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
-    self.btest('browser_test_hello_world.c', expected='0', args=['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"', '-O2'])
-
   @requires_sync_compilation
   def test_binaryen_async(self):
     # notice when we use async compilation
@@ -3888,7 +3884,6 @@ window.close = function() {
       (['-O3'], 1),
       (['-s', 'BINARYEN_ASYNC_COMPILATION=1'], 1), # force it on
       (['-O1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'], 0), # force it off
-      (['-s', 'BINARYEN_ASYNC_COMPILATION=1', '-s', 'BINARYEN_METHOD="interpret-binary"'], 0), # try to force it on, but have it disabled
     ]:
       print(opts, expect)
       self.btest('binaryen_async.c', expected=str(expect), args=common_args + opts)
@@ -4175,7 +4170,7 @@ window.close = function() {
 
   # Tests that base64 utils work in browser with no native atob function
   def test_base64_atob_fallback(self):
-    opts = ['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='interpret-binary'"]
+    opts = ['-s', 'SINGLE_FILE=1', '-s', 'WASM=1']
     src = r'''
       #include <stdio.h>
       #include <emscripten.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8021,7 +8021,6 @@ asm2nn = make_run('asm2nn', emcc_args=['-O2'], settings={'WASM': 0}, env={'EMCC_
 binaryen2jo = make_run('binaryen2jo', emcc_args=['-O2'], settings={'BINARYEN_METHOD': 'native-wasm,asmjs'})
 binaryen3jo = make_run('binaryen3jo', emcc_args=['-O3'], settings={'BINARYEN_METHOD': 'native-wasm,asmjs'})
 binaryen2s = make_run('binaryen2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
-binaryen2_interpret = make_run('binaryen2_interpret', emcc_args=['-O2'], settings={'BINARYEN_METHOD', 'interpret-binary'})
 
 # emterpreter
 asmi = make_run('asmi', emcc_args=[], settings={'ASM_JS': 2, 'EMTERPRETIFY': 1, 'WASM': 0})

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8223,7 +8223,6 @@ int main() {
         expect_emterpretify_file = False
         expect_meminit = False
         expect_wasm = False
-        expect_wast = False
         cmd += ['-s', 'SINGLE_FILE=1']
       if meminit1_enabled:
         cmd += ['--memory-init-file', '1']
@@ -8250,11 +8249,12 @@ int main() {
       if expect_success and proc.returncode != 0:
         print(proc.stdout)
       assert expect_success == (proc.returncode == 0)
-      assert expect_asmjs_code == os.path.exists('a.out.asm.js')
-      assert expect_emterpretify_file == os.path.exists('a.out.dat')
-      assert expect_meminit == (os.path.exists('a.out.mem') or os.path.exists('a.out.js.mem'))
-      assert expect_wasm == os.path.exists('a.out.wasm')
-      assert expect_wast == os.path.exists('a.out.wast')
+      if proc.returncode == 0:
+        assert expect_asmjs_code == os.path.exists('a.out.asm.js')
+        assert expect_emterpretify_file == os.path.exists('a.out.dat')
+        assert expect_meminit == (os.path.exists('a.out.mem') or os.path.exists('a.out.js.mem'))
+        assert expect_wasm == os.path.exists('a.out.wasm')
+        assert expect_wast == os.path.exists('a.out.wast')
       if should_run_js:
         self.assertContained('hello, world!', run_js('a.out.js'))
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3428,7 +3428,7 @@ int main() {
     self.assertEqual(out.count(expected_output), 2)
 
     # test an abort during startup
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_METHOD="interpret-binary"'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
     os.remove('a.out.wasm') # trigger onAbort by intentionally causing startup to fail
     add_on_abort_and_verify()
 
@@ -7536,20 +7536,20 @@ int main() {
           (['-O2', '-s', 'EVAL_CTORS=1'], False, True, True), # ctor evaller turned off since only-wasm
           (['-O2', '-s', 'OUTLINING_LIMIT=1000'], True, True, False), # option forced
           (['-O2', '-s', 'OUTLINING_LIMIT=1000', '-s', 'ALLOW_MEMORY_GROWTH=1'], True, True, False), # option forced, and also check growth does not interfere
-          (['-O2', '-s', "BINARYEN_METHOD='interpret-s-expr,asmjs'"], True, True, False), # asmjs in methods means we need good asm.js
+          (['-O2', '-s', "BINARYEN_METHOD='native-wasm,asmjs'"], True, True, False), # asmjs in methods means we need good asm.js
           (['-O3'], False, True, True),
           (['-Os'], False, True, True),
           (['-Oz'], False, True, True), # ctor evaller turned off since only-wasm
         ]:
         try_delete('a.out.js')
         try_delete('a.out.wast')
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c'), '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
+        cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c')] + args
         print(args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd))
         err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
         assert expect_js_opts == ('applying js optimization passes:' in err), err
         if not self.is_wasm_backend():
           assert expect_only_wasm == ('-emscripten-only-wasm' in err and '--wasm-only' in err), err # check both flag to fastcomp and to asm2wasm
-        wast = open('a.out.wast').read()
+        wast = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
         # i64s
         i64s = wast.count('(i64.')
         print('    seen i64s:', i64s)
@@ -7585,7 +7585,7 @@ int main() {
         ]:
         print(args, expect)
         try_delete('a.out.js')
-        err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'] + args, stdout=PIPE, stderr=PIPE).stderr
+        err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1'] + args, stdout=PIPE, stderr=PIPE).stderr
         assert expect == (' -emscripten-precise-f32' in err), err
         self.assertContained('hello, world!', run_js('a.out.js'))
 
@@ -7632,8 +7632,8 @@ int main() {
 
   @unittest.skipIf(SPIDERMONKEY_ENGINE not in JS_ENGINES, 'cannot run without spidermonkey')
   def test_binaryen_warn_sync(self):
-    # interpreting will disable async
-    for method in ['interpret-binary', 'native-wasm', None]:
+    # non-native wasm will disable async
+    for method in ['asmjs', 'native-wasm', None]:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')]
       if method is not None:
         cmd += ['-s', 'BINARYEN_METHOD="' + method + '"']
@@ -7641,7 +7641,7 @@ int main() {
       err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
       print(err)
       warning = 'BINARYEN_ASYNC_COMPILATION disabled due to user options. This will reduce performance and compatibility'
-      if method and 'interpret' in method:
+      if method:
         self.assertContained(warning, err)
       else:
         self.assertNotContained(warning, err)
@@ -7690,10 +7690,11 @@ int main() {
         (['-s', 'TOTAL_MEMORY=20971520',                                '-s', 'WASM_MEM_MAX=41943040'], 320, 640),
         (['-s', 'TOTAL_MEMORY=20971520', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM_MEM_MAX=41943040'], 320, 640),
       ]:
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2', '-s', 'BINARYEN_METHOD="interpret-s-expr"'] + args
+      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2'] + args
       print(' '.join(cmd))
       run_process(cmd)
-      for line in open('a.out.wast').readlines():
+      wast = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
+      for line in wast:
         if '(import "env" "memory" (memory ' in line:
           parts = line.strip().replace('(', '').replace(')', '').split(' ')
           print(parts)
@@ -7815,7 +7816,7 @@ int main() {
     print('sizes:', sizes)
 
   def test_binaryen_methods(self):
-    for method_init in ['interpret-asm2wasm', 'interpret-s-expr', 'asmjs', 'interpret-binary', 'asmjs,interpret-binary', 'interpret-binary,asmjs']:
+    for method_init in ['asmjs', 'asmjs,native-wasm', 'native-wasm,asmjs']:
       # check success and failure for simple modes, only success for combined/fallback ones
       for success in [1, 0] if ',' not in method_init else [1]:
         method = method_init
@@ -7828,7 +7829,7 @@ int main() {
 
         see_polyfill = 'var WasmJS = ' in open('a.wasm.js').read()
 
-        if method and 'interpret' not in method:
+        if method:
           assert not see_polyfill, 'verify polyfill was not added - we specified a method, and it does not need it'
         else:
           assert see_polyfill, 'we need the polyfill'
@@ -7841,24 +7842,16 @@ int main() {
           with open('a.wasm.asm.js', 'w') as o:
             o.write(asm)
 
-        if method.startswith('interpret-asm2wasm'):
+        if method.startswith('native-wasm'):
           try_delete('a.wasm.wast') # we should not need the .wast
+          break_cashew() # we don't use cashew, so ok to break it
           if not success:
-            break_cashew() # we need cashew
-        elif method.startswith('interpret-s-expr'):
-          try_delete('a.wasm.asm.js') # we should not need the .asm.js
-          if not success:
-            try_delete('a.wasm.wast')
+            try_delete('a.wasm.wasm')
         elif method.startswith('asmjs'):
           try_delete('a.wasm.wast') # we should not need the .wast
           break_cashew() # we don't use cashew, so ok to break it
           if not success:
             try_delete('a.wasm.js')
-        elif method.startswith('interpret-binary'):
-          try_delete('a.wasm.wast') # we should not need the .wast
-          try_delete('a.wasm.asm.js') # we should not need the .asm.js
-          if not success:
-            try_delete('a.wasm.wasm')
         else:
           raise Exception('internal test error')
 
@@ -8050,12 +8043,12 @@ int main() {
         (['-s', 'TOTAL_MEMORY=32MB'], 2048),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1'], (2 * 1024 * 1024 * 1024 - 65536) // 16384),
         (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM=0'], (2 * 1024 * 1024 * 1024 - 16777216) // 16384),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], 2048),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"'], (2 * 1024 * 1024 * 1024 - 65536) // 16384),
-        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-asm2wasm"', '-s', 'WASM_MEM_MAX=128MB'], 2048 * 4)
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'BINARYEN=1'], 2048),
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1'], (2 * 1024 * 1024 * 1024 - 65536) // 16384),
+        (['-s', 'TOTAL_MEMORY=32MB', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN=1', '-s', 'WASM_MEM_MAX=128MB'], 2048 * 4)
       ]:
       if self.is_wasm_backend():
-        if 'WASM=0' in args or 'BINARYEN_METHOD="interpret-asm2wasm"' in args:
+        if 'WASM=0' in args:
           continue
       cmd = [PYTHON, EMCC, path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')] + args
       print(str(cmd))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1014,13 +1014,13 @@ BINARYEN_ROOT = ''
       prep()
       run_process([PYTHON, EMBUILDER, 'build', 'binaryen'])
       assert os.path.exists(tag_file)
-      run_process([PYTHON, EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
+      run_process([PYTHON, EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'BINARYEN=1'])
       self.assertContained('hello, world!', run_js('a.out.js'))
 
       print('see we show an error for emmake (we cannot build natively under emmake)')
       prep()
       try_delete('a.out.js')
-      out = self.do([PYTHON, path_from_root('emmake.py'), EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"'])
+      out = self.do([PYTHON, path_from_root('emmake.py'), EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'BINARYEN=1'])
       assert not os.path.exists(tag_file)
       assert not os.path.exists('a.out.js')
       self.assertContained('For example, for binaryen, do "python embuilder.py build binaryen"', out)
@@ -1039,7 +1039,7 @@ BINARYEN_ROOT = ''
           else:
             # EM_ASM doesn't work in a wasm side module, build a normal program
             cmd += [path_from_root('tests', 'hello_world.c'), '-s', 'SIDE_MODULE=1']
-          cmd += ['-s', 'BINARYEN=1', '-s', 'BINARYEN_METHOD="interpret-binary"']
+          cmd += ['-s', 'BINARYEN=1']
           run_process(cmd)
           assert os.path.exists(tag_file)
           assert os.path.exists('a.out.wasm')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2707,18 +2707,6 @@ class Building(object):
     Building.get_binaryen()
     return os.path.join(Settings.BINARYEN_ROOT, 'bin')
 
-  @staticmethod
-  def get_binaryen_lib():
-    Building.get_binaryen()
-    # The wasm.js and binaryen.js libraries live in 'bin' in the binaryen
-    # source tree, but are installed to share/binaryen.
-    paths = (os.path.join(Settings.BINARYEN_ROOT, 'bin'),
-             os.path.join(Settings.BINARYEN_ROOT, 'share', 'binaryen'))
-    for dirname in paths:
-      if os.path.exists(os.path.join(dirname, 'wasm.js')):
-        return dirname
-    exit_with_error('emcc: cannot find binaryen js libraries (tried: %s)', str(paths))
-
 
 # compatibility with existing emcc, etc. scripts
 Cache = cache.Cache()


### PR DESCRIPTION
It was useful to bring up wasm support to have a way to interpret wasms, before VMs were up to speed, but at this point we have many VMs with correct behavior. Removing this simplifies our code and speeds up some tests.