### PR TITLE
Remove BINARYEN_METHOD

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - Remove BINARYEN_METHOD: no more support for interpret modes, and if you want
+   non-wasm, use WASM=0.
 
 v1.38.22: 01/08/2019
 --------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1299,10 +1299,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.OUTLINING_LIMIT:
         logger.warning('for wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow')
       # default precise-f32 to on, since it works well in wasm
-      # also always use f32s when asm.js is not in the picture
-      if ('PRECISE_F32=0' not in settings_changes and 'PRECISE_F32=2' not in settings_changes) or 'asmjs' not in shared.Settings.BINARYEN_METHOD:
-        shared.Settings.PRECISE_F32 = 1
-      if options.js_opts and not options.force_js_opts and 'asmjs' not in shared.Settings.BINARYEN_METHOD:
+      shared.Settings.PRECISE_F32 = 1
+      if options.js_opts and not options.force_js_opts:
         options.js_opts = None
         logger.debug('asm.js opts not forced by user or an option that depends them, and we do not intend to run the asm.js, so disabling and leaving opts to the binaryen optimizer')
       if options.use_closure_compiler == 2:
@@ -1341,8 +1339,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # we will include the mem init data in the wasm, when we don't need the
       # mem init file to be loadable by itself
-      shared.Settings.MEM_INIT_IN_WASM = 'asmjs' not in shared.Settings.BINARYEN_METHOD and \
-                                         not shared.Settings.USE_PTHREADS
+      shared.Settings.MEM_INIT_IN_WASM = not shared.Settings.USE_PTHREADS
 
       # wasm side modules have suffix .wasm
       if shared.Settings.SIDE_MODULE and target.endswith('.js'):
@@ -1369,7 +1366,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
       # this is an issue in asm.js, but not wasm
-      if not shared.Settings.WASM or 'asmjs' in shared.Settings.BINARYEN_METHOD:
+      if not shared.Settings.WASM:
         shared.WarningManager.warn('ALMOST_ASM')
         shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
 
@@ -1414,7 +1411,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs.append('-disable-llvm-optzns')
 
     if not shared.Settings.LEGALIZE_JS_FFI:
-      assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS and non-wasm BINARYEN_METHOD.'
+      assert shared.Building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS.'
 
     shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
     shared.Settings.OPT_LEVEL = options.opt_level
@@ -2063,7 +2060,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         generated_text_files_with_native_eols += [asm_target]
 
       if shared.Settings.WASM:
-        binaryen_method_sanity_check()
         do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                     wasm_text_target, misc_temp_files, optimizer)
 
@@ -2457,19 +2453,10 @@ def separate_asm_js(final, asm_target):
     shutil.move(temp, asm_target)
 
 
-def binaryen_method_sanity_check():
-  if shared.Settings.BINARYEN_METHOD:
-    methods = shared.Settings.BINARYEN_METHOD.split(',')
-    valid_methods = ['asmjs', 'native-wasm']
-    for m in methods:
-      if m.strip() not in valid_methods:
-        exit_with_error('Unrecognized BINARYEN_METHOD "' + m.strip() + '" specified! Please pass a comma-delimited list containing one or more of: ' + ','.join(valid_methods))
-
-
 def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                 wasm_text_target, misc_temp_files, optimizer):
   global final
-  logger.debug('using binaryen, with method: ' + shared.Settings.BINARYEN_METHOD)
+  logger.debug('using binaryen')
   binaryen_bin = shared.Building.get_binaryen_bin()
   # normally we emit binary, but for debug info, we might emit text first
   debug_info = options.debug_level >= 2 or options.profiling_funcs
