### PR TITLE
Stack simplification

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -394,6 +394,7 @@ def create_module_asmjs(function_table_sigs, metadata,
   asm_runtime_thread_local_vars = create_asm_runtime_thread_local_vars()
   asm_start = asm_start_pre + '\n' + asm_global_vars + asm_temp_vars + asm_runtime_thread_local_vars + '\n' + asm_global_funcs
 
+  stack = apply_memory('  var STACKTOP = {{{ STACK_BASE }}};\n  var STACK_MAX = {{{ STACK_MAX }}};\n', metadata)
   temp_float = '  var tempFloat = %s;\n' % ('Math_fround(0)' if provide_fround() else '0.0')
   async_state = '  var asyncState = 0;\n' if shared.Settings.EMTERPRETIFY_ASYNC else ''
   f0_fround = '  const f0 = Math_fround(0);\n' if provide_fround() else ''
@@ -406,6 +407,7 @@ def create_module_asmjs(function_table_sigs, metadata,
 
   module = [
     asm_start,
+    stack,
     temp_float,
     async_state,
     f0_fround,
@@ -1423,8 +1425,6 @@ def create_basic_funcs(function_table_sigs, invoke_function_names):
 
 def create_basic_vars(exported_implemented_functions, forwarded_json, metadata):
   basic_vars = ['DYNAMICTOP_PTR', 'tempDoublePtr']
-  if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-    basic_vars += ['STACKTOP', 'STACK_MAX']
   if shared.Settings.RELOCATABLE:
     if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
       basic_vars += ['gb', 'fb']

--- a/emscripten.py
+++ b/emscripten.py
@@ -394,7 +394,10 @@ def create_module_asmjs(function_table_sigs, metadata,
   asm_runtime_thread_local_vars = create_asm_runtime_thread_local_vars()
   asm_start = asm_start_pre + '\n' + asm_global_vars + asm_temp_vars + asm_runtime_thread_local_vars + '\n' + asm_global_funcs
 
-  stack = apply_memory('  var STACKTOP = {{{ STACK_BASE }}};\n  var STACK_MAX = {{{ STACK_MAX }}};\n', metadata)
+  if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
+    stack = apply_memory('  var STACKTOP = {{{ STACK_BASE }}};\n  var STACK_MAX = {{{ STACK_MAX }}};\n', metadata)
+  else:
+    stack = ''
   temp_float = '  var tempFloat = %s;\n' % ('Math_fround(0)' if provide_fround() else '0.0')
   async_state = '  var asyncState = 0;\n' if shared.Settings.EMTERPRETIFY_ASYNC else ''
   f0_fround = '  const f0 = Math_fround(0);\n' if provide_fround() else ''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7874,12 +7874,12 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      19, ['assert'], ['waka'], 33171, 11,  15, 69), # noqa
-        (['-O1'], 17, ['assert'], ['waka'], 14720,  9,  14, 28), # noqa
-        (['-O2'], 17, ['assert'], ['waka'], 14569,  9,  14, 24), # noqa
-        (['-O3'],  6, [],         [],        3395,  8,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
-        (['-Os'],  6, [],         [],        3350,  8,   3, 15), # noqa
-        (['-Oz'],  6, [],         [],        3309,  8,   2, 14), # noqa
+        ([],      17, ['assert'], ['waka'], 33171, 10,  15, 69), # noqa
+        (['-O1'], 15, ['assert'], ['waka'], 14720,  8,  14, 28), # noqa
+        (['-O2'], 15, ['assert'], ['waka'], 14569,  8,  14, 24), # noqa
+        (['-O3'],  5, [],         [],        3395,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
+        (['-Os'],  5, [],         [],        3350,  7,   3, 15), # noqa
+        (['-Oz'],  5, [],         [],        3309,  7,   2, 14), # noqa
         # finally, check what happens when we export nothing. wasm should be almost empty
         (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                    0, [],         [],          61,  0,   1,  1), # noqa; almost totally empty!
@@ -7887,9 +7887,9 @@ int main() {
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      19, ['assert'], ['waka'], 14567, 10, 15, 24), # noqa
-        (['-O1'], 12, ['assert'], ['waka'], 11255,  3, 12, 10), # noqa
-        (['-O2'], 12, ['assert'], ['waka'], 11255,  3, 12, 10), # noqa
+        ([],      17, ['assert'], ['waka'], 14567,  9, 15, 24), # noqa
+        (['-O1'], 10, ['assert'], ['waka'], 11255,  2, 12, 10), # noqa
+        (['-O2'], 10, ['assert'], ['waka'], 11255,  2, 12, 10), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [],         [],          61,  0,  1,  1), # noqa
         (['-Os'],  0, [],         [],          61,  0,  1,  1), # noqa

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7837,25 +7837,25 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      23, ['assert'], ['waka'], 46505,  24,   16, 59), # noqa
-        (['-O1'], 18, ['assert'], ['waka'], 12630,  16,   14, 31), # noqa
-        (['-O2'], 18, ['assert'], ['waka'], 12616,  16,   14, 31), # noqa
-        (['-O3'],  7, [],         [],        2690,  10,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
-        (['-Os'],  7, [],         [],        2690,  10,    2, 21), # noqa
-        (['-Oz'],  7, [],         [],        2690,  10,    2, 21), # noqa
+        ([],      21, ['assert'], ['waka'], 46505,  22,   16, 59), # noqa
+        (['-O1'], 16, ['assert'], ['waka'], 12630,  14,   14, 31), # noqa
+        (['-O2'], 16, ['assert'], ['waka'], 12616,  14,   14, 31), # noqa
+        (['-O3'],  6, [],         [],        2690,   9,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
+        (['-Os'],  6, [],         [],        2690,   9,    2, 21), # noqa
+        (['-Oz'],  6, [],         [],        2690,   9,    2, 21), # noqa
         # finally, check what happens when we export nothing. wasm should be almost empty
         (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1507, [],         [],      226057,  30,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1505, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      23, ['assert'], ['waka'], 22712, 24, 15, 28), # noqa
-        (['-O1'], 13, ['assert'], ['waka'], 10450,  9, 12, 12), # noqa
-        (['-O2'], 13, ['assert'], ['waka'], 10440,  9, 12, 12), # noqa
+        ([],      21, ['assert'], ['waka'], 22712, 22, 15, 28), # noqa
+        (['-O1'], 11, ['assert'], ['waka'], 10450,  7, 12, 12), # noqa
+        (['-O2'], 11, ['assert'], ['waka'], 10440,  7, 12, 12), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [],         [],          55,  0,  1, 1), # noqa
         (['-Os'],  0, [],         [],          55,  0,  1, 1), # noqa
@@ -7864,9 +7864,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 36, ['assert'], ['waka'], 196709,  30,   41, 659), # noqa
+        (['-O2'], 34, ['assert'], ['waka'], 196709,  28,   41, 659), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  36, ['assert'], ['waka'], 196709,  30,   22, 620), # noqa
+                  34, ['assert'], ['waka'], 196709,  28,   22, 620), # noqa
       ], size_slack) # noqa
     else:
       # wasm-backend

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7898,9 +7898,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 42, ['assert'], ['waka'], 348370,  28,  220, 723), # noqa
+        (['-O2'], 40, ['assert'], ['waka'], 348370,  27,  220, 723), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  42, ['assert'], ['waka'], 348249,  28,  220, 723), # noqa
+                  40, ['assert'], ['waka'], 348249,  27,  220, 723), # noqa
       ], size_slack) # noqa
 
   # ensures runtime exports work, even with metadce

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -5,7 +5,7 @@
 
 import os, shutil, logging
 
-TAG = 'version_63'
+TAG = 'stack' # FIXME temp
 
 def needed(settings, shared, ports):
   if not settings.WASM:


### PR DESCRIPTION
Depends on https://github.com/WebAssembly/binaryen/pull/1870 (has a hardcoded binaryen port value for testing, before landing needs to be a new tag there)

This is the emscripten side of that PR:
 * For asm2wasm, define STACKTOP/STACK_MAX in the asm.js code with the hardcoded value directly.
 * For wasm-emscripten-finalize, send it using `--stack-base`.

This saves 1 or 2 imports in the wasm, and JS to send it there. Not a huge savings in code size (16 bytes in hello world), but it is simpler and also simpler in the compiler code too.