### PR TITLE
Use --post-emscripten pass with wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1352,7 +1352,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             passes += ['--no-exit-runtime']
           if options.opt_level > 0 or options.shrink_level > 0:
             passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
-          if shared.Settings.GLOBAL_BASE >= 1024: # 1024 is hardcoded in the binaryen pass
+          if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
             passes += ['--post-emscripten']
           if options.debug_level < 3:
             passes += ['--strip']

--- a/emcc.py
+++ b/emcc.py
@@ -1330,20 +1330,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           shared.Settings.DECLARE_ASM_MODULE_EXPORTS = 1
           logger.warning('Enabling -s DECLARE_ASM_MODULE_EXPORTS=1 since -O3/-Os build with Wasm meta-DCE is used')
 
-      # run safe-heap as a binaryen pass
-      if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
-        if shared.Settings.BINARYEN_PASSES:
-          shared.Settings.BINARYEN_PASSES += ','
-        shared.Settings.BINARYEN_PASSES += 'safe-heap'
-      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-        # emulated function pointer casts is emulated in wasm using a binaryen pass
-        if shared.Settings.BINARYEN_PASSES:
-          shared.Settings.BINARYEN_PASSES += ','
-        shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
-        # we also need emulated function pointers for that, as we need a single flat
-        # table, as is standard in wasm, and not asm.js split ones.
-        shared.Settings.EMULATED_FUNCTION_POINTERS = 1
-
       # we will include the mem init data in the wasm, when we don't need the
       # mem init file to be loadable by itself
       shared.Settings.MEM_INIT_IN_WASM = not shared.Settings.USE_PTHREADS
@@ -1375,6 +1361,20 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
         # to bootstrap struct_info, we need binaryen
         os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
+
+      # run safe-heap as a binaryen pass
+      if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only():
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'safe-heap'
+      if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+        # emulated function pointer casts is emulated in wasm using a binaryen pass
+        if shared.Settings.BINARYEN_PASSES:
+          shared.Settings.BINARYEN_PASSES += ','
+        shared.Settings.BINARYEN_PASSES += 'fpcast-emu'
+        # we also need emulated function pointers for that, as we need a single flat
+        # table, as is standard in wasm, and not asm.js split ones.
+        shared.Settings.EMULATED_FUNCTION_POINTERS = 1
 
     # wasm outputs are only possible with a side wasm
     if target.endswith(WASM_ENDINGS):


### PR DESCRIPTION
That pass optimizes load and store offsets, turning a load of (x + y) into a load of x with a load offset of y, where y is a small enough constant. By setting `GLOBAL_BASE`, we can ensure that valid memory locations start above a certain value, avoiding overflows that would invalidate using a load/store offset.

This wastes a little static storage space which is then never touched, but it doesn't take space in the wasm file (we emit data segments without it). The cost is only in somewhat larger constants for static global locations, which might take more room as LEBs, and a little wasted RAM at runtime. The benefit, on the other hand, is using load/store offsets in more places, saving code size and compile time, and appears much bigger in practice.

On asm2wasm we always did this, whereas with the wasm backend we did the bad half, but not the good half... by mistake. That is, we set `GLOBAL_BASE` higher, but still never ran the optimization for it. All this PR does is fix that, that is, it does **not** change `GLOBAL_BASE` - so this PR regresses nothing, and just helps. Specifically, with this PR we shrink the final wasm by over 1% (e.g. on hello libc++).

In theory the wasm backend could optimize such things (in which case we would not need to raise `GLOBAL_BASE`). But it doesn't seem to do so in all cases, see #7715 cc @sunfishcode @dschuff Perhaps it's just a matter of the analysis not catching all cases there, and the higher `GLOBAL_BASE` approach is a simple guarantee that works consistently (at the cost of a little wasted static space)?

The constant value of 1024 has been used in asm2wasm in practice for a long time, and seems slightly better than other reasonable values (I re-measured now on the wasm backend).