@@ -2605,10 +2592,10 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     for target, replacement_string, should_embed in (
         (wasm_binary_target,
          shared.FilenameReplacementStrings.WASM_BINARY_FILE,
-         'native-wasm' in shared.Settings.BINARYEN_METHOD),
+         True),
         (asm_target,
          shared.FilenameReplacementStrings.ASMJS_CODE_FILE,
-         'asmjs' in shared.Settings.BINARYEN_METHOD),
+         False),
       ):
       if should_embed and os.path.isfile(target):
         js = js.replace(replacement_string, shared.JS.get_subresource_location(target))
@@ -2777,7 +2764,7 @@ def generate_html(target, options, js_target, target_basename,
 
     # Download .asm.js if --separate-asm was passed in an asm.js build, or if 'asmjs' is one
     # of the wasm run methods.
-    if not options.separate_asm or (shared.Settings.WASM and 'asmjs' not in shared.Settings.BINARYEN_METHOD):
+    if not options.separate_asm or shared.Settings.WASM:
       if len(asm_mods):
          exit_with_error('no --separate-asm means no client code mods are possible')
     else:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1438,7 +1438,7 @@ def function_tables(function_table_data):
 
 def create_the_global(metadata):
   # the global is only needed for asm.js
-  if shared.Settings.WASM and shared.Settings.BINARYEN_METHOD == 'native-wasm':
+  if shared.Settings.WASM:
     return '{}'
   fundamentals = ['Math']
   fundamentals += ['Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Float32Array', 'Float64Array']

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -30,11 +30,10 @@ var proxiedFunctionTable = ["null" /* Reserve index 0 for an undefined function*
 // map: pair(sig, syncOrAsync) -> function body
 var proxiedFunctionInvokers = {};
 
-// We include asm2wasm imports if we may interpret (where we call out to JS to do some math stuff)
-// or if the trap mode is 'js' (where we do the same). However, we always need some of them (like
-// the frem import because % is in asm.js but not in wasm). But we can avoid emitting all the others
-// in many cases.
-var NEED_ALL_ASM2WASM_IMPORTS = BINARYEN_METHOD != 'native-wasm' || BINARYEN_TRAP_MODE == 'js';
+// We include asm2wasm imports if the trap mode is 'js' (to call out to JS to do some math stuff).
+// However, we always need some of them (like the frem import because % is in asm.js but not in wasm).
+// But we can avoid emitting all the others in many cases.
+var NEED_ALL_ASM2WASM_IMPORTS = BINARYEN_TRAP_MODE == 'js';
 
 // used internally. set when there is a main() function.
 // also set when in a linkable module, as the main() function might

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1456,6 +1456,8 @@ function makeRetainedCompilerSettings() {
   return ret;
 }
 
+// In wasm, the heap size must be a multiple of 64KB.
+// In asm.js, it must be a multiple of 16MB.
 var WASM_PAGE_SIZE = 65536;
 var ASMJS_PAGE_SIZE = 16777216;
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1456,3 +1456,10 @@ function makeRetainedCompilerSettings() {
   return ret;
 }
 
+var WASM_PAGE_SIZE = 65536;
+var ASMJS_PAGE_SIZE = 16777216;
+
+function getPageSize() {
+  return WASM ? WASM_PAGE_SIZE : ASMJS_PAGE_SIZE;
+}
+

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -880,8 +880,8 @@ function stackTrace() {
 // Memory management
 
 var PAGE_SIZE = 16384;
-var WASM_PAGE_SIZE = 65536;
-var ASMJS_PAGE_SIZE = 16777216;
+var WASM_PAGE_SIZE = {{{ WASM_PAGE_SIZE }}};
+var ASMJS_PAGE_SIZE = {{{ ASMJS_PAGE_SIZE }}};
 var MIN_TOTAL_MEMORY = 16777216;
 
 function alignUp(x, multiple) {
@@ -1025,7 +1025,8 @@ function enlargeMemory() {
   _emscripten_trace_report_memory_layout();
 #endif
 
-  var PAGE_MULTIPLE = Module["usingWasm"] ? WASM_PAGE_SIZE : ASMJS_PAGE_SIZE; // In wasm, heap size must be a multiple of 64KB. In asm.js, they need to be multiples of 16MB.
+ // In wasm, heap size must be a multiple of 64KB. In asm.js, they need to be multiples of 16MB.
+  var PAGE_MULTIPLE = {{{ getPageSize() }}};
   var LIMIT = 2147483648 - PAGE_MULTIPLE; // We can do one page short of 2GB as theoretical maximum.
 
   if (HEAP32[DYNAMICTOP_PTR>>2] > LIMIT) {
@@ -1093,10 +1094,8 @@ function enlargeMemory() {
   updateGlobalBuffer(replacement);
   updateGlobalBufferViews();
 
-#if ASSERTIONS
-  if (!Module["usingWasm"]) {
-    err('Warning: Enlarging memory arrays, this is not fast! ' + [OLD_TOTAL_MEMORY, TOTAL_MEMORY]);
-  }
+#if ASSERTIONS && !WASM
+  err('Warning: Enlarging memory arrays, this is not fast! ' + [OLD_TOTAL_MEMORY, TOTAL_MEMORY]);
 #endif
 
 #if EMSCRIPTEN_TRACING
@@ -1757,26 +1756,9 @@ var cyberDWARFFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
 
 #if WASM
 function integrateWasmJS() {
-  // wasm.js has several methods for creating the compiled code module here:
-  //  * 'native-wasm' : use native WebAssembly support in the browser
-  //  * 'asmjs': no wasm, just load the asm.js code and use that (good for testing)
-  // The method is set at compile time (BINARYEN_METHOD)
-  // The method can be a comma-separated list, in which case, we will try the
-  // options one by one. Some of them can fail gracefully, and then we can try
-  // the next.
-
-  // inputs
-
-  var method = '{{{ BINARYEN_METHOD }}}';
-
   var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
-  var asmjsCodeFile = '{{{ ASMJS_CODE_FILE }}}';
-
   if (!isDataURI(wasmBinaryFile)) {
     wasmBinaryFile = locateFile(wasmBinaryFile);
-  }
-  if (!isDataURI(asmjsCodeFile)) {
-    asmjsCodeFile = locateFile(asmjsCodeFile);
   }
 
   // utilities
@@ -1863,33 +1845,10 @@ function integrateWasmJS() {
 
   // do-method functions
 
-#if BINARYEN_METHOD != 'native-wasm'
-  function doJustAsm(global, env, providedBuffer) {
-    // if no Module.asm, or it's the method handler helper (see below), then apply
-    // the asmjs
-    if (typeof Module['asm'] !== 'function' || Module['asm'] === methodHandler) {
-      if (!Module['asmPreload']) {
-        // you can load the .asm.js file before this, to avoid this sync xhr and eval
-        {{{ makeEval("eval(Module['read'](asmjsCodeFile));") }}} // set Module.asm
-      } else {
-        Module['asm'] = Module['asmPreload'];
-      }
-    }
-    if (typeof Module['asm'] !== 'function') {
-      err('asm evalling did not set the module properly');
-      return false;
-    }
-    return Module['asm'](global, env, providedBuffer);
-  }
-#endif // BINARYEN_METHOD != 'native-wasm'
-
   function doNativeWasm(global, env, providedBuffer) {
     if (typeof WebAssembly !== 'object') {
-#if BINARYEN_METHOD == 'native-wasm'
 #if ASSERTIONS
-      // when the method is just native-wasm, our error message can be very specific
       abort('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.');
-#endif
 #endif
       err('no native wasm support detected');
       return false;
@@ -1913,7 +1872,6 @@ function integrateWasmJS() {
       exports = instance.exports;
       if (exports.memory) mergeMemory(exports.memory);
       Module['asm'] = exports;
-      Module["usingWasm"] = true;
 #if USE_PTHREADS
       // Keep a reference to the compiled module so we can post it to the workers.
       Module['wasmModule'] = module;
@@ -2010,42 +1968,31 @@ function integrateWasmJS() {
 
   // Memory growth integration code
 
-  var asmjsReallocBuffer = Module['reallocBuffer'];
-
   var wasmReallocBuffer = function(size) {
-    var PAGE_MULTIPLE = Module["usingWasm"] ? WASM_PAGE_SIZE : ASMJS_PAGE_SIZE; // In wasm, heap size must be a multiple of 64KB. In asm.js, they need to be multiples of 16MB.
+    var PAGE_MULTIPLE = {{{ getPageSize() }}};
     size = alignUp(size, PAGE_MULTIPLE); // round up to wasm page size
     var old = Module['buffer'];
     var oldSize = old.byteLength;
-    if (Module["usingWasm"]) {
-      // native wasm support
-      try {
-        var result = Module['wasmMemory'].grow((size - oldSize) / wasmPageSize); // .grow() takes a delta compared to the previous size
-        if (result !== (-1 | 0)) {
-          // success in native wasm memory growth, get the buffer from the memory
-          return Module['buffer'] = Module['wasmMemory'].buffer;
-        } else {
-          return null;
-        }
-      } catch(e) {
-#if ASSERTIONS
-        console.error('Module.reallocBuffer: Attempted to grow from ' + oldSize  + ' bytes to ' + size + ' bytes, but got error: ' + e);
-#endif
+    // native wasm support
+    try {
+      var result = Module['wasmMemory'].grow((size - oldSize) / wasmPageSize); // .grow() takes a delta compared to the previous size
+      if (result !== (-1 | 0)) {
+        // success in native wasm memory growth, get the buffer from the memory
+        return Module['buffer'] = Module['wasmMemory'].buffer;
+      } else {
         return null;
       }
+    } catch(e) {
+#if ASSERTIONS
+      console.error('Module.reallocBuffer: Attempted to grow from ' + oldSize  + ' bytes to ' + size + ' bytes, but got error: ' + e);
+#endif
+      return null;
     }
   };
 
   Module['reallocBuffer'] = function(size) {
-    if (finalMethod === 'asmjs') {
-      return asmjsReallocBuffer(size);
-    } else {
-      return wasmReallocBuffer(size);
-    }
+    return wasmReallocBuffer(size);
   };
-
-  // we may try more than one; this is the final one, that worked and we are using
-  var finalMethod = '';
 
   // Provide an "asm.js function" for the application, called to "link" the asm.js module. We instantiate
   // the wasm module at that time, and it receives imports and provides exports and so forth, the app
@@ -2078,51 +2025,15 @@ function integrateWasmJS() {
       env['__table_base'] = 0; // table starts at 0 by default, in dynamic linking this will change
     }
 
-    // try the methods. each should return the exports if it succeeded
-
     var exports;
-#if BINARYEN_METHOD == 'native-wasm'
     exports = doNativeWasm(global, env, providedBuffer);
-#else // native-wasm
-#if BINARYEN_METHOD == 'asmjs'
-    exports = doJustAsm(global, env, providedBuffer);
-#else
-    var methods = method.split(',');
-
-    for (var i = 0; i < methods.length; i++) {
-      var curr = methods[i];
-
-#if RUNTIME_LOGGING
-      err('trying binaryen method: ' + curr);
-#endif
-
-      finalMethod = curr;
-
-      if (curr === 'native-wasm') {
-        if (exports = doNativeWasm(global, env, providedBuffer)) break;
-      } else if (curr === 'asmjs') {
-        if (exports = doJustAsm(global, env, providedBuffer)) break;
-      } else {
-        abort('bad method: ' + curr);
-      }
-    }
-#endif // asmjs
-#endif // native-wasm
 
 #if ASSERTIONS
-    assert(exports, 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#binaryen-methods');
-#else
-    assert(exports, 'no binaryen method succeeded.');
-#endif
-
-#if RUNTIME_LOGGING
-    err('binaryen method succeeded.');
+    assert(exports, 'binaryen setup failed (no wasm support?)');
 #endif
 
     return exports;
   };
-
-  var methodHandler = Module['asm']; // note our method handler, as we may modify Module['asm'] later
 }
 
 integrateWasmJS();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1025,7 +1025,6 @@ function enlargeMemory() {
   _emscripten_trace_report_memory_layout();
 #endif
 
- // In wasm, heap size must be a multiple of 64KB. In asm.js, they need to be multiples of 16MB.
   var PAGE_MULTIPLE = {{{ getPageSize() }}};
   var LIMIT = 2147483648 - PAGE_MULTIPLE; // We can do one page short of 2GB as theoretical maximum.
 
@@ -1843,9 +1842,9 @@ function integrateWasmJS() {
     });
   }
 
-  // do-method functions
-
-  function doNativeWasm(global, env, providedBuffer) {
+  // Create the wasm instance.
+  // Receives the wasm imports, returns the exports.
+  function createWasm(global, env, providedBuffer) {
     if (typeof WebAssembly !== 'object') {
 #if ASSERTIONS
       abort('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.');
@@ -2025,8 +2024,7 @@ function integrateWasmJS() {
       env['__table_base'] = 0; // table starts at 0 by default, in dynamic linking this will change
     }
 
-    var exports;
-    exports = doNativeWasm(global, env, providedBuffer);
+    var exports = createWasm(global, env, providedBuffer);
 
 #if ASSERTIONS
     assert(exports, 'binaryen setup failed (no wasm support?)');

--- a/src/settings.js
+++ b/src/settings.js
@@ -1000,10 +1000,6 @@ var WASM_BACKEND = 0;
 // of using LLVM IR.
 var WASM_OBJECT_FILES = 0;
 
-// How we should run WebAssembly code. By default, we run it natively.
-// See binaryen's src/preamble.js for more details and options.
-var BINARYEN_METHOD = "native-wasm";
-
 // An optional comma-separated list of script hooks to run after binaryen,
 // in binaryen's /scripts dir.
 var BINARYEN_SCRIPTS = "";
@@ -1051,8 +1047,7 @@ var BINARYEN_ROOT = "";
 // to automatically demote i64 to i32 and promote f32 to f64. This is necessary
 // in order to interface with JavaScript, both for asm.js and wasm.  For
 // non-web/non-JS embeddings, setting this to 0 may be desirable.
-// LEGALIZE_JS_FFI=0 is incompatible with RUNNING_JS_OPTS and using non-wasm
-// BINARYEN_METHOD settings.
+// LEGALIZE_JS_FFI=0 is incompatible with RUNNING_JS_OPTS.
 var LEGALIZE_JS_FFI = 1;
 
 // Ports

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4208,7 +4208,7 @@ window.close = function() {
 
   # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
   def test_single_file_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"], also_proxied=True)
+    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
     assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
 
   # Tests that SINGLE_FILE works as intended with locateFile
@@ -4243,7 +4243,7 @@ window.close = function() {
   # Tests that SINGLE_FILE works as intended in a Worker in JS output
   def test_single_file_worker_js(self):
     create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
-    run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1', '-s', "BINARYEN_METHOD='native-wasm'"])
+    run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1'])
     create_test_file('test.html', '<script src="test.js"></script>')
     self.run_browser('test.html', None, '/report_result?0')
     assert os.path.exists('test.js') and not os.path.exists('test.worker.js')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8018,8 +8018,6 @@ asm2f = make_run('asm2f', emcc_args=['-Oz'], settings={'PRECISE_F32': 1, 'ALLOW_
 asm2nn = make_run('asm2nn', emcc_args=['-O2'], settings={'WASM': 0}, env={'EMCC_NATIVE_OPTIMIZER': '0'})
 
 # wasm
-binaryen2jo = make_run('binaryen2jo', emcc_args=['-O2'], settings={'BINARYEN_METHOD': 'native-wasm,asmjs'})
-binaryen3jo = make_run('binaryen3jo', emcc_args=['-O3'], settings={'BINARYEN_METHOD': 'native-wasm,asmjs'})
 binaryen2s = make_run('binaryen2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
 
 # emterpreter

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3433,10 +3433,6 @@ int main() {
     os.remove('a.out.wasm') # trigger onAbort by intentionally causing startup to fail
     add_on_abort_and_verify()
 
-    # test an abort due to lack of a working binaryen method
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'BINARYEN_METHOD="asmjs"'])
-    add_on_abort_and_verify(extra='Module.asm = "string-instead-of-code, asmjs method will fail";')
-
   def test_no_exit_runtime(self):
     create_test_file('code.cpp', r'''
 #include <stdio.h>
@@ -7537,7 +7533,6 @@ int main() {
           (['-O2', '-s', 'EVAL_CTORS=1'], False, True, True), # ctor evaller turned off since only-wasm
           (['-O2', '-s', 'OUTLINING_LIMIT=1000'], True, True, False), # option forced
           (['-O2', '-s', 'OUTLINING_LIMIT=1000', '-s', 'ALLOW_MEMORY_GROWTH=1'], True, True, False), # option forced, and also check growth does not interfere
-          (['-O2', '-s', "BINARYEN_METHOD='native-wasm,asmjs'"], True, True, False), # asmjs in methods means we need good asm.js
           (['-O3'], False, True, True),
           (['-Os'], False, True, True),
           (['-Oz'], False, True, True), # ctor evaller turned off since only-wasm
@@ -7580,7 +7575,6 @@ int main() {
       for args, expect in [
           ([], True),
           (['-s', 'PRECISE_F32=0'], True), # disabled, but no asm.js, so we definitely want f32
-          (['-s', 'PRECISE_F32=0', '-s', 'BINARYEN_METHOD="asmjs"'], False), # disabled, and we need the asm.js
           (['-s', 'PRECISE_F32=1'], True),
           (['-s', 'PRECISE_F32=2'], True),
         ]:
@@ -7622,35 +7616,14 @@ int main() {
   def test_binaryen_warn_mem(self):
     # if user changes TOTAL_MEMORY at runtime, the wasm module may not accept the memory import if it is too big/small
     create_test_file('pre.js', 'var Module = { TOTAL_MEMORY: 50 * 1024 * 1024 };\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'TOTAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'TOTAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
     out = run_js('a.out.js', engine=SPIDERMONKEY_ENGINE, full_output=True, stderr=PIPE, assert_returncode=None)
     self.assertContained('imported Memory with incompatible size', out)
     self.assertContained('Memory size incompatibility issues may be due to changing TOTAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set TOTAL_MEMORY at runtime to something smaller than it was at compile time).', out)
     self.assertNotContained('hello, world!', out)
     # and with memory growth, all should be good
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN_METHOD="native-wasm"', '-s', 'TOTAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'TOTAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'BINARYEN_ASYNC_COMPILATION=0'])
     self.assertContained('hello, world!', run_js('a.out.js', engine=SPIDERMONKEY_ENGINE))
-
-  @unittest.skipIf(SPIDERMONKEY_ENGINE not in JS_ENGINES, 'cannot run without spidermonkey')
-  def test_binaryen_warn_sync(self):
-    # non-native wasm will disable async
-    for method in ['asmjs', 'native-wasm', None]:
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')]
-      if method is not None:
-        cmd += ['-s', 'BINARYEN_METHOD="' + method + '"']
-      print(' '.join(cmd))
-      err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
-      print(err)
-      warning = 'BINARYEN_ASYNC_COMPILATION disabled due to user options. This will reduce performance and compatibility'
-      if method:
-        self.assertContained(warning, err)
-      else:
-        self.assertNotContained(warning, err)
-
-  def test_binaryen_invalid_method(self):
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'test.js', '-s', "BINARYEN_METHOD='invalid'"], stderr=PIPE, check=False)
-    self.assertContained('Unrecognized BINARYEN_METHOD', proc.stderr)
-    assert proc.returncode != 0
 
   @no_wasm_backend()
   def test_binaryen_asmjs_outputs(self):
@@ -7658,8 +7631,6 @@ int main() {
     for args, output_asmjs in [
       ([], False),
       (['-s', 'MAIN_MODULE=2'], False),
-      (['-s', 'BINARYEN_METHOD="native-wasm"'], False),
-      (['-s', 'BINARYEN_METHOD="native-wasm,asmjs"'], True)
     ]:
       with temp_directory(self.get_dir()) as temp_dir:
         cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join(temp_dir, 'a.js')] + args
@@ -7815,53 +7786,6 @@ int main() {
         assert expect == (' --ignore-implicit-traps ' in asm2wasm_line)
         sizes.append(os.path.getsize('a.out.wasm'))
     print('sizes:', sizes)
-
-  def test_binaryen_methods(self):
-    for method_init in ['asmjs', 'asmjs,native-wasm', 'native-wasm,asmjs']:
-      # check success and failure for simple modes, only success for combined/fallback ones
-      for success in [1, 0] if ',' not in method_init else [1]:
-        method = method_init
-        if self.is_wasm_backend() and ('asmjs' in method or 'asm2wasm' in method):
-          continue
-        command = [PYTHON, EMCC, '-o', 'a.wasm.js', '-s', 'BINARYEN=1', path_from_root('tests', 'hello_world.c')]
-        command += ['-s', 'BINARYEN_METHOD="' + method + '"']
-        print(method, ' : ', ' '.join(command), ' => ', success)
-        run_process(command)
-
-        see_polyfill = 'var WasmJS = ' in open('a.wasm.js').read()
-
-        if method:
-          assert not see_polyfill, 'verify polyfill was not added - we specified a method, and it does not need it'
-        else:
-          assert see_polyfill, 'we need the polyfill'
-
-        def break_cashew():
-          with open('a.wasm.asm.js') as f:
-            asm = f.read()
-          asm = asm.replace('"almost asm"', '"use asm"; var not_in_asm = [].length + (true || { x: 5 }.x);')
-          asm = asm.replace("'almost asm'", '"use asm"; var not_in_asm = [].length + (true || { x: 5 }.x);')
-          with open('a.wasm.asm.js', 'w') as o:
-            o.write(asm)
-
-        if method.startswith('native-wasm'):
-          try_delete('a.wasm.wast') # we should not need the .wast
-          break_cashew() # we don't use cashew, so ok to break it
-          if not success:
-            try_delete('a.wasm.wasm')
-        elif method.startswith('asmjs'):
-          try_delete('a.wasm.wast') # we should not need the .wast
-          break_cashew() # we don't use cashew, so ok to break it
-          if not success:
-            try_delete('a.wasm.js')
-        else:
-          raise Exception('internal test error')
-
-        proc = run_process(NODE_JS + ['a.wasm.js'], stdout=PIPE, check=success)
-        if success:
-          self.assertIn('hello, world!', proc.stdout)
-        else:
-          assert proc.returncode != 0, proc.stderr
-          self.assertNotIn('hello, world!', proc.stdout)
 
   def test_binaryen_metadce(self):
     def test(filename, expectations, size_slack):
@@ -8235,12 +8159,7 @@ int main() {
         cmd += ['-s', "EMTERPRETIFY_FILE='a.out.dat'"]
       if closure_enabled:
         cmd += ['--closure', '1']
-      if wasm_enabled:
-        method = 'native-wasm'
-        if asmjs_fallback_enabled:
-          method += ',asmjs'
-        cmd += ['-s', 'WASM=1', '-s', "BINARYEN_METHOD='" + method + "'"]
-      else:
+      if not wasm_enabled:
         cmd += ['-s', 'WASM=0']
 
       print(' '.join(cmd))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8119,23 +8119,18 @@ int main() {
          emterpreter_enabled,
          emterpreter_file_enabled,
          closure_enabled,
-         wasm_enabled,
-         asmjs_fallback_enabled) in itertools.product([True, False], repeat=8):
+         wasm_enabled) in itertools.product([True, False], repeat=7):
       # skip unhelpful option combinations
-      if (
-          (asmjs_fallback_enabled and not wasm_enabled) or
-          (emterpreter_file_enabled and not emterpreter_enabled)
-      ):
+      if emterpreter_file_enabled and not emterpreter_enabled:
         continue
 
       expect_wasm = wasm_enabled
       expect_emterpretify_file = emterpreter_file_enabled
-      expect_meminit = (meminit1_enabled and not wasm_enabled) or (wasm_enabled and asmjs_fallback_enabled)
+      expect_meminit = meminit1_enabled and not wasm_enabled
       expect_success = not (emterpreter_file_enabled and single_file_enabled)
-      expect_asmjs_code = asmjs_fallback_enabled and wasm_enabled and not self.is_wasm_backend()
       expect_wast = debug_enabled and wasm_enabled and not self.is_wasm_backend()
 
-      if self.is_wasm_backend() and (asmjs_fallback_enabled or emterpreter_enabled or not wasm_enabled):
+      if self.is_wasm_backend() and (emterpreter_enabled or not wasm_enabled):
         continue
 
       # currently, the emterpreter always fails with JS output since we do not preload the emterpreter file, which in non-HTML we would need to do manually
@@ -8144,7 +8139,6 @@ int main() {
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c')]
 
       if single_file_enabled:
-        expect_asmjs_code = False
         expect_emterpretify_file = False
         expect_meminit = False
         expect_wasm = False
@@ -8170,7 +8164,6 @@ int main() {
         print(proc.stdout)
       assert expect_success == (proc.returncode == 0)
       if proc.returncode == 0:
-        assert expect_asmjs_code == os.path.exists('a.out.asm.js')
         assert expect_emterpretify_file == os.path.exists('a.out.dat')
         assert expect_meminit == (os.path.exists('a.out.mem') or os.path.exists('a.out.js.mem'))
         assert expect_wasm == os.path.exists('a.out.wasm')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2262,9 +2262,6 @@ class Building(object):
     # Explicitly separate asm.js requires it
     if Settings.SEPARATE_ASM:
       return True
-    # A binaryen method may require it.
-    if 'asmjs' in Settings.BINARYEN_METHOD or 'interpret-asm2wasm' in Settings.BINARYEN_METHOD:
-      return True
     return False
 
   @staticmethod
@@ -2283,9 +2280,6 @@ class Building(object):
       # emitting code compatible with JS, and there is no reason not to
       # be wasm-only, regardless of everything else
       return True
-    if 'asmjs' in Settings.BINARYEN_METHOD or 'interpret-asm2wasm' in Settings.BINARYEN_METHOD:
-      # code compatible with asm.js cannot be wasm-only
-      return False
     if Settings.RUNNING_JS_OPTS:
       # if the JS optimizer runs, it must run on valid asm.js
       return False


### PR DESCRIPTION
Followup to #7831. This removes BINARYEN_METHOD, which means that if you build with WASM you get wasm, and have no option for an asm.js fallback, and if you build with WASM=0 you get asm.js.

This removes and simplifies a bunch of things, so it seems worth it. We do lose the `BINARYEN_METHOD=wasm-native,asmjs` option which let a single build run either way. That was useful for debugging back when asm.js worked well but not wasm, but those days are far in the past. Another use is to have a single build for both, but it was always a very unoptimized "compromise" build, and not recommended, so removing it avoids a possible footgun for users (if a single build is crucial for people, we should look into a more proper way to do it).