### PR TITLE
Allow .mjs for js module output

### DIFF
--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -573,15 +573,24 @@ Options that are modified or new in *emcc* are listed below:
    The "target" file name extension defines the output type to be
    generated:
 
-      * <name> **.js** : JavaScript.
+      * <name> **.js** : JavaScript (+ separate **<name>.wasm** file
+        if emitting WebAssembly). (default)
+
+      * <name> **.mjs** : ES6 JavaScript module (+ separate
+        **<name>.wasm** file if emitting WebAssembly).
 
       * <name> **.html** : HTML + separate JavaScript file
-        (**<name>.js**). Having the separate JavaScript file improves
-        page load time.
+        (**<name>.js**; + separate **<name>.wasm** file if emitting
+        WebAssembly).
 
-      * <name> **.bc** : LLVM bitcode (default).
+      * <name> **.bc** : LLVM bitcode.
 
-      * <name> **.o** : LLVM bitcode (same as .bc).
+      * <name> **.o** : LLVM bitcode (same as .bc), unless in
+        *WASM_OBJECT_FILES* mode, in which case it will contain a
+        WebAssembly object.
+
+      * <name> **.wasm** : WebAssembly without JavaScript support
+        code ("standalone wasm").
 
    Note: If "--memory-init-file" is used, a **.mem** file will be
      created in addition to the generated **.js** and/or **.html**

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -446,6 +446,7 @@ Options that are modified or new in *emcc* are listed below:
   The ``target`` file name extension defines the output type to be generated:
 
     - <name> **.js** : JavaScript (+ separate **<name>.wasm** file if emitting WebAssembly). (default)
+    - <name> **.mjs** : ES6 JavaScript module (+ separate **<name>.wasm** file if emitting WebAssembly).
     - <name> **.html** : HTML + separate JavaScript file (**<name>.js**; + separate **<name>.wasm** file if emitting WebAssembly).
     - <name> **.bc** : LLVM bitcode.
     - <name> **.o** : LLVM bitcode (same as .bc), unless in `WASM_OBJECT_FILES` mode, in which case it will contain a WebAssembly object.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -148,6 +148,12 @@ class other(RunnerCore):
       self.assertContained('LLVM_ROOT', config_contents)
       os.remove(config_path)
 
+  def test_emcc_output_mjs(self):
+    run_process([PYTHON, EMCC, '-o', 'hello_world.mjs', path_from_root('tests', 'hello_world.c')])
+    with open('hello_world.mjs') as f:
+      output = f.read()
+    self.assertContained('The Module object', output)
+
   def test_emcc_1(self):
     for compiler, suffix in [(EMCC, '.c'), (EMXX, '.cpp')]:
       # --version

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -155,7 +155,7 @@ class other(RunnerCore):
     self.assertContained('export default Module;', output)
     # TODO(sbc): Test that this is actually runnable.  We currently don't have
     # any tests for EXPORT_ES6 but once we do this should be enabled.
-    #self.assertContained('hello, world!', run_js('hello_world.mjs'))
+    # self.assertContained('hello, world!', run_js('hello_world.mjs'))
 
   def test_emcc_1(self):
     for compiler, suffix in [(EMCC, '.c'), (EMXX, '.cpp')]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -152,7 +152,10 @@ class other(RunnerCore):
     run_process([PYTHON, EMCC, '-o', 'hello_world.mjs', path_from_root('tests', 'hello_world.c')])
     with open('hello_world.mjs') as f:
       output = f.read()
-    self.assertContained('The Module object', output)
+    self.assertContained('export default Module;', output)
+    # TODO(sbc): Test that this is actually runnable.  We currently don't have
+    # any tests for EXPORT_ES6 but once we do this should be enabled.
+    #self.assertContained('hello, world!', run_js('hello_world.mjs'))
 
   def test_emcc_1(self):
     for compiler, suffix in [(EMCC, '.c'), (EMXX, '.cpp')]:


### PR DESCRIPTION
Asking for a file of this extension enables EXPORT_ES6 and
MODULARIZE.

Fixes https://github.com/kripken/emscripten/issues/7853